### PR TITLE
feat: use an env variable `VITE_MCP_SERVER_URL` to make it possible that devtools can point at a different url

### DIFF
--- a/packages/devtools/src/lib/mcp/index.ts
+++ b/packages/devtools/src/lib/mcp/index.ts
@@ -6,8 +6,8 @@ import { useSelectedToolName } from "../nuqs.js";
 import { McpClient } from "./client.js";
 
 const client = new McpClient();
-
-client.connect("http://localhost:3000/mcp").then(() => {
+const mcpServerUrl = process.env.MCP_SERVER_URL || 'http://localhost:3000/mcp';
+client.connect(mcpServerUrl).then(() => {
   console.info("Connected to MCP server");
 });
 

--- a/packages/devtools/src/lib/mcp/index.ts
+++ b/packages/devtools/src/lib/mcp/index.ts
@@ -6,7 +6,7 @@ import { useSelectedToolName } from "../nuqs.js";
 import { McpClient } from "./client.js";
 
 const client = new McpClient();
-const mcpServerUrl = process.env.MCP_SERVER_URL || 'http://localhost:3000/mcp';
+const mcpServerUrl = import.meta.env.VITE_MCP_SERVER_URL || 'http://localhost:3000/mcp';
 client.connect(mcpServerUrl).then(() => {
   console.info("Connected to MCP server");
 });


### PR DESCRIPTION
see https://github.com/alpic-ai/skybridge/issues/444

This pull request adds a support that the devtools can point at a different mcp server url than the hardcoded `localhost:3000/mcp`. while defaulting to the same

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the devtools MCP client initialization to allow overriding the default MCP endpoint (previously hardcoded to `http://localhost:3000/mcp`) via an environment variable (`MCP_SERVER_URL`).

The change is implemented in `packages/devtools/src/lib/mcp/index.ts`, which is imported by multiple React UI components and therefore runs in the Vite browser bundle at module load time.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is due to a likely browser runtime error in devtools.
- The PR reads `process.env.MCP_SERVER_URL` in code that is bundled for the browser via Vite. Without explicit Vite `define` configuration or using `import.meta.env`, `process` is typically undefined in the browser, which can crash the devtools UI at startup. Fixing the env access pattern should make the change safe.
- packages/devtools/src/lib/mcp/index.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->