### PR TITLE
[Devtools] Allow all borders to be resizable

### DIFF
--- a/packages/devtools/src/components/layout/tool-panel/tool-panel.tsx
+++ b/packages/devtools/src/components/layout/tool-panel/tool-panel.tsx
@@ -20,6 +20,23 @@ export const ToolPanel = () => {
     id: "skybridge-devtools-input-column",
     storage: localStorage,
   });
+  const { defaultLayout: widgetLayout, onLayoutChange: onWidgetLayoutChange } =
+    useDefaultLayout({
+      id: "skybridge-devtools-widget-section",
+      storage: localStorage,
+    });
+  const {
+    defaultLayout: inspectorLayout,
+    onLayoutChange: onInspectorLayoutChange,
+  } = useDefaultLayout({
+    id: "skybridge-devtools-inspector-section",
+    storage: localStorage,
+  });
+  const { defaultLayout: mainLayout, onLayoutChange: onMainLayoutChange } =
+    useDefaultLayout({
+      id: "skybridge-devtools-main-section",
+      storage: localStorage,
+    });
 
   const shouldDisplayWidgetSection = Boolean(
     tool._meta?.["openai/outputTemplate"] &&
@@ -30,43 +47,83 @@ export const ToolPanel = () => {
   return (
     <div className="flex-1 flex flex-col overflow-hidden relative z-10">
       <Group
-        orientation="horizontal"
-        className="flex-1 overflow-hidden border-b border-border"
-        defaultLayout={defaultLayout}
-        onLayoutChange={onLayoutChange}
+        orientation="vertical"
+        className="flex-1 overflow-hidden"
+        defaultLayout={mainLayout}
+        onLayoutChange={onMainLayoutChange}
       >
-        <Panel id="input-column" minSize="20" maxSize="60">
-          <div className="flex flex-col overflow-hidden h-full">
-            <InputForm />
-          </div>
+        <Panel id="top-section" minSize="30">
+          <Group
+            orientation="horizontal"
+            className="flex-1 overflow-hidden"
+            defaultLayout={defaultLayout}
+            onLayoutChange={onLayoutChange}
+          >
+            <Panel id="input-column" minSize="20" maxSize="60">
+              <div className="flex flex-col overflow-hidden h-full">
+                <InputForm />
+              </div>
+            </Panel>
+            <Separator className="w-px bg-border" />
+            <Panel id="output-column" minSize="30">
+              <div className="flex flex-col overflow-hidden h-full">
+                <Output />
+              </div>
+            </Panel>
+          </Group>
         </Panel>
-        <Separator className="w-px bg-border" />
-        <Panel id="output-column" minSize="30">
-          <div className="flex flex-col overflow-hidden h-full">
-            <Output />
-          </div>
-        </Panel>
+        {shouldDisplayWidgetSection && (
+          <>
+            <Separator className="h-px bg-border" />
+            <Panel id="widget-section" minSize="20">
+              <Group
+                orientation="horizontal"
+                className="flex-1 overflow-hidden bg-card"
+                defaultLayout={inspectorLayout}
+                onLayoutChange={onInspectorLayoutChange}
+              >
+                <Panel id="widget-logs-panel" minSize="30">
+                  <div className="flex flex-col h-full overflow-hidden">
+                    <Group
+                      orientation="vertical"
+                      className="flex-1 overflow-hidden"
+                      defaultLayout={widgetLayout}
+                      onLayoutChange={onWidgetLayoutChange}
+                    >
+                      <Panel id="widget-panel" minSize="20" maxSize="80">
+                        <div className="h-full overflow-hidden">
+                          <Suspense>
+                            <Widget />
+                          </Suspense>
+                        </div>
+                      </Panel>
+                      <Separator className="h-px bg-border" />
+                      <Panel id="logs-panel" minSize="20">
+                        <div className="p-4 flex flex-col h-full min-h-0">
+                          <OpenAiLogs />
+                        </div>
+                      </Panel>
+                    </Group>
+                  </div>
+                </Panel>
+                <Separator className="w-px bg-border" />
+                <Panel
+                  id="inspector-panel"
+                  minSize="20"
+                  maxSize="50"
+                  defaultSize={30}
+                >
+                  <div className="flex flex-col overflow-hidden h-full min-h-0">
+                    <div className="overflow-auto">
+                      <OpenAiInspector />
+                    </div>
+                  </div>
+                </Panel>
+              </Group>
+            </Panel>
+          </>
+        )}
       </Group>
-      {shouldDisplayWidgetSection && (
-        <div className="flex overflow-hidden bg-card relative h-[60%]">
-          <div className="flex flex-col flex-1 h-full overflow-hidden bg-card border-r border-border">
-            <div className="border-b border-border">
-              <Suspense>
-                <Widget />
-              </Suspense>
-            </div>
-            <div className="p-4 flex flex-col h-full min-h-0">
-              <OpenAiLogs />
-            </div>
-          </div>
-
-          <div className="flex flex-col overflow-hidden w-[400px] flex-none min-h-0">
-            <div className="overflow-auto">
-              <OpenAiInspector />
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   );
 };

--- a/packages/devtools/src/components/layout/tool-panel/widget/widget.tsx
+++ b/packages/devtools/src/components/layout/tool-panel/widget/widget.tsx
@@ -53,14 +53,6 @@ export const Widget = () => {
     iframe.contentDocument.write(injectWaitForOpenai(html));
     iframe.contentDocument.close();
 
-    const doc = iframe.contentDocument;
-
-    const resizeObserver = new ResizeObserver(() => {
-      iframe.style.height = `${doc.documentElement.scrollHeight}px`;
-    });
-
-    resizeObserver.observe(doc.body);
-
     setToolData(tool.name, {
       openaiRef: iframeRef as React.RefObject<HTMLIFrameElement>,
     });
@@ -83,6 +75,7 @@ export const Widget = () => {
       className="relative overflow-auto"
       style={{
         width: "100%",
+        height: "100%",
       }}
     >
       <iframe
@@ -91,9 +84,9 @@ export const Widget = () => {
         onLoad={handleLoad}
         style={{
           width: "100%",
+          height: "100%",
           border: "none",
           display: "block",
-          maxHeight: "300px",
         }}
         sandbox="allow-scripts allow-same-origin"
         title="html-preview"


### PR DESCRIPTION
![Kapture 2026-01-13 at 15 57 14](https://github.com/user-attachments/assets/24296b47-fdab-483b-814d-96c1053be452)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR refactors the devtools layout to make all borders resizable using nested `react-resizable-panels` Groups. The main changes include:

**Layout Restructure:**
- Wraps the entire panel in a vertical main Group to enable top/bottom resizing
- Converts the previously fixed-height widget section (h-[60%]) into a fully resizable panel system
- Creates three levels of nested Groups: main vertical split → horizontal inspector split → vertical widget/logs split
- Adds three new `useDefaultLayout` hooks with unique localStorage keys for persisting each section's layout

**Widget Changes:**
- Removes the ResizeObserver that dynamically adjusted iframe height based on content
- Changes iframe from auto-height (max 300px) to 100% height to work with the resizable panel system
- Iframe now fills its parent panel and users can resize the panel itself

The implementation properly uses unique Panel IDs and storage keys for each Group, ensuring layout state is correctly persisted across sessions. The nesting structure follows react-resizable-panels best practices with appropriate Separators between panels.

### Confidence Score: 5/5

- Safe to merge - clean refactoring with no bugs or breaking changes
- The PR correctly implements a nested resizable panel structure with proper use of unique Panel IDs and storage keys. The removal of ResizeObserver and transition to percentage-based sizing is intentional and correct for the resizable panels feature. All conditional rendering logic is preserved, and the nesting structure follows react-resizable-panels best practices.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->