### PR TITLE
fix: Remove legacy commands in examples and template

### DIFF
--- a/examples/capitals/package.json
+++ b/examples/capitals/package.json
@@ -8,11 +8,7 @@
     "dev": "skybridge dev",
     "build": "skybridge build",
     "start": "skybridge start",
-    "inspector": "mcp-inspector http://localhost:3000/mcp",
-    "server:build": "tsc -p tsconfig.server.json",
-    "server:start": "node dist/index.js",
-    "web:build": "tsc -b web && vite build -c web/vite.config.ts",
-    "web:preview": "vite preview -c web/vite.config.ts"
+    "inspector": "mcp-inspector http://localhost:3000/mcp"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.2",

--- a/examples/ecom-carousel/package.json
+++ b/examples/ecom-carousel/package.json
@@ -8,11 +8,7 @@
     "dev": "skybridge dev",
     "build": "skybridge build",
     "start": "skybridge start",
-    "inspector": "mcp-inspector http://localhost:3000/mcp",
-    "server:build": "tsc -p tsconfig.server.json",
-    "server:start": "node dist/index.js",
-    "web:build": "tsc -b web && vite build -c web/vite.config.ts",
-    "web:preview": "vite preview -c web/vite.config.ts"
+    "inspector": "mcp-inspector http://localhost:3000/mcp"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.2",

--- a/examples/everything/package.json
+++ b/examples/everything/package.json
@@ -8,11 +8,7 @@
     "dev": "skybridge dev",
     "build": "skybridge build",
     "start": "skybridge start",
-    "inspector": "mcp-inspector http://localhost:3000/mcp",
-    "server:build": "tsc -p tsconfig.server.json",
-    "server:start": "node dist/index.js",
-    "web:build": "tsc -b web && vite build -c web/vite.config.ts",
-    "web:preview": "vite preview -c web/vite.config.ts"
+    "inspector": "mcp-inspector http://localhost:3000/mcp"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.1",

--- a/packages/create-skybridge/template/package.json
+++ b/packages/create-skybridge/template/package.json
@@ -8,11 +8,7 @@
     "dev": "skybridge dev",
     "build": "skybridge build",
     "start": "skybridge start",
-    "inspector": "mcp-inspector http://localhost:3000/mcp",
-    "server:build": "tsc -p tsconfig.server.json",
-    "server:start": "node dist/index.js",
-    "web:build": "tsc -b web && vite build -c web/vite.config.ts",
-    "web:preview": "vite preview -c web/vite.config.ts"
+    "inspector": "mcp-inspector http://localhost:3000/mcp"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.2",


### PR DESCRIPTION
Closes #310 

## Description:
Removes legacy commands `server"build`, `server:start`, `web:build`, `web:preview` from `packages/create-skybridge/template/package.json` and `examples/`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR removes legacy npm scripts (`server:build`, `server:start`, `web:build`, `web:preview`) from all example projects and the create-skybridge template. These commands are no longer needed as the Skybridge CLI now handles the build and start operations through the `skybridge build` and `skybridge start` commands. This cleanup resolves issue #310 where the `pnpm web:build` command was failing due to missing configuration files. The changes are consistent across all affected files (3 examples + 1 template) and maintain the essential `inspector` script while keeping the standardized `dev`, `build`, and `start` scripts.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no concerns - it safely removes deprecated scripts that are no longer used.
- Score of 5 reflects that this is a straightforward cleanup of deprecated npm scripts. The changes are consistent across all four files, no references to these commands exist in documentation or other code, and the removal directly resolves the reported issue #310. The changes maintain code formatting and structure while removing only the obsolete commands.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->