### PR TITLE
feat(everything): add GitHub code link to home tab #371

### DIFF
--- a/examples/everything/web/src/widgets/tabs/home-tab.tsx
+++ b/examples/everything/web/src/widgets/tabs/home-tab.tsx
@@ -16,7 +16,7 @@ export function HomeTab() {
           target="_blank"
           rel="noopener noreferrer"
         >
-          github.com/alpic-ai/skybridge/examples/everything
+          github.com/alpic-ai/skybridge/tree/main/examples/everything
         </a>
       </p>
     </div>


### PR DESCRIPTION
Closes #371

Added a message on the Home tab linking to the full code implementation of the everything example on GitHub.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added a link to the GitHub repository on the Home tab of the everything example app, directing users to the full code implementation. The change matches the requirements from issue #371 and follows React best practices with proper security attributes.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The change is minimal, well-implemented, and directly addresses the issue requirements. The link uses proper security attributes (`rel="noopener noreferrer"`), follows existing code patterns, and contains no logical errors or security vulnerabilities.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->