### PR TITLE
[BUG] Check if host is http and if is not loopback for local access permission check

### DIFF
--- a/packages/core/src/server/templates/development.hbs
+++ b/packages/core/src/server/templates/development.hbs
@@ -14,6 +14,21 @@
       return;
     }
 
+    // Skip for non-http(s) protocols (file://, custom protocols in Electron, etc.)
+    const protocol = window.location.protocol;
+    const isNonHttpProtocol = protocol !== 'http:' && protocol !== 'https:'
+    if (isNonHttpProtocol) {
+      return;
+    }
+
+    const host = window.location.hostname;
+    const isLoopback = host === 'localhost'
+      || /^127\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.test(host)
+      || host === '::1';
+    if (isLoopback) {
+      return;
+    }
+    
     try {
       const status = await navigator.permissions.query({ name: "local-network-access" });
       if (status.state === "denied") {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Adds two safety checks before querying the local-network-access permission: skips the check for non-HTTP(S) protocols (file://, Electron custom protocols) and for loopback addresses (localhost, 127.x.x.x, ::1).

- prevents unnecessary permission checks on local development environments
- avoids potential errors when running in non-HTTP contexts like Electron apps
- the IPv4 loopback regex validation is too permissive and could match invalid IP addresses

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with one minor regex validation issue
- The changes add sensible safety checks to skip permission queries in appropriate contexts. The logic is sound and improves developer experience. However, the IPv4 loopback regex allows invalid IP addresses (e.g., 127.999.999.999), though in practice this is unlikely to cause issues since `window.location.hostname` typically contains valid values
- The regex validation in `packages/core/src/server/templates/development.hbs` should be corrected to prevent edge cases

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->