### PR TITLE
chore: use new doc url

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The fullstack TypeScript framework for ChatGPT Apps.<br />
 
 <br />
 
-[Documentation](https://skybridge.tech) · [Quick Start](https://github.com/new?template_name=apps-sdk-template&template_owner=alpic-ai) · [Examples](https://github.com/alpic-ai/apps-sdk-template)
+[Documentation](https://docs.skybridge.tech) · [Quick Start](https://github.com/new?template_name=apps-sdk-template&template_owner=alpic-ai) · [Examples](https://github.com/alpic-ai/apps-sdk-template)
 
 </div>
 
@@ -58,7 +58,7 @@ deno add skybridge
 
 <div align="center">
 
-**👉 [Read the Docs](https://skybridge.tech) 👈**
+**👉 [Read the Docs](https://docs.skybridge.tech) 👈**
 
 </div>
 

--- a/examples/everything/web/src/widgets/widget.tsx
+++ b/examples/everything/web/src/widgets/widget.tsx
@@ -85,7 +85,7 @@ function Widget() {
           type="button"
           className="btn btn-outline muted btn-small"
           onClick={() =>
-            openExternal(`https://www.skybridge.tech/api-reference/${docPath}`)
+            openExternal(`https://docs.skybridge.tech/api-reference/${docPath}`)
           }
         >
           ↗ See in docs

--- a/packages/core/src/commands/dev.tsx
+++ b/packages/core/src/commands/dev.tsx
@@ -55,7 +55,7 @@ export default class Dev extends Command {
               <Text color="#20a832">→{"  "}</Text>
               <Text>Documentation: </Text>
               <Text color="white" bold>
-                https://skybridge.tech/
+                https://docs.skybridge.tech/
               </Text>
             </Text>
           </Box>

--- a/packages/devtools/src/components/layout/header.tsx
+++ b/packages/devtools/src/components/layout/header.tsx
@@ -38,7 +38,7 @@ export const Header = () => {
         <div className="flex items-center gap-2">
           <Button variant="ghost" size="sm" className="h-8 gap-2">
             <a
-              href="https://www.skybridge.tech/"
+              href="https://docs.skybridge.tech/"
               target="_blank"
               rel="noopener noreferrer"
               className="flex items-center gap-2"


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Updated documentation URLs from `skybridge.tech` to `docs.skybridge.tech` across README and core packages. This aligns with the new documentation domain structure.

**Changes:**
- Updated README.md documentation links (2 occurrences)
- Updated dev command console output URL
- Updated devtools header link

**Issue Found:**
- Missed one documentation URL in `examples/everything/web/src/widgets/widget.tsx:88` that still references the old domain

<h3>Confidence Score: 3/5</h3>


- This PR is safe to merge but has one incomplete URL update
- The changes are straightforward URL updates with no logic changes. However, the PR is incomplete as it missed updating one documentation URL in the examples directory, which could lead to users accessing the wrong documentation URL from that widget.
- Check `examples/everything/web/src/widgets/widget.tsx` for the missed URL update

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->