### PR TITLE
Fix: Start command not working in dev environment

### DIFF
--- a/packages/core/src/commands/start.tsx
+++ b/packages/core/src/commands/start.tsx
@@ -25,7 +25,7 @@ export default class Start extends Command {
 
     runCommand("node dist/index.js", {
       stdio: ["ignore", "ignore", "inherit"],
-      env: { ...process.env, NODE_ENV: "production" },
+      env: process.env,
     });
 
     const App = () => {


### PR DESCRIPTION
### Context 

I am trying to debug my Skybridge app. My widget runs fine in Dev mode (`npm run dev`) but fails to load with a deployed version of my app. 

Hence, I ran `npm run build` & `npm run start` and then exposed my server running locally via an ngrok tunnel. The idea is to iterate quickly and validate that my fix works locally in a production-like environment.

### Current behavior

The HTML of my widget tries to load JS and CSS assets by making a call to https://localhost:...

### Desired behavior

It should point to http://localhost instead 

### Temporary fix

Removed NODE_ENV set to production in the start command to have a version that works locally; will need to discuss the actual fix together @harijoe 

