### PR TITLE
Expose MCP App meta on tool and resources defined with widget

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -7,20 +7,39 @@ import type { ZodRawShape } from "zod";
 import { templateHelper } from "./templateHelper.js";
 
 /** @see https://developers.openai.com/apps-sdk/reference#tool-descriptor-parameters */
-type ToolMeta = {
+type OpenaiToolMeta = {
   "openai/outputTemplate": string;
   "openai/widgetAccessible"?: boolean;
   "openai/toolInvocation/invoking"?: string;
   "openai/toolInvocation/invoked"?: string;
 };
 
+/** @see https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/draft/apps.mdx#resource-discovery */
+type McpAppsToolMeta = {
+  "ui/resourceUri": string;
+};
+
+type ToolMeta = OpenaiToolMeta & McpAppsToolMeta;
+
 /** @see https://developers.openai.com/apps-sdk/reference#component-resource-_meta-fields */
-type ResourceMeta = {
+type OpenaiResourceMeta = {
   "openai/widgetDescription"?: string;
   "openai/widgetPrefersBorder"?: boolean;
   "openai/widgetCSP"?: Record<"connect_domains" | "resource_domains", string[]>;
   "openai/widgetDomain"?: string;
 };
+
+/** @see https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/draft/apps.mdx#ui-resource-format */
+type McpAppsResourceMeta = {
+  csp?: {
+    connectDomains?: string[];
+    resourceDomains?: string[];
+  };
+  domain?: string;
+  prefersBorder?: boolean;
+};
+
+type ResourceMeta = OpenaiResourceMeta & McpAppsResourceMeta;
 
 type McpServerOriginalResourceConfig = Omit<
   Resource,
@@ -43,7 +62,9 @@ export class McpServer extends McpServerBase {
     toolCallback: ToolCallback<InputArgs>
   ) {
     const uri = `ui://widgets/${name}.html`;
-    const resourceMetadata: ResourceMeta = { ...(resourceConfig._meta ?? {}) };
+    const resourceMetadata: ResourceMeta = {
+      ...(resourceConfig._meta ?? {}),
+    };
     if (toolConfig.description !== undefined) {
       resourceMetadata["openai/widgetDescription"] = toolConfig.description;
     }
@@ -89,6 +110,7 @@ export class McpServer extends McpServerBase {
     const toolMeta: ToolMeta = {
       ...toolConfig._meta,
       "openai/outputTemplate": uri,
+      "ui/resourceUri": uri,
     };
 
     this.registerTool(


### PR DESCRIPTION
Addresses #14 

Exposing MCP Apps specific meta tags on tools and resources defined with the `widget` API on server.