### PR TITLE
Group updates of minor and patch in a single PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "group:recommended"],
+  "extends": ["config:recommended", "group:allNonMajor"],
   "prConcurrentLimit": 5,
   "timezone": "Europe/Paris",
-  "rangeStrategy": "bump",
-  "packageRules": [
-    {
-      "matchPackageNames": "@rjsf/**",
-      "groupName": "React JSON Schema Form packages"
-    }
-  ]
+  "rangeStrategy": "bump"
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Changed Renovate configuration to group all minor and patch dependency updates into a single PR by replacing `group:recommended` with `group:allNonMajor`. This will reduce PR noise by consolidating minor/patch updates that were previously creating separate PRs (as seen in recent commits #194, #195, #196). The custom `@rjsf/**` grouping rule was removed as it's now redundant with the broader grouping strategy.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is a straightforward Renovate configuration update that consolidates dependency PRs. The `group:allNonMajor` preset is a well-documented Renovate feature that groups all non-major updates together, which aligns with the PR title and reduces maintenance overhead. No logic, security, or functional code changes are involved.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->