### PR TITLE
fix: use MemoryRouter in capital widget

### DIFF
--- a/examples/capitals/web/src/widgets/capital.tsx
+++ b/examples/capitals/web/src/widgets/capital.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { mountWidget, useDisplayMode } from "skybridge/web";
 import { Spinner } from "@/components/ui/shadcn-io/spinner/index.js";
 import { useCallTool, useToolInfo } from "../helpers.js";
@@ -105,13 +105,13 @@ function CapitalExplorer() {
 
 function CapitalWidget() {
   return (
-    <BrowserRouter>
+    <MemoryRouter initialEntries={["/"]}>
       <Routes>
         <Route path="/" element={<CapitalExplorer />}>
           <Route path="/:capitalName" element={<CapitalExplorer />} />
         </Route>
       </Routes>
-    </BrowserRouter>
+    </MemoryRouter>
   );
 }
 


### PR DESCRIPTION
So it's rendered correctly in MCPJam

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

Changed `BrowserRouter` to `MemoryRouter` to ensure the capital widget renders correctly in MCPJam Inspector and other embedded contexts.

- `MemoryRouter` keeps routing state in memory instead of manipulating browser URLs, making it more suitable for widgets embedded in iframes or external tools
- Added `initialEntries={["/"]}` to properly initialize the router at the root path
- This change improves widget portability across different rendering environments without affecting functionality

### Confidence Score: 5/5

- This PR is safe to merge with no risk - it's a straightforward router swap that improves widget compatibility
- The change from `BrowserRouter` to `MemoryRouter` is appropriate for embedded widget contexts and follows React Router best practices. The implementation is correct with proper `initialEntries` configuration. No functionality is lost, and the change specifically addresses the rendering issue in MCPJam mentioned in the PR description.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->