### PR TITLE
(feat): entering JSON manually

### DIFF
--- a/packages/devtools/src/components/layout/tool-panel/input-form.tsx
+++ b/packages/devtools/src/components/layout/tool-panel/input-form.tsx
@@ -1,7 +1,3 @@
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs.js";
-import { useSelectedTool } from "@/lib/mcp/index.js";
-import { useCallToolResult, useStore } from "@/lib/store.js";
-import { cn } from "@/lib/utils.js";
 import type Form from "@rjsf/core";
 import { Form as FormComponent } from "@rjsf/shadcn";
 import type {
@@ -12,6 +8,15 @@ import type {
 } from "@rjsf/utils";
 import validator from "@rjsf/validator-ajv8";
 import { useEffect, useRef, useState } from "react";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs.js";
+import { useSelectedTool } from "@/lib/mcp/index.js";
+import { useCallToolResult, useStore } from "@/lib/store.js";
+import { cn } from "@/lib/utils.js";
 import { Card, CardContent } from "../../ui/card.js";
 import { CallToolButton } from "../call-tool-button.js";
 import { ViewToolMetaButton } from "../view-tool-meta-button.js";
@@ -108,7 +113,6 @@ const JsonContent = ({
   formData: Record<string, unknown> | null;
   setFormData: (data: Record<string, unknown> | null) => void;
 }) => {
-
   const [json, setJson] = useState(JSON.stringify(formData, null, 2));
 
   useEffect(() => {
@@ -134,7 +138,7 @@ const JsonContent = ({
         onChange={(e) => handleChange(e.target.value)}
       />
     </div>
-  )
+  );
 };
 
 export const InputForm = () => {


### PR DESCRIPTION
**What this PR adds**
- This PR addresses https://github.com/alpic-ai/skybridge/issues/332
- And lets you enter / paste JSON manually as an input to an MCP tool
- That's extremely handy for debugging when you need to quickly paste an input from ChatGPT

**What this PR does not add**
- JSON validation
- Fancy formatting
- It can be all done separately

**Fun fact**
- I was 'thrown out' of the pub while working on this PR
- Wel... not really, but the waitress said they had a no-laptop policy on Sundays... eh, London...

https://github.com/user-attachments/assets/63bb6272-c320-405a-9480-f8ff79f67371

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a JSON tab alongside the existing form interface for MCP tool inputs, allowing users to manually paste JSON for debugging purposes. The implementation introduces a tabbed interface using the Tabs component, with a new `JsonContent` component that renders a textarea for direct JSON input.

Key changes:
- Added `Tabs`, `TabsContent`, `TabsList`, `TabsTrigger` imports from the UI library
- Created new `JsonContent` component with textarea for JSON editing
- Wrapped existing `FormContent` and new `JsonContent` in tab panels
- Import reorganization (moved some imports to the top)

Critical issues found:
- **Unhandled JSON parsing error**: The `JSON.parse` call in the textarea's `onChange` handler (line 116) will crash the component when users type invalid JSON, preventing them from continuing to type and fix their input
- **Missing form validation integration**: When the JSON tab is active, the form validation ref won't be mounted, potentially allowing invalid data to be submitted through the Call Tool button

<h3>Confidence Score: 2/5</h3>

- This PR has critical runtime errors that will crash the component when users enter invalid JSON
- The unhandled `JSON.parse` on line 116 will throw exceptions during normal usage (typing incomplete JSON), causing the component to crash. Additionally, form validation won't work when the JSON tab is active, potentially allowing invalid data submission. These are not edge cases but will occur during typical usage.
- The input-form.tsx file needs error handling for JSON parsing and validation logic integration

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->