### PR TITLE
docs: update README for Skybridge template to make it multi-client

### DIFF
--- a/packages/create-skybridge/template/README.md
+++ b/packages/create-skybridge/template/README.md
@@ -1,13 +1,13 @@
 # Skybridge Starter
 
-A minimal TypeScript template for building MCP and ChatGPT Apps with the [Skybridge](https://docs.skybridge.tech/home) framework. 
+A minimal TypeScript template for building MCP and ChatGPT Apps with the [Skybridge](https://docs.skybridge.tech/home) framework.
 
 ## Getting Started
 
 ### Prerequisites
 
 - Node.js 24+
-- HTTP tunnel such as [ngrok](https://ngrok.com/download) if you want to test with remote MCP Clients like ChatGPT or Claude.ai.
+- HTTP tunnel such as [ngrok](https://ngrok.com/download) if you want to test with remote MCP hosts like ChatGPT or Claude.ai.
 
 ### Local Development
 
@@ -69,7 +69,7 @@ This command starts:
 
 #### 2. Edit widgets with Hot Module Replacement (HMR)
 
-Edit and save components in `web/src/widgets/` — changes will appear instantly inside your testing MCP Client.
+Edit and save components in `web/src/widgets/` — changes will appear instantly inside your App.
 
 #### 3. Edit server code
 


### PR DESCRIPTION
- removing all ChatGPT specific parts
- adding links to Skybridge doc and MCP Apps
- adding project structure section

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the `create-skybridge` template README to be MCP-client-agnostic (not ChatGPT-specific), adds links to Skybridge docs and MCP Apps docs, and documents the template’s project structure plus a local testing workflow via the DevTools UI.

These changes live in `packages/create-skybridge/template/README.md` and affect the first-run experience for users scaffolding a new Skybridge app from the template.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge; the main risk is documentation URLs/claims not matching actual dev behavior.
- Only documentation changed, but a couple of links/endpoint descriptions may be inaccurate (e.g., `registerWidget` docs URL and where the DevTools UI is served), which can mislead new template users.
- packages/create-skybridge/template/README.md (verify links and the dev server/UI URLs match the template behavior)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->