### PR TITLE
Replace deprecated ui/resourceUri with ui.resourceUri

### DIFF
--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
+import type { McpUiToolMeta } from "@modelcontextprotocol/ext-apps";
 import {
   McpServer as McpServerBase,
   type RegisteredTool,
@@ -40,7 +41,7 @@ type OpenaiToolMeta = {
 
 /** @see https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/draft/apps.mdx#resource-discovery */
 type McpAppsToolMeta = {
-  "ui/resourceUri": string;
+  ui: McpUiToolMeta;
 };
 
 type ToolMeta = OpenaiToolMeta & McpAppsToolMeta;
@@ -210,7 +211,9 @@ export class McpServer<
     const toolMeta: ToolMeta = {
       ...toolConfig._meta,
       "openai/outputTemplate": appsSdkResourceConfig.uri,
-      "ui/resourceUri": extAppsResourceConfig.uri,
+      ui: {
+        resourceUri: extAppsResourceConfig.uri,
+      },
     };
 
     this.registerTool(

--- a/packages/core/src/test/widget.test.ts
+++ b/packages/core/src/test/widget.test.ts
@@ -308,4 +308,27 @@ describe("McpServer.registerWidget", () => {
       'window.skybridge = { hostType: "mcp-app" }',
     );
   });
+
+  it("should register tool with ui.resourceUri metadata (not deprecated ui/resourceUri)", async () => {
+    const mockToolCallback = vi.fn();
+    const mockRegisterResourceConfig = { description: "Test widget" };
+    const mockToolConfig = { description: "Test tool" };
+
+    server.registerWidget(
+      "my-widget",
+      mockRegisterResourceConfig,
+      mockToolConfig,
+      mockToolCallback,
+    );
+
+    expect(mockRegisterTool).toHaveBeenCalledTimes(1);
+
+    const toolCallArgs = mockRegisterTool.mock.calls[0];
+    const toolConfig = toolCallArgs?.[1] as { _meta?: Record<string, unknown> };
+
+    expect(toolConfig._meta).toHaveProperty("ui");
+    expect(toolConfig._meta?.ui).toEqual({
+      resourceUri: "ui://widgets/ext-apps/my-widget.html",
+    });
+  });
 });


### PR DESCRIPTION
<h2>Greptile Overview</h2>

### Greptile Summary

Migrates tool metadata from deprecated `ui/resourceUri` bracket notation to MCP spec-compliant nested `ui.resourceUri` property access. Imports the proper `McpUiToolMeta` type from `@modelcontextprotocol/ext-apps` package for improved type safety. Adds test coverage to verify the new metadata format is correctly applied to registered widgets.

### Confidence Score: 5/5

- This PR is safe to merge - it's a straightforward metadata format migration with proper test coverage.
- The changes correctly migrate from deprecated bracket notation to nested object notation as specified in the MCP spec. The implementation is type-safe with proper TypeScript imports, all existing tests pass (based on PR description), and a new test verifies the correct format. The metadata is only written, not read within this codebase, so there's no risk of breaking internal functionality. The migration aligns with external spec requirements for MCP clients that consume this metadata.
- No files require special attention