### PR TITLE
feat: add create-skybridge smoke test

### DIFF
--- a/packages/create-skybridge/index.js
+++ b/packages/create-skybridge/index.js
@@ -1,3 +1,8 @@
 #!/usr/bin/env node
 
-import "./dist/index.js";
+import { init } from "./dist/index.js";
+
+init().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/create-skybridge/package.json
+++ b/packages/create-skybridge/package.json
@@ -18,6 +18,8 @@
   ],
   "scripts": {
     "build": "tsc",
+    "test": "pnpm run test:unit && pnpm run test:type && pnpm run test:format",
+    "test:unit": "vitest run",
     "test:type": "tsc --noEmit",
     "test:format": "biome ci",
     "prepublishOnly": "pnpm run build"
@@ -28,6 +30,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.0.3",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^2.1.9"
   }
 }

--- a/packages/create-skybridge/src/index.test.ts
+++ b/packages/create-skybridge/src/index.test.ts
@@ -1,0 +1,28 @@
+import { randomBytes } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, it } from "vitest";
+import { init } from "./index.js";
+
+describe("create-skybridge", () => {
+  let tempDirName: string;
+
+  beforeEach(() => {
+    tempDirName = `test-${randomBytes(2).toString("hex")}`;
+  });
+
+  afterEach(async () => {
+    await fs.rm(path.join(process.cwd(), tempDirName), {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  it("should scaffold a new project", async () => {
+    const name = `../../${tempDirName}//project$`;
+    await init([name]);
+    await fs.access(
+      path.join(process.cwd(), tempDirName, "project", ".gitignore"),
+    );
+  });
+});

--- a/packages/create-skybridge/vitest.config.ts
+++ b/packages/create-skybridge/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@25.0.3)(@vitest/ui@2.1.9)(jsdom@25.0.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@25.0.3)(typescript@5.9.3))(terser@5.44.1)
 
   packages/devtools:
     dependencies:
@@ -10493,6 +10496,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.1
 
+  '@inquirer/confirm@5.1.21(@types/node@25.0.3)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@25.0.3)
+      '@inquirer/type': 3.0.10(@types/node@25.0.3)
+    optionalDependencies:
+      '@types/node': 25.0.3
+    optional: true
+
   '@inquirer/core@10.3.2(@types/node@22.18.12)':
     dependencies:
       '@inquirer/ansi': 1.0.2
@@ -10520,6 +10531,20 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.1
 
+  '@inquirer/core@10.3.2(@types/node@25.0.3)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@25.0.3)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 25.0.3
+    optional: true
+
   '@inquirer/figures@1.0.15': {}
 
   '@inquirer/type@3.0.10(@types/node@22.18.12)':
@@ -10530,6 +10555,11 @@ snapshots:
   '@inquirer/type@3.0.10(@types/node@24.10.1)':
     optionalDependencies:
       '@types/node': 24.10.1
+
+  '@inquirer/type@3.0.10(@types/node@25.0.3)':
+    optionalDependencies:
+      '@types/node': 25.0.3
+    optional: true
 
   '@isaacs/balanced-match@4.0.1': {}
 
@@ -11977,6 +12007,15 @@ snapshots:
     optionalDependencies:
       msw: 2.12.4(@types/node@22.18.12)(typescript@5.9.3)
       vite: 5.4.21(@types/node@22.18.12)(lightningcss@1.30.2)(terser@5.44.1)
+
+  '@vitest/mocker@2.1.9(msw@2.12.4(@types/node@25.0.3)(typescript@5.9.3))(vite@5.4.21(@types/node@25.0.3)(lightningcss@1.30.2)(terser@5.44.1))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.4(@types/node@25.0.3)(typescript@5.9.3)
+      vite: 5.4.21(@types/node@25.0.3)(lightningcss@1.30.2)(terser@5.44.1)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -15104,6 +15143,32 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  msw@2.12.4(@types/node@25.0.3)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 5.1.21(@types/node@25.0.3)
+      '@mswjs/interceptors': 0.40.0
+      '@open-draft/deferred-promise': 2.2.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.12.0
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.7.0
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.0
+      type-fest: 5.3.1
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
   multicast-dns@7.2.5:
     dependencies:
       dns-packet: 5.6.1
@@ -17153,6 +17218,24 @@ snapshots:
       - supports-color
       - terser
 
+  vite-node@2.1.9(@types/node@25.0.3)(lightningcss@1.30.2)(terser@5.44.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@25.0.3)(lightningcss@1.30.2)(terser@5.44.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite@5.4.21(@types/node@22.18.12)(lightningcss@1.30.2)(terser@5.44.1):
     dependencies:
       esbuild: 0.21.5
@@ -17160,6 +17243,17 @@ snapshots:
       rollup: 4.52.5
     optionalDependencies:
       '@types/node': 22.18.12
+      fsevents: 2.3.3
+      lightningcss: 1.30.2
+      terser: 5.44.1
+
+  vite@5.4.21(@types/node@25.0.3)(lightningcss@1.30.2)(terser@5.44.1):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.6
+      rollup: 4.52.5
+    optionalDependencies:
+      '@types/node': 25.0.3
       fsevents: 2.3.3
       lightningcss: 1.30.2
       terser: 5.44.1
@@ -17218,6 +17312,43 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.18.12
+      '@vitest/ui': 2.1.9(vitest@2.1.9)
+      jsdom: 25.0.1
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vitest@2.1.9(@types/node@25.0.3)(@vitest/ui@2.1.9)(jsdom@25.0.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@25.0.3)(typescript@5.9.3))(terser@5.44.1):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(msw@2.12.4(@types/node@25.0.3)(typescript@5.9.3))(vite@5.4.21(@types/node@25.0.3)(lightningcss@1.30.2)(terser@5.44.1))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.2.2
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@25.0.3)(lightningcss@1.30.2)(terser@5.44.1)
+      vite-node: 2.1.9(@types/node@25.0.3)(lightningcss@1.30.2)(terser@5.44.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.0.3
       '@vitest/ui': 2.1.9(vitest@2.1.9)
       jsdom: 25.0.1
     transitivePeerDependencies:


### PR DESCRIPTION
We're adding a unit test to make sure the creation script does not break on further changes.

This PR addresses few things:
- the script main function is explicitly invoked by the actual entrypoint, not the underlying modules: IMO it's cleaner and makes it easier to test
- in the same fashion, `argv` are read when the script is actually run, not when the module is loaded
- we were not properly sanitizing user input regarding project dir, this is fixed with `formatDir` becoming `sanitizeDir`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Adds unit test for `create-skybridge` script to prevent regressions from future changes. The PR includes three main improvements:

- **Refactored entry point**: The `init()` function is now explicitly invoked by `index.js`, making it easier to test
- **Parameterized argv**: Arguments are read when the script runs (not at module load), allowing the test to pass custom arguments
- **Enhanced input sanitization**: Renamed `formatTargetDir` to `sanitizeTargetDir` with additional security measures to prevent path traversal and filter special characters

The test verifies that the script can scaffold a project with sanitized input (e.g., `../../test-1234//project$` becomes `test-1234/project`).

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are well-structured and improve code quality by making the script testable and adding security measures. The refactoring is minimal and non-breaking, with clear improvements to input sanitization. The test validates the core functionality.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->