### PR TITLE
fix: call tool from openai returns meta key instead of _meta. Unify interface

### DIFF
--- a/docs/docs/api-reference/use-call-tool.md
+++ b/docs/docs/api-reference/use-call-tool.md
@@ -85,11 +85,11 @@ The type of arguments your tool accepts. Defaults to `null` for tools that don't
 
 ```tsx
 ToolResponse extends Partial<
-  { structuredContent: Record<string, unknown>; _meta: Record<string, unknown> }
+  { structuredContent: Record<string, unknown>; meta: Record<string, unknown> }
 > = {}
 ```
 
-The type of the response returned by your tool. This allows you to specify the exact shape of both the `structuredContent` and `_meta` fields of your tool's response.
+The type of the response returned by your tool. This allows you to specify the exact shape of both the `structuredContent` and `meta` fields of your tool's response.
 
 ## Returns
 
@@ -164,7 +164,7 @@ type CallToolResponse = {
   result: string;
   /** structuredContent and meta are shaped according to your ToolResponse type parameter */
   structuredContent: Record<string, unknown>;
-  _meta: Record<string, unknown>;
+  meta: Record<string, unknown>;
 };
 ```
 

--- a/packages/core/src/web/bridges/adaptors/mcp-app-adaptor.ts
+++ b/packages/core/src/web/bridges/adaptors/mcp-app-adaptor.ts
@@ -88,7 +88,7 @@ export class McpAppAdaptor implements Adaptor {
       structuredContent: response.structuredContent ?? {},
       isError: response.isError ?? false,
       result,
-      _meta: response._meta ?? {},
+      meta: response._meta ?? {},
     } as ToolResponse;
   };
 

--- a/packages/core/src/web/bridges/types.ts
+++ b/packages/core/src/web/bridges/types.ts
@@ -8,7 +8,7 @@ export type CallToolResponse = {
   structuredContent: NonNullable<CallToolResult["structuredContent"]>;
   isError: NonNullable<CallToolResult["isError"]>;
   result: string;
-  _meta?: CallToolResult["_meta"];
+  meta?: CallToolResult["_meta"];
 };
 
 export type DisplayMode = "pip" | "inline" | "fullscreen" | "modal";

--- a/packages/core/src/web/hooks/use-call-tool.test-d.ts
+++ b/packages/core/src/web/hooks/use-call-tool.test-d.ts
@@ -71,7 +71,7 @@ test("callToolAsync returns correctly typed promise", () => {
   type Args = { name: string };
   type Response = {
     structuredContent: { greeting: string };
-    _meta: { id: number };
+    meta: { id: number };
   };
 
   const { callToolAsync } = useCallTool<Args, Response>("test-tool");
@@ -79,7 +79,7 @@ test("callToolAsync returns correctly typed promise", () => {
   const promise = callToolAsync({ name: "test" });
 
   expectTypeOf(promise).resolves.toHaveProperty("structuredContent");
-  expectTypeOf(promise).resolves.toHaveProperty("_meta");
+  expectTypeOf(promise).resolves.toHaveProperty("meta");
 });
 
 test("state narrowing works correctly with status", () => {

--- a/packages/core/src/web/hooks/use-call-tool.test.ts
+++ b/packages/core/src/web/hooks/use-call-tool.test.ts
@@ -191,7 +191,7 @@ describe("useCallTool - TypeScript typing", () => {
   it("should have correct return types when ToolArgs is null and ToolResponse is specified", async () => {
     type TestResponse = CallToolResponse & {
       structuredContent: { result: string };
-      _meta: { id: number };
+      meta: { id: number };
     };
 
     const { result } = renderHook(() =>
@@ -202,7 +202,7 @@ describe("useCallTool - TypeScript typing", () => {
       structuredContent: { result: "test" },
       isError: false,
       result: "test",
-      _meta: { id: 123 },
+      meta: { id: 123 },
     };
 
     OpenaiMock.callTool.mockResolvedValueOnce(data);
@@ -231,7 +231,7 @@ describe("useCallTool - TypeScript typing", () => {
       structuredContent: { answer: "test answer" },
       isError: false,
       result: "answer",
-      _meta: {},
+      meta: {},
     };
 
     OpenaiMock.callTool.mockResolvedValueOnce(mockResponse);
@@ -257,7 +257,7 @@ describe("useCallTool - TypeScript typing", () => {
       structuredContent: { data: "test data" },
       isError: false,
       result: "data",
-      _meta: {},
+      meta: {},
     };
 
     OpenaiMock.callTool.mockResolvedValueOnce(mockResponse);

--- a/packages/core/src/web/hooks/use-call-tool.ts
+++ b/packages/core/src/web/hooks/use-call-tool.ts
@@ -92,7 +92,7 @@ export type CallToolAsyncFn<TArgs, TResponse> =
 
 type ToolResponseSignature = Pick<
   CallToolResponse,
-  "structuredContent" | "_meta"
+  "structuredContent" | "meta"
 >;
 
 export const useCallTool = <

--- a/packages/core/src/web/types.ts
+++ b/packages/core/src/web/types.ts
@@ -75,7 +75,7 @@ export type CallToolResponse = {
   structuredContent: Record<string, unknown>;
   isError: boolean;
   result: string;
-  _meta?: CallToolResult["_meta"];
+  meta?: CallToolResult["_meta"];
 };
 
 export type RequestModalOptions = {

--- a/packages/devtools/src/lib/mcp/client.ts
+++ b/packages/devtools/src/lib/mcp/client.ts
@@ -51,7 +51,13 @@ export class McpClient {
       name: toolName,
       arguments: args ?? {},
     });
-    return result as CallToolResponse;
+
+    // Transform _meta → meta to match OpenAI's behavior
+    const { _meta, ...rest } = result;
+    return {
+      ...rest,
+      meta: _meta,
+    } as CallToolResponse;
   }
 
   async listResources() {

--- a/packages/devtools/src/lib/mcp/index.ts
+++ b/packages/devtools/src/lib/mcp/index.ts
@@ -75,7 +75,7 @@ export const useCallTool = () => {
           ...defaultOpenaiObject,
           toolInput: args ?? {},
           toolOutput: response.structuredContent,
-          toolResponseMetadata: response._meta ?? null,
+          toolResponseMetadata: response.meta ?? null,
           widgetState: null,
         },
       });


### PR DESCRIPTION
Fixes #292

We mistyped callTool from openai that returns the metadata in a meta key and not _meta key.

Propose to unify the interface and adapt devtools to mimic the behavior

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR unifies the interface for tool call responses by standardizing on `meta` instead of `_meta` as the property name. The change addresses a mismatch where OpenAI's SDK returns metadata in a `meta` key, while the MCP SDK uses `_meta`.

## Key Changes
- Updated `CallToolResponse` type definitions across the codebase to use `meta` instead of `_meta`
- Modified both the MCP app adaptor and devtools client to transform MCP SDK's `_meta` to `meta` when constructing responses
- Updated all tests and type tests to reflect the new `meta` property
- Updated documentation to reference `meta` instead of `_meta` in the response type

## Analysis
The PR correctly identifies and addresses the interface inconsistency. The type system properly maps `CallToolResult["_meta"]` from the MCP SDK to the `meta` property in the unified `CallToolResponse` interface. All test files have been updated to use the new `meta` property name, ensuring type safety is maintained.

However, there is one inconsistency in the implementation between the two adaptors that could lead to different runtime behavior when `_meta` is undefined.

### Confidence Score: 4/5

- This PR is mostly safe to merge with one minor inconsistency that should be addressed
- The PR successfully unifies the interface by renaming `_meta` to `meta` across the codebase. The changes are well-tested with updated type definitions and test cases. However, there is one logic inconsistency in the devtools client where `meta` is not defaulted to an empty object when `_meta` is undefined, unlike the MCP app adaptor implementation. This could lead to subtle behavioral differences between the two implementations. The fix is straightforward - add `?? {}` to match the pattern used in the MCP app adaptor.
- packages/devtools/src/lib/mcp/client.ts - needs to add default empty object for consistency

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->