### PR TITLE
feat: infer type of __meta

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -4,6 +4,7 @@ export type {
   ToolInput,
   ToolNames,
   ToolOutput,
+  ToolResponseMetadata,
 } from "./inferUtilityTypes.js";
 export type { McpServerTypes, ToolDef } from "./server.js";
 export { McpServer } from "./server.js";

--- a/src/server/inferUtilityTypes.ts
+++ b/src/server/inferUtilityTypes.ts
@@ -67,3 +67,17 @@ export type ToolOutput<
   ServerType,
   ToolName extends ToolNames<ServerType>,
 > = ExtractTool<ServerType, ToolName>["output"];
+
+/**
+ * Get the responseMetadata type for a specific tool (widget or regular tool).
+ * This is inferred from the `_meta` property of the tool callback's return value.
+ *
+ * @example
+ * ```ts
+ * type SearchMeta = ToolResponseMetadata<MyServer, "search">;
+ * ```
+ */
+export type ToolResponseMetadata<
+  ServerType,
+  ToolName extends ToolNames<ServerType>,
+> = ExtractTool<ServerType, ToolName>["responseMetadata"];

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -162,6 +162,79 @@ export function createTestServer() {
           },
         };
       },
+    )
+    .registerWidget(
+      "widget-with-metadata",
+      {},
+      {
+        description: "Widget that returns response metadata",
+        inputSchema: {
+          resourceId: z.string(),
+        },
+      },
+      async ({ resourceId }) => {
+        return {
+          content: [{ type: "text", text: `Resource: ${resourceId}` }],
+          structuredContent: {
+            data: { id: resourceId, loaded: true },
+          },
+          _meta: {
+            requestId: "req-123",
+            timestamp: 1704067200000,
+            cached: false,
+          },
+        };
+      },
+    )
+    .registerTool(
+      "tool-with-metadata",
+      {
+        description: "Tool that returns response metadata",
+        inputSchema: {
+          query: z.string(),
+        },
+      },
+      async ({ query }) => {
+        return {
+          content: [{ type: "text", text: `Query: ${query}` }],
+          structuredContent: {
+            results: [query],
+          },
+          _meta: {
+            executionTime: 150,
+            source: "cache",
+          },
+        };
+      },
+    )
+    .registerWidget(
+      "widget-with-mixed-returns",
+      {},
+      {
+        description:
+          "Widget with mixed return paths (some with _meta, some without)",
+        inputSchema: {
+          shouldSucceed: z.boolean(),
+        },
+      },
+      async ({ shouldSucceed }) => {
+        if (!shouldSucceed) {
+          // Error path - no _meta
+          return {
+            content: [{ type: "text", text: "Error occurred" }],
+            structuredContent: { error: "Something went wrong" },
+          };
+        }
+        // Success path - has _meta
+        return {
+          content: [{ type: "text", text: "Success" }],
+          structuredContent: { data: "result" },
+          _meta: {
+            processedAt: 1704067200000,
+            region: "eu-west-1",
+          },
+        };
+      },
     );
 }
 

--- a/src/web/generate-helpers.ts
+++ b/src/web/generate-helpers.ts
@@ -1,4 +1,9 @@
-import type { InferTools, ToolInput, ToolOutput } from "../server/index.js";
+import type {
+  InferTools,
+  ToolInput,
+  ToolOutput,
+  ToolResponseMetadata,
+} from "../server/index.js";
 import {
   type CallToolAsyncFn,
   type CallToolFn,
@@ -19,10 +24,10 @@ type TypedCallToolReturn<TInput, TOutput> = Prettify<
   }
 >;
 
-type TypedToolInfoReturn<TInput, TOutput> = ToolState<
+type TypedToolInfoReturn<TInput, TOutput, TResponseMetadata> = ToolState<
   Objectify<TInput>,
   Objectify<TOutput>,
-  Objectify<{}>
+  Objectify<TResponseMetadata>
 >;
 
 /**
@@ -125,26 +130,30 @@ export function generateHelpers<ServerType = never>() {
      * const toolInfo = useToolInfo<"search-voyage">();
      * // toolInfo.input is typed as { destination: string; ... }
      * // toolInfo.output is typed as { results: Array<...>; ... }
+     * // toolInfo.responseMetadata is typed based on _meta in callback return
      * // toolInfo.status narrows correctly: "pending" | "success"
      *
      * if (toolInfo.isPending) {
-     *   // TypeScript knows output is undefined here
+     *   // TypeScript knows output and responseMetadata are undefined here
      *   console.log(toolInfo.input.destination);
      * }
      *
      * if (toolInfo.isSuccess) {
-     *   // TypeScript knows output is defined here
+     *   // TypeScript knows output and responseMetadata are defined here
      *   console.log(toolInfo.output.results);
+     *   console.log(toolInfo.responseMetadata);
      * }
      * ```
      */
     useToolInfo: <ToolName extends ToolNames>(): TypedToolInfoReturn<
       ToolInput<ServerType, ToolName>,
-      ToolOutput<ServerType, ToolName>
+      ToolOutput<ServerType, ToolName>,
+      ToolResponseMetadata<ServerType, ToolName>
     > => {
       return useToolInfo() as TypedToolInfoReturn<
         ToolInput<ServerType, ToolName>,
-        ToolOutput<ServerType, ToolName>
+        ToolOutput<ServerType, ToolName>,
+        ToolResponseMetadata<ServerType, ToolName>
       >;
     },
   };


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Added type inference support for the `__meta` field (referred to as `_meta` in code) returned by tool and widget callbacks, enabling full type safety for response metadata.

- Introduced `ToolResponseMetadata<ServerType, ToolName>` utility type to extract `_meta` field types from callback return values
- Updated `ToolDef` to include `responseMetadata` as a third generic parameter
- Created `ExtractMeta<T>` helper that uses `Extract` to identify union members with `_meta` and infer its type
- Modified `registerWidget` and `registerTool` to track response metadata types through the `AddTool` helper
- Extended `generateHelpers` to thread response metadata types through `useToolInfo` hook
- Added comprehensive type tests demonstrating metadata extraction for widgets, tools, and mixed return paths (some branches with `_meta`, some without)

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no issues detected
- The implementation follows a clean, type-safe approach using TypeScript's advanced type utilities. The `ExtractMeta` utility correctly uses `Extract` to filter union members with `_meta` properties, and comprehensive type tests verify correctness for all scenarios including mixed return paths. All changes are purely additive (no breaking changes), and the new `responseMetadata` field defaults to `unknown` for existing tools without `_meta`.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->