### PR TITLE
feat: fix template widget height

### DIFF
--- a/packages/create-skybridge/template/web/src/widgets/magic-8-ball.tsx
+++ b/packages/create-skybridge/template/web/src/widgets/magic-8-ball.tsx
@@ -5,15 +5,18 @@ import { useToolInfo } from "../helpers";
 
 function Magic8Ball() {
   const { input, output } = useToolInfo<"magic-8-ball">();
-  if (!output) {
-    return <div>Shaking...</div>;
-  }
 
   return (
     <div className="container">
       <div className="ball">
-        <div className="question">{input.question}</div>
-        <div className="answer">{output.answer}</div>
+        {output ? (
+          <>
+            <div className="question">{input.question}</div>
+            <div className="answer">{output.answer}</div>
+          </>
+        ) : (
+          <div className="question">Shaking...</div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
On ChatGPT the widget height seems to be sometimes constrained by what was rendered at first, in the case of the magic 8 ball a single line of text ("shaking..."). Displaying the ball from the beginning fixes it.

<img width="1024" height="372" alt="Screenshot 2026-02-07 at 16 58 15" src="https://github.com/user-attachments/assets/075b1854-aad7-4e23-acf2-b26c5d046c64" />