### PR TITLE
Enforce lint/correctness/noUnusedVariables

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -16,7 +16,10 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "correctness": {
+        "noUnusedVariables": "error"
+      }
     }
   },
   "javascript": {

--- a/src/server/templateHelper.ts
+++ b/src/server/templateHelper.ts
@@ -6,11 +6,6 @@ import Handlebars from "handlebars";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-type TemplateData = {
-  serverUrl: string;
-  widgetName: string;
-};
-
 class TemplateHelper {
   private templateCache = new Map<string, HandlebarsTemplateDelegate>();
 

--- a/src/server/widgetsDevServer.ts
+++ b/src/server/widgetsDevServer.ts
@@ -26,7 +26,7 @@ export const widgetsDevServer = async (): Promise<RequestHandler> => {
     webAppRoot,
   );
 
-  // Remove build-specific options that don't apply to dev server
+  // biome-ignore lint/correctness/noUnusedVariables: Remove build-specific options that don't apply to dev server
   const { build, preview, ...devConfig } = configResult?.config || {};
 
   const vite = await createServer({


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Enabled the `noUnusedVariables` lint rule in Biome configuration and cleaned up unused code by removing the `TemplateData` type and adding a biome-ignore comment for intentionally unused destructured variables.

- Enforced `noUnusedVariables` as an error in `biome.json`
- Removed unused `TemplateData` type definition from `templateHelper.ts`
- Added biome-ignore comment for intentional destructuring of `build` and `preview` to exclude them from `devConfig`

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are straightforward linting configuration updates with appropriate code cleanup. The removed type was genuinely unused, and the biome-ignore comment is properly justified for intentional destructuring pattern. No functional logic changes were made.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->