### PR TITLE
[Feature] Add error message when local network access is denied

### DIFF
--- a/packages/core/src/server/templates/development.hbs
+++ b/packages/core/src/server/templates/development.hbs
@@ -26,7 +26,15 @@
 
         const errorMessage = document.createElement("div");
         errorMessage.style.cssText = "color: #ef4444; font-size: 14px;";
-        errorMessage.textContent = "Local network access is required for your widget to connect to the local dev server. Please enable it in your browser settings.";
+        errorMessage.textContent = "Local network access is required for your widget to connect to the local dev server. Please enable it in your browser settings. ";
+
+        const link = document.createElement("a");
+        link.href = "https://developer.chrome.com/blog/local-network-access";
+        link.target = "_blank";
+        link.rel = "noopener noreferrer";
+        link.style.cssText = "color: #ef4444; text-decoration: underline;";
+        link.textContent = "Learn more";
+        errorMessage.appendChild(link);
 
         errorDiv.appendChild(errorTitle);
         errorDiv.appendChild(errorMessage);


### PR DESCRIPTION
Following : https://github.com/alpic-ai/skybridge/issues/173

<img width="1712" height="1560" alt="image" src="https://github.com/user-attachments/assets/7fa3eb0e-1b4e-458e-82db-990001875050" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added user-friendly error detection for local network access permission denial in development mode. When browsers block local network access (causing CORS errors), the code now checks the `navigator.permissions` API and displays a clear error message guiding developers to enable the permission in browser settings. Also added FAQ documentation explaining the issue and resolution steps.

**Key changes:**
- Created new Handlebars partial template `local-network-access-check.hbs` with permission check script
- Registered the partial in `templateHelper.ts` at module initialization
- Integrated the partial into `development.hbs` (runs only in dev mode, not production)
- Added FAQ entry documenting the CORS/local network access error

**Issues found:**
- Error message positioning incomplete - fixed element needs top/left positioning

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with one minor positioning fix needed
- The implementation correctly addresses the reported issue by detecting local network access denial and providing helpful feedback. The approach is sound - using feature detection, graceful degradation for unsupported browsers, and only running in development mode. One CSS positioning issue needs correction to ensure the error message displays properly
- packages/core/src/server/templates/local-network-access-check.hbs requires a minor CSS fix for error message positioning

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->