### PR TITLE
Register one resource per mimeType

### DIFF
--- a/src/test/widget.test.ts
+++ b/src/test/widget.test.ts
@@ -82,21 +82,21 @@ describe("McpServer.registerWidget", () => {
     );
 
     // Get the resource callback function
-    const resourceCallback = mockRegisterResource.mock
+    const appsSdkResourceCallback = mockRegisterResource.mock
       .calls[0]?.[3] as unknown as (
       uri: URL,
       extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
     ) => Promise<{
       contents: Array<{ uri: URL | string; mimeType: string; text?: string }>;
     }>;
-    expect(resourceCallback).toBeDefined();
+    expect(appsSdkResourceCallback).toBeDefined();
 
     const serverUrl = "http://localhost:3000";
     const mockExtra = createMockExtra(
       "__not_used__",
     ) as unknown as RequestHandlerExtra<ServerRequest, ServerNotification>;
-    const result = await resourceCallback(
-      new URL("ui://widgets/my-widget.html"),
+    const result = await appsSdkResourceCallback(
+      new URL("ui://widgets/apps-sdk/my-widget.html"),
       mockExtra,
     );
 
@@ -137,21 +137,21 @@ describe("McpServer.registerWidget", () => {
     );
 
     // Get the resource callback function
-    const resourceCallback = mockRegisterResource.mock
+    const appsSdkResourceCallback = mockRegisterResource.mock
       .calls[0]?.[3] as unknown as (
       uri: URL,
       extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
     ) => Promise<{
       contents: Array<{ uri: URL | string; mimeType: string; text?: string }>;
     }>;
-    expect(resourceCallback).toBeDefined();
+    expect(appsSdkResourceCallback).toBeDefined();
 
     const serverUrl = "https://myapp.com";
     const mockExtra = createMockExtra(
       serverUrl,
     ) as unknown as RequestHandlerExtra<ServerRequest, ServerNotification>;
-    const result = await resourceCallback(
-      new URL("ui://widgets/my-widget.html"),
+    const result = await appsSdkResourceCallback(
+      new URL("ui://widgets/apps-sdk/my-widget.html"),
       mockExtra,
     );
 
@@ -190,21 +190,21 @@ describe("McpServer.registerWidget", () => {
       mockToolCallback,
     );
 
-    const resourceCallback = mockRegisterResource.mock
+    const appsSdkResourceCallback = mockRegisterResource.mock
       .calls[0]?.[3] as unknown as (
       uri: URL,
       extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
     ) => Promise<{
       contents: Array<{ uri: URL | string; mimeType: string; text?: string }>;
     }>;
-    expect(resourceCallback).toBeDefined();
+    expect(appsSdkResourceCallback).toBeDefined();
 
     const serverUrl = "https://myapp.com";
     const mockExtra = createMockExtra(
       serverUrl,
     ) as unknown as RequestHandlerExtra<ServerRequest, ServerNotification>;
-    const result = await resourceCallback(
-      new URL("ui://widgets/folder-widget.html"),
+    const result = await appsSdkResourceCallback(
+      new URL("ui://widgets/apps-sdk/folder-widget.html"),
       mockExtra,
     );
 
@@ -214,7 +214,7 @@ describe("McpServer.registerWidget", () => {
     );
   });
 
-  it("should register resources for both apps-sdk and ext-apps formats", () => {
+  it("should register resources for both apps-sdk and ext-apps formats", async () => {
     const mockToolCallback = vi.fn();
     const mockRegisterResourceConfig = { description: "Test widget" };
     const mockToolConfig = { description: "Test tool" };
@@ -231,7 +231,30 @@ describe("McpServer.registerWidget", () => {
     const [, appsSdkUri] = mockRegisterResource.mock.calls[0] ?? [];
     expect(appsSdkUri).toBe("ui://widgets/apps-sdk/my-widget.html");
 
-    const [, extAppsUri] = mockRegisterResource.mock.calls[1] ?? [];
-    expect(extAppsUri).toBe("ui://widgets/ext-apps/my-widget.html");
+    const extAppsResourceCallback = mockRegisterResource.mock
+      .calls[1]?.[3] as unknown as (
+      uri: URL,
+      extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
+    ) => Promise<{
+      contents: Array<{ uri: URL | string; mimeType: string; text?: string }>;
+    }>;
+    expect(extAppsResourceCallback).toBeDefined();
+
+    const extAppsResult = await extAppsResourceCallback(
+      new URL("ui://widgets/ext-apps/my-widget.html"),
+      createMockExtra("__not_used__") as unknown as RequestHandlerExtra<
+        ServerRequest,
+        ServerNotification
+      >,
+    );
+    expect(extAppsResult).toEqual({
+      contents: [
+        {
+          uri: "ui://widgets/ext-apps/my-widget.html",
+          mimeType: "text/html;profile=mcp-app",
+          text: expect.stringContaining('<div id="root"></div>'),
+        },
+      ],
+    });
   });
 });


### PR DESCRIPTION
Implements the suggestion of this issue: https://github.com/alpic-ai/skybridge/issues/111

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Refactors widget registration to create separate resources for each mime type, addressing compatibility issues between OpenAI Apps SDK (`text/html+skybridge`) and MCP ext-apps (`text/html;profile=mcp-app`).

**Key changes:**
- Extracts resource registration logic into `registerWidgetResource` helper method
- Registers two separate resources per widget with distinct URIs and mime types:
  - `ui://widgets/apps-sdk/${name}.html` for OpenAI Apps SDK
  - `ui://widgets/ext-apps/${name}.html` for MCP ext-apps
- Updates tool metadata to reference appropriate URIs for each platform

**Issues found:**
- Critical bug in widget file path that will cause production builds to fail (see inline comment)

<h3>Confidence Score: 2/5</h3>


- This PR has a critical bug that will break widget loading in production
- The architectural approach of registering separate resources per mime type is sound and aligns with the issue requirements. However, the introduction of `.tsx` extension in line 275 creates a double-extension bug (`.tsx.tsx`) that will prevent widgets from loading in production. This is a blocking issue that must be fixed before merging.
- src/server/server.ts requires immediate attention to fix the widget file path bug on line 275

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->