### PR TITLE
[MCP Apps] feat: bump ext-apps version and fix new interface

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,7 +56,7 @@
     "zustand": "^5.0.9"
   },
   "devDependencies": {
-    "@modelcontextprotocol/ext-apps": "^0.2.2",
+    "@modelcontextprotocol/ext-apps": "^0.3.1",
     "@modelcontextprotocol/sdk": "^1.25.2",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.1",

--- a/packages/core/src/web/bridges/adaptors/mcp-app-adaptor.ts
+++ b/packages/core/src/web/bridges/adaptors/mcp-app-adaptor.ts
@@ -149,8 +149,14 @@ export class McpAppAdaptor implements Adaptor {
         ({ displayMode }) => displayMode ?? "inline",
       ),
       maxHeight: this.createExternalStore(
-        ["viewport"],
-        ({ viewport }) => viewport?.maxHeight ?? window.innerHeight,
+        ["containerDimensions"],
+        ({ containerDimensions }) => {
+          if (containerDimensions && "maxHeight" in containerDimensions) {
+            return containerDimensions.maxHeight ?? window.innerHeight;
+          }
+
+          return window.innerHeight;
+        },
       ),
       userAgent: this.createExternalStore(
         ["platform", "deviceCapabilities"],

--- a/packages/core/src/web/hooks/use-layout.test.ts
+++ b/packages/core/src/web/hooks/use-layout.test.ts
@@ -80,7 +80,7 @@ describe("useLayout", () => {
       vi.stubGlobal("parent", {
         postMessage: getMcpAppHostPostMessageMock({
           theme: "dark",
-          viewport: { height: 400, width: 400, maxHeight: 800 },
+          containerDimensions: { height: 400, width: 400, maxHeight: 800 },
           safeAreaInsets: { top: 20, right: 0, bottom: 34, left: 0 },
         }),
       });
@@ -99,7 +99,7 @@ describe("useLayout", () => {
       vi.stubGlobal("parent", {
         postMessage: getMcpAppHostPostMessageMock({
           theme: "light",
-          viewport: { height: 400, width: 400, maxHeight: 500 },
+          containerDimensions: { height: 400, width: 400, maxHeight: 500 },
           safeAreaInsets: { top: 44, right: 0, bottom: 34, left: 0 },
         }),
       });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -308,8 +308,8 @@ importers:
         version: 5.0.9(@types/react@19.2.7)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
     devDependencies:
       '@modelcontextprotocol/ext-apps':
-        specifier: ^0.2.2
-        version: 0.2.2(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.3.5))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.3.5)
+        specifier: ^0.3.1
+        version: 0.3.1(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.3.5))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.3.5)
       '@modelcontextprotocol/sdk':
         specifier: ^1.25.2
         version: 1.25.2(hono@4.11.3)(zod@4.3.5)
@@ -2283,8 +2283,8 @@ packages:
       react: '>= 15'
       react-dom: '>= 15'
 
-  '@modelcontextprotocol/ext-apps@0.2.2':
-    resolution: {integrity: sha512-h8sN3QIBLqMsRXjKL76M5VmBQf3N0I1G1DiDiSYAgtdynYQctHqCs79WEo1d5wClyZVYBWXdRcxgiR/WBfSOqw==}
+  '@modelcontextprotocol/ext-apps@0.3.1':
+    resolution: {integrity: sha512-Iivz2KwWK8xlRbiWwFB/C4NXqE8VJBoRCbBkJCN98ST2UbQvA6kfyebcLsypiqylJS467XOOaBcI9DeQ3t+zqA==}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.24.0
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -3050,6 +3050,11 @@ packages:
 
   '@rollup/rollup-win32-arm64-msvc@4.52.5':
     resolution: {integrity: sha512-w0cDWVR6MlTstla1cIfOGyl8+qb93FlAVutcor14Gf5Md5ap5ySfQ7R9S/NjNaMLSFdUnKGEasmVnu3lCMqB7w==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-arm64-msvc@4.55.1':
+    resolution: {integrity: sha512-yR6Bl3tMC/gBok5cz/Qi0xYnVbIxGx5Fcf/ca0eB6/6JwOY+SRUcJfI0OpeTpPls7f194as62thCt/2BjxYN8g==}
     cpu: [arm64]
     os: [win32]
 
@@ -7294,11 +7299,6 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
-
-  prettier@3.7.4:
-    resolution: {integrity: sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==}
-    engines: {node: '>=14'}
-    hasBin: true
 
   pretty-error@4.0.0:
     resolution: {integrity: sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==}
@@ -11581,10 +11581,9 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@modelcontextprotocol/ext-apps@0.2.2(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.3.5))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.3.5)':
+  '@modelcontextprotocol/ext-apps@0.3.1(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.3.5))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.3.5)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.25.2(hono@4.11.3)(zod@4.3.5)
-      prettier: 3.7.4
       zod: 4.3.5
     optionalDependencies:
       '@oven/bun-darwin-aarch64': 1.3.5
@@ -11602,6 +11601,7 @@ snapshots:
       '@rollup/rollup-darwin-x64': 4.54.0
       '@rollup/rollup-linux-arm64-gnu': 4.54.0
       '@rollup/rollup-linux-x64-gnu': 4.54.0
+      '@rollup/rollup-win32-arm64-msvc': 4.55.1
       '@rollup/rollup-win32-x64-msvc': 4.54.0
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
@@ -12910,6 +12910,9 @@ snapshots:
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.52.5':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.55.1':
     optional: true
 
   '@rollup/rollup-win32-ia32-msvc@4.52.5':
@@ -18036,8 +18039,6 @@ snapshots:
   powershell-utils@0.1.0: {}
 
   prelude-ls@1.2.1: {}
-
-  prettier@3.7.4: {}
 
   pretty-error@4.0.0:
     dependencies:


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR updates the `@modelcontextprotocol/ext-apps` dependency from version 0.2.2 to 0.3.1 and adapts the codebase to handle a breaking API change in the MCP host context interface.

**Key Changes:**
- **Dependency Update**: Bumped `@modelcontextprotocol/ext-apps` from `^0.2.2` to `^0.3.1`
- **Interface Migration**: Replaced the deprecated `viewport` property with the new `containerDimensions` property in the MCP host context
- **Implementation Update**: Modified `mcp-app-adaptor.ts` to extract `maxHeight` from `containerDimensions` instead of `viewport`, with proper null-checking
- **Test Updates**: Updated test mocks in `use-layout.test.ts` to use the new `containerDimensions` interface

The changes correctly handle the API migration by checking for the existence of `containerDimensions` and its `maxHeight` property before accessing it, falling back to `window.innerHeight` when not available. All affected test cases have been updated to reflect the new interface.

### Confidence Score: 5/5

- This PR is safe to merge - it's a straightforward dependency upgrade with proper interface migration.
- The PR correctly handles the breaking API change from ext-apps 0.2.2 to 0.3.1 by migrating from the deprecated 'viewport' property to the new 'containerDimensions' property. All code changes are consistent, defensive with proper null-checking, and all affected tests have been updated. The implementation maintains backward compatibility by falling back to window.innerHeight when the new property is unavailable. No bugs or blocking issues identified.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->