### PR TITLE
Compute Claude expected domain signature in resource meta

### DIFF
--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import type {
@@ -395,6 +396,8 @@ export class McpServer<
         const isProduction = process.env.NODE_ENV === "production";
         const useForwardedHost =
           process.env.SKYBRIDGE_USE_FORWARDED_HOST === "true";
+        const isClaude =
+          extra?.requestInfo?.headers?.["user-agent"] === "Claude-User";
 
         const serverUrl =
           isProduction || useForwardedHost
@@ -421,7 +424,13 @@ export class McpServer<
         const contentMeta = buildContentMeta({
           resourceDomains: [serverUrl],
           connectDomains: !isProduction ? [VITE_HMR_WEBSOCKET_DEFAULT_URL] : [],
-          domain: serverUrl,
+          domain: isClaude
+            ? `${crypto
+                .createHash("sha256")
+                .update(`${serverUrl}/mcp`)
+                .digest("hex")
+                .slice(0, 32)}.claudemcpcontent.com`
+            : serverUrl,
           baseUriDomains: [serverUrl],
         });
 


### PR DESCRIPTION
Fixes #395

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR implements Claude's expected domain signature computation for widget resources. When the client is detected as Claude (via `user-agent` header set to "Claude-User"), the resource metadata's domain field is set to a computed subdomain in the format `<sha256-hash>.claudemcpcontent.com`, where the hash is derived from `${serverUrl}/mcp`. For non-Claude clients, the domain continues to use the actual server URL.

**Key changes:**
- Added `crypto` module import for SHA-256 hashing
- Introduced Claude client detection via `user-agent` header comparison
- Computed domain signature using first 32 characters of SHA-256 hash of `${serverUrl}/mcp`
- Applied the computed domain to both apps-sdk (`openai/widgetDomain`) and mcp-app (`ui.domain`) resource metadata

The implementation is clean, uses safe optional chaining for header access, and maintains backward compatibility for non-Claude clients.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is well-contained, uses built-in crypto module correctly, implements safe optional chaining for header access, and maintains backward compatibility. The logic is straightforward and deterministic.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->