### PR TITLE
Add Vercel Analytics plugin to Docusaurus docs

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -45,6 +45,8 @@ const config: Config = {
     ],
   ],
 
+  plugins: ["@docusaurus/plugin-vercel-analytics"],
+
   themeConfig: {
     image: "img/logo.png",
     colorMode: {

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "3.9.2",
+    "@docusaurus/plugin-vercel-analytics": "^3.9.2",
     "@docusaurus/preset-classic": "3.9.2",
     "@mdx-js/react": "^3.1.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@docusaurus/core':
         specifier: 3.9.2
         version: 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+      '@docusaurus/plugin-vercel-analytics':
+        specifier: ^3.9.2
+        version: 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       '@docusaurus/preset-classic':
         specifier: 3.9.2
         version: 3.9.2(@algolia/client-search@5.44.0)(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(search-insights@2.17.3)(typescript@5.9.3)
@@ -1799,6 +1802,13 @@ packages:
 
   '@docusaurus/plugin-svgr@3.9.2':
     resolution: {integrity: sha512-n+1DE+5b3Lnf27TgVU5jM1d4x5tUh2oW5LTsBxJX4PsAPV0JGcmI6p3yLYtEY0LRVEIJh+8RsdQmRE66wSV8mw==}
+    engines: {node: '>=20.0'}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  '@docusaurus/plugin-vercel-analytics@3.9.2':
+    resolution: {integrity: sha512-4ZrTEuFkQBCzo5gplgwlmw/r0dXQR4ATruSwfkfzvXnm3WruhX2oNE3cuzy5yOJ80bFgTJTC4MiUYviQouUbGw==}
     engines: {node: '>=20.0'}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
@@ -3671,6 +3681,32 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@vercel/analytics@1.6.1':
+    resolution: {integrity: sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vercel/oidc@3.0.5':
     resolution: {integrity: sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==}
@@ -10901,6 +10937,41 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
+  '@docusaurus/plugin-vercel-analytics@3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)':
+    dependencies:
+      '@docusaurus/core': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+      '@docusaurus/logger': 3.9.2
+      '@docusaurus/types': 3.9.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@docusaurus/utils': 3.9.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@docusaurus/utils-validation': 3.9.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@vercel/analytics': 1.6.1(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@docusaurus/faster'
+      - '@mdx-js/react'
+      - '@parcel/css'
+      - '@remix-run/react'
+      - '@rspack/core'
+      - '@sveltejs/kit'
+      - '@swc/core'
+      - '@swc/css'
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
+      - lightningcss
+      - next
+      - supports-color
+      - svelte
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue
+      - vue-router
+      - webpack-cli
+
   '@docusaurus/preset-classic@3.9.2(@algolia/client-search@5.44.0)(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(search-insights@2.17.3)(typescript@5.9.3)':
     dependencies:
       '@docusaurus/core': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
@@ -13771,6 +13842,10 @@ snapshots:
       eslint-visitor-keys: 4.2.1
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@vercel/analytics@1.6.1(react@19.2.3)':
+    optionalDependencies:
+      react: 19.2.3
 
   '@vercel/oidc@3.0.5': {}
 


### PR DESCRIPTION
This PR adds the @docusaurus/plugin-vercel-analytics plugin to enable Vercel Analytics tracking on the documentation site.

Changes:
- Added @docusaurus/plugin-vercel-analytics package dependency
- Configured the plugin in docusaurus.config.ts
- Updated pnpm-lock.yaml

The plugin will automatically work when deployed to Vercel, using the VERCEL environment variable that Vercel sets automatically.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR adds Vercel Analytics tracking to the Docusaurus documentation site by integrating the official `@docusaurus/plugin-vercel-analytics` plugin.

**Changes Made:**
- Added `@docusaurus/plugin-vercel-analytics` (v3.9.2) to dependencies in `docs/package.json`
- Configured the plugin in `docs/docusaurus.config.ts` by adding it to the `plugins` array
- Updated `pnpm-lock.yaml` with the new package and its transitive dependency `@vercel/analytics@1.6.1`

**How it Works:**
The plugin automatically detects when the site is deployed on Vercel by checking for the `VERCEL` environment variable (which Vercel sets automatically), and enables analytics tracking in that environment. No additional configuration is required.

**Integration with Existing Infrastructure:**
The documentation site is already deployed to Vercel via the GitHub Actions workflow in `.github/workflows/publish.yml`, which runs `vercel deploy` commands. The plugin will seamlessly integrate with this existing deployment process.

**Version Compatibility:**
All Docusaurus packages are aligned at version 3.9.2, including the new plugin. The plugin's peer dependencies (React 19.2.3 and React DOM 19.2.3) match the versions already in use by the docs site.

**Additional Lockfile Changes:**
The `pnpm-lock.yaml` includes some unrelated changes (e.g., `@types/node` version references switching between 24.10.4 and 25.0.3, and some `optional: true` flag removals). These are routine lockfile reorganizations that pnpm performs during dependency resolution and do not affect functionality.

### Confidence Score: 5/5

- This PR is safe to merge with minimal risk - it's a straightforward addition of an official Docusaurus plugin with no code changes
- The implementation is clean and follows Docusaurus best practices. The plugin is official (@docusaurus/plugin-vercel-analytics), properly versioned (matching other Docusaurus packages at 3.9.2), and requires no additional configuration. The plugin auto-detects the Vercel environment and only activates when deployed, so there's no risk to local development. The lockfile changes are consistent and include the expected transitive dependency (@vercel/analytics). The existing Vercel deployment infrastructure will work seamlessly with this addition.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->