### PR TITLE
feat: update skill docs

### DIFF
--- a/docs/devtools/skills.mdx
+++ b/docs/devtools/skills.mdx
@@ -1,8 +1,6 @@
 ---
 title: Skills
 description: "Use AI coding assistants pre-loaded with Skybridge expertise to build your app."
-icon: "brain"
-iconType: "regular"
 ---
 
 <Tip>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -41,7 +41,6 @@
                   "fundamentals/mcp-apps"
                 ]
               },
-              "quickstart/skills",
               "quickstart/create-new-app",
               "quickstart/test-your-app",
               "quickstart/build-for-production",
@@ -73,7 +72,7 @@
           {
             "group": "DevTools",
             "icon": "wrench",
-            "pages": ["devtools/index"]
+            "pages": ["devtools/skills", "devtools/index"]
           },
           {
             "group": "Resources",

--- a/docs/quickstart/create-new-app.mdx
+++ b/docs/quickstart/create-new-app.mdx
@@ -5,7 +5,7 @@ icon: "bolt"
 iconType: "regular"
 ---
 
-The fastest way to start building is using our starter template. It comes pre-configured with an MCP server, a basic UI widget, and a full dev server with a local emulator and HMR.
+The easiest way to bootstrap a project is using our [🧠 Skill](/devtools/skills). To get a running codebase right away, you can use our starter template — it comes pre-configured with an MCP server, a basic UI widget, and a full dev server with a local emulator and HMR.
 
 <Tip>
 **New to ChatGPT or MCP Apps**? Read [Fundamentals](/fundamentals) first to understand the concepts.
@@ -15,7 +15,7 @@ The fastest way to start building is using our starter template. It comes pre-co
 **Don't know if you should start with a ChatGPT or MCP App?** It doesn't matter! With Skybridge, you build your App once, and it runs seamlessly with both runtimes.
 </Tip>
 
-## Bootstrap your project
+## Scaffold your project
 
 Set up your app with a single command:
 


### PR DESCRIPTION
move to devtools, mention in quickstart

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR relocates the Skills documentation from `docs/quickstart/skills.mdx` into `docs/devtools/skills.mdx`, updates the docs navigation (`docs/docs.json`) to remove the old Quickstart entry and add the new DevTools page, and updates the Quickstart “Create new app” page to point readers to the new Skills page while renaming the section header from “Bootstrap” to “Scaffold”.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are isolated to documentation and navigation; the moved Skills page content is preserved and navigation updates appear consistent with the new location.
- docs/quickstart/create-new-app.mdx (minor doc style consistency)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->