### PR TITLE
[MCPApps] feat: support ui resource teardown messages

### DIFF
--- a/packages/core/src/web/bridges/mcp-app-bridge.ts
+++ b/packages/core/src/web/bridges/mcp-app-bridge.ts
@@ -38,6 +38,14 @@ export type McpAppBridgeKey = keyof McpAppBridgeContext;
 
 const LATEST_PROTOCOL_VERSION = "2025-11-21";
 
+enum JsonRpcErrorCode {
+  ParseError = -32700,
+  InvalidRequest = -32600,
+  MethodNotFound = -32601,
+  InvalidParams = -32602,
+  InternalError = -32603,
+}
+
 type McpAppResponse = {
   jsonrpc: "2.0";
   id: string | number;
@@ -46,7 +54,7 @@ type McpAppResponse = {
       result: unknown;
     }
   | {
-      error: { code: number; message: string };
+      error: { code: JsonRpcErrorCode; message: string };
     }
 );
 
@@ -277,6 +285,18 @@ export class McpAppBridge implements Bridge<McpUiHostContext> {
           "*",
         );
         return;
+      default:
+        window.parent.postMessage(
+          {
+            jsonrpc: "2.0",
+            id: request.id,
+            error: {
+              code: JsonRpcErrorCode.MethodNotFound,
+              message: "Unsupported Request",
+            },
+          } satisfies McpAppResponse,
+          "*",
+        );
     }
   };
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR adds support for handling `ui/resource-teardown` request messages from the parent window in the MCP app bridge. The change refactors message handling to distinguish between three message types (requests, responses, and notifications) based on JSON-RPC 2.0 semantics:

- **Requests** (have both `id` and `method`): Incoming requests from parent, now handled by new `handleRequest` method
- **Responses** (have `id` but no `method`): Responses to outgoing requests, handled by refactored `handleResponse` method  
- **Notifications** (no `id`): One-way messages, handled by existing `handleNotification` method

When a `ui/resource-teardown` request is received, the bridge calls its cleanup method to remove event listeners, clear pending requests, and stop the size observer, then sends back an empty success response.

The refactoring correctly separates the previously monolithic message handler into three distinct handlers, making the code more maintainable and aligned with JSON-RPC 2.0 protocol. The new `McpAppRequest` type properly represents incoming requests with both id and method fields.

### Confidence Score: 4/5

- Safe to merge with one minor issue that should be addressed
- The PR correctly implements the core functionality for handling resource teardown requests and properly refactors message handling to distinguish between requests, responses, and notifications per JSON-RPC 2.0. The message routing logic is sound, and the teardown implementation appropriately cleans up resources before responding. However, there's one logic issue: the handleRequest method lacks a default case to handle unknown request methods, which violates JSON-RPC 2.0 spec and could cause the parent to wait indefinitely for responses to unrecognized requests. This won't affect the current teardown functionality but represents incomplete protocol compliance that should be fixed.
- packages/core/src/web/bridges/mcp-app-bridge.ts needs a default error case in handleRequest

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->