### PR TITLE
doc: improve readme, showcase

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Skybridge
 
-Thank you for your interest in contributing to Skybridge! Every contribution helps make this framework better for everyone building ChatGPT apps.
+Thank you for your interest in contributing to Skybridge! Every contribution helps make this framework better for everyone building ChatGPT and MCP Apps.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -65,10 +65,12 @@ deno add skybridge
 
 <br />
 
-## 📦 The Stack
+## 📦 Architecture
 
-- **`skybridge/server`** — Drop-in MCP SDK replacement with widget registration and type inference.
-- **`skybridge/web`** — React hooks for Apps SDK (ChatGPT) and MCP Apps runtimes.
+Skybridge is a fullstack framework with unified server and client modules:
+
+- **`skybridge/server`** — Define tools and widgets with full type inference. Extends the MCP SDK.
+- **`skybridge/web`** — React hooks that consume your server types. Works with Apps SDK (ChatGPT) and MCP Apps.
 - **Dev Environment** — Vite plugin with HMR, DevTools emulator, and optimized builds.
 
 ### Server
@@ -116,9 +118,11 @@ function FlightsWidget() {
 
 Explore production-ready examples:
 
-- **[Capitals Explorer](https://capitals.skybridge.tech/try)** — Interactive world map with geolocation and Wikipedia integration
-- **[Ecommerce Carousel](https://ecommerce.skybridge.tech/try)** — Product carousel with cart, localization, and modals
-- **[Everything](https://everything.skybridge.tech/try)** — Comprehensive playground showcasing all hooks and features
+| Example | Description | Demo | Code |
+|---------|-------------|------|------|
+| **Capitals Explorer** | Interactive world map with geolocation and Wikipedia integration | [Try Demo](https://capitals.skybridge.tech/try) | [View Code](https://github.com/alpic-ai/skybridge/tree/main/examples/capitals) |
+| **Ecommerce Carousel** | Product carousel with cart, localization, and modals | [Try Demo](https://ecommerce.skybridge.tech/try) | [View Code](https://github.com/alpic-ai/skybridge/tree/main/examples/ecom-carousel) |
+| **Everything** | Comprehensive playground showcasing all hooks and features | [Try Demo](https://everything.skybridge.tech/try) | [View Code](https://github.com/alpic-ai/skybridge/tree/main/examples/everything) |
 
 See all examples in the [Showcase](https://docs.skybridge.tech/showcase) or browse the [examples/](examples/) directory.
 

--- a/context7.json
+++ b/context7.json
@@ -3,7 +3,7 @@
   "url": "https://context7.com/alpic-ai/skybridge",
   "public_key": "pk_QmCV6r1eoYWNTIq1jxP0h",
   "projectTitle": "Skybridge",
-  "description": "Fullstack TypeScript framework for building ChatGPT Apps with type safety, React hooks, and HMR",
+  "description": "Fullstack TypeScript framework for building ChatGPT and MCP Apps with type safety, React hooks, and HMR",
   "folders": ["docs/docs", "examples"],
   "excludeFolders": [
     "node_modules",
@@ -37,7 +37,7 @@
     "Use React hooks from skybridge/web (useToolInfo, useCallTool, useWidgetState, useLayout, useUser) instead of raw window.openai APIs for better state management",
     "Use useToolInfo for initial data hydration - it provides the data from the tool call that rendered the widget",
     "Use useCallTool for user-triggered actions only - do NOT call tools on mount, pass initial data through structuredContent instead",
-    "Use the data-llm attribute on DOM elements to sync UI state with the ChatGPT model, enabling contextual responses",
+    "Use the data-llm attribute on DOM elements to sync UI state with the model, enabling contextual responses",
     "Widget endpoint names must match widget file names exactly (e.g., 'pokemon-card' endpoint requires 'pokemon-card.tsx' file in web/src/widgets/)",
     "Use Zod schemas for input and output validation in widget registration (inputSchema and outputSchema)",
     "Use generateHelpers to create fully typed hooks with autocomplete - import AppType from server and call generateHelpers<AppType>()",

--- a/docs/api-reference/data-llm.mdx
+++ b/docs/api-reference/data-llm.mdx
@@ -1,10 +1,10 @@
 ---
 title: data-llm Attribute
-description: "Create a feedback loop between your widget UI state and ChatGPT for contextual responses."
+description: "Create a feedback loop between your widget UI state and the model for contextual responses."
 ---
 
 
-The `data-llm` attribute allows your widget to communicate its current UI state back to the ChatGPT model. This creates a feedback loop where the model can understand what the user is seeing and respond contextually to their questions.
+The `data-llm` attribute allows your widget to communicate its current UI state back to the model. This creates a feedback loop where the model can understand what the user is seeing and respond contextually to their questions.
 
 ## Basic usage
 
@@ -44,7 +44,7 @@ export function FlightWidget() {
 
 ## Why it exists
 
-ChatGPT Apps introduce a unique challenge: the model needs to understand both the conversation history **and** what the user is currently viewing in your widget. Without `data-llm`, the model only knows about the initial tool call that rendered your widget. As users interact with your UI, the model remains unaware of state changes unless you explicitly sync them.
+Apps introduce a unique challenge: the model needs to understand both the conversation history **and** what the user is currently viewing in your widget. Without `data-llm`, the model only knows about the initial tool call that rendered your widget. As users interact with your UI, the model remains unaware of state changes unless you explicitly sync them.
 
 **Example scenario:**
 1. User asks "Show me flights to Paris"
@@ -391,7 +391,7 @@ Avoid `data-llm` when:
 2. Each component gets a unique ID and registers itself in a global map
 3. When content changes, the entire tree is traversed and formatted
 4. The formatted string is stored in `window.openai.widgetState.__widget_context`
-5. ChatGPT reads this value and includes it in the model's context
+5. The host reads this value and includes it in the model's context
 
 ### Component lifecycle
 

--- a/docs/api-reference/register-widget.mdx
+++ b/docs/api-reference/register-widget.mdx
@@ -1,6 +1,6 @@
 ---
 title: registerWidget
-description: "Register an interactive widget with React UI that renders in ChatGPT's iframe environment."
+description: "Register an interactive widget with React UI that renders in the host's iframe environment."
 ---
 
 
@@ -253,7 +253,7 @@ server.registerWidget("user-profile", {
 
 ## CSP & Domains
 
-ChatGPT apps run widgets in a sandboxed iframe with strict Content Security Policy. If your widget needs to:
+Apps run widgets in a sandboxed iframe with strict Content Security Policy. If your widget needs to:
 - **Fetch data from external APIs** → add to `connectDomains`
 - **Load images, fonts, or scripts from CDNs** → add to `resourceDomains`
 - **Embed external iframes** → add to `frameDomains`

--- a/docs/concepts/data-flow.mdx
+++ b/docs/concepts/data-flow.mdx
@@ -1,10 +1,10 @@
 ---
 title: Data Flow
-description: "Learn how data moves between ChatGPT, your MCP server, and widgets in Skybridge applications."
+description: "Learn how data moves between the host, your MCP server, and widgets in Skybridge applications."
 ---
 
 
-**Problem:** ChatGPT Apps involve three actors (ChatGPT, your server, your widget) communicating in complex patterns. Understanding this flow is essential.
+**Problem:** Apps involve three actors (the host, your server, your widget) communicating in complex patterns. Understanding this flow is essential.
 
 **Solution:** Skybridge provides clear abstractions for each communication pattern.
 
@@ -29,9 +29,9 @@ flowchart LR
     style Server fill:#2d7a9a,stroke:#1e6a87,color:#fff
 ```
 
-1. **ChatGPT (Host)**: The conversational interface where users type messages and the model responds
+1. **The Host**: The conversational interface where users type messages and the model responds (ChatGPT, Goose, etc.)
 2. **Your MCP Server**: The backend that exposes tools and business logic
-3. **Your Widget (Guest)**: The React component rendered in an iframe inside ChatGPT
+3. **Your Widget (Guest)**: The React component rendered in an iframe inside the host
 
 ## Key Terms
 
@@ -71,7 +71,7 @@ server.registerWidget("chart", { /* ... */ }, { /* ... */ }, async (args) => {
 
 ### 1. Tool → Widget (Initial Hydration)
 
-When ChatGPT calls one of your widgets, it returns `structuredContent` to hydrate the React component:
+When the host calls one of your widgets, it returns `structuredContent` to hydrate the React component:
 
 **Server:**
 ```typescript
@@ -180,7 +180,7 @@ This creates a continuous loop: the widget can ask the model for help, and the m
 - **`data-llm`**: For passive context—the model reads it when the user asks a question
 - **`sendFollowUpMessage`**: For active prompts—triggers a new model response immediately
 
-If the model's response triggers another widget, ChatGPT renders a new widget instance (not nested inside the current one).
+If the model's response triggers another widget, the host renders a new widget instance (not nested inside the current one).
 </Tip>
 
 ## Response Fields Explained
@@ -189,7 +189,7 @@ Tool responses have three fields:
 
 | Field | Purpose | Consumed by |
 |-------|---------|-------------|
-| `content` | Text description for the model | ChatGPT (shown in conversation) |
+| `content` | Text description for the model | The host (shown in conversation) |
 | `structuredContent` | Typed data for the widget | Widget (`useToolInfo`, `useCallTool`) |
 | `_meta` | Response metadata | Both (optional) |
 
@@ -230,16 +230,16 @@ Direct API calls don't add to context. Use them only for data the model doesn't 
 <Warning>
 **Direct fetch requires CSP configuration**
 
-If you use `fetch()` directly from widgets, you need to configure Content Security Policy (CSP) headers. ChatGPT blocks requests to domains not explicitly allowed. Add allowed domains to `connectDomains` in your widget configuration. See [registerWidget](/api-reference/register-widget).
+If you use `fetch()` directly from widgets, you need to configure Content Security Policy (CSP) headers. The host blocks requests to domains not explicitly allowed. Add allowed domains to `connectDomains` in your widget configuration. See [registerWidget](/api-reference/register-widget).
 </Warning>
 
 ## The Communication Loop
 
-1. **ChatGPT calls your tool** → Server responds with `structuredContent`
+1. **Host calls your tool** → Server responds with `structuredContent`
 2. **Widget hydrates** with [`useToolInfo`](/api-reference/use-tool-info)
 3. **User interacts** → Widget updates `data-llm` → Model sees the context
 4. **User triggers action** → Widget calls [`useCallTool`](/api-reference/use-call-tool) → Server responds
-5. **Widget sends follow-up** → [`useSendFollowUpMessage`](/api-reference/use-send-follow-up-message) → ChatGPT replies
+5. **Widget sends follow-up** → [`useSendFollowUpMessage`](/api-reference/use-send-follow-up-message) → Model replies
 
 This loop creates a seamless experience where the conversation, the UI, and your backend work together.
 

--- a/docs/concepts/fast-iteration.mdx
+++ b/docs/concepts/fast-iteration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Fast Iteration
-description: "Develop ChatGPT Apps locally with Skybridge's emulator and Vite HMR for instant feedback without ngrok."
+description: "Develop Apps locally with Skybridge's emulator and Vite HMR for instant feedback without ngrok."
 ---
 
 
@@ -10,7 +10,7 @@ description: "Develop ChatGPT Apps locally with Skybridge's emulator and Vite HM
 
 ## The Challenge
 
-When building ChatGPT Apps the traditional way, your development loop looks like:
+When building Apps the traditional way, your development loop looks like:
 
 1. Make a code change
 2. Restart your server

--- a/docs/concepts/llm-context-sync.mdx
+++ b/docs/concepts/llm-context-sync.mdx
@@ -10,7 +10,7 @@ description: "Keep the LLM informed about widget state with data-llm attributes 
 
 ## The Dual Interaction Surface
 
-ChatGPT Apps have a unique challenge: **two interaction surfaces**.
+Apps have a unique challenge: **two interaction surfaces**.
 
 ```mermaid
 flowchart TB
@@ -62,7 +62,7 @@ export function FlightWidget() {
 }
 ```
 
-Now when the user asks about "this one", ChatGPT appends this context to the conversation:
+Now when the user asks about "this one", the host appends this context to the conversation:
 
 ```
 Widget context:
@@ -80,7 +80,7 @@ The model can now understand "this one" = Flight AF123.
 2. **Runtime**: `DataLLM` components register their content in a global tree
 3. **State sync**: When content changes, the tree generates a hierarchical string
 4. **Model context**: This string is stored in `window.openai.widgetState.__widget_context`
-5. **LLM reads**: ChatGPT includes this context when generating responses
+5. **LLM reads**: The host includes this context when generating responses
 
 ```tsx
 // What you write:
@@ -132,7 +132,7 @@ User selects flight → `data-llm`. User clicks "Book" → `sendFollowUpMessage`
 <div data-llm="User is logged in">
 ```
 
-**Why?** The `data-llm` content is sent to ChatGPT's servers and included in the model's context. Avoid exposing tokens, passwords, internal IDs, or any data you wouldn't want in a prompt.
+**Why?** The `data-llm` content is sent to the host's servers and included in the model's context. Avoid exposing tokens, passwords, internal IDs, or any data you wouldn't want in a prompt.
 
 ### Don't: Sync everything
 
@@ -197,7 +197,7 @@ window.openai.widgetState = {
 This key is:
 - Automatically managed by `DataLLM` components
 - Filtered out when you use `useWidgetState` (you only see your own state)
-- Read by ChatGPT when the user sends a message (passive context)
+- Read by the host when the user sends a message (passive context)
 
 ## Example: Multi-step Wizard
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -82,7 +82,7 @@
           {
             "group": "Resources",
             "icon": "circle-question",
-            "pages": ["showcase", "faq"]
+            "pages": ["faq"]
           }
         ]
       },
@@ -139,6 +139,16 @@
               "api-reference/use-apps-sdk-context",
               "api-reference/use-mcp-app-context"
             ]
+          }
+        ]
+      },
+      {
+        "tab": "Showcase",
+        "groups": [
+          {
+            "group": "Showcase",
+            "icon": "star",
+            "pages": ["showcase"]
           }
         ]
       }

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -1,6 +1,6 @@
 ---
 title: FAQ
-description: "Common questions and troubleshooting for Skybridge type safety, deployment, and ChatGPT App development."
+description: "Common questions and troubleshooting for Skybridge type safety, deployment, and App development."
 ---
 
 # Frequently Asked Questions

--- a/docs/guides/communicating-with-model.mdx
+++ b/docs/guides/communicating-with-model.mdx
@@ -60,7 +60,7 @@ function FlightWidget() {
 }
 ```
 
-The message appears in the conversation as if the user typed it, and ChatGPT responds naturally.
+The message appears in the conversation as if the user typed it, and the model responds naturally.
 
 ### Use Cases
 

--- a/docs/guides/fetching-data.mdx
+++ b/docs/guides/fetching-data.mdx
@@ -15,7 +15,7 @@ How to get data into your widget and fetch more when the user interacts.
 
 ## Initial Hydration with useToolInfo
 
-When ChatGPT calls your widget's tool, the server returns `structuredContent`. Access it with `useToolInfo`:
+When the host calls your widget's tool, the server returns `structuredContent`. Access it with `useToolInfo`:
 
 ```tsx
 import { useToolInfo } from "skybridge/web";

--- a/docs/guides/host-environment-context.mdx
+++ b/docs/guides/host-environment-context.mdx
@@ -1,10 +1,10 @@
 ---
 title: Host Environment Context
-description: "Adapt your widget to ChatGPT's theme, locale, display mode, and device with environment hooks."
+description: "Adapt your widget to the host's theme, locale, display mode, and device with environment hooks."
 ---
 
 
-How to make your widget adapt to ChatGPT's theme, locale, display mode, and device.
+How to make your widget adapt to the host's theme, locale, display mode, and device.
 
 ## Available Hooks
 
@@ -18,7 +18,7 @@ How to make your widget adapt to ChatGPT's theme, locale, display mode, and devi
 
 ## Theme Adaptation with useLayout
 
-Match ChatGPT's light/dark theme:
+Match the host's light/dark theme:
 
 ```tsx
 import { useLayout } from "skybridge/web";

--- a/docs/guides/managing-state.mdx
+++ b/docs/guides/managing-state.mdx
@@ -15,7 +15,7 @@ What kind of state do you need?
 │   (The model needs to know what user is viewing)
 │
 ├── Simple key/value state? → useWidgetState
-│   (Form inputs, selected items, flags — persisted in ChatGPT)
+│   (Form inputs, selected items, flags — persisted by the host)
 │
 └── Complex state with actions? → createStore
     (Multiple related values, computed state, async actions)
@@ -23,7 +23,7 @@ What kind of state do you need?
 
 ## useWidgetState
 
-Persistent state that survives re-renders and display mode changes. Unlike React's `useState`, this state is stored by ChatGPT and restored when your widget remounts.
+Persistent state that survives re-renders and display mode changes. Unlike React's `useState`, this state is stored by the host and restored when your widget remounts.
 
 ```tsx
 import { useWidgetState } from "skybridge/web";
@@ -85,7 +85,7 @@ const toggleItem = (id: string) => {
 
 ## createStore
 
-A Zustand store that automatically syncs with ChatGPT's persistent state. Unlike `useWidgetState`, this provides actions, computed values, and middleware support for complex state management.
+A Zustand store that automatically syncs with the host's persistent state. Unlike `useWidgetState`, this provides actions, computed values, and middleware support for complex state management.
 
 ```tsx
 import { createStore } from "skybridge/web";

--- a/docs/home.mdx
+++ b/docs/home.mdx
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: "Build production-ready ChatGPT Apps faster with full-stack TypeScript tooling and modern developer experience."
+description: "Build production-ready ChatGPT and MCP Apps faster with full-stack TypeScript tooling and modern developer experience."
 ---
 
 **Skybridge is a modular framework for quickly building ChatGPT and MCP Apps, the _modern TypeScript way_.**
@@ -17,11 +17,11 @@ OpenAI announced the [ChatGPT Apps SDK](https://developers.openai.com/apps-sdk) 
 
 In addition, these apps introduce a new challenge: building for **dual interaction surfaces**. With widgets interacting with both the user and the model, you need to make sure everything the user sees and does in the UI is also shared with the model, and vice-versa.
 
-<img src="/images/chatgpt-apps-interaction.png" alt="ChatGPT Apps architecture" style={{maxWidth: '500px', width: '100%', display: 'block', margin: '0 auto'}} />
+<img src="/images/chatgpt-apps-interaction.png" alt="Apps architecture" style={{maxWidth: '500px', width: '100%', display: 'block', margin: '0 auto'}} />
 
 Finally, there are no developer tools or environment. Developers can test their apps only inside ChatGPT Developer mode, which has infinite caching policies, no hot module replacement, and requires you to refresh or re-install your app to test any change - losing precious minutes at each small iteration.
 
-After building dozens of ChatGPT Apps, we quickly saw repeating patterns and frustrations, and realized developers were spending too much time stitching together SDKs and managing low-level wiring instead of focusing on their product.
+After building dozens of Apps, we quickly saw repeating patterns and frustrations, and realized developers were spending too much time stitching together SDKs and managing low-level wiring instead of focusing on their product.
 
 We built Skybridge so other developers wouldn't have to deal with these same frustrations. Our goal is to bring full-stack development standards back into ChatGPT and MCP Apps and help teams ship production-ready apps much faster.
 

--- a/docs/quickstart/add-to-existing-app/web.mdx
+++ b/docs/quickstart/add-to-existing-app/web.mdx
@@ -1,6 +1,6 @@
 ---
 title: Use skybridge/web
-description: "Add React hooks and utilities to your ChatGPT App widgets with skybridge/web standalone package."
+description: "Add React hooks and utilities to your App widgets with skybridge/web standalone package."
 ---
 
 # Use skybridge/web
@@ -10,7 +10,7 @@ This guide shows you how to use `skybridge/web` without `skybridge/server` to ad
 ## Prerequisites
 
 You should already have:
-- A working ChatGPT app MCP server backend (in any technology)
+- A working MCP server backend (in any technology)
 - Node.js 24+
 
 ## Install
@@ -23,7 +23,7 @@ pnpm add skybridge
 
 ## Package overview
 
-`skybridge/web` provides React hooks and utilities for building advanced ChatGPT Apps:
+`skybridge/web` provides React hooks and utilities for building advanced Apps:
 
 ### State Management
 - **[`useToolInfo`](/api-reference/use-tool-info)**: Get initial tool input, output and metadata
@@ -100,11 +100,11 @@ const MyWidget: React.FC = () => {
 
 ## Learn more
 
-To learn more about how to build a ChatGPT App, please read the Core Concepts and Interaction Model sections below.
+To learn more about how to build an App, please read the Core Concepts and Interaction Model sections below.
 
 <CardGroup cols={3}>
   <Card title="MCP Fundamentals" icon="graduation-cap" href="/mcp-and-chatgpt-fundamentals">
-    Learn the fundamentals of MCP servers and ChatGPT Apps
+    Learn the fundamentals of MCP servers and Apps
   </Card>
   <Card title="Data Flow" icon="arrows-rotate" href="/concepts/data-flow">
     Understand how tools, widgets, and the model communicate

--- a/docs/quickstart/create-new-app.mdx
+++ b/docs/quickstart/create-new-app.mdx
@@ -79,8 +79,8 @@ This runs the `skybridge` command, which starts a development server with the fo
 
 The `skybridge` command:
 - **Starts an Express server** on port 3000 that packages:
-  - An MCP endpoint on `/mcp` - the ChatGPT App Backend
-  - A React application on Vite HMR dev server - the ChatGPT App Frontend
+  - An MCP endpoint on `/mcp` - the App Backend
+  - A React application on Vite HMR dev server - the App Frontend
 - **Watches for file changes** using nodemon, automatically restarting the server when you modify server-side code
 
 ### Development workflow
@@ -90,7 +90,7 @@ When you run `skybridge`:
 2. You can access **DevTools** at `http://localhost:3000/` to test your app locally
 3. The **MCP server** is available at `http://localhost:3000/mcp`
 4. **File watching** is enabled - changes to server code will automatically restart the server
-5. **Hot Module Reload (HMR)** is active for Widgets components - changes appear instantly in ChatGPT without reconnecting
+5. **Hot Module Reload (HMR)** is active for Widgets components - changes appear instantly in the host without reconnecting
 
 ## Next step
 

--- a/docs/quickstart/test-your-app.mdx
+++ b/docs/quickstart/test-your-app.mdx
@@ -63,7 +63,7 @@ Copy the forwarding URL (e.g., `https://abc123.ngrok-free.app`).
 
 ### Hot Module Reload
 
-Widget changes in `web/src/widgets/` appear instantly in ChatGPT without reconnecting.
+Widget changes in `web/src/widgets/` appear instantly without reconnecting.
 
 Server changes in `server/src/` require starting a new conversation to take effect.
 

--- a/docs/showcase.mdx
+++ b/docs/showcase.mdx
@@ -14,7 +14,9 @@ Explore real-world examples built with Skybridge. Each app demonstrates differen
 >
   Interactive world map with geolocation, country information from Wikipedia, and dynamic capital exploration.
 
-  <a href="https://github.com/alpic-ai/skybridge/tree/main/examples/capitals" target="_blank" onClick={(e) => e.stopPropagation()}><Icon icon="github" iconType="brands" /> View on GitHub</a>
+  <a href="https://capitals.skybridge.tech/try" target="_blank" onClick={(e) => e.stopPropagation()}><Icon icon="play" /> Try Demo</a>
+  <br />
+  <a href="https://github.com/alpic-ai/skybridge/tree/main/examples/capitals" target="_blank" onClick={(e) => e.stopPropagation()}><Icon icon="github" iconType="brands" /> View code on GitHub</a>
 </Card>
 
 <Card
@@ -24,7 +26,9 @@ Explore real-world examples built with Skybridge. Each app demonstrates differen
 >
   Product carousel with persistent cart, localization support, theme switching, and modal dialogs.
 
-  <a href="https://github.com/alpic-ai/skybridge/tree/main/examples/ecom-carousel" target="_blank" onClick={(e) => e.stopPropagation()}><Icon icon="github" iconType="brands" /> View on GitHub</a>
+  <a href="https://ecommerce.skybridge.tech/try" target="_blank" onClick={(e) => e.stopPropagation()}><Icon icon="play" /> Try Demo</a>
+  <br />
+  <a href="https://github.com/alpic-ai/skybridge/tree/main/examples/ecom-carousel" target="_blank" onClick={(e) => e.stopPropagation()}><Icon icon="github" iconType="brands" /> View code on GitHub</a>
 </Card>
 
 <Card
@@ -34,7 +38,9 @@ Explore real-world examples built with Skybridge. Each app demonstrates differen
 >
   Comprehensive playground showcasing all Skybridge hooks and features. The ultimate reference implementation.
 
-  <a href="https://github.com/alpic-ai/skybridge/tree/main/examples/everything" target="_blank" onClick={(e) => e.stopPropagation()}><Icon icon="github" iconType="brands" /> View on GitHub</a>
+  <a href="https://everything.skybridge.tech/try" target="_blank" onClick={(e) => e.stopPropagation()}><Icon icon="play" /> Try Demo</a>
+  <br />
+  <a href="https://github.com/alpic-ai/skybridge/tree/main/examples/everything" target="_blank" onClick={(e) => e.stopPropagation()}><Icon icon="github" iconType="brands" /> View code on GitHub</a>
 </Card>
 
 </CardGroup>

--- a/examples/capitals/README.md
+++ b/examples/capitals/README.md
@@ -4,7 +4,7 @@
 
 This capitals explorer example demonstrates key Skybridge capabilities:
 
-- **Interactive Widget Rendering**: A React-based widget that displays an interactive map of world capitals directly in ChatGPT
+- **Interactive Widget Rendering**: A React-based widget that displays an interactive map of world capitals directly in AI conversations
 - **Display Mode Switching**: Seamless transition between inline and fullscreen display modes using `useDisplayMode()`
 - **Tool Calling from Widgets**: Widgets can call server tools programmatically using `useCallTool()` to fetch additional data
 - **Tool Info Access**: Widgets access tool input, output, and metadata via `useToolInfo()` hook
@@ -69,7 +69,7 @@ bun dev
 This command starts an Express server on port 3000. This server packages:
 
 - an MCP endpoint on `/mcp` (the app backend)
-- a React application on Vite HMR dev server (the UI elements to be displayed in ChatGPT)
+- a React application on Vite HMR dev server (the UI elements to be displayed in the host)
 
 #### 4. Connect to ChatGPT
 

--- a/examples/ecom-carousel/README.md
+++ b/examples/ecom-carousel/README.md
@@ -2,7 +2,7 @@
 
 ## What This Example Showcases
 This "Ecommerce Carousel" example demonstrates key Skybridge capabilities:
-- **Interactive Widget Rendering**: A React-based widget that displays an interactive product carousel directly in ChatGPT
+- **Interactive Widget Rendering**: A React-based widget that displays an interactive product carousel directly in AI conversations
 - **Tool Info Access**: Widgets access tool input, output, and metadata via `useToolInfo()` hook
 - **Theme Support**: Adapts to light/dark mode using the `useLayout()` hook
 - **Localization**: Translates UI based on user locale via `useUser()` hook
@@ -55,7 +55,7 @@ bun dev
 This command starts an Express server on port 3000. This server packages:
 
 - an MCP endpoint on `/mcp` (the app backend)
-- a React application on Vite HMR dev server (the UI elements to be displayed in ChatGPT)
+- a React application on Vite HMR dev server (the UI elements to be displayed in the host)
 
 #### 3. Connect to ChatGPT
 
@@ -74,7 +74,7 @@ ngrok http 3000
 
 #### 2. Edit widgets with Hot Module Replacement (HMR)
 
-Edit and save components in `web/src/widgets/` — changes appear instantly in ChatGPT
+Edit and save components in `web/src/widgets/` — changes appear instantly in the host
 
 #### 3. Edit server code
 

--- a/examples/everything/README.md
+++ b/examples/everything/README.md
@@ -43,7 +43,7 @@ bun dev
 This command starts an Express server on port 3000. This server packages:
 
 - an MCP endpoint on `/mcp` (the app backend)
-- a React application on Vite HMR dev server (the UI elements to be displayed in ChatGPT)
+- a React application on Vite HMR dev server (the UI elements to be displayed in the host)
 
 #### 3. Connect to ChatGPT
 
@@ -62,7 +62,7 @@ ngrok http 3000
 
 #### 2. Edit widgets with Hot Module Replacement (HMR)
 
-Edit and save components in `web/src/widgets/` — changes appear instantly in ChatGPT
+Edit and save components in `web/src/widgets/` — changes appear instantly in the host
 
 #### 3. Edit server code
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@skybridge/monorepo",
   "version": "0.0.0",
-  "description": "Skybridge is a framework for building ChatGPT apps",
+  "description": "Skybridge is a framework for building ChatGPT and MCP Apps",
   "type": "module",
   "scripts": {
     "build": "pnpm --filter \"./packages/*\" build",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "skybridge",
   "version": "0.0.0",
-  "description": "Skybridge is a framework for building ChatGPT apps",
+  "description": "Skybridge is a framework for building ChatGPT and MCP Apps",
   "repository": {
     "type": "git",
     "url": "https://github.com/alpic-ai/skybridge.git"

--- a/packages/create-skybridge/template/README.md
+++ b/packages/create-skybridge/template/README.md
@@ -1,6 +1,6 @@
-# ChatGPT Apps SDK Alpic Starter
+# Skybridge Starter
 
-A minimal TypeScript template for building OpenAI Apps SDK compatible MCP servers with widget rendering in ChatGPT.
+A minimal TypeScript template for building ChatGPT and MCP Apps with widget rendering.
 
 ## Getting Started
 
@@ -40,7 +40,7 @@ bun dev
 This command starts an Express server on port 3000. This server packages:
 
 - an MCP endpoint on `/mcp` (the app backend)
-- a React application on Vite HMR dev server (the UI elements to be displayed in ChatGPT)
+- a React application on Vite HMR dev server (the UI elements to be displayed in the host)
 
 #### 3. Connect to ChatGPT
 
@@ -59,7 +59,7 @@ ngrok http 3000
 
 #### 2. Edit widgets with Hot Module Replacement (HMR)
 
-Edit and save components in `web/src/widgets/` — changes appear instantly in ChatGPT
+Edit and save components in `web/src/widgets/` — changes appear instantly in the host
 
 #### 3. Edit server code
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR reorganizes the documentation structure and enhances the showcase page by moving it to a dedicated tab and adding live demo links for each example app.

- Moved showcase from Resources group to its own top-level tab for better visibility
- Added "Try Demo" links to all three example apps (Capitals Explorer, Ecommerce Carousel, Everything)
- Improved link text clarity by changing "View on GitHub" to "View code on GitHub"
- Added line breaks between demo and code links for better formatting

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no issues
- Changes are purely documentation-related with valid JSON structure and consistent URL patterns. No code logic or security concerns.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->