### PR TITLE
[POLYFILL] feat: add support for open external on mcp app

### DIFF
--- a/packages/core/src/web/bridges/adaptors/apps-sdk-adaptor.ts
+++ b/packages/core/src/web/bridges/adaptors/apps-sdk-adaptor.ts
@@ -50,4 +50,8 @@ export class AppsSdkAdaptor implements Adaptor {
   public sendFollowUpMessage = (prompt: string): Promise<void> => {
     return window.openai.sendFollowUpMessage({ prompt });
   };
+
+  public openExternal(href: string): void {
+    window.openai.openExternal({ href });
+  }
 }

--- a/packages/core/src/web/bridges/adaptors/mcp-app-adaptor.ts
+++ b/packages/core/src/web/bridges/adaptors/mcp-app-adaptor.ts
@@ -1,6 +1,8 @@
 import type {
   McpUiMessageRequest,
   McpUiMessageResult,
+  McpUiOpenLinkRequest,
+  McpUiOpenLinkResult,
   McpUiRequestDisplayModeRequest,
   McpUiRequestDisplayModeResult,
 } from "@modelcontextprotocol/ext-apps";
@@ -115,6 +117,14 @@ export class McpAppAdaptor implements Adaptor {
       },
     });
   };
+
+  public openExternal(href: string): void {
+    const bridge = McpAppBridge.getInstance();
+    bridge.request<McpUiOpenLinkRequest, McpUiOpenLinkResult>({
+      method: "ui/open-link",
+      params: { url: href },
+    });
+  }
 
   private initializeStores(): {
     [K in keyof BridgeInterface]: ExternalStore<K>;

--- a/packages/core/src/web/bridges/types.ts
+++ b/packages/core/src/web/bridges/types.ts
@@ -64,4 +64,5 @@ export interface Adaptor {
     mode: DisplayMode;
   }>;
   sendFollowUpMessage(prompt: string): Promise<void>;
+  openExternal(href: string): void;
 }

--- a/packages/core/src/web/hooks/use-open-external.ts
+++ b/packages/core/src/web/hooks/use-open-external.ts
@@ -1,5 +1,12 @@
+import { useCallback } from "react";
+import { useAdaptor } from "../bridges/index.js";
+
 export function useOpenExternal() {
-  return (href: string) => {
-    window.openai.openExternal({ href });
-  };
+  const adaptor = useAdaptor();
+  const openExternal = useCallback(
+    (href: string) => adaptor.openExternal(href),
+    [adaptor],
+  );
+
+  return openExternal;
 }


### PR DESCRIPTION
Fixes #166 

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added `openExternal` support for MCP apps by implementing the method in `mcp-app-adapter.ts` that sends `ui/open-link` requests to the MCP host. Updated `useOpenExternal` hook to use the bridge adapter pattern via `getBridgeMethods()` instead of directly accessing `window.openai`, enabling it to work with both apps-sdk and mcp-app hosts.

**Key changes:**
- Implemented `openExternal` in `mcp-app-adapter.ts` using `ui/open-link` method
- Added `openExternal` export in `apps-sdk-adapter.ts` for consistency
- Updated `useOpenExternal` hook to use bridge adapter pattern
- Added comprehensive tests for both host types

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk
- The implementation correctly follows established patterns in the codebase (matching `sendFollowUpMessage` and `requestDisplayMode`), includes comprehensive test coverage for both host types, and the changes are straightforward. One point deducted due to a pre-existing type inconsistency between `types.ts` and `bridges/types.ts` for the `openExternal` signature that could cause confusion, though this doesn't affect runtime behavior since the implementation correctly uses the string parameter signature.
- No files require special attention - the implementation is solid and well-tested

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->