### PR TITLE
fix: export devtools package.json

### DIFF
--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -13,7 +13,8 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
<h2>Greptile Overview</h2>

### Greptile Summary

Adds `./package.json` to the exports field of the `@skybridge/devtools` package to fix ERR_PACKAGE_PATH_NOT_EXPORTED error. This allows Node.js module resolution to access the package.json file when needed for path resolution or package metadata lookups.

### Confidence Score: 5/5

- Safe to merge - this is a minimal, correct fix for a package export issue.
- The change adds a single, standard export entry to expose the package.json file, which is a common practice in Node.js packages that need to support module resolution. The syntax is correct, follows the existing pattern in the exports field, and addresses the ERR_PACKAGE_PATH_NOT_EXPORTED error mentioned in the PR description. This fix aligns with the previous implementation (before commit d9419c7) which used `require.resolve("@skybridge/devtools/package.json")` to locate the package. No functional logic is changed, only package metadata is exposed.
- No files require special attention