### PR TITLE
Disable peer dependencies update with renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "group:allNonMajor"],
+  "extends": [
+    "config:recommended",
+    "group:allNonMajor",
+    ":disablePeerDependencies"
+  ],
   "prConcurrentLimit": 5,
   "timezone": "Europe/Paris",
   "rangeStrategy": "bump"


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added `:disablePeerDependencies` preset to Renovate configuration to prevent automatic updates of peer dependencies.

- This prevents Renovate from creating PRs that update `@modelcontextprotocol/sdk`, `react`, and `react-dom` peer dependencies in `packages/core/package.json`
- Peer dependency versions should be controlled by consuming applications rather than automatically bumped, ensuring compatibility across different usage contexts

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is a simple configuration update that adds a standard Renovate preset. It follows best practices by preventing automatic peer dependency updates, which could otherwise cause breaking changes for consumers of the library. The syntax is correct and the configuration is valid.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->