### PR TITLE
Add i18n support for checkout UI strings in ecom-carousel

### DIFF
--- a/examples/ecom-carousel/web/src/widgets/ecom-carousel.tsx
+++ b/examples/ecom-carousel/web/src/widgets/ecom-carousel.tsx
@@ -17,24 +17,36 @@ const translations: Record<string, Record<string, string>> = {
     noProducts: "No product found",
     addToCart: "Add to cart",
     removeFromCart: "Remove",
+    checkout: "Checkout",
+    orderSummary: "Order summary",
+    total: "Total",
   },
   fr: {
     loading: "Chargement des produits...",
     noProducts: "Aucun produit trouvé",
     addToCart: "Ajouter",
     removeFromCart: "Retirer",
+    checkout: "Payer",
+    orderSummary: "Récapitulatif de commande",
+    total: "Total",
   },
   es: {
     loading: "Cargando productos...",
     noProducts: "No se encontraron productos",
     addToCart: "Añadir",
     removeFromCart: "Quitar",
+    checkout: "Pagar",
+    orderSummary: "Resumen del pedido",
+    total: "Total",
   },
   de: {
     loading: "Produkte werden geladen...",
     noProducts: "Keine Produkte gefunden",
     addToCart: "Hinzufügen",
     removeFromCart: "Entfernen",
+    checkout: "Zur Kasse",
+    orderSummary: "Bestellübersicht",
+    total: "Gesamt",
   },
 };
 
@@ -96,7 +108,7 @@ function EcomCarousel() {
 
     return (
       <div className={`${theme} checkout`}>
-        <div className="checkout-title">Order summary</div>
+        <div className="checkout-title">{translate("orderSummary")}</div>
         <div className="checkout-items">
           {cartItems.map((item) => (
             <div key={item.id} className="checkout-item">
@@ -106,7 +118,7 @@ function EcomCarousel() {
           ))}
         </div>
         <div className="checkout-total">
-          <span>Total</span>
+          <span>{translate("total")}</span>
           <span>${total.toFixed(2)}</span>
         </div>
         <button
@@ -114,7 +126,7 @@ function EcomCarousel() {
           className="checkout-button"
           onClick={() => openExternal(checkoutUrl.toString())}
         >
-          Checkout
+          {translate("checkout")}
         </button>
       </div>
     );


### PR DESCRIPTION
## Summary
This PR adds internationalization (i18n) support for checkout-related UI strings in the ecom-carousel widget. Previously, checkout labels were hardcoded in English, limiting the widget's usability for non-English users.
Solves https://github.com/alpic-ai/skybridge/issues/364

## Changes
- Added three new translation keys to all supported languages (English, French, Spanish, German):
  - `checkout`: Button label for initiating checkout
  - `orderSummary`: Title for the order summary section
  - `total`: Label for the total price display
- Updated the checkout component to use the `translate()` function for all three strings instead of hardcoded English text

## Implementation Details
- Translations follow the existing pattern in the `translations` object
- All four language variants (en, fr, es, de) have been updated consistently
- The changes maintain backward compatibility with existing translation infrastructure
- No new dependencies or breaking changes introduced

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added internationalization support for checkout UI strings (`checkout`, `orderSummary`, `total`) across all four supported languages (English, French, Spanish, German). The hardcoded English strings in the checkout component were replaced with `translate()` function calls.

- Added three new translation keys consistently across all language variants
- Updated checkout component to use translated strings on lines 111, 121, and 129
- Translations follow the existing pattern and maintain consistency with the current i18n infrastructure

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward and follow the existing i18n pattern correctly. All translations are properly added to all language variants, and the `translate()` function is used consistently. No logic changes or breaking modifications were introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->