### PR TITLE
Enable local dev on Claude

### DIFF
--- a/packages/core/src/server/templateHelper.ts
+++ b/packages/core/src/server/templateHelper.ts
@@ -37,6 +37,7 @@ class TemplateHelper {
   renderDevelopment(data: {
     hostType: WidgetHostType;
     serverUrl: string;
+    useLocalNetworkAccess: boolean;
     widgetName: string;
   }): string {
     const template = this.loadTemplate("development");

--- a/packages/core/src/server/templates/development.hbs
+++ b/packages/core/src/server/templates/development.hbs
@@ -6,6 +6,7 @@
   window.__vite_plugin_react_preamble_installed__ = true;
 </script>
 <script type="module" src="{{serverUrl}}/@vite/client"></script>
+{{#if useLocalNetworkAccess}}
 <script type="module">
   // Checks for browser support and shows error if local network access is denied
   (async () => {
@@ -59,6 +60,7 @@
     }
   })();
 </script>
+{{/if}}
 <div id="root"></div>
 <script type="module" id="dev-widget-entry">
   import('{{serverUrl}}/src/widgets/{{widgetName}}');

--- a/packages/core/src/server/widgetsDevServer.ts
+++ b/packages/core/src/server/widgetsDevServer.ts
@@ -52,6 +52,11 @@ export const widgetsDevServer = async (): Promise<Router> => {
     server: {
       allowedHosts: true,
       middlewareMode: true,
+      hmr: {
+        protocol: "ws",
+        host: "localhost",
+        port: 24678,
+      },
     },
     root: webAppRoot,
     optimizeDeps: {

--- a/packages/core/src/web/proxy.ts
+++ b/packages/core/src/web/proxy.ts
@@ -7,9 +7,6 @@ const colors = {
 
 export function installOpenAILoggingProxy() {
   if (typeof window === "undefined" || !window.openai) {
-    console.warn(
-      "[openai-proxy] window.openai not found, skipping proxy installation",
-    );
     return;
   }
 


### PR DESCRIPTION
## Current limitations:

- CSP issue when displaying the image (localhost not included in the allowed domains)
- useWidgetState and data-llm trigger an error when changing the state
- displayMode: PiP mode not available on Claude

## Note: 

- SendFollowUpMessage pre-fills the input instead of sending the prompt directly

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR enables local development on Claude by making the development environment work seamlessly with Claude's user agent detection. The key changes include:

- Conditionally disabling local network access checks when running through Claude (`useLocalNetworkAccess: !useExternalHost`)
- Fixing the Claude domain signature calculation to consistently use `https://${hostFromHeaders}/mcp` instead of `${serverUrl}/mcp`, ensuring the hash is computed correctly for Claude's CSP expectations
- Configuring Vite HMR with explicit WebSocket settings (protocol: ws, host: localhost, port: 24678) for better local development
- Removing unnecessary warning log when `window.openai` is not found, reducing console noise in Claude environment

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-structured and address specific issues with local development on Claude. The domain signature fix ensures consistency (always using https protocol for Claude), the conditional local network access check prevents unnecessary browser permission checks, and the HMR configuration is explicit. The logic flow ensures that when `isClaude` is true, `useExternalHost` is also true, maintaining consistency. No security vulnerabilities or breaking changes introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->