### PR TITLE
chore: remove shx dependency from skybridge projects

### DIFF
--- a/examples/capitals/package.json
+++ b/examples/capitals/package.json
@@ -38,7 +38,7 @@
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.4",
     "nodemon": "^3.1.10",
-    "shx": "^0.3.4",
+    "shx": "^0.4.0",
     "tsx": "^4.19.4",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.7.2",

--- a/packages/core/src/cli/use-execute-steps.ts
+++ b/packages/core/src/cli/use-execute-steps.ts
@@ -3,7 +3,8 @@ import { runCommand } from "./run-command.js";
 
 export interface CommandStep {
   label: string;
-  command: string;
+  command?: string;
+  run?: () => void | Promise<void>;
 }
 
 export const useExecuteSteps = (steps: CommandStep[]) => {
@@ -19,7 +20,12 @@ export const useExecuteSteps = (steps: CommandStep[]) => {
         const step = steps[i];
         if (step) {
           setCurrentStep(i);
-          await runCommand(step.command);
+          if (step.run) {
+            await step.run();
+          }
+          if (step.command) {
+            await runCommand(step.command);
+          }
         }
       }
       setStatus("success");

--- a/packages/core/src/commands/build.tsx
+++ b/packages/core/src/commands/build.tsx
@@ -1,3 +1,4 @@
+import { cpSync, rmSync } from "node:fs";
 import { Command } from "@oclif/core";
 import { Box, render, Text } from "ink";
 import { useEffect } from "react";
@@ -11,11 +12,12 @@ export const commandSteps: CommandStep[] = [
   },
   {
     label: "Compiling server",
-    command: "shx rm -rf dist && tsc -p tsconfig.server.json",
+    run: () => rmSync("dist", { recursive: true, force: true }),
+    command: "tsc -p tsconfig.server.json",
   },
   {
     label: "Copying static assets",
-    command: "shx cp -r web/dist dist/assets",
+    run: () => cpSync("web/dist", "dist/assets", { recursive: true }),
   },
 ];
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,8 +106,8 @@ importers:
         specifier: ^3.1.10
         version: 3.1.11
       shx:
-        specifier: ^0.3.4
-        version: 0.3.4
+        specifier: ^0.4.0
+        version: 0.4.0
       tsx:
         specifier: ^4.19.4
         version: 4.21.0
@@ -4305,9 +4305,6 @@ packages:
     resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
     engines: {node: '>= 8'}
 
-  fs.realpath@1.0.0:
-    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4412,10 +4409,6 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
-
-  glob@7.2.3:
-    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -4649,10 +4642,6 @@ packages:
   indent-string@5.0.0:
     resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
     engines: {node: '>=12'}
-
-  inflight@1.0.6:
-    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -5901,10 +5890,6 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
-  path-is-absolute@1.0.1:
-    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
-    engines: {node: '>=0.10.0'}
-
   path-is-inside@1.0.2:
     resolution: {integrity: sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==}
 
@@ -6617,11 +6602,6 @@ packages:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
 
-  shelljs@0.8.5:
-    resolution: {integrity: sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==}
-    engines: {node: '>=4'}
-    hasBin: true
-
   shelljs@0.9.2:
     resolution: {integrity: sha512-S3I64fEiKgTZzKCC46zT/Ib9meqofLrQVbpSswtjFfAVDW+AZ54WTnAM/3/yENoxz/V1Cy6u3kiiEbQ4DNphvw==}
     engines: {node: '>=18'}
@@ -6629,11 +6609,6 @@ packages:
 
   shiki@3.21.0:
     resolution: {integrity: sha512-N65B/3bqL/TI2crrXr+4UivctrAGEjmsib5rPMMPpFp1xAx/w03v8WZ9RDDFYteXoEgY7qZ4HGgl5KBIu1153w==}
-
-  shx@0.3.4:
-    resolution: {integrity: sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==}
-    engines: {node: '>=6'}
-    hasBin: true
 
   shx@0.4.0:
     resolution: {integrity: sha512-Z0KixSIlGPpijKgcH6oCMCbltPImvaKy0sGH8AkLRXw1KyzpKtaCTizP2xen+hNDqVF4xxgvA0KXSb9o4Q6hnA==}
@@ -13754,8 +13729,6 @@ snapshots:
     dependencies:
       minipass: 3.3.6
 
-  fs.realpath@1.0.0: {}
-
   fsevents@2.3.3:
     optional: true
 
@@ -13856,15 +13829,6 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
-
-  glob@7.2.3:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.2
-      once: 1.4.0
-      path-is-absolute: 1.0.1
 
   globals@14.0.0: {}
 
@@ -14218,11 +14182,6 @@ snapshots:
   indent-string@4.0.0: {}
 
   indent-string@5.0.0: {}
-
-  inflight@1.0.6:
-    dependencies:
-      once: 1.4.0
-      wrappy: 1.0.2
 
   inherits@2.0.4: {}
 
@@ -15898,8 +15857,6 @@ snapshots:
 
   path-exists@4.0.0: {}
 
-  path-is-absolute@1.0.1: {}
-
   path-is-inside@1.0.2: {}
 
   path-key@2.0.1: {}
@@ -16999,12 +16956,6 @@ snapshots:
 
   shell-quote@1.8.3: {}
 
-  shelljs@0.8.5:
-    dependencies:
-      glob: 7.2.3
-      interpret: 1.4.0
-      rechoir: 0.6.2
-
   shelljs@0.9.2:
     dependencies:
       execa: 1.0.0
@@ -17022,11 +16973,6 @@ snapshots:
       '@shikijs/types': 3.21.0
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
-
-  shx@0.3.4:
-    dependencies:
-      minimist: 1.2.8
-      shelljs: 0.8.5
 
   shx@0.4.0:
     dependencies:


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Replaces the `shx` cross-platform shell utility with native Node.js `fs` methods (`cpSync` and `rmSync`) in the build command to reduce external dependencies.

- Removed `shx` dependency from all example projects and the create-skybridge template
- Updated `use-execute-steps.ts` to support both `command` (string) and `run` (function) execution in steps
- Replaced `shx rm -rf` and `shx cp -r` commands in `build.tsx` with native `rmSync()` and `cpSync()` calls
- **Issue**: `packages/core/package.json` still references `shx` in both npm scripts and devDependencies - this needs to be completed

<h3>Confidence Score: 2/5</h3>


- PR is incomplete and will fail in production - `shx` is still used in core package build scripts
- The refactoring is sound and well-implemented where applied (build command), but the PR is incomplete. The `packages/core/package.json` still uses `shx` in its `prepublishOnly` and `build` scripts, and still has `shx` as a dependency. This means the dependency removal is only partial, and builds will fail when those scripts are executed after `shx` is removed from the lockfile.
- packages/core/package.json - still contains shx references that will break builds

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->