### PR TITLE
Handle state where server doesnt provide any tool

### DIFF
--- a/packages/devtools/src/components/layout/app-layout.tsx
+++ b/packages/devtools/src/components/layout/app-layout.tsx
@@ -1,10 +1,10 @@
-import { useSelectedToolOrNull } from "@/lib/mcp/index.js";
 import {
   Group,
   Panel,
   Separator,
   useDefaultLayout,
 } from "react-resizable-panels";
+import { useSelectedToolOrNull } from "@/lib/mcp/index.js";
 import { Header } from "./header.js";
 import { Intro } from "./intro.js";
 import { ToolPanel } from "./tool-panel/tool-panel.js";

--- a/packages/devtools/src/lib/mcp/client.ts
+++ b/packages/devtools/src/lib/mcp/client.ts
@@ -42,7 +42,6 @@ export class McpClient {
       // A server without any tool throws a "Method not found" error for listTools
       if (
         error instanceof Error &&
-        error.name === "McpError" &&
         error.message.includes("MCP error -32601: Method not found")
       ) {
         return [];


### PR DESCRIPTION
<img width="912" height="578" alt="image" src="https://github.com/user-attachments/assets/f29e2908-5767-4a61-a85d-27bbe25281a7" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added graceful handling for MCP servers that don't implement the `listTools` method by catching the "Method not found" error (JSON-RPC error -32601) and returning an empty array instead of throwing.

- Wrapped `client.listTools()` call in try-catch block in `packages/devtools/src/lib/mcp/client.ts:38-52`
- Updated empty state message in `tools-list.tsx:24` from "No tools available" to "No tools registered yet."
- Minor import reordering in `app-layout.tsx:1`

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk - it adds defensive error handling for edge cases
- The change properly handles an edge case where MCP servers don't provide tools. The error checking logic has a minor fragility (checking error.name) but will likely work in practice. The changes are isolated and improve user experience by preventing crashes.
- Review the error checking logic in `packages/devtools/src/lib/mcp/client.ts:44` - the error.name check may be fragile

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->