### PR TITLE
Fix: Pass env to dev command

### DIFF
--- a/packages/core/src/commands/dev.tsx
+++ b/packages/core/src/commands/dev.tsx
@@ -17,6 +17,7 @@ export default class Dev extends Command {
     const { flags } = await this.parse(Dev);
 
     const env = {
+      ...process.env,
       ...(flags["use-forwarded-host"]
         ? { SKYBRIDGE_USE_FORWARDED_HOST: "true" }
         : {}),


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added `...process.env` spread to the env object in the dev command, ensuring that environment variables from the parent process are inherited by the spawned nodemon process. This aligns with the pattern already used in the `start.tsx` command (line 28) and prevents potential issues where nodemon might not have access to necessary environment variables like `PATH`, `NODE_OPTIONS`, or user-defined variables needed for the development server to run correctly.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is a straightforward bug fix that adds missing environment variable inheritance. The implementation matches the existing pattern in start.tsx, is correctly ordered (process.env spread comes first so explicit flags can override), and prevents potential runtime issues where the spawned process wouldn't have access to critical environment variables
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->