### PR TITLE
Apply biome unsafe fixes

### DIFF
--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -7,7 +7,7 @@ import { McpServer } from "../server/server.js";
  */
 export function createMockMcpServer(): {
   server: McpServer;
-  mockResource: MockInstance<McpServer["registerResource"]>;
+  mockRegisterResource: MockInstance<McpServer["registerResource"]>;
   mockRegisterTool: MockInstance<McpServer["registerTool"]>;
 } {
   // Create a real McpServer instance
@@ -20,12 +20,12 @@ export function createMockMcpServer(): {
   );
 
   // Mock the underlying methods to track calls
-  const mockResource = vi.spyOn(server, "registerResource");
+  const mockRegisterResource = vi.spyOn(server, "registerResource");
   const mockRegisterTool = vi.spyOn(server, "registerTool");
 
   return {
     server,
-    mockResource,
+    mockRegisterResource,
     mockRegisterTool,
   };
 }

--- a/src/test/widget.test.ts
+++ b/src/test/widget.test.ts
@@ -1,4 +1,3 @@
-import * as fs from "node:fs";
 import {
   afterEach,
   beforeEach,
@@ -40,12 +39,12 @@ vi.mock("node:fs", async () => {
 
 describe("McpServer.registerWidget", () => {
   let server: McpServer;
-  let mockResource: MockInstance<McpServer["registerResource"]>;
+  let mockRegisterResource: MockInstance<McpServer["registerResource"]>;
   let mockRegisterTool: MockInstance<McpServer["registerTool"]>;
-  const readFileSyncSpy: any = null;
 
   beforeEach(() => {
-    ({ server, mockResource, mockRegisterTool } = createMockMcpServer());
+    ({ server, mockRegisterResource, mockRegisterTool } =
+      createMockMcpServer());
   });
 
   afterEach(() => {
@@ -57,18 +56,18 @@ describe("McpServer.registerWidget", () => {
     setTestEnv({ NODE_ENV: "development" });
 
     const mockToolCallback = vi.fn();
-    const mockResourceConfig = { description: "Test widget" };
+    const mockRegisterResourceConfig = { description: "Test widget" };
     const mockToolConfig = { description: "Test tool" };
 
     server.registerWidget(
       "my-widget",
-      mockResourceConfig,
+      mockRegisterResourceConfig,
       mockToolConfig,
       mockToolCallback,
     );
 
     // Get the resource callback function
-    const resourceCallback = mockResource.mock.calls[0]?.[3] as (
+    const resourceCallback = mockRegisterResource.mock.calls[0]?.[3] as (
       uri: URL,
       extra: any,
     ) => any;
@@ -81,6 +80,7 @@ describe("McpServer.registerWidget", () => {
       mockExtra,
     );
 
+    expect(mockRegisterTool).toHaveBeenCalled();
     expect(result).toEqual({
       contents: [
         {
@@ -92,10 +92,10 @@ describe("McpServer.registerWidget", () => {
     });
 
     // Check development-specific content
-    expect(result.contents[0]?.text).toContain(serverUrl + "/@react-refresh");
-    expect(result.contents[0]?.text).toContain(serverUrl + "/@vite/client");
+    expect(result.contents[0]?.text).toContain(`${serverUrl}/@react-refresh`);
+    expect(result.contents[0]?.text).toContain(`${serverUrl}/@vite/client`);
     expect(result.contents[0]?.text).toContain(
-      serverUrl + "/src/widgets/my-widget.tsx",
+      `${serverUrl}/src/widgets/my-widget.tsx`,
     );
   });
 
@@ -103,18 +103,18 @@ describe("McpServer.registerWidget", () => {
     setTestEnv({ NODE_ENV: "production" });
 
     const mockToolCallback = vi.fn();
-    const mockResourceConfig = { description: "Test widget" };
+    const mockRegisterResourceConfig = { description: "Test widget" };
     const mockToolConfig = { description: "Test tool" };
 
     server.registerWidget(
       "my-widget",
-      mockResourceConfig,
+      mockRegisterResourceConfig,
       mockToolConfig,
       mockToolCallback,
     );
 
     // Get the resource callback function
-    const resourceCallback = mockResource.mock.calls[0]?.[3] as (
+    const resourceCallback = mockRegisterResource.mock.calls[0]?.[3] as (
       uri: URL,
       extra: any,
     ) => any;
@@ -122,7 +122,7 @@ describe("McpServer.registerWidget", () => {
 
     const serverUrl = "https://myapp.com";
     const mockExtra = createMockExtra(serverUrl);
-    const result = await resourceCallback!(
+    const result = await resourceCallback?.(
       new URL("ui://widgets/my-widget.html"),
       mockExtra,
     );
@@ -139,12 +139,12 @@ describe("McpServer.registerWidget", () => {
 
     // Check production-specific content
     expect(result.contents[0]?.text).not.toContain(
-      serverUrl + "@react-refresh",
+      `${serverUrl}@react-refresh`,
     );
-    expect(result.contents[0]?.text).not.toContain(serverUrl + "@vite/client");
+    expect(result.contents[0]?.text).not.toContain(`${serverUrl}@vite/client`);
     expect(result.contents[0]?.text).toContain(
-      serverUrl + "/assets/my-widget.js",
+      `${serverUrl}/assets/my-widget.js`,
     );
-    expect(result.contents[0]?.text).toContain(serverUrl + "/assets/style.css");
+    expect(result.contents[0]?.text).toContain(`${serverUrl}/assets/style.css`);
   });
 });

--- a/src/web/data-llm.tsx
+++ b/src/web/data-llm.tsx
@@ -73,7 +73,7 @@ function getLLMDescriptionString(): string {
   for (const node of Array.from(nodes.values())) {
     const key = node.parentId ?? null;
     if (!byParent.has(key)) byParent.set(key, []);
-    byParent.get(key)!.push(node);
+    byParent.get(key)?.push(node);
   }
 
   for (const list of byParent.values()) {
@@ -87,7 +87,7 @@ function getLLMDescriptionString(): string {
     if (!children) return;
 
     for (const child of children) {
-      if (child.content && child.content.trim()) {
+      if (child.content?.trim()) {
         const indent = "  ".repeat(depth);
         lines.push(`${indent}- ${child.content.trim()}`);
       }

--- a/src/web/generate-helpers.test-d.ts
+++ b/src/web/generate-helpers.test-d.ts
@@ -161,7 +161,7 @@ test("callTool requires args for tools with required inputs", () => {
 
 test("callTool supports sideEffects for tools with required inputs", () => {
   const { useCallTool } = generateHelpers<TestServer>();
-  const { callTool, data } = useCallTool("search-voyage");
+  const { callTool } = useCallTool("search-voyage");
 
   callTool(
     { destination: "Spain" },
@@ -178,6 +178,7 @@ test("callTool supports sideEffects for tools with required inputs", () => {
         if (response) {
           expectTypeOf(response.structuredContent.totalCount).toBeNumber();
         }
+        expectTypeOf(error).toBeUnknown();
         expectTypeOf(args.destination).toBeString();
       },
     },

--- a/src/web/helpers/state.test.ts
+++ b/src/web/helpers/state.test.ts
@@ -1,19 +1,6 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  type Mock,
-  vi,
-} from "vitest";
+import { describe, expect, it } from "vitest";
 import { WIDGET_CONTEXT_KEY } from "../data-llm.js";
-import {
-  filterWidgetContext,
-  getInitialState,
-  injectWidgetContext,
-  serializeState,
-} from "./state.js";
+import { filterWidgetContext, serializeState } from "./state.js";
 
 describe("state helpers", () => {
   describe("filterWidgetContext", () => {

--- a/src/web/hooks/use-tool-info.test-d.ts
+++ b/src/web/hooks/use-tool-info.test-d.ts
@@ -1,4 +1,3 @@
-import { renderHook } from "@testing-library/react";
 import { expectTypeOf, test } from "vitest";
 import { useToolInfo } from "./use-tool-info.js";
 

--- a/src/web/hooks/use-user-agent.test.ts
+++ b/src/web/hooks/use-user-agent.test.ts
@@ -1,13 +1,5 @@
 import { renderHook } from "@testing-library/react";
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  type Mock,
-  vi,
-} from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { UserAgent } from "../types.js";
 import { useUserAgent } from "./use-user-agent.js";
 

--- a/src/web/types.ts
+++ b/src/web/types.ts
@@ -1,7 +1,8 @@
 import "react";
 
 declare module "react" {
-  interface HTMLAttributes<T extends Element = HTMLElement> {
+  // biome-ignore lint/correctness/noUnusedVariables: HTMLAttributes must have the same signature and requires a type parameter
+  interface HTMLAttributes<T> {
     "data-llm"?: string;
   }
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Applied Biome unsafe fixes across test and type definition files. Changes include:
- Removed unused imports from test files
- Prefixed unused variables with underscore (`_`) to silence warnings
- Changed string concatenation to template literals
- Modified optional chaining from `!` assertions to `?.` operators
- Renamed generic type parameter to indicate it's unused

**Critical Issue Found:**
- The destructuring in `widget.test.ts:47` attempts to extract `_mockRegisterTool` but the function returns `mockRegisterTool`, which will cause a runtime error and test failures.

<h3>Confidence Score: 1/5</h3>


- This PR contains a critical bug that will cause test failures
- While most of the automated linter fixes are safe (unused imports removal, template literal conversions, optional chaining improvements), there is a critical error in `widget.test.ts` where the destructuring variable name doesn't match the property returned by `createMockMcpServer()`. This will cause runtime errors when tests run.
- `src/test/widget.test.ts` requires immediate attention to fix the destructuring bug

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->