### PR TITLE
feat: expose back mcp apps resource

### DIFF
--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -39,11 +39,11 @@ type OpenaiToolMeta = {
 };
 
 /** @see https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/draft/apps.mdx#resource-discovery */
-// type McpAppsToolMeta = {
-//   "ui/resourceUri": string;
-// };
+type McpAppsToolMeta = {
+  "ui/resourceUri": string;
+};
 
-type ToolMeta = OpenaiToolMeta /* & McpAppsToolMeta */;
+type ToolMeta = OpenaiToolMeta & McpAppsToolMeta;
 
 /** @see https://developers.openai.com/apps-sdk/reference#component-resource-_meta-fields */
 type OpenaiResourceMeta = {
@@ -210,7 +210,7 @@ export class McpServer<
     const toolMeta: ToolMeta = {
       ...toolConfig._meta,
       "openai/outputTemplate": appsSdkResourceConfig.uri,
-      // "ui/resourceUri": extAppsResourceConfig.uri,
+      "ui/resourceUri": extAppsResourceConfig.uri,
     };
 
     this.registerTool(


### PR DESCRIPTION
Resolves #171

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR re-enables MCP Apps resource support by uncommenting the `McpAppsToolMeta` type and `ui/resourceUri` metadata field. The code was previously commented out in commit 786f7eb ("comment out ui resource uri on tool meta for the moment") and is now being restored.

The change:
- Uncomments the `McpAppsToolMeta` type definition that includes the `"ui/resourceUri"` field
- Changes `ToolMeta` from `OpenaiToolMeta` alone back to the intersection type `OpenaiToolMeta & McpAppsToolMeta`
- Re-enables setting `"ui/resourceUri": extAppsResourceConfig.uri` in the tool metadata

This enables MCP Apps clients to discover the correct resource URI for widgets through the `ui/resourceUri` field in tool metadata, complementing the existing OpenAI Apps SDK support via `openai/outputTemplate`.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change simply uncomments previously working code that was temporarily disabled. The `extAppsResourceConfig` is already being registered as a resource (line 197-208), and the tests verify both apps-sdk and ext-apps resources are properly registered. The type changes are consistent and the functionality is well-tested. No breaking changes or new logic introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->