### PR TITLE
feat: allow barrel file to reference widget in development

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -192,7 +192,7 @@ export class McpServer<
           process.env.NODE_ENV === "production"
             ? templateHelper.renderProduction({
                 serverUrl,
-                widgetFile: this.lookupDistFile(`src/widgets/${name}.tsx`),
+                widgetFile: this.lookupDistBarrelFile(`src/widgets/${name}`),
                 styleFile: this.lookupDistFile("style.css"),
               })
             : templateHelper.renderDevelopment({
@@ -268,13 +268,24 @@ export class McpServer<
   }
 
   private lookupDistFile(key: string): string {
-    const manifest = JSON.parse(
+    const manifest = this.readManifest();
+    return manifest[key]?.file;
+  }
+
+  private lookupDistBarrelFile(basePath: string): string {
+    const manifest = this.readManifest();
+
+    const flatFileKey = `${basePath}.tsx`;
+    const barrelFileKey = `${basePath}/index.tsx`;
+    return manifest[flatFileKey]?.file ?? manifest[barrelFileKey]?.file;
+  }
+
+  private readManifest() {
+    return JSON.parse(
       readFileSync(
         path.join(process.cwd(), "dist", "assets", ".vite", "manifest.json"),
         "utf-8",
       ),
     );
-
-    return manifest[key]?.file;
   }
 }

--- a/src/server/templates/development.hbs
+++ b/src/server/templates/development.hbs
@@ -8,5 +8,5 @@
 <script type="module" src="{{serverUrl}}/@vite/client"></script>
 <div id="root"></div>
 <script type="module" id="dev-widget-entry">
-  import('{{serverUrl}}/src/widgets/{{widgetName}}.tsx');
+  import('{{serverUrl}}/src/widgets/{{widgetName}}');
 </script>


### PR DESCRIPTION
if you agree with me on the issue, it fixes #112

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR enables widgets to be organized as barrel files (e.g., `src/widgets/my-widget/index.tsx`) in addition to flat files (e.g., `src/widgets/my-widget.tsx`).

- In development, the template now imports without `.tsx` extension, allowing Vite to resolve both file structures via standard module resolution
- In production, a new `lookupDistBarrelFile` method checks the manifest for flat files first, then falls back to barrel files
- Test coverage added for barrel file resolution in production mode

<h3>Confidence Score: 5/5</h3>


- Safe to merge - straightforward feature addition with proper test coverage
- The changes are well-structured, follow existing patterns, and include appropriate test coverage. The logic correctly prioritizes flat files over barrel files for backwards compatibility. No breaking changes or security concerns.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->