### PR TITLE
Fix connect domain issue when mcp server also hosts API

### DIFF
--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -425,11 +425,15 @@ export class McpServer<
               widgetName: name,
             });
 
-        const VITE_HMR_WEBSOCKET_DEFAULT_URL = "ws://localhost:24678";
+        const connectDomains = [serverUrl];
+        if (!isProduction) {
+          const VITE_HMR_WEBSOCKET_DEFAULT_URL = "ws://localhost:24678";
+          connectDomains.push(VITE_HMR_WEBSOCKET_DEFAULT_URL);
+        }
 
         const contentMeta = buildContentMeta({
           resourceDomains: [serverUrl],
-          connectDomains: !isProduction ? [VITE_HMR_WEBSOCKET_DEFAULT_URL] : [],
+          connectDomains,
           domain: isClaude
             ? `${crypto
                 .createHash("sha256")

--- a/packages/core/src/test/widget.test.ts
+++ b/packages/core/src/test/widget.test.ts
@@ -108,7 +108,7 @@ describe("McpServer.registerWidget", () => {
           _meta: {
             "openai/widgetCSP": {
               resource_domains: [serverUrl],
-              connect_domains: ["ws://localhost:24678"],
+              connect_domains: [serverUrl, "ws://localhost:24678"],
             },
             "openai/widgetDomain": serverUrl,
             "openai/widgetDescription": "Test tool",
@@ -174,7 +174,7 @@ describe("McpServer.registerWidget", () => {
           _meta: {
             "openai/widgetCSP": {
               resource_domains: [serverUrl],
-              connect_domains: [],
+              connect_domains: [serverUrl],
             },
             "openai/widgetDomain": serverUrl,
             "openai/widgetDescription": "Test tool",
@@ -265,6 +265,7 @@ describe("McpServer.registerWidget", () => {
         ServerNotification
       >,
     );
+    const serverUrl = "http://localhost:3000";
 
     expect(appsSdkResult).toEqual({
       contents: [
@@ -274,10 +275,10 @@ describe("McpServer.registerWidget", () => {
           text: expect.stringContaining('<div id="root"></div>'),
           _meta: {
             "openai/widgetCSP": {
-              resource_domains: ["http://localhost:3000"],
-              connect_domains: ["ws://localhost:24678"],
+              resource_domains: [serverUrl],
+              connect_domains: [serverUrl, "ws://localhost:24678"],
             },
-            "openai/widgetDomain": "http://localhost:3000",
+            "openai/widgetDomain": serverUrl,
             "openai/widgetDescription": "Test tool",
             "openai/widgetPrefersBorder": true,
           },
@@ -319,10 +320,10 @@ describe("McpServer.registerWidget", () => {
           _meta: {
             ui: {
               csp: {
-                resourceDomains: ["http://localhost:3000"],
-                connectDomains: ["ws://localhost:24678"],
+                resourceDomains: [serverUrl],
+                connectDomains: [serverUrl, "ws://localhost:24678"],
               },
-              domain: "http://localhost:3000",
+              domain: serverUrl,
             },
           },
         },
@@ -396,6 +397,7 @@ describe("McpServer.registerWidget", () => {
         _meta?: Record<string, unknown>;
       }>;
     }>;
+    const serverUrl = "http://localhost:3000";
 
     const result = await appsSdkCallback(
       new URL("ui://widgets/apps-sdk/override-test.html"),
@@ -409,8 +411,12 @@ describe("McpServer.registerWidget", () => {
 
     // CSP arrays are merged with union - all unique domains from defaults and user config are preserved
     expect(meta["openai/widgetCSP"]).toEqual({
-      resource_domains: ["http://localhost:3000", "https://from-ui-csp.com"],
-      connect_domains: ["ws://localhost:24678", "https://from-ui-csp.com"],
+      resource_domains: [serverUrl, "https://from-ui-csp.com"],
+      connect_domains: [
+        serverUrl,
+        "ws://localhost:24678",
+        "https://from-ui-csp.com",
+      ],
       frame_domains: undefined,
       redirect_domains: undefined,
     });


### PR DESCRIPTION
# Fix: Allow MCP server–hosted REST APIs in CSP connect domains

This change updates the Content Security Policy (CSP) configuration so that the MCP server can safely host REST APIs alongside the WebSocket endpoint used for Hot Module Replacement (HMR).

## What changed

The build now:

- Continues to allow the Vite HMR WebSocket (`ws://localhost:24678`) in `connect-src`
- Explicitly includes `serverUrl` (the MCP server) in `connectDomains`
- Preserves existing `resourceDomains` behavior for assets served from the MCP server

## Why this matters

Previously, when the MCP server used a **dynamic URL** (for example, via CNAME-based routing) and also exposed REST endpoints, the CSP configuration could block those API requests—even though they originated from the same logical server.

This fix ensures that the MCP server is consistently treated as a valid connection origin during local development, regardless of how its hostname is configured.

### Use case

A primary motivation for this change is to support MCP servers that:

- Serve multiple dynamic URLs (e.g., via CNAME)
- Apply different configurations per URL
- Still need to expose REST APIs without triggering CSP violations

With this update, each dynamically configured MCP endpoint can operate correctly while maintaining secure defaults.

## Additional Note:
 - This change partially reverts the updates done in https://github.com/alpic-ai/skybridge/pull/263/changes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes how widget CSP `connect-src` defaults are computed in `McpServer.registerWidgetResource`.

Instead of always including the Vite HMR WebSocket origin in development and *also* implicitly granting the MCP server origin for all widgets, the server now only adds the MCP server `serverUrl` to `connectDomains` when the widget opts in via `addServerUrlInConnectDomains`. The dev-only HMR WebSocket origin (`ws://localhost:24678`) remains included when not in production.

A new unit test validates that when `addServerUrlInConnectDomains: true` is provided on widget registration, both Apps SDK (`openai/widgetCSP.connect_domains`) and MCP Apps (`ui.csp.connectDomains`) metadata include `serverUrl` alongside the HMR WebSocket domain in development mode.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is localized, adds an explicit opt-in for including `serverUrl` in CSP connect domains, keeps prior dev HMR behavior, and includes a focused unit test covering both metadata formats. No breaking signature changes were found outside the touched codepaths.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->