### PR TITLE
fix: Rename server.widget() to server.registerWidget()

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ _Project structure_
 ```
 server/
 └── src/
-    └── index.ts // Register the widget with McpServer.widget()
+    └── index.ts // Register the widget with McpServer.registerWidget()
 web/
 └── src/
     └── widgets/
@@ -56,7 +56,7 @@ import { McpServer } from "skybridge/server";
 
 const server = new McpServer();
 
-server.widget(
+server.registerWidget(
   "pokemon"
   // Remaining arguments...
 );
@@ -103,7 +103,7 @@ Skybridge provides fully typed hooks that give you autocomplete for tool names a
 
 > **Tip:** For the best TypeScript experience, use typed hooks throughout your application. They provide autocomplete, type safety, and better IDE support.
 
-> **Important:** For `generateHelpers` to work correctly, your MCP server must be defined using method chaining (e.g., `server.widget(...).widget(...).registerTool(...)`). This ensures TypeScript can properly infer the tool registry type from the chained calls.
+> **Important:** For `generateHelpers` to work correctly, your MCP server must be defined using method chaining (e.g., `server.registerWidget(...).registerWidget(...).registerTool(...)`). This ensures TypeScript can properly infer the tool registry type from the chained calls.
 
 **Examples:**
 
@@ -114,7 +114,7 @@ import { McpServer } from "skybridge/server";
 import { z } from "zod";
 
 const server = new McpServer({ name: "my-app", version: "1.0" }, {})
-  .widget("search-voyage", {}, {
+  .registerWidget("search-voyage", {}, {
     inputSchema: { destination: z.string() },
   }, async ({ destination }) => {
     return { content: [{ type: "text", text: `Found trips to ${destination}` }] };
@@ -136,7 +136,7 @@ import { z } from "zod";
 
 const server = new McpServer({ name: "my-app", version: "1.0" }, {});
 
-server.widget("search-voyage", {}, {
+server.registerWidget("search-voyage", {}, {
   inputSchema: { destination: z.string() },
 }, async ({ destination }) => {
   return { content: [{ type: "text", text: `Found trips to ${destination}` }] };
@@ -158,7 +158,7 @@ import { McpServer } from "skybridge/server";
 import { z } from "zod";
 
 const server = new McpServer({ name: "my-app", version: "1.0" }, {})
-  .widget("search-voyage", {}, {
+  .registerWidget("search-voyage", {}, {
     description: "Search for trips",
     inputSchema: {
       destination: z.string(),
@@ -172,7 +172,7 @@ const server = new McpServer({ name: "my-app", version: "1.0" }, {})
     // Your tool logic here...
     return { content: [{ type: "text", text: `Found trips to ${destination}` }] };
   })
-  .widget("get-details", {}, {
+  .registerWidget("get-details", {}, {
     inputSchema: { tripId: z.string() },
   }, async ({ tripId }) => {
     return { content: [{ type: "text", text: `Details for ${tripId}` }] };

--- a/docs/docs/api-reference/generateHelpers.md
+++ b/docs/docs/api-reference/generateHelpers.md
@@ -45,7 +45,7 @@ import { McpServer } from "skybridge/server";
 import { z } from "zod";
 
 const server = new McpServer({ name: "my-app", version: "1.0" }, {})
-  .widget(
+  .registerWidget(
     "search-voyage",
     {},
     {
@@ -78,7 +78,7 @@ import { z } from "zod";
 
 const server = new McpServer({ name: "my-app", version: "1.0" }, {});
 
-server.widget(
+server.registerWidget(
   "search-voyage",
   {},
   {

--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -36,7 +36,7 @@ _Project structure_
 ```
 server/
 └── src/
-    └── index.ts // Register the widget with McpServer.widget()
+    └── index.ts // Register the widget with McpServer.registerWidget()
 web/
 └── src/
     └── widgets/
@@ -50,7 +50,7 @@ import { McpServer } from "skybridge/server";
 
 const server = new McpServer();
 
-server.widget(
+server.registerWidget(
   "pokemon"
   // Remaining arguments...
 );

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -117,7 +117,7 @@ export class McpServer<
 > extends McpServerBase {
   declare readonly $types: McpServerTypes<TTools>;
 
-  widget<
+  registerWidget<
     TName extends string,
     TInput extends ZodRawShape,
     TReturn extends CallToolResult

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -35,7 +35,7 @@ export function createTestServer() {
     { name: "test-app", version: "1.0.0" },
     {}
   )
-    .widget(
+    .registerWidget(
       "search-voyage",
       {},
       {
@@ -66,7 +66,7 @@ export function createTestServer() {
         };
       }
     )
-    .widget(
+    .registerWidget(
       "get-trip-details",
       {},
       {
@@ -91,7 +91,7 @@ export function createTestServer() {
         };
       }
     )
-    .widget(
+    .registerWidget(
       "no-input-widget",
       {},
       {
@@ -106,7 +106,7 @@ export function createTestServer() {
         };
       }
     )
-    .widget(
+    .registerWidget(
       "inferred-output-widget",
       {},
       {
@@ -172,7 +172,7 @@ export function createMinimalTestServer() {
   return new McpServer(
     { name: "test-app", version: "1.0.0" },
     {}
-  ).widget(
+  ).registerWidget(
     "search-voyage",
     {},
     {

--- a/src/test/widget.test.ts
+++ b/src/test/widget.test.ts
@@ -38,7 +38,7 @@ vi.mock("node:fs", async () => {
   };
 });
 
-describe("McpServer.widget", () => {
+describe("McpServer.registerWidget", () => {
   let server: McpServer;
   let mockResource: MockInstance<McpServer["resource"]>;
   let mockRegisterTool: MockInstance<McpServer["registerTool"]>;
@@ -60,7 +60,7 @@ describe("McpServer.widget", () => {
     const mockResourceConfig = { description: "Test widget" };
     const mockToolConfig = { description: "Test tool" };
 
-    server.widget(
+    server.registerWidget(
       "my-widget",
       mockResourceConfig,
       mockToolConfig,
@@ -106,7 +106,7 @@ describe("McpServer.widget", () => {
     const mockResourceConfig = { description: "Test widget" };
     const mockToolConfig = { description: "Test tool" };
 
-    server.widget(
+    server.registerWidget(
       "my-widget",
       mockResourceConfig,
       mockToolConfig,


### PR DESCRIPTION
fixes: #66 

Here's summary
Files Modified:
  1. src/server/server.ts - Renamed the core method from widget() to registerWidget()
  2. src/test/widget.test.ts - Updated test description and 2 test calls
  3. src/test/utils.ts - Updated 5 widget calls in test helper functions (createTestServer() and createMinimalTestServer())
  4. README.md - Updated 6 occurrences in code examples and documentation text
  5. docs/docs/introduction.md - Updated 2 occurrences in code examples
  6. docs/docs/api-reference/generateHelpers.md - Updated 2 occurrences in the "Works" and "Doesn't work" examples