### PR TITLE
feat: Add console warning when setWidgetState/data-llm exceeds 4K tokens

### DIFF
--- a/packages/core/src/web/bridges/apps-sdk/adaptor.ts
+++ b/packages/core/src/web/bridges/apps-sdk/adaptor.ts
@@ -1,3 +1,4 @@
+import { warnIfExceedsTokenLimit } from "../../helpers/warn-token-limit.js";
 import type {
   Adaptor,
   CallToolResponse,
@@ -64,6 +65,8 @@ export class AppsSdkAdaptor implements Adaptor {
       typeof stateOrUpdater === "function"
         ? stateOrUpdater(window.openai.widgetState)
         : stateOrUpdater;
+
+    warnIfExceedsTokenLimit(newState, "setWidgetState");
 
     return window.openai.setWidgetState(newState);
   };

--- a/packages/core/src/web/bridges/mcp-app/adaptor.ts
+++ b/packages/core/src/web/bridges/mcp-app/adaptor.ts
@@ -12,6 +12,7 @@ import type {
   CallToolResult,
 } from "@modelcontextprotocol/sdk/types.js";
 import { dequal } from "dequal/lite";
+import { warnIfExceedsTokenLimit } from "../../helpers/warn-token-limit.js";
 import type {
   Adaptor,
   CallToolResponse,
@@ -219,6 +220,8 @@ export class McpAppAdaptor implements Adaptor {
       typeof stateOrUpdater === "function"
         ? stateOrUpdater(this._widgetState)
         : stateOrUpdater;
+
+    warnIfExceedsTokenLimit(newState, "setWidgetState");
 
     const bridge = McpAppBridge.getInstance();
     await bridge.request<McpUiUpdateModelContextRequest, unknown>({

--- a/packages/core/src/web/data-llm.tsx
+++ b/packages/core/src/web/data-llm.tsx
@@ -6,6 +6,7 @@ import {
   useId,
 } from "react";
 import { getAdaptor } from "./bridges/index.js";
+import { warnIfExceedsTokenLimit } from "./helpers/warn-token-limit.js";
 
 export type DataLLMContent = string;
 
@@ -31,6 +32,7 @@ function removeNode(id: string) {
 
 function onChange() {
   const description = getLLMDescriptionString();
+  warnIfExceedsTokenLimit(description, "data-llm");
   const adaptor = getAdaptor();
   adaptor.setWidgetState((prevState) => ({
     ...prevState,

--- a/packages/core/src/web/helpers/warn-token-limit.test.ts
+++ b/packages/core/src/web/helpers/warn-token-limit.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  resetTokenLimitWarning,
+  warnIfExceedsTokenLimit,
+} from "./warn-token-limit.js";
+
+describe("warnIfExceedsTokenLimit", () => {
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    resetTokenLimitWarning();
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("should not warn for null state", () => {
+    warnIfExceedsTokenLimit(null, "setWidgetState");
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it("should not warn for undefined state", () => {
+    warnIfExceedsTokenLimit(undefined, "setWidgetState");
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it("should not warn for small payloads", () => {
+    warnIfExceedsTokenLimit({ small: "data" }, "setWidgetState");
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it("should warn for payloads exceeding 4K tokens (~16K chars)", () => {
+    const largePayload = { data: "x".repeat(20000) };
+    warnIfExceedsTokenLimit(largePayload, "setWidgetState");
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[Skybridge] Warning: setWidgetState payload"),
+    );
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("4000 token limit"),
+    );
+  });
+
+  it("should warn with data-llm specific message for data-llm source", () => {
+    const largePayload = "x".repeat(20000);
+    warnIfExceedsTokenLimit(largePayload, "data-llm");
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[Skybridge] Warning: data-llm content"),
+    );
+  });
+
+  it("should only warn once until reset", () => {
+    const largePayload = { data: "x".repeat(20000) };
+    warnIfExceedsTokenLimit(largePayload, "setWidgetState");
+    warnIfExceedsTokenLimit(largePayload, "setWidgetState");
+    warnIfExceedsTokenLimit(largePayload, "setWidgetState");
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("should warn again after reset", () => {
+    const largePayload = { data: "x".repeat(20000) };
+    warnIfExceedsTokenLimit(largePayload, "setWidgetState");
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+
+    resetTokenLimitWarning();
+    warnIfExceedsTokenLimit(largePayload, "setWidgetState");
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("should reset warning state when payload goes back under limit", () => {
+    const largePayload = { data: "x".repeat(20000) };
+    warnIfExceedsTokenLimit(largePayload, "setWidgetState");
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+
+    const smallPayload = { data: "small" };
+    warnIfExceedsTokenLimit(smallPayload, "setWidgetState");
+
+    warnIfExceedsTokenLimit(largePayload, "setWidgetState");
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("should include estimated token count in warning", () => {
+    const largePayload = { data: "x".repeat(20000) };
+    warnIfExceedsTokenLimit(largePayload, "setWidgetState");
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/estimated ~\d+ tokens/),
+    );
+  });
+
+  it("should handle circular references gracefully", () => {
+    const circular: Record<string, unknown> = { a: 1 };
+    circular.self = circular;
+    warnIfExceedsTokenLimit(circular, "setWidgetState");
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/web/helpers/warn-token-limit.ts
+++ b/packages/core/src/web/helpers/warn-token-limit.ts
@@ -1,0 +1,52 @@
+const TOKEN_LIMIT = 4000;
+const CHARS_PER_TOKEN = 4;
+const CHAR_LIMIT = TOKEN_LIMIT * CHARS_PER_TOKEN;
+
+let hasWarned = false;
+
+function estimateTokens(str: string): number {
+  return Math.ceil(str.length / CHARS_PER_TOKEN);
+}
+
+export function warnIfExceedsTokenLimit(
+  state: unknown,
+  source: "setWidgetState" | "data-llm",
+): void {
+  if (state === null || state === undefined) {
+    return;
+  }
+
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(state);
+  } catch {
+    return;
+  }
+
+  if (serialized.length <= CHAR_LIMIT) {
+    hasWarned = false;
+    return;
+  }
+
+  if (hasWarned) {
+    return;
+  }
+
+  hasWarned = true;
+  const estimatedTokens = estimateTokens(serialized);
+
+  const message =
+    source === "data-llm"
+      ? `[Skybridge] Warning: data-llm content exceeds recommended ${TOKEN_LIMIT} token limit (estimated ~${estimatedTokens} tokens). ` +
+        `Large payloads sent via data-llm may impact model performance. ` +
+        `Consider reducing the amount of data exposed to the model.`
+      : `[Skybridge] Warning: setWidgetState payload exceeds recommended ${TOKEN_LIMIT} token limit (estimated ~${estimatedTokens} tokens). ` +
+        `Large payloads sent to the model may impact performance. ` +
+        `Keep the payload small and focused on data the model needs.`;
+
+  console.warn(message);
+}
+
+export function resetTokenLimitWarning(): void {
+  hasWarned = false;
+}


### PR DESCRIPTION
Closes #356 

## Description

Add token limit warnings to help developers keep widget state payloads small. When setWidgetState or data-llm content exceeds ~4K tokens (~16K chars), a console.warn is displayed with guidance to reduce payload size.

- Add warnIfExceedsTokenLimit utility with token estimation
- Integrate warning into McpAppAdaptor.setWidgetState
- Integrate warning into AppsSdkAdaptor.setWidgetState
- Add specific data-llm warning in data-llm.tsx
- Add comprehensive test coverage

## Test
All Tests Passed including 4k Token Warning
<img width="1869" height="386" alt="fix3563" src="https://github.com/user-attachments/assets/eb144549-bf64-47a5-aab1-d2f55ddcbaff" />
How warning is given:
<img width="1445" height="225" alt="fix3562" src="https://github.com/user-attachments/assets/a3678c38-6e13-4bad-a099-1b40b0a82b8b" />
<img width="1445" height="145" alt="fix3561" src="https://github.com/user-attachments/assets/4269a96a-00b7-4c51-868c-3c5f0c95e888" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Adds token limit warnings to help developers keep widget state payloads under 4K tokens (~16K characters). When `setWidgetState` or `data-llm` content exceeds this limit, a `console.warn` displays guidance to reduce payload size.

**Changes:**
- Created `warnIfExceedsTokenLimit` utility with ~4 chars/token estimation
- Integrated warnings into both `McpAppAdaptor.setWidgetState` and `AppsSdkAdaptor.setWidgetState`
- Added specific data-llm warning in `data-llm.tsx:35`
- Comprehensive test coverage for warning behavior

**Issue Found:**
- Global `hasWarned` flag causes sequential calls (like in `data-llm.tsx` line 35 then 37 via `setWidgetState`) to suppress the second warning, potentially hiding issues with the complete widget state size

<h3>Confidence Score: 3/5</h3>


- Safe to merge with minor fix needed for warning suppression logic
- Core functionality works correctly with good test coverage, but the global `hasWarned` flag creates a logic error in `data-llm.tsx` where sequential calls suppress important warnings. This won't cause runtime errors but reduces the effectiveness of the feature
- packages/core/src/web/helpers/warn-token-limit.ts needs attention for the warning suppression logic

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->