### PR TITLE
feat: merge CSP domains with union instead of index replacement

### DIFF
--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -393,8 +393,6 @@ export class McpServer<
           ? `https://${extra?.requestInfo?.headers?.["x-forwarded-host"] ?? extra?.requestInfo?.headers?.host}`
           : "http://localhost:3000";
 
-        const wsServerUrl = serverUrl.replace(/^http/, "ws");
-
         const html = isProduction
           ? templateHelper.renderProduction({
               hostType,
@@ -410,15 +408,11 @@ export class McpServer<
               widgetName: name,
             });
 
-        const connectDomains = [serverUrl, wsServerUrl];
-        if (!isProduction) {
-          const VITE_HMR_WEBSOCKET_DEFAULT_URL = "ws://localhost:24678";
-          connectDomains.push(VITE_HMR_WEBSOCKET_DEFAULT_URL);
-        }
+        const VITE_HMR_WEBSOCKET_DEFAULT_URL = "ws://localhost:24678";
 
         const contentMeta = buildContentMeta({
           resourceDomains: [serverUrl],
-          connectDomains,
+          connectDomains: !isProduction ? [VITE_HMR_WEBSOCKET_DEFAULT_URL] : [],
           domain: serverUrl,
         });
 

--- a/packages/core/src/test/widget.test.ts
+++ b/packages/core/src/test/widget.test.ts
@@ -108,11 +108,7 @@ describe("McpServer.registerWidget", () => {
           _meta: {
             "openai/widgetCSP": {
               resource_domains: [serverUrl],
-              connect_domains: [
-                serverUrl,
-                "ws://localhost:3000",
-                "ws://localhost:24678",
-              ],
+              connect_domains: ["ws://localhost:24678"],
             },
             "openai/widgetDomain": serverUrl,
             "openai/widgetDescription": "Test tool",
@@ -178,7 +174,7 @@ describe("McpServer.registerWidget", () => {
           _meta: {
             "openai/widgetCSP": {
               resource_domains: [serverUrl],
-              connect_domains: [serverUrl, `wss://${host}`],
+              connect_domains: [],
             },
             "openai/widgetDomain": serverUrl,
             "openai/widgetDescription": "Test tool",
@@ -279,11 +275,7 @@ describe("McpServer.registerWidget", () => {
           _meta: {
             "openai/widgetCSP": {
               resource_domains: ["http://localhost:3000"],
-              connect_domains: [
-                "http://localhost:3000",
-                "ws://localhost:3000",
-                "ws://localhost:24678",
-              ],
+              connect_domains: ["ws://localhost:24678"],
             },
             "openai/widgetDomain": "http://localhost:3000",
             "openai/widgetDescription": "Test tool",
@@ -328,11 +320,7 @@ describe("McpServer.registerWidget", () => {
             ui: {
               csp: {
                 resourceDomains: ["http://localhost:3000"],
-                connectDomains: [
-                  "http://localhost:3000",
-                  "ws://localhost:3000",
-                  "ws://localhost:24678",
-                ],
+                connectDomains: ["ws://localhost:24678"],
               },
               domain: "http://localhost:3000",
             },
@@ -422,12 +410,7 @@ describe("McpServer.registerWidget", () => {
     // CSP arrays are merged with union - all unique domains from defaults and user config are preserved
     expect(meta["openai/widgetCSP"]).toEqual({
       resource_domains: ["http://localhost:3000", "https://from-ui-csp.com"],
-      connect_domains: [
-        "http://localhost:3000",
-        "ws://localhost:3000",
-        "ws://localhost:24678",
-        "https://from-ui-csp.com",
-      ],
+      connect_domains: ["ws://localhost:24678", "https://from-ui-csp.com"],
       frame_domains: undefined,
       redirect_domains: undefined,
     });


### PR DESCRIPTION
<h2>Greptile Overview</h2>

### Greptile Summary

Replaces index-based CSP domain merging with union-based merging to preserve all unique domains from both defaults and user configuration. The `mergeWithUnion` utility correctly uses es-toolkit's `union` function within `mergeWith` to deduplicate arrays during deep merge. Also simplifies default connect_domains to only include Vite HMR websocket in development and empty array in production, requiring explicit user configuration for widget websocket connections.

### Confidence Score: 5/5

- This PR is safe to merge with no issues identified
- The implementation is clean and correct. The `mergeWithUnion` function properly uses es-toolkit's `union` within `mergeWith` to deduplicate and combine arrays during deep merge, maintaining order (defaults first, then user values). Tests comprehensively cover the new behavior including edge cases with undefined values and multi-level merging. The documentation comment was appropriately updated to reflect the new union-based behavior. The change from automatic serverUrl/wsServerUrl inclusion in connect_domains to explicit user configuration is an intentional architectural improvement that makes CSP policies more explicit and secure by default.
- No files require special attention