### PR TITLE
[ALP-580] Add mention to Alpic CLI in skills

### DIFF
--- a/skills/chatgpt-app-builder/references/deploy.md
+++ b/skills/chatgpt-app-builder/references/deploy.md
@@ -15,12 +15,12 @@ Execute `npx alpic@latest login` to login to Alpic.
 
 2. **Deploy to Alpic**
 
-If it's a new project, **ask the user for the project name**.
+If it's a first time deployment (absence of `.alpic/` folder in the project directory), **ask the user for the project name**.
 Then, execute `npx alpic@latest deploy --yes --project-name {project-name} {path-to-project}`.
 
-3. **Subsequent deploys**
+3. **Subsequent deployments**
 
-For existing projects (presence of `.alpic/` folder), execute `npx alpic@latest deploy --yes {path-to-project}`.
+For subsequent deployments (presence of `.alpic/` folder in the project directory), execute `npx alpic@latest deploy --yes {path-to-project}`.
 
 4. **Setup GitHub integration**
 


### PR DESCRIPTION
This PR updates deployment instructions across multiple skills documentation.

- Enhances deployment notes by specifying usage of the **Alpic CLI** for command-line deployment and the choices available in the dashboard for GitHub-based deployment.
- Clarifies the deployment process for Alpic, including API key setup and project linking via the CLI.
- Standardizes the deployment instructions across `chatgpt-app-builder`, `mcp-app-builder`, and `skybridge` skills documentation.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Enhanced deployment documentation across three skills (`chatgpt-app-builder`, `mcp-app-builder`, and `skybridge`) by adding **Alpic CLI** deployment instructions alongside the existing dashboard-based GitHub deployment method.

**Key changes:**
- Added Option A (CLI deployment) with instructions for API key setup, environment configuration, and project linking via `.alpic/project.json`
- Reorganized existing dashboard deployment instructions as Option B
- Standardized deployment instructions across all three SKILL.md files with inline CLI command reference
- Maintained consistency in formatting and structure across all documentation files

The changes are documentation-only and provide developers with clearer deployment options without modifying any functional code.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Documentation-only changes that enhance clarity and provide additional deployment options without affecting any functional code or introducing breaking changes
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->