### PR TITLE
feat: add tunnel support with explicit tunnelHost config

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -5,6 +5,7 @@ export type {
   ToolNames,
   ToolOutput,
 } from "./inferUtilityTypes.js";
-export type { McpServerTypes, ToolDef } from "./server.js";
+export type { McpServerOptions, McpServerTypes, ToolDef } from "./server.js";
 export { McpServer } from "./server.js";
 export { widgetsDevServer } from "./widgetsDevServer.js";
+export type { WidgetsDevServerOptions } from "./widgetsDevServer.js";

--- a/src/server/widgetsDevServer.ts
+++ b/src/server/widgetsDevServer.ts
@@ -1,18 +1,54 @@
+import type { Server } from "node:http";
 import path from "node:path";
 import cors from "cors";
 import express, { type RequestHandler } from "express";
+import type { HmrOptions } from "vite";
+
+export interface WidgetsDevServerOptions {
+  /**
+   * Tunnel hostname for remote development (e.g., ngrok, cloudflare tunnel).
+   * When set, configures HMR to use wss:// on port 443.
+   *
+   * @example "your-subdomain.trycloudflare.com"
+   */
+  tunnelHost?: string;
+
+  /**
+   * Node HTTP server to attach HMR WebSocket to.
+   * Required when using `tunnelHost` so HMR WebSocket goes through the tunnel.
+   *
+   * @example
+   * ```ts
+   * const httpServer = http.createServer(app);
+   * app.use(await widgetsDevServer({ tunnelHost, hmrServer: httpServer }));
+   * ```
+   */
+  hmrServer?: Server;
+}
 
 /**
- * Install Vite dev server
- * This router MUST be installed at the application root, like so:
+ * Create Vite dev server middleware for widget development.
  *
- *  const app = express();
+ * @example Basic usage (local development)
+ * ```ts
+ * app.use(await widgetsDevServer());
+ * app.listen(3000);
+ * ```
  *
- * if (env.NODE_ENV !== "production") {
- *   app.use(await widgetsRouter());
- * }
+ * @example With tunnel support (ngrok, cloudflare tunnel)
+ * ```ts
+ * import http from "node:http";
+ *
+ * const tunnelHost = process.env.TUNNEL_HOST;
+ * const httpServer = http.createServer(app);
+ * app.use(await widgetsDevServer({ tunnelHost, hmrServer: httpServer }));
+ * httpServer.listen(3000);
+ * ```
  */
-export const widgetsDevServer = async (): Promise<RequestHandler> => {
+export const widgetsDevServer = async (
+  options: WidgetsDevServerOptions = {},
+): Promise<RequestHandler> => {
+  const { tunnelHost, hmrServer } = options;
   const router = express.Router();
 
   const { createServer, searchForWorkspaceRoot, loadConfigFromFile } =
@@ -29,11 +65,24 @@ export const widgetsDevServer = async (): Promise<RequestHandler> => {
   // biome-ignore lint/correctness/noUnusedVariables: Remove build-specific options that don't apply to dev server
   const { build, preview, ...devConfig } = configResult?.config || {};
 
+  // Configure HMR for tunnel support when tunnelHost is provided.
+  // This attaches the WebSocket to the same HTTP server (port 3000),
+  // so HMR traffic goes through the tunnel instead of a separate port.
+  let hmrOptions: HmrOptions | undefined;
+  if (tunnelHost && hmrServer) {
+    hmrOptions = {
+      server: hmrServer,
+      protocol: "wss",
+      clientPort: 443,
+    };
+  }
+
   const vite = await createServer({
     ...devConfig,
     configFile: false, // Keep this to prevent vite from trying to resolve path in the target config file
     appType: "custom",
     server: {
+      hmr: hmrOptions,
       allowedHosts: true,
       middlewareMode: true,
     },


### PR DESCRIPTION
Hey, thank you for building this library, I found it quite convenient with the HMR and the automatic type safety. I wanted to share my MCP server with my teammates, but realized that the serverUrl in development is assigned as localhost:3000 automatically, even if I tunnel the local server.

As such, this PR adds support for developing widgets through tunnels (ngrok, cloudflare tunnel), enabling testing widgets from remote machines with full HMR support.

## Problem
When developing locally, widgets work fine because:
- Widget HTML references http://localhost:3000 for assets
- Vite's HMR WebSocket runs on a separate port (e.g., 5173) which is accessible locally

When accessing through a tunnel (e.g., https://xxx.trycloudflare.com):
1. Asset URLs break - Widget HTML still references localhost:3000, but remote clients can't access localhost
2. HMR WebSocket fails - The tunnel only forwards port 3000; Vite's separate WebSocket port isn't forwarded

## Solution
This PR adds two configuration options that work together:

`McpServer({ tunnelHost })` - Configures widget HTML to use the tunnel URL for assets:
```typescript
const server = new McpServer(
  { name: "my-app", version: "1.0.0" },
  { capabilities: {} },
  { tunnelHost: "xxx.trycloudflare.com" }
);
```

`widgetsDevServer({ tunnelHost, hmrServer })` - Configures Vite HMR to work through the tunnel:
```typescript
const httpServer = http.createServer(app);
app.use(await widgetsDevServer({
  tunnelHost: "xxx.trycloudflare.com",
  hmrServer: httpServer,
}));
httpServer.listen(3000);
```

**Why hmrServer is required for tunnel HMR**

Vite in middleware mode creates its own WebSocket server on a separate port by default. This works locally (all ports accessible) but fails through tunnels (only port 3000 forwarded).

The only way to make HMR work through tunnels is to attach Vite's WebSocket to the same HTTP server handling port 3000, using Vite's server.hmr.server option. This requires passing the Node http.Server instance.

**Why not auto-detect the server?**
I considered detecting the HTTP server from req.socket.server on the first request, but this requires recreating the Vite server mid-request (hacky, race conditions). Explicitly passing the server is cleaner and more predictable.

## Usage
```typescript
import http from "node:http";
import express from "express";
import { McpServer, widgetsDevServer } from "skybridge/server";

const tunnelHost = process.env.TUNNEL_HOST;

const server = new McpServer(
  { name: "my-app", version: "1.0.0" },
  { capabilities: {} },
  { tunnelHost }
);

const app = express();
const httpServer = http.createServer(app);

app.use(await widgetsDevServer({
  tunnelHost,
  hmrServer: tunnelHost ? httpServer : undefined,
}));

httpServer.listen(3000);
```

Then run with:
```bash
# Terminal 1: Start tunnel
cloudflared tunnel --url http://localhost:3000
```

```bash
# Terminal 2: Start server with tunnel host
TUNNEL_HOST=xxx.trycloudflare.com npm run dev
```

## Breaking Changes

None. Both options are optional and the library behaves exactly as before when not provided.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Adds optional tunnel support for remote widget development through `tunnelHost` configuration in both `McpServer` and `widgetsDevServer`. When configured, widgets use the tunnel URL for assets and HMR WebSocket traffic is routed through the main HTTP server on port 3000 instead of a separate port.

- `McpServer` constructor accepts optional `tunnelHost` parameter, used to generate `https://` widget URLs in dev mode
- `widgetsDevServer` accepts `tunnelHost` and optional `hmrServer` to configure Vite HMR with WebSocket on same port as tunnel
- Implementation properly scoped to development mode only - production mode unaffected
- Changes are backward compatible - all new parameters are optional

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- Implementation is clean, well-documented, backward compatible, and properly scoped to development mode. No security issues or logical errors found.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->