### PR TITLE
feat: interface return type is correctly inferred by generateHelpers

### DIFF
--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -263,6 +263,55 @@ export function createMinimalTestServer() {
   );
 }
 
+interface InterfaceOutput {
+  itemName: string;
+  quantity: number;
+}
+
+interface InterfaceMeta {
+  processedBy: string;
+  version: number;
+}
+
+interface InterfaceReturnType {
+  content: [{ type: "text"; text: string }];
+  structuredContent: InterfaceOutput;
+  _meta: InterfaceMeta;
+}
+
+export function createInterfaceTestServer() {
+  return new McpServer(
+    { name: "interface-test-app", version: "1.0.0" },
+    {},
+  ).registerWidget<
+    "interface-widget",
+    { id: z.ZodString },
+    InterfaceReturnType
+  >(
+    "interface-widget",
+    {},
+    {
+      description: "Widget with interface-typed output",
+      inputSchema: {
+        id: z.string(),
+      },
+    },
+    async ({ id }): Promise<InterfaceReturnType> => {
+      return {
+        content: [{ type: "text", text: `Item ${id}` }],
+        structuredContent: {
+          itemName: "Test Item",
+          quantity: 42,
+        },
+        _meta: {
+          processedBy: "test",
+          version: 1,
+        },
+      };
+    },
+  );
+}
+
 /**
  * Mock extra parameter for resource callback
  */


### PR DESCRIPTION
should fix #108

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes TypeScript type inference for `generateHelpers` when using interface declarations for return types. Previously, when developers used interface types (rather than inline object types) for widget/tool return values, the type extraction utilities couldn't properly infer the `structuredContent` and `_meta` properties.

Key changes:
- Wrapped `ExtractStructuredContent` and `ExtractMeta` results with `Simplify<T>` utility to expand interface references into their actual shape
- Improved `ExtractMeta` to properly handle cases where `_meta` doesn't exist using tuple-based `never` check
- Loosened `TReturn` constraint from `CallToolResult` to `{ content: CallToolResult["content"] }` to allow interfaces with additional properties
- Added comprehensive type tests demonstrating the fix works for interface-typed return values

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are purely type-level improvements with comprehensive type tests demonstrating correctness. The modifications properly handle edge cases (like `never` types) and maintain backward compatibility while extending functionality to support interface declarations. No runtime behavior changes.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->