### PR TITLE
Fix devtools request modal

### DIFF
--- a/packages/devtools/src/components/layout/tool-panel/widget/create-openai-mock.ts
+++ b/packages/devtools/src/components/layout/tool-panel/widget/create-openai-mock.ts
@@ -47,6 +47,7 @@ function createOpenaiMethods(
     requestModal: async (args: { title?: string }) => {
       log("requestModal", args);
       openai.displayMode = "modal" as DisplayMode; // TODO: To remove once https://github.com/alpic-ai/skybridge/pull/92 is merged
+      openai.view = { mode: "modal" };
       setValue("displayMode", "modal");
     },
     uploadFile: async (file: File) => {

--- a/packages/devtools/src/components/layout/tool-panel/widget/utils.ts
+++ b/packages/devtools/src/components/layout/tool-panel/widget/utils.ts
@@ -1,5 +1,4 @@
 export function injectWaitForOpenai(html: string) {
-  console.log("injectWaitForOpenai", html);
   const doc = new DOMParser().parseFromString(html, "text/html");
   const target = doc.querySelector('script[type="module"]#dev-widget-entry');
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes the devtools request modal functionality by properly setting the `view` property when `requestModal` is called. The `useRequestModal` hook relies on `view?.mode === "modal"` to determine if the modal is open, but the mock implementation was only setting `displayMode` without updating `view`. This fix adds `openai.view = { mode: "modal" }` to ensure the devtools correctly simulates the real widget behavior.

- Fixed `requestModal` mock to set `openai.view = { mode: "modal" }` in addition to `displayMode`
- Removed debug `console.log` statement from `injectWaitForOpenai` utility function

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - it's a targeted bug fix with minimal scope
- The changes are small, focused, and correct. The fix properly addresses the issue by setting the `view` property that `useRequestModal` depends on. The debug log removal is a simple cleanup with no risk.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->