### PR TITLE
chore: remove shx from devdeps for examples

### DIFF
--- a/examples/capitals/package.json
+++ b/examples/capitals/package.json
@@ -22,7 +22,7 @@
     "react-dom": "^19.1.1",
     "react-map-gl": "^7.1.8",
     "react-router-dom": "^7.11.0",
-    "skybridge": ">=0.25.0 <1.0.0",
+    "skybridge": ">=0.26.0 <1.0.0",
     "tailwindcss": "^4.1.14",
     "tailwind-merge": "^3.4.0",
     "zod": "^4.1.13"
@@ -38,7 +38,6 @@
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.4",
     "nodemon": "^3.1.10",
-    "shx": "^0.4.0",
     "tsx": "^4.19.4",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.7.2",

--- a/examples/ecom-carousel/package.json
+++ b/examples/ecom-carousel/package.json
@@ -15,7 +15,7 @@
     "express": "^5.2.1",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
-    "skybridge": ">=0.25.0 <1.0.0",
+    "skybridge": ">=0.26.0 <1.0.0",
     "vite": "^7.3.1",
     "zod": "^4.3.5"
   },
@@ -28,7 +28,6 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.2",
     "nodemon": "^3.1.11",
-    "shx": "^0.4.0",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   }

--- a/examples/everything/package.json
+++ b/examples/everything/package.json
@@ -16,7 +16,7 @@
     "express": "^5.2.1",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
-    "skybridge": ">=0.25.0 <1.0.0",
+    "skybridge": ">=0.26.0 <1.0.0",
     "vite": "^7.3.0",
     "zod": "^4.3.5"
   },
@@ -29,7 +29,6 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.2",
     "nodemon": "^3.1.11",
-    "shx": "^0.4.0",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   },

--- a/examples/productivity/package.json
+++ b/examples/productivity/package.json
@@ -15,7 +15,7 @@
     "express": "^5.2.1",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
-    "skybridge": ">=0.25.0 <1.0.0",
+    "skybridge": ">=0.26.0 <1.0.0",
     "vite": "^7.3.1",
     "zod": "^4.3.5"
   },
@@ -28,7 +28,6 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.2",
     "nodemon": "^3.1.11",
-    "shx": "^0.4.0",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   },

--- a/packages/create-skybridge/template/package.json
+++ b/packages/create-skybridge/template/package.json
@@ -16,7 +16,7 @@
     "express": "^5.2.1",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
-    "skybridge": ">=0.25.0 <1.0.0",
+    "skybridge": ">=0.26.0 <1.0.0",
     "vite": "^7.3.1",
     "zod": "^4.3.5"
   },
@@ -29,7 +29,6 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.2",
     "nodemon": "^3.1.11",
-    "shx": "^0.4.0",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: ^7.11.0
         version: 7.11.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       skybridge:
-        specifier: '>=0.25.0 <1.0.0'
-        version: 0.25.0(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.3.5))(@types/node@22.19.3)(@types/react@19.2.7)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.0))(yaml@2.8.2)
+        specifier: '>=0.26.0 <1.0.0'
+        version: 0.26.0(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.3.5))(@types/node@22.19.3)(@types/react@19.2.7)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(nodemon@3.1.11)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.0))(yaml@2.8.2)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -105,9 +105,6 @@ importers:
       nodemon:
         specifier: ^3.1.10
         version: 3.1.11
-      shx:
-        specifier: ^0.4.0
-        version: 0.4.0
       tsx:
         specifier: ^4.19.4
         version: 4.21.0
@@ -136,8 +133,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
       skybridge:
-        specifier: '>=0.25.0 <1.0.0'
-        version: 0.25.0(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.3.5))(@types/node@22.19.3)(@types/react@19.2.7)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.3))(yaml@2.8.2)
+        specifier: '>=0.26.0 <1.0.0'
+        version: 0.26.0(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.3.5))(@types/node@22.19.3)(@types/react@19.2.7)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(nodemon@3.1.11)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.3))(yaml@2.8.2)
       vite:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
@@ -169,9 +166,6 @@ importers:
       nodemon:
         specifier: ^3.1.11
         version: 3.1.11
-      shx:
-        specifier: ^0.4.0
-        version: 0.4.0
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -197,8 +191,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
       skybridge:
-        specifier: '>=0.25.0 <1.0.0'
-        version: 0.25.0(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.3.5))(@types/node@25.0.3)(@types/react@19.2.7)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.3))(yaml@2.8.2)
+        specifier: '>=0.26.0 <1.0.0'
+        version: 0.26.0(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.3.5))(@types/node@25.0.3)(@types/react@19.2.7)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(nodemon@3.1.11)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.3))(yaml@2.8.2)
       vite:
         specifier: ^7.3.0
         version: 7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
@@ -230,9 +224,6 @@ importers:
       nodemon:
         specifier: ^3.1.11
         version: 3.1.11
-      shx:
-        specifier: ^0.4.0
-        version: 0.4.0
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -258,8 +249,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
       skybridge:
-        specifier: '>=0.25.0 <1.0.0'
-        version: 0.25.0(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.3.5))(@types/node@25.0.3)(@types/react@19.2.8)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.3))(yaml@2.8.2)
+        specifier: '>=0.26.0 <1.0.0'
+        version: 0.26.0(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.3.5))(@types/node@25.0.3)(@types/react@19.2.8)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(nodemon@3.1.11)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.3))(yaml@2.8.2)
       vite:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
@@ -291,9 +282,6 @@ importers:
       nodemon:
         specifier: ^3.1.11
         version: 3.1.11
-      shx:
-        specifier: ^0.4.0
-        version: 0.4.0
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -444,8 +432,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
       skybridge:
-        specifier: '>=0.25.0 <1.0.0'
-        version: 0.25.0(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.3.5))(@types/node@25.0.3)(@types/react@19.2.8)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.3))(yaml@2.8.2)
+        specifier: '>=0.26.0 <1.0.0'
+        version: 0.26.0(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.3.5))(@types/node@25.0.3)(@types/react@19.2.8)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(nodemon@3.1.11)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.3))(yaml@2.8.2)
       vite:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
@@ -477,9 +465,6 @@ importers:
       nodemon:
         specifier: ^3.1.11
         version: 3.1.11
-      shx:
-        specifier: ^0.4.0
-        version: 0.4.0
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -6672,6 +6657,15 @@ packages:
     hasBin: true
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.0.0'
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+
+  skybridge@0.26.0:
+    resolution: {integrity: sha512-kZcOu27L2sNqt6PkO+CLtyalFKg1j8+bHMAuAUJKSVgLBLo+M1IStyNyAFLEU3ZFLwuVJBpd4KrR4ca/BT904A==}
+    hasBin: true
+    peerDependencies:
+      '@modelcontextprotocol/sdk': '>=1.0.0'
+      nodemon: '>=3.0.0'
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
 
@@ -17141,82 +17135,6 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  skybridge@0.25.0(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.3.5))(@types/node@22.19.3)(@types/react@19.2.7)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.0))(yaml@2.8.2):
-    dependencies:
-      '@babel/core': 7.28.6
-      '@modelcontextprotocol/sdk': 1.25.2(hono@4.11.3)(zod@4.3.5)
-      '@oclif/core': 4.8.0
-      ci-info: 4.3.1
-      cors: 2.8.5
-      dequal: 2.0.3
-      es-toolkit: 1.43.0
-      express: 5.2.1
-      handlebars: 4.7.8
-      ink: 6.6.0(@types/react@19.2.7)(react@19.2.0)
-      posthog-node: 5.23.0
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      superjson: 2.2.6
-      vite: 7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
-      zustand: 5.0.10(@types/react@19.2.7)(immer@9.0.21)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))
-    transitivePeerDependencies:
-      - '@types/node'
-      - '@types/react'
-      - bufferutil
-      - immer
-      - jiti
-      - less
-      - lightningcss
-      - react-devtools-core
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - use-sync-external-store
-      - utf-8-validate
-      - yaml
-
-  skybridge@0.25.0(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.3.5))(@types/node@22.19.3)(@types/react@19.2.7)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.3))(yaml@2.8.2):
-    dependencies:
-      '@babel/core': 7.28.6
-      '@modelcontextprotocol/sdk': 1.25.2(hono@4.11.3)(zod@4.3.5)
-      '@oclif/core': 4.8.0
-      ci-info: 4.3.1
-      cors: 2.8.5
-      dequal: 2.0.3
-      es-toolkit: 1.43.0
-      express: 5.2.1
-      handlebars: 4.7.8
-      ink: 6.6.0(@types/react@19.2.7)(react@19.2.3)
-      posthog-node: 5.23.0
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      superjson: 2.2.6
-      vite: 7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
-      zustand: 5.0.10(@types/react@19.2.7)(immer@9.0.21)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
-    transitivePeerDependencies:
-      - '@types/node'
-      - '@types/react'
-      - bufferutil
-      - immer
-      - jiti
-      - less
-      - lightningcss
-      - react-devtools-core
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - use-sync-external-store
-      - utf-8-validate
-      - yaml
-
   skybridge@0.25.0(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.3.5))(@types/node@25.0.3)(@types/react@19.2.7)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.3))(yaml@2.8.2):
     dependencies:
       '@babel/core': 7.28.6
@@ -17255,7 +17173,124 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  skybridge@0.25.0(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.3.5))(@types/node@25.0.3)(@types/react@19.2.8)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.3))(yaml@2.8.2):
+  skybridge@0.26.0(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.3.5))(@types/node@22.19.3)(@types/react@19.2.7)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(nodemon@3.1.11)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.0))(yaml@2.8.2):
+    dependencies:
+      '@babel/core': 7.28.6
+      '@modelcontextprotocol/sdk': 1.25.2(hono@4.11.3)(zod@4.3.5)
+      '@oclif/core': 4.8.0
+      ci-info: 4.3.1
+      cors: 2.8.5
+      dequal: 2.0.3
+      es-toolkit: 1.43.0
+      express: 5.2.1
+      handlebars: 4.7.8
+      ink: 6.6.0(@types/react@19.2.7)(react@19.2.0)
+      nodemon: 3.1.11
+      posthog-node: 5.23.0
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      superjson: 2.2.6
+      vite: 7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      zustand: 5.0.10(@types/react@19.2.7)(immer@9.0.21)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))
+    transitivePeerDependencies:
+      - '@types/node'
+      - '@types/react'
+      - bufferutil
+      - immer
+      - jiti
+      - less
+      - lightningcss
+      - react-devtools-core
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - use-sync-external-store
+      - utf-8-validate
+      - yaml
+
+  skybridge@0.26.0(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.3.5))(@types/node@22.19.3)(@types/react@19.2.7)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(nodemon@3.1.11)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.3))(yaml@2.8.2):
+    dependencies:
+      '@babel/core': 7.28.6
+      '@modelcontextprotocol/sdk': 1.25.2(hono@4.11.3)(zod@4.3.5)
+      '@oclif/core': 4.8.0
+      ci-info: 4.3.1
+      cors: 2.8.5
+      dequal: 2.0.3
+      es-toolkit: 1.43.0
+      express: 5.2.1
+      handlebars: 4.7.8
+      ink: 6.6.0(@types/react@19.2.7)(react@19.2.3)
+      nodemon: 3.1.11
+      posthog-node: 5.23.0
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      superjson: 2.2.6
+      vite: 7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      zustand: 5.0.10(@types/react@19.2.7)(immer@9.0.21)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+    transitivePeerDependencies:
+      - '@types/node'
+      - '@types/react'
+      - bufferutil
+      - immer
+      - jiti
+      - less
+      - lightningcss
+      - react-devtools-core
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - use-sync-external-store
+      - utf-8-validate
+      - yaml
+
+  skybridge@0.26.0(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.3.5))(@types/node@25.0.3)(@types/react@19.2.7)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(nodemon@3.1.11)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.3))(yaml@2.8.2):
+    dependencies:
+      '@babel/core': 7.28.6
+      '@modelcontextprotocol/sdk': 1.25.2(hono@4.11.3)(zod@4.3.5)
+      '@oclif/core': 4.8.0
+      ci-info: 4.3.1
+      cors: 2.8.5
+      dequal: 2.0.3
+      es-toolkit: 1.43.0
+      express: 5.2.1
+      handlebars: 4.7.8
+      ink: 6.6.0(@types/react@19.2.7)(react@19.2.3)
+      nodemon: 3.1.11
+      posthog-node: 5.23.0
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      superjson: 2.2.6
+      vite: 7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      zustand: 5.0.10(@types/react@19.2.7)(immer@9.0.21)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+    transitivePeerDependencies:
+      - '@types/node'
+      - '@types/react'
+      - bufferutil
+      - immer
+      - jiti
+      - less
+      - lightningcss
+      - react-devtools-core
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - use-sync-external-store
+      - utf-8-validate
+      - yaml
+
+  skybridge@0.26.0(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.3.5))(@types/node@25.0.3)(@types/react@19.2.8)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(nodemon@3.1.11)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.3))(yaml@2.8.2):
     dependencies:
       '@babel/core': 7.28.6
       '@modelcontextprotocol/sdk': 1.25.2(hono@4.11.3)(zod@4.3.5)
@@ -17267,6 +17302,7 @@ snapshots:
       express: 5.2.1
       handlebars: 4.7.8
       ink: 6.6.0(@types/react@19.2.8)(react@19.2.3)
+      nodemon: 3.1.11
       posthog-node: 5.23.0
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Completed cleanup of `shx` dependency from example projects and template following PR #378, which replaced `shx` usage in the core build commands with native Node.js `fs` methods (`rmSync` and `cpSync`). Since examples and template rely on `skybridge build` rather than directly invoking `shx`, this dependency is no longer needed in those locations.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- This is a straightforward dependency cleanup that removes an unused devDependency from multiple package.json files. The changes are minimal, consistent across all affected files, and the lockfile has been properly updated. No code logic is affected, and the removed dependency was already replaced with native Node.js methods in PR #378.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->