### PR TITLE
fix: use skybridge@latest in quickstart doc

### DIFF
--- a/docs/docs/quickstart/create-new-app.md
+++ b/docs/docs/quickstart/create-new-app.md
@@ -11,7 +11,7 @@ The fastest way to start building is using our starter template. It comes pre-co
 Set up your app with a single command:
 
 ```bash
-npm create skybridge@dev my-chatgpt-app
+npm create skybridge@latest my-chatgpt-app
 ```
 
 Alternatively, clone the [starter template](https://github.com/alpic-ai/apps-sdk-template) directly or [use it as a GitHub template](https://github.com/new?template_name=apps-sdk-template&template_owner=alpic-ai).


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR updates the quickstart documentation to use `skybridge@latest` instead of `skybridge@dev` when creating a new app. This is a simple documentation fix that aligns the quickstart guide with the stable version installation instruction already present in the README, ensuring users follow best practices by installing the latest stable version rather than the development version.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risks - it's a straightforward documentation update with a single line changed.
- This is a minimal, low-risk change that only updates documentation. The change corrects the quickstart command to use `skybridge@latest` instead of `skybridge@dev`, which is consistent with the README and represents a best practice. There are no code changes, no dependencies affected, and no functional impact. The change is straightforward and has been reviewed as correct.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->