### PR TITLE
fix(docs): resolve 404 errors in add-to-existing-app navigation

### DIFF
--- a/docs/docs/quickstart/add-to-existing-app/index.md
+++ b/docs/docs/quickstart/add-to-existing-app/index.md
@@ -15,7 +15,7 @@ Skybridge contains 2 main packages that can be used together or independently.
 
 <div className="card-grid">
   <div className="card">
-    <h3><a href="server">Use skybridge/server</a></h3>
+    <h3><a href="/quickstart/add-to-existing-app/server">Use skybridge/server</a></h3>
     <p>**Best if**: you're using the official TypeScript MCP SDK and want to add rich UI widgets with full type safety.</p>
   </div>
 </div>
@@ -24,7 +24,7 @@ Skybridge contains 2 main packages that can be used together or independently.
 
 <div className="card-grid">
   <div className="card">
-    <h3><a href="web">Use skybridge/web only</a></h3>
+    <h3><a href="/quickstart/add-to-existing-app/web">Use skybridge/web only</a></h3>
     <p>**Best if**: you already have an MCP server in a non-TypeScript runtime and only want React hooks for UI components.</p>
   </div>
 </div>


### PR DESCRIPTION
Fixes 404 errors when navigating from "Introduction" to "Add to Existing App" page to the server and web setup guides.

https://github.com/user-attachments/assets/fab0b25c-fa3b-4241-be26-1f59e135aa85

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Fixed broken navigation links by converting relative paths to absolute paths in the "Add to Existing App" documentation page.

- Changed `href="server"` to `href="/quickstart/add-to-existing-app/server"`
- Changed `href="web"` to `href="/quickstart/add-to-existing-app/web"`

This resolves 404 errors when users click the navigation cards to access the server and web setup guides.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risks
- The changes are minimal, focused, and correct. The fix properly converts relative links to absolute paths that match the Docusaurus routing configuration. Both target files exist at the specified paths, and the syntax is correct.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->