### PR TITLE
feat: add `immediate` option to create-skybridge

### DIFF
--- a/packages/create-skybridge/src/index.ts
+++ b/packages/create-skybridge/src/index.ts
@@ -1,7 +1,7 @@
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { spawn } from "node:child_process";
 import * as prompts from "@clack/prompts";
 import mri from "mri";
 


### PR DESCRIPTION
Closes https://github.com/alpic-ai/skybridge/issues/133

## Description

Command: create-skybridge my-app --immediate
Create a new project and auto-install all the depedencies.
(Used Claude Code heavily)

Below are Test Screenshots:
<img width="1244" height="325" alt="Screenshot (1033)" src="https://github.com/user-attachments/assets/25979b70-9a82-4d48-b1b5-cfc532cefac6" />
<img width="1347" height="747" alt="Screenshot (1037)" src="https://github.com/user-attachments/assets/88cfe13f-d24a-4964-a88c-66e8843fda26" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR adds the `--immediate` flag to the create-skybridge command, enabling users to auto-install dependencies and start the development server in one step. The implementation includes intelligent package manager detection (checking lock files, `package.json` field, then defaulting to pnpm), availability checking, and proper error handling with helpful fallback instructions. The changes integrate seamlessly with the existing codebase, adding new utility functions while preserving backward compatibility when the flag is not used.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with high confidence. The implementation is solid with proper error handling and backward compatibility.
- The implementation demonstrates thoughtful design with comprehensive package manager detection, proper error handling for all failure scenarios, and cross-platform compatibility. Edge cases are handled gracefully with informative user feedback. The feature maintains backward compatibility - when `--immediate` is not used, the CLI behaves exactly as before but now with automatic package manager detection for the suggested next steps. Process spawning is correctly implemented with appropriate signal handling.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->