### PR TITLE
[POLYFILL] feat: add support for safe area insets

### DIFF
--- a/src/web/bridges/hooks/use-bridge.ts
+++ b/src/web/bridges/hooks/use-bridge.ts
@@ -9,6 +9,9 @@ export type BridgeInterface = Required<
   safeArea: {
     insets: NonNullable<McpUiHostContext["safeAreaInsets"]>;
   };
+  maxHeight: NonNullable<
+    NonNullable<McpUiHostContext["viewport"]>["maxHeight"]
+  >;
 };
 
 type BridgeExternalStore<K extends keyof BridgeInterface> = {
@@ -28,6 +31,7 @@ const DEFAULT_VALUE_FOR_MCP_APP_BRIDGE: BridgeInterface = {
       left: 0,
     },
   },
+  maxHeight: window.innerHeight,
 };
 
 const getExternalStore = <K extends keyof BridgeInterface>(
@@ -51,6 +55,15 @@ const getExternalStore = <K extends keyof BridgeInterface>(
         return safeArea
           ? ({ insets: safeArea } as BridgeInterface[K])
           : defaultValue;
+      },
+    };
+  }
+  if (key === "maxHeight") {
+    return {
+      subscribe: bridge.subscribe("viewport"),
+      getSnapshot: () => {
+        const viewport = bridge.getSnapshot("viewport");
+        return (viewport?.maxHeight ?? defaultValue) as BridgeInterface[K];
       },
     };
   }

--- a/src/web/hooks/use-layout.ts
+++ b/src/web/hooks/use-layout.ts
@@ -1,4 +1,4 @@
-import { useAppsSdkBridge, useBridge } from "../bridges/index.js";
+import { useBridge } from "../bridges/index.js";
 import type { SafeArea, Theme } from "../types.js";
 
 export type LayoutState = {
@@ -24,7 +24,7 @@ export type LayoutState = {
  */
 export function useLayout(): LayoutState {
   const theme = useBridge("theme");
-  const maxHeight = useAppsSdkBridge("maxHeight");
+  const maxHeight = useBridge("maxHeight");
   const safeArea = useBridge("safeArea");
 
   return { theme, maxHeight, safeArea };


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Adds support for safe area insets in the MCP runtime by bridging the difference between `OpenAiProperties` (which has `safeArea`) and `McpUiHostContext` (which has `safeAreaInsets`). The PR correctly fixes the subscription bug mentioned in the previous thread:

- **Fixed subscription mechanism**: When subscribing to `safeArea` in MCP runtime, the code now correctly subscribes to `safeAreaInsets` (the actual key in `McpUiHostContext`) and transforms the data to match the unified `BridgeInterface`
- **Unified API**: The `useBridge` hook now provides consistent `safeArea` access across both apps-sdk and MCP runtimes
- **Updated `useLayout`**: Changed from runtime-specific `useAppsSdkBridge` to unified `useBridge` for `safeArea`

The implementation properly handles the data transformation (wrapping `safeAreaInsets` as `{ insets: safeAreaInsets }`) and includes appropriate default values.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no issues found
- The implementation correctly fixes the subscription bug identified in the previous review. The data transformation between MCP's `safeAreaInsets` and the unified `safeArea` interface is properly implemented, with correct subscription handling and fallback to default values. The change to `useLayout` appropriately unifies access across both runtimes.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->