### PR TITLE
Remove defaultValue override option

### DIFF
--- a/packages/core/src/web/bridges/hooks/use-bridge.ts
+++ b/packages/core/src/web/bridges/hooks/use-bridge.ts
@@ -25,8 +25,8 @@ const DEFAULT_VALUE_FOR_MCP_APP_BRIDGE: BridgeInterface = {
 
 const getExternalStore = <K extends keyof BridgeInterface>(
   key: K,
-  defaultValue: BridgeInterface[K] = DEFAULT_VALUE_FOR_MCP_APP_BRIDGE[key],
 ): BridgeExternalStore<K> => {
+  const defaultValue = DEFAULT_VALUE_FOR_MCP_APP_BRIDGE[key];
   const hostType = window.skybridge.hostType;
   if (hostType === "apps-sdk") {
     const bridge = AppsSdkBridge.getInstance();
@@ -65,9 +65,8 @@ const getExternalStore = <K extends keyof BridgeInterface>(
 
 export const useBridge = <K extends keyof BridgeInterface>(
   key: K,
-  defaultValue: BridgeInterface[K] = DEFAULT_VALUE_FOR_MCP_APP_BRIDGE[key],
 ): BridgeInterface[K] => {
-  const externalStore = getExternalStore(key, defaultValue);
+  const externalStore = getExternalStore(key);
 
   return useSyncExternalStore(
     externalStore.subscribe,


### PR DESCRIPTION
No useBridge implementation uses optional argument `defaultValue` to override the defaults specified in `useBridge`. This argument is unnecessary ATM.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Removed the unused `defaultValue` parameter from both `useBridge` and `getExternalStore` functions. The default value is now always sourced from `DEFAULT_VALUE_FOR_MCP_APP_BRIDGE[key]` internally within `getExternalStore`, maintaining the same behavior while simplifying the API.

- Simplified function signatures by removing optional `defaultValue` parameter
- Default values are still used internally via `DEFAULT_VALUE_FOR_MCP_APP_BRIDGE`
- No consumers in the codebase were passing the second parameter
- Behavior remains unchanged - defaults are still applied when bridge values are unavailable

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The change removes an unused optional parameter that was never utilized by any consumer in the codebase. The default value behavior is preserved by moving the default assignment inside the function. All existing usages of `useBridge` only pass a single argument, so this is a non-breaking change.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->