### PR TITLE
Fix: replaced shx dependency with native Node.js fs calls

### DIFF
--- a/packages/core/src/commands/build.tsx
+++ b/packages/core/src/commands/build.tsx
@@ -10,12 +10,16 @@ export const commandSteps: CommandStep[] = [
     command: "vite build -c web/vite.config.ts",
   },
   {
+    label: "Cleaning dist folder",
+    command: `node -e "require('fs').rmSync('dist', {recursive: true, force: true})"`,
+  },
+  {
     label: "Compiling server",
-    command: "shx rm -rf dist && tsc -p tsconfig.server.json",
+    command: "tsc -p tsconfig.server.json",
   },
   {
     label: "Copying static assets",
-    command: "shx cp -r web/dist dist/assets",
+    command: `node -e "require('fs').cpSync('web/dist', 'dist/assets', {recursive: true})"`
   },
 ];
 


### PR DESCRIPTION
**ISSUE:**
As described in #375, the build command failed for users who didn't have `shx` installed --> creates a hidden dependency that broke the Windows setup

**SOLUTION:**
I replaced external shell commands like `rm` and `cp` with native Node.js `fs` (File System module) operations: `fs.rmSync`, `fs.cpSync`, and separated the execution steps.

**OUTCOME:**
The build process is now self-reliant & cross-platform. Users do not need to install missing dependencies anymore.

***Related Issue:***
Fix #375

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Replaced `shx` dependency with native Node.js `fs` operations in the build command. The change removes a hidden dependency that was causing build failures on Windows for users who didn't have `shx` installed.

- Separated the cleanup step from TypeScript compilation for better clarity
- Used `fs.rmSync` with `{recursive: true, force: true}` to remove the `dist` folder
- Used `fs.cpSync` with `{recursive: true}` to copy static assets
- All operations are executed via `node -e` commands for cross-platform compatibility

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is straightforward and directly addresses the reported issue. Native Node.js `fs` methods (`rmSync` and `cpSync`) are well-tested, cross-platform alternatives to shell commands. The separation of the cleanup step improves clarity and maintainability. No logical errors or security concerns identified.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->