### PR TITLE
fix: hook imports

### DIFF
--- a/packages/core/src/web/hooks/use-files.ts
+++ b/packages/core/src/web/hooks/use-files.ts
@@ -1,4 +1,4 @@
-import { getAdaptor } from "../bridges";
+import { getAdaptor } from "../bridges/index.js";
 
 export function useFiles() {
   const adaptor = getAdaptor();

--- a/packages/core/src/web/hooks/use-request-modal.ts
+++ b/packages/core/src/web/hooks/use-request-modal.ts
@@ -3,7 +3,7 @@ import {
   getAdaptor,
   type RequestModalOptions,
   useHostContext,
-} from "../bridges";
+} from "../bridges/index.js";
 
 /**
  * Triggers a modal containing the widget rendered in display mode "modal"


### PR DESCRIPTION
Which should use the extension.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Updated import statements in `use-files.ts` and `use-request-modal.ts` to include the `.js` file extension (`../bridges/index.js`), which is required for ES modules when `"type": "module"` is set in `package.json`.

- Fixed two hook files to use explicit `.js` extensions in their imports
- One additional file (`modal-provider.tsx`) still needs the same fix

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minor incompleteness
- The changes are correct and necessary for ES module compatibility, but the fix is incomplete as one file was missed
- Verify that `modal-provider.tsx` also gets updated with the `.js` extension

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->