### PR TITLE
[POLYFILL] Feat/add-max-height-support

### DIFF
--- a/src/web/bridges/hooks/use-bridge.ts
+++ b/src/web/bridges/hooks/use-bridge.ts
@@ -9,6 +9,9 @@ export type BridgeInterface = Required<
   safeArea: {
     insets: NonNullable<McpUiHostContext["safeAreaInsets"]>;
   };
+  maxHeight: NonNullable<
+    NonNullable<McpUiHostContext["viewport"]>["maxHeight"]
+  >;
 };
 
 type BridgeExternalStore<K extends keyof BridgeInterface> = {
@@ -28,6 +31,7 @@ const DEFAULT_VALUE_FOR_MCP_APP_BRIDGE: BridgeInterface = {
       left: 0,
     },
   },
+  maxHeight: window.innerHeight,
 };
 
 const getExternalStore = <K extends keyof BridgeInterface>(
@@ -51,6 +55,15 @@ const getExternalStore = <K extends keyof BridgeInterface>(
         return safeArea
           ? ({ insets: safeArea } as BridgeInterface[K])
           : defaultValue;
+      },
+    };
+  }
+  if (key === "maxHeight") {
+    return {
+      subscribe: bridge.subscribe("viewport"),
+      getSnapshot: () => {
+        const viewport = bridge.getSnapshot("viewport");
+        return (viewport?.maxHeight ?? defaultValue) as BridgeInterface[K];
       },
     };
   }

--- a/src/web/hooks/use-layout.ts
+++ b/src/web/hooks/use-layout.ts
@@ -1,4 +1,4 @@
-import { useAppsSdkBridge, useBridge } from "../bridges/index.js";
+import { useBridge } from "../bridges/index.js";
 import type { SafeArea, Theme } from "../types.js";
 
 export type LayoutState = {
@@ -24,7 +24,7 @@ export type LayoutState = {
  */
 export function useLayout(): LayoutState {
   const theme = useBridge("theme");
-  const maxHeight = useAppsSdkBridge("maxHeight");
+  const maxHeight = useBridge("maxHeight");
   const safeArea = useBridge("safeArea");
 
   return { theme, maxHeight, safeArea };


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added support for `maxHeight`, `safeArea`, and `displayMode` properties in the unified bridge API, extending support beyond apps-sdk to mcp-app runtime. The bridge pattern now maps MCP's `safeAreaInsets` and `viewport.maxHeight` to a consistent interface.

**Key changes:**
- Added `IBridge` interface with `requestDisplayMode` method implemented by both bridge classes
- Extended `BridgeInterface` type to include `displayMode`, `safeArea`, and `maxHeight`
- Updated `useBridge` hook to handle special cases for mcp-app (mapping `safeAreaInsets` → `safeArea` and `viewport.maxHeight` → `maxHeight`)
- Migrated `useDisplayMode` and `useLayout` from apps-sdk specific hooks to unified `useBridge`
- Created `getBridge()` helper to select correct bridge based on `hostType`

**Critical issue found:**
- Line 43-47 in `use-bridge.ts`: Logic bug in apps-sdk mode for `safeArea` and `maxHeight` keys that will cause incorrect subscriptions

<h3>Confidence Score: 2/5</h3>


- Critical bug will cause runtime errors in apps-sdk mode when using maxHeight or safeArea
- Score reflects a critical logic bug in `use-bridge.ts` lines 43-47 that will break functionality in apps-sdk runtime. The code tries to use `"safeArea"` and `"maxHeight"` as keys for apps-sdk bridge subscriptions, but these mappings only work for mcp-app. In apps-sdk mode, `OpenAiProperties` already has these keys directly, so the current code flow doesn't handle them correctly. This will cause incorrect subscriptions and potential runtime errors.
- Pay close attention to `src/web/bridges/hooks/use-bridge.ts` - the logic for handling apps-sdk bridge needs fixing before merge

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->