### PR TITLE
[Devtools] Change iframe type from srcdoc to about:blank

### DIFF
--- a/packages/devtools/src/components/layout/tool-panel/widget/widget.tsx
+++ b/packages/devtools/src/components/layout/tool-panel/widget/widget.tsx
@@ -79,6 +79,7 @@ export const Widget = () => {
       <iframe
         ref={iframeRef}
         src="about:blank"
+        onLoad={handleLoad}
         style={{
           width: "100%",
           border: "none",


### PR DESCRIPTION
## Summary

Using an srcdoc iframe prevents usage of routing features (such as react-router-dom). Fixed by moving to a about:blank iframe.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Changed iframe from `srcDoc` to `src="about:blank"` with manual content injection via `document.write()` to enable routing features like `react-router-dom`.

- **Critical Issue**: Replaced `onLoad` event handler with `useEffect`, which may execute before iframe is ready, causing content to never be injected
- Added `maxHeight: "300px"` constraint to iframe styling
- Moved HTML injection from declarative `srcDoc` to imperative `document.write()` approach

<h3>Confidence Score: 2/5</h3>


- This PR has a critical race condition that could prevent the iframe content from loading
- Score reflects a logical error in the iframe loading mechanism - the `useEffect` approach removes the load event handler without proper replacement, creating a race condition where content injection may never occur if the iframe isn't ready when the effect runs
- The `widget.tsx` file needs immediate attention to fix the iframe loading race condition

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->