### PR TITLE
fix: template widget container growth

### DIFF
--- a/packages/create-skybridge/template/web/src/index.css
+++ b/packages/create-skybridge/template/web/src/index.css
@@ -4,8 +4,11 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 100%;
+  min-height: 100%;
+  max-height: 100%;
+  overflow: hidden;
   padding: 1rem;
+  box-sizing: border-box;
 }
 
 .ball {


### PR DESCRIPTION
Fixes #407 

<img width="864" height="627" alt="image" src="https://github.com/user-attachments/assets/4aa0c797-8c5f-4bd8-9930-061f02f5026e" />

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed container growth issue by constraining height and preventing overflow in the magic 8-ball widget template.

**Changes:**
- Replaced `height: 100%` with `min-height: 100%` and `max-height: 100%` to constrain container dimensions
- Added `overflow: hidden` to prevent content overflow
- Added `box-sizing: border-box` to include padding in height calculations

**Notes:**
- The fix prevents the container from growing beyond viewport bounds
- The `box-sizing: border-box` addition ensures padding (1rem) doesn't cause the container to exceed 100% height

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The CSS changes are straightforward and focused on fixing a container growth issue. The addition of `box-sizing: border-box` properly accounts for padding in height calculations, and the height constraints prevent unwanted expansion. The changes are isolated to styling with no logic changes.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->