### PR TITLE
Actually enable devtools

### DIFF
--- a/packages/create-skybridge/template/package.json
+++ b/packages/create-skybridge/template/package.json
@@ -19,20 +19,19 @@
     "express": "^5.1.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "skybridge": ">=0.16.0 <1.0.0",
+    "skybridge": ">=0.16.2 <1.0.0",
     "vite": "^7.1.11",
     "zod": "^4.1.13"
   },
   "devDependencies": {
     "@modelcontextprotocol/inspector": "^0.17.5",
-    "@skybridge/devtools": ">=0.16.0 <1.0.0",
+    "@skybridge/devtools": ">=0.16.2 <1.0.0",
     "@types/express": "^5.0.3",
     "@types/node": "^22.15.30",
     "@types/react": "^19.1.16",
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.1.2",
     "nodemon": "^3.1.10",
-    "open": "^11.0.0",
     "shx": "^0.3.4",
     "tsx": "^4.19.4",
     "typescript": "^5.7.2"

--- a/packages/create-skybridge/template/server/src/index.ts
+++ b/packages/create-skybridge/template/server/src/index.ts
@@ -1,5 +1,4 @@
 import express, { type Express } from "express";
-import open from "open";
 import { devtoolsStaticServer, widgetsDevServer } from "skybridge/server";
 import type { ViteDevServer } from "vite";
 import { mcp } from "./middleware.js";
@@ -30,8 +29,7 @@ app.listen(3000, (error) => {
   );
 
   if (env !== "production") {
-    console.log("Opening devtools at http://localhost:3000");
-    open(`http://localhost:3000`);
+    console.log("Devtools available at http://localhost:3000");
   }
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,8 +174,8 @@ importers:
         specifier: ^19.1.1
         version: 19.2.0(react@19.2.0)
       skybridge:
-        specifier: '>=0.16.0 <1.0.0'
-        version: 0.16.1(@modelcontextprotocol/sdk@1.24.3(zod@4.1.13))(@types/node@22.18.12)(@types/react@19.2.7)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.0))
+        specifier: '>=0.16.2 <1.0.0'
+        version: 0.16.2(@modelcontextprotocol/sdk@1.24.3(zod@4.1.13))(@types/node@22.18.12)(@types/react@19.2.7)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.0))
       vite:
         specifier: ^7.1.11
         version: 7.2.7(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)
@@ -187,7 +187,7 @@ importers:
         specifier: ^0.17.5
         version: 0.17.5(@types/node@22.18.12)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(typescript@5.9.3)
       '@skybridge/devtools':
-        specifier: '>=0.16.0 <1.0.0'
+        specifier: '>=0.16.2 <1.0.0'
         version: 0.16.2(@types/node@22.18.12)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(jiti@2.6.1)(lightningcss@1.30.2)(react-router-dom@5.3.4(react@19.2.0))(react-router@5.3.4(react@19.2.0))(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.0))(zod@4.1.13)
       '@types/express':
         specifier: ^5.0.3
@@ -207,9 +207,6 @@ importers:
       nodemon:
         specifier: ^3.1.10
         version: 3.1.11
-      open:
-        specifier: ^11.0.0
-        version: 11.0.0
       shx:
         specifier: ^0.3.4
         version: 0.3.4
@@ -7679,13 +7676,6 @@ packages:
   skin-tone@2.0.0:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
     engines: {node: '>=8'}
-
-  skybridge@0.16.1:
-    resolution: {integrity: sha512-YdnWaQ5/hkXMVVA4KEd0JpaZBOlVc3zKSmr7ORZT9KNeDfbFwq1wkCyCkZCa3Nf6+Yv/ZGbGYQ0fPcnX/ftwXA==}
-    peerDependencies:
-      '@modelcontextprotocol/sdk': '>=1.0.0'
-      react: '>=18.0.0'
-      react-dom: '>=18.0.0'
 
   skybridge@0.16.2:
     resolution: {integrity: sha512-aaRtKAKaSmd3HJT2sjaILROURCiQF/jip6NQRHXdwS0mcD+tfG27B96yBmkM8QDoFYSfWxGbyyla03JeIdew4w==}
@@ -18068,36 +18058,6 @@ snapshots:
   skin-tone@2.0.0:
     dependencies:
       unicode-emoji-modifier-base: 1.0.0
-
-  skybridge@0.16.1(@modelcontextprotocol/sdk@1.24.3(zod@4.1.13))(@types/node@22.18.12)(@types/react@19.2.7)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.0)):
-    dependencies:
-      '@babel/core': 7.28.5
-      '@modelcontextprotocol/sdk': 1.24.3(zod@4.1.13)
-      cors: 2.8.5
-      dequal: 2.0.3
-      express: 5.1.0
-      handlebars: 4.7.8
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      superjson: 2.2.6
-      vite: 7.2.7(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)
-      zustand: 5.0.9(@types/react@19.2.7)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))
-    transitivePeerDependencies:
-      - '@types/node'
-      - '@types/react'
-      - immer
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - use-sync-external-store
-      - yaml
 
   skybridge@0.16.2(@modelcontextprotocol/sdk@1.24.3(zod@4.1.13))(@types/node@22.18.12)(@types/react@19.2.7)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.0)):
     dependencies:


### PR DESCRIPTION
Following : https://github.com/alpic-ai/skybridge/pull/176
Also includes opening the emulator on startup

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR completes the devtools enablement by adding the `devtoolsStaticServer()` middleware and automatically opening the devtools UI on server startup in non-production environments.

- Added `@skybridge/devtools` package dependency to enable devtools UI
- Added `open` package to automatically launch browser
- Imported and mounted `devtoolsStaticServer()` middleware before `widgetsDevServer()`
- Added auto-open functionality that launches browser to `http://localhost:3000` on startup

The implementation follows the expected pattern from PR #176 and correctly guards both the middleware and browser opening with environment checks.

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with one minor improvement needed for error handling
- The implementation is straightforward and correctly follows the expected pattern from the preparatory PR #176. All dependencies are properly added, and the environment checks are in place. The only issue is the unhandled promise from `open()` which could cause warnings in headless environments, but won't break functionality.
- The `index.ts` file needs attention for the unhandled promise in the `open()` call

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->