### PR TITLE
Replace skybridge commands in examples

### DIFF
--- a/examples/capitals/package.json
+++ b/examples/capitals/package.json
@@ -6,8 +6,8 @@
   "type": "module",
   "scripts": {
     "dev": "skybridge",
-    "build": "vite build -c web/vite.config.ts && shx rm -rf dist && tsc -p tsconfig.server.json && mkdir -p dist/assets && shx cp -r web/dist/. dist/assets",
-    "start": "node dist/index.js",
+    "build": "skybridge build",
+    "start": "skybridge start",
     "inspector": "mcp-inspector http://localhost:3000/mcp",
     "server:build": "tsc -p tsconfig.server.json",
     "server:start": "node dist/index.js",

--- a/examples/capitals/server/src/index.ts
+++ b/examples/capitals/server/src/index.ts
@@ -45,11 +45,6 @@ app.listen(3000, (error) => {
     console.error("Failed to start server:", error);
     process.exit(1);
   }
-
-  console.log(`Server listening on port 3000 - ${env.NODE_ENV}`);
-  console.log(
-    "Make your local server accessible with 'ngrok http 3000' and connect to ChatGPT with URL https://xxxxxx.ngrok-free.app/mcp",
-  );
 });
 
 process.on("SIGINT", async () => {

--- a/examples/ecom-carousel/package.json
+++ b/examples/ecom-carousel/package.json
@@ -6,8 +6,8 @@
   "type": "module",
   "scripts": {
     "dev": "skybridge",
-    "build": "vite build -c web/vite.config.ts && shx rm -rf dist && tsc -p tsconfig.server.json && mkdir -p dist/assets && shx cp -r web/dist/. dist/assets",
-    "start": "node dist/index.js",
+    "build": "skybridge build",
+    "start": "skybridge start",
     "inspector": "mcp-inspector http://localhost:3000/mcp",
     "server:build": "tsc -p tsconfig.server.json",
     "server:start": "node dist/index.js",

--- a/examples/ecom-carousel/server/src/index.ts
+++ b/examples/ecom-carousel/server/src/index.ts
@@ -23,15 +23,6 @@ app.listen(3000, (error) => {
     console.error("Failed to start server:", error);
     process.exit(1);
   }
-
-  console.log(`Server listening on port 3000 - ${env}`);
-  console.log(
-    "Make your local server accessible with 'ngrok http 3000' and connect to ChatGPT with URL https://xxxxxx.ngrok-free.app/mcp",
-  );
-
-  if (env !== "production") {
-    console.log("Devtools available at http://localhost:3000");
-  }
 });
 
 process.on("SIGINT", async () => {

--- a/examples/everything/package.json
+++ b/examples/everything/package.json
@@ -6,8 +6,8 @@
   "type": "module",
   "scripts": {
     "dev": "skybridge",
-    "build": "vite build -c web/vite.config.ts && shx rm -rf dist && tsc -p tsconfig.server.json && mkdir -p dist/assets && shx cp -r web/dist/. dist/assets",
-    "start": "node dist/index.js",
+    "build": "skybridge build",
+    "start": "skybridge start",
     "inspector": "mcp-inspector http://localhost:3000/mcp",
     "server:build": "tsc -p tsconfig.server.json",
     "server:start": "node dist/index.js",

--- a/examples/everything/server/src/index.ts
+++ b/examples/everything/server/src/index.ts
@@ -23,15 +23,6 @@ app.listen(3000, (error) => {
     console.error("Failed to start server:", error);
     process.exit(1);
   }
-
-  console.log(`Server listening on port 3000 - ${env}`);
-  console.log(
-    "Make your local server accessible with 'ngrok http 3000' and connect to ChatGPT with URL https://xxxxxx.ngrok-free.app/mcp",
-  );
-
-  if (env !== "production") {
-    console.log("Devtools available at http://localhost:3000");
-  }
 });
 
 process.on("SIGINT", async () => {

--- a/packages/create-skybridge/template/server/src/index.ts
+++ b/packages/create-skybridge/template/server/src/index.ts
@@ -34,15 +34,6 @@ app.listen(3000, (error) => {
     console.error("Failed to start server:", error);
     process.exit(1);
   }
-
-  console.log(`Server listening on port 3000 - ${env}`);
-  console.log(
-    "Make your local server accessible with 'ngrok http 3000' and connect to ChatGPT with URL https://xxxxxx.ngrok-free.app/mcp",
-  );
-
-  if (env !== "production") {
-    console.log("Devtools available at http://localhost:3000");
-  }
 });
 
 process.on("SIGINT", async () => {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR modernizes the build and start scripts across all examples and the project template by replacing manual command chains with dedicated `skybridge build` and `skybridge start` CLI commands. The changes consolidate complex build steps (vite build, TypeScript compilation, asset copying) into a single command and delegate user-facing messaging to the CLI. Console.log statements for server startup information (port, environment, ngrok instructions, devtools URL) are removed from the application code since the skybridge CLI now displays this information in a formatted way.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risks
- The changes are straightforward refactoring that replaces manual build commands with equivalent CLI commands. The build steps in `skybridge build` match the old manual commands exactly, and the `skybridge start` command properly runs the production server. Removed console.log statements are superseded by the CLI's formatted output. No functional behavior changes.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->