### PR TITLE
Hotfix user vite plugins

### DIFF
--- a/examples/everything/tsconfig.json
+++ b/examples/everything/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx",
+    "types": ["vite/client"],
 
     "strict": true,
     "skipLibCheck": true,

--- a/packages/core/src/server/widgetsDevServer.ts
+++ b/packages/core/src/server/widgetsDevServer.ts
@@ -38,7 +38,12 @@ export const widgetsDevServer = async (): Promise<Router> => {
     webAppRoot,
   );
 
-  const { build, preview, ...devConfig } = configResult?.config || {};
+  const {
+    build,
+    preview,
+    plugins: userPlugins = [],
+    ...devConfig
+  } = configResult?.config || {};
 
   const vite = await createServer({
     ...devConfig,
@@ -53,6 +58,7 @@ export const widgetsDevServer = async (): Promise<Router> => {
       include: ["react", "react-dom/client"],
     },
     plugins: [
+      ...userPlugins,
       assetBaseUrlTransformPlugin({ devServerOrigin: "http://localhost:3000" }),
     ],
   });


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This hotfix restores user-defined Vite plugins (like React Refresh) to the dev server and adds TypeScript support for Vite client types. Previously, plugins defined in `vite.config.ts` were being excluded from the dev server configuration, which would break features like React Fast Refresh.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes correctly restore user plugins to the dev server configuration and add necessary TypeScript types. The plugin ordering is preserved correctly, and the changes follow Vite's configuration patterns.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->