### PR TITLE
feat: make widgetsDevServer support single package projects

### DIFF
--- a/packages/core/src/server/widgetsDevServer.ts
+++ b/packages/core/src/server/widgetsDevServer.ts
@@ -1,4 +1,4 @@
-import * as fsPromises from "node:fs/promises";
+import { existsSync } from "node:fs";
 import path from "node:path";
 import cors from "cors";
 import express, { type RequestHandler } from "express";
@@ -24,10 +24,7 @@ export const widgetsDevServer = async (): Promise<RequestHandler> => {
   let webAppRoot = path.join(process.cwd(), "web");
 
   // fallback to the old behavior for backward compatibility
-  const hasWebAppRoot = await fsPromises
-    .stat(webAppRoot)
-    .then(() => true)
-    .catch(() => false);
+  const hasWebAppRoot = existsSync(webAppRoot);
   if (!hasWebAppRoot) {
     const workspaceRoot = searchForWorkspaceRoot(process.cwd());
     webAppRoot = path.join(workspaceRoot, "web");


### PR DESCRIPTION
Since 0.16.0, the template is a single package that does (should) not rely on workspace. When starting the server, the working dir is the template root, so we first check for a web directory directly at cwd. If it doesn't exist, we fall back to the previous behavior using `searchForWorkspaceRoot` for backward compatibility with workspace-based setups.

This still assumes the web package lives in a web subdirectory. A more flexible approach (like Vite's config override for the root directory) could be considered. It depends of where we land for the upcoming changes of the framework structure I guess.

I'll remove the "workspaces" field from the package.json when this gets shipped.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Modified `widgetsDevServer` to support the new single-package template structure introduced in v0.16.0. The change checks for a `web` directory at the current working directory first, then falls back to the previous workspace-based approach using `searchForWorkspaceRoot` for backward compatibility. This allows the dev server to work with both the new single-package template structure and older workspace-based setups.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The implementation is straightforward and follows a safe fallback pattern. The logic first attempts to use the new single-package structure, then gracefully falls back to the previous workspace-based approach. Any actual errors (missing directories, invalid configs) will be caught downstream by Vite when it attempts to use the paths. The change is well-commented and aligns with the stated architectural shift in v0.16.0.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->