### PR TITLE
feat: add vite ws in csp to make it work on goose

### DIFF
--- a/packages/core/src/test/widget.test.ts
+++ b/packages/core/src/test/widget.test.ts
@@ -108,7 +108,11 @@ describe("McpServer.registerWidget", () => {
           _meta: {
             "openai/widgetCSP": {
               resource_domains: [serverUrl],
-              connect_domains: [serverUrl, "ws://localhost:3000"],
+              connect_domains: [
+                serverUrl,
+                "ws://localhost:3000",
+                "ws://localhost:24678",
+              ],
             },
             "openai/widgetDomain": serverUrl,
             "openai/widgetDescription": "Test tool",
@@ -275,7 +279,11 @@ describe("McpServer.registerWidget", () => {
           _meta: {
             "openai/widgetCSP": {
               resource_domains: ["http://localhost:3000"],
-              connect_domains: ["http://localhost:3000", "ws://localhost:3000"],
+              connect_domains: [
+                "http://localhost:3000",
+                "ws://localhost:3000",
+                "ws://localhost:24678",
+              ],
             },
             "openai/widgetDomain": "http://localhost:3000",
             "openai/widgetDescription": "Test tool",
@@ -323,6 +331,7 @@ describe("McpServer.registerWidget", () => {
                 connectDomains: [
                   "http://localhost:3000",
                   "ws://localhost:3000",
+                  "ws://localhost:24678",
                 ],
               },
               domain: "http://localhost:3000",
@@ -413,7 +422,11 @@ describe("McpServer.registerWidget", () => {
     // CSP arrays are merged by index - user value replaces at index 0, defaults remain at other indices
     expect(meta["openai/widgetCSP"]).toEqual({
       resource_domains: ["https://from-ui-csp.com"],
-      connect_domains: ["https://from-ui-csp.com", "ws://localhost:3000"],
+      connect_domains: [
+        "https://from-ui-csp.com",
+        "ws://localhost:3000",
+        "ws://localhost:24678",
+      ],
       frame_domains: undefined,
       redirect_domains: undefined,
     });


### PR DESCRIPTION
<h2>Greptile Overview</h2>

### Greptile Summary

Adds Vite HMR websocket URL (`ws://localhost:24678`) to CSP `connect_domains` in development mode to enable hot module replacement in Goose. Refactors `buildContentMeta` function signature to accept computed CSP domains instead of raw server URLs, improving separation of concerns.

### Confidence Score: 4/5

- Safe to merge after standard review - well-structured change with proper test coverage and development-only scope
- The PR properly restricts the Vite HMR websocket addition to development mode only using the `!isProduction` check, preventing security issues in production. The refactoring of `buildContentMeta` improves code organization by computing CSP domains at a single point. All tests are updated to reflect the new behavior. The only minor consideration is the hardcoded port 24678, which could be made configurable for custom Vite setups, but this doesn't affect correctness for the default configuration.
- No files require special attention