### PR TITLE
doc fix: add missing closing brace in custom.css

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -92,6 +92,8 @@
 
 .card-link:hover {
   text-decoration: underline;
+}
+
 /* GitHub Stars Badge */
 .github-stars-badge {
   transform: scale(1.2);


### PR DESCRIPTION
Fixes CSS syntax error where .card-link:hover block was missing its closing brace, causing build errors.