### PR TITLE
fix: do not install proxy when window.openai is read only

### DIFF
--- a/src/web/proxy.ts
+++ b/src/web/proxy.ts
@@ -13,6 +13,14 @@ export function installOpenAILoggingProxy() {
     return;
   }
 
+  const descriptor = Object.getOwnPropertyDescriptor(window, "openai");
+  if (descriptor?.configurable === false || descriptor?.writable === false) {
+    console.warn(
+      "[openai-proxy] window.openai is not configurable or writable, skipping proxy installation",
+    );
+    return;
+  }
+
   const originalOpenAI = window.openai;
 
   const handler: ProxyHandler<typeof originalOpenAI> = {


### PR DESCRIPTION
- Currently on MCPJam, the window.openai proxy assignment makes the app to fail because the window.openai is readonly (hence we can't add a proxy on it)
- Skipping the logging is the window.openai is not assignable


<img width="1548" height="87" alt="image" src="https://github.com/user-attachments/assets/8d27a877-1337-4d01-90f1-b15acc5f6ea9" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added property descriptor check to prevent proxy installation when `window.openai` is read-only or non-configurable in MCPJam environment.

- Prevented runtime errors in environments where `window.openai` is frozen or sealed
- Early exit with warning when property cannot be modified

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change adds a defensive check that prevents runtime errors without affecting existing functionality. The implementation correctly uses `Object.getOwnPropertyDescriptor` to detect readonly properties before attempting assignment, and gracefully handles the case with appropriate logging. This is a straightforward bug fix that improves compatibility.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->