### PR TITLE
chore: remove ink on start command, prevent error swallowing

### DIFF
--- a/packages/core/src/commands/start.ts
+++ b/packages/core/src/commands/start.ts
@@ -28,7 +28,7 @@ export default class Start extends Command {
       `Server running at: \x1b[32m\x1b[1mhttp://localhost:3000/mcp\x1b[0m`,
     );
 
-    runCommand("node dist/index.js", {
+    await runCommand("node dist/index.js", {
       stdio: ["ignore", "inherit", "inherit"],
       env: { ...process.env, NODE_ENV: "production" },
     });


### PR DESCRIPTION
fixes #406

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR removes the Ink dependency from the start command, replacing React-based UI rendering with simple console output using ANSI escape codes. The stdio configuration was updated to inherit stdout (changed from `["ignore", "ignore", "inherit"]` to `["ignore", "inherit", "inherit"]`), which allows server output to display in real-time rather than being ignored.

**Key changes:**
- Removed Ink imports (`Box`, `render`, `Text`) and `Header` component
- Replaced Ink UI with console.log statements using ANSI color codes
- Changed stdio to inherit stdout, preventing output from being swallowed
- Renamed file from `.tsx` to `.ts`

**Issues found:**
- Critical: `runCommand` is not awaited, which will cause errors to become unhandled promise rejections

<h3>Confidence Score: 2/5</h3>

- This PR has a critical bug that prevents proper error handling
- While the changes successfully remove the Ink dependency and fix stdout output, the missing await on runCommand creates an unhandled promise rejection issue that defeats the purpose of preventing error swallowing
- packages/core/src/commands/start.ts requires fixing the await on line 31

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->