### PR TITLE
Use recommended groups and bump version in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
+  "extends": ["config:recommended", "group:recommended"],
+  "prConcurrentLimit": 5,
+  "timezone": "Europe/Paris",
+  "rangeStrategy": "bump",
+  "packageRules": [
+    {
+      "matchPackageNames": "@rjsf/**",
+      "groupName": "React JSON Schema Form packages"
+    }
   ]
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Enhanced Renovate configuration to improve dependency management. Added `group:recommended` preset to leverage Renovate's built-in grouping strategies, set `rangeStrategy: "bump"` to update version ranges rather than pinning, and created a custom package rule to group `@rjsf/**` updates together.

- Added `group:recommended` preset for better dependency grouping
- Set `prConcurrentLimit: 5` to limit simultaneous PRs
- Configured `rangeStrategy: "bump"` to update version ranges in package.json
- Added timezone `Europe/Paris` for scheduled updates
- Grouped React JSON Schema Form packages (`@rjsf/core`, `@rjsf/shadcn`, `@rjsf/utils`, `@rjsf/validator-ajv8`) to keep related packages in sync

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- All changes are configuration-only for Renovate Bot. The added settings follow Renovate best practices: `group:recommended` is an official preset, `rangeStrategy: "bump"` is a standard strategy, and the custom `@rjsf/**` grouping correctly targets the four React JSON Schema Form packages used in the devtools package. No code execution or runtime behavior is affected.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->