### PR TITLE
feat: add migrate docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -45,6 +45,7 @@
                 ]
               },
               "quickstart/create-new-app",
+              "quickstart/migrate",
               "quickstart/test-your-app",
               "quickstart/build-for-production",
               "quickstart/deploy"

--- a/docs/quickstart/migrate.mdx
+++ b/docs/quickstart/migrate.mdx
@@ -1,0 +1,35 @@
+---
+title: Migrate
+description: "Migrate ChatGPT App or ext-apps to Skybridge"
+icon: "right-to-bracket"
+---
+
+Already have an app built with the [OpenAI Apps SDK](https://developers.openai.com/apps-sdk/) or [`@modelcontextprotocol/ext-apps`](https://github.com/modelcontextprotocol/ext-apps)? The Skybridge [Skill](/devtools/skills) can migrate it for you — it teaches your coding agent the full Skybridge framework so it can scaffold, rewrite, and wire up your project automatically.
+
+## Install the skill
+
+<CodeGroup>
+```bash npm
+npx skills add alpic-ai/skybridge -s skybridge
+```
+```bash pnpm
+pnpm dlx skills add alpic-ai/skybridge -s skybridge
+```
+```bash yarn
+yarn dlx skills add alpic-ai/skybridge -s skybridge
+```
+```bash bun
+bunx skills add alpic-ai/skybridge -s skybridge
+```
+```bash deno
+deno run -A npm:skills add alpic-ai/skybridge -s skybridge
+```
+</CodeGroup>
+
+## Prompt your agent
+
+```
+Migrate my app to /skybridge
+```
+
+That's it! Once migrated, keep using the [🧠 Skill](/devtools/skills) for ongoing development — brainstorming ideas, designing widgets and tools, running dev server, debugging, deploying, and more.

--- a/docs/telemetry.mdx
+++ b/docs/telemetry.mdx
@@ -1,8 +1,6 @@
 ---
 title: Telemetry
 description: "Learn what data Skybridge collects, why we collect it, and how to opt out."
-icon: "chart-line"
-iconType: "regular"
 ---
 
 # Telemetry


### PR DESCRIPTION
and remove telemetry icon to be consistent with other pages.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new Quickstart "Migrate" documentation page and registers it in `docs/docs.json` navigation. Also removes the custom icon frontmatter from the Telemetry page to align styling with other docs pages.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are limited to documentation: adding a new MDX page, wiring it into the docs navigation, and removing optional frontmatter fields. The new content matches existing docs patterns (e.g., CodeGroup usage) and internal links resolve to existing pages.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->