### PR TITLE
feat: add examples to docs

### DIFF
--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -66,6 +66,14 @@ Ready to build your first ChatGPT App with Skybridge? Choose your path:
   </div>
 </div>
 
+## Example Projects
+
+| Example                                                                 | Source Code | Live Demo                                                              |
+|-------------------------------------------------------------------------|-------------|------------------------------------------------------------------------|
+| **Capitals Explorer** – Interactive world map with capital city details | [examples/capitals](https://github.com/alpic-ai/skybridge/tree/main/examples/capitals) | [capitals.skybridge.tech/mcp](https://capitals.skybridge.tech/mcp)     |
+| **Ecommerce Carousel** – Product carousel with cart and checkout        | [examples/ecom-carousel](https://github.com/alpic-ai/skybridge/tree/main/examples/ecom-carousel) | [ecommerce.skybridge.tech/mcp](https://ecommerce.skybridge.tech/mcp)   |
+| **Everything** – Playground showcasing all Skybridge hooks & features   | [examples/everything](https://github.com/alpic-ai/skybridge/tree/main/examples/everything) | [everything.skybridge.tech/mcp](https://everything.skybridge.tech/mcp) |
+
 ## Want to dig deeper?
 
 <div className="card-grid">


### PR DESCRIPTION
This PR adds example app references to the Skybridge doc in the Introduction section.

<img width="861" height="316" alt="image" src="https://github.com/user-attachments/assets/a6fc44da-f780-4eb1-91c2-5544a646f701" />

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

Added an "Example Projects" section to the documentation with a markdown table linking to three example applications (Capitals Explorer, Ecommerce Carousel, and Everything) along with their source code locations and live demo URLs.

- All example directories exist and are correctly referenced
- Descriptions accurately reflect the content of each example based on their README files
- Links follow the correct format pointing to GitHub source and live demo URLs
- Table formatting is clean and consistent with documentation style

### Confidence Score: 5/5

- This PR is safe to merge with minimal risk
- The change is a straightforward documentation update that adds an example projects table. All referenced directories exist, descriptions are accurate, and the markdown formatting is correct. There are no code changes, no logical errors, and no potential runtime issues.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->