### PR TITLE
fix: do not use localhost on dev server

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -57,12 +57,10 @@ export class McpServer extends McpServerBase {
       },
       async (_uri, extra) => {
         const serverUrl =
-          process.env.NODE_ENV === "production"
-            ? `https://${
-                extra?.requestInfo?.headers?.["x-forwarded-host"] ??
-                extra?.requestInfo?.headers?.host
-              }`
-            : `http://localhost:3000`;
+          `https://${
+            extra?.requestInfo?.headers?.["x-forwarded-host"] ??
+            extra?.requestInfo?.headers?.host
+          }`;
 
         const templateData = {
           serverUrl,


### PR DESCRIPTION
### Why this change ?
I've been facing some issues to get the frontend to load properly in widgets inside ChatGPT because trying to reach `localhost` was not possible on ChatGPT UI somehow.

My fix have been to directly use the host that is making the call, since anyway we are exposing our local through tools like `ngrok` and `cloudflared`.

I don't know if i'm missing something, otherwise, would make sense to either always use the host (like i did) or to at least make it more configurable.