### PR TITLE
Add proxy logger on window.openai

### DIFF
--- a/src/web/mount-widget.ts
+++ b/src/web/mount-widget.ts
@@ -1,5 +1,8 @@
+/// <reference types="vite/client" />
+
 import { createElement, StrictMode } from "react";
 import { createRoot, type Root } from "react-dom/client";
+import { installOpenAILoggingProxy } from "./proxy.js";
 
 let rootInstance: Root | null = null;
 
@@ -11,6 +14,10 @@ export const mountWidget = (component: React.ReactNode) => {
 
   if (!rootInstance) {
     rootInstance = createRoot(rootElement);
+  }
+
+  if (import.meta.env.DEV) {
+    installOpenAILoggingProxy();
   }
 
   rootInstance.render(createElement(StrictMode, null, component));

--- a/src/web/proxy.ts
+++ b/src/web/proxy.ts
@@ -1,0 +1,86 @@
+const colors = {
+  brand: "#6366f1",
+  info: "#22223b",
+  success: "#22c55e",
+  error: "#ef4444",
+} as const;
+
+export function installOpenAILoggingProxy() {
+  if (typeof window === "undefined" || !window.openai) {
+    console.warn(
+      "[openai-proxy] window.openai not found, skipping proxy installation"
+    );
+    return;
+  }
+
+  const originalOpenAI = window.openai;
+
+  const handler: ProxyHandler<typeof originalOpenAI> = {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+
+      if (typeof value !== "function") {
+        return value;
+      }
+
+      return function (...args: unknown[]) {
+        const methodName = String(prop);
+
+        console.group(
+          `%c[openai] %cmethod %c${methodName}`,
+          `color: ${colors.brand}; font-weight: normal`,
+          `color: ${colors.info}; font-weight: normal`,
+          `color: ${colors.success}`
+        );
+        console.log("%c← args:", `color: ${colors.info}`, args);
+
+        const result = value.apply(target, args);
+
+        if (result && typeof result.then === "function") {
+          return result.then(
+            (resolved: unknown) => {
+              console.log(
+                "%c→ resolved:",
+                `color: ${colors.success}`,
+                resolved
+              );
+              console.groupEnd();
+              return resolved;
+            },
+            (error: unknown) => {
+              console.error("%c→ rejected:", `color: ${colors.error}`, error);
+              console.groupEnd();
+              throw error;
+            }
+          );
+        }
+
+        console.log("%c→ returned:", `color: ${colors.success}`, result);
+        console.groupEnd();
+
+        return result;
+      };
+    },
+
+    set(target, prop, value, receiver) {
+      console.log(
+        `%c[openai] %cupdate %c${String(prop)}`,
+        `color: ${colors.brand}`,
+        `color: ${colors.info}`,
+        `color: ${colors.success}; font-weight: bold`,
+        "←",
+        value
+      );
+
+      return Reflect.set(target, prop, value, receiver);
+    },
+  };
+
+  window.openai = new Proxy(originalOpenAI, handler);
+
+  console.log(
+    "%c[openai-proxy] %cInstalled logging proxy for window.openai",
+    `color: ${colors.brand}`,
+    `color: ${colors.info}`
+  );
+}


### PR DESCRIPTION
This PR aims at improving DX while working on ChatGPT apps by enabling a logger proxy on window.openai interface.

Enabled by default in vite dev env.

<img width="963" height="611" alt="image" src="https://github.com/user-attachments/assets/8ca80a03-5a0f-4d13-9911-a2fa10d0fca6" />
