### PR TITLE
feat: push file ids to widget state

### DIFF
--- a/packages/core/src/web/bridges/apps-sdk/adaptor.ts
+++ b/packages/core/src/web/bridges/apps-sdk/adaptor.ts
@@ -8,6 +8,7 @@ import type {
   SetWidgetStateAction,
 } from "../types.js";
 import { AppsSdkBridge } from "./bridge.js";
+import type { WidgetState } from "./types.js";
 
 export class AppsSdkAdaptor implements Adaptor {
   private static instance: AppsSdkAdaptor | null = null;
@@ -78,7 +79,17 @@ export class AppsSdkAdaptor implements Adaptor {
   };
 
   public uploadFile = (file: File) => {
-    return window.openai.uploadFile(file);
+    return window.openai.uploadFile(file).then(async (metadata) => {
+      const state: WidgetState = window.openai.widgetState
+        ? { ...window.openai.widgetState }
+        : { modelContent: {} };
+      if (!state.imageIds) {
+        state.imageIds = [];
+      }
+      state.imageIds.push(metadata.fileId);
+      await window.openai.setWidgetState(state);
+      return metadata;
+    });
   };
 
   public getFileDownloadUrl = (file: { fileId: string }) => {

--- a/packages/core/src/web/bridges/apps-sdk/types.ts
+++ b/packages/core/src/web/bridges/apps-sdk/types.ts
@@ -8,8 +8,9 @@ import type {
 
 type DisplayMode = "pip" | "inline" | "fullscreen" | "modal";
 
-type WidgetState = {
+export type WidgetState = {
   modelContent: Record<string, unknown>;
+  imageIds?: string[];
 };
 
 export const TOOL_RESPONSE_EVENT_TYPE = "openai:tool_response";

--- a/packages/core/src/web/hooks/use-files.test.ts
+++ b/packages/core/src/web/hooks/use-files.test.ts
@@ -4,8 +4,12 @@ import { useFiles } from "./use-files.js";
 
 describe("useFiles", () => {
   const OpenaiMock = {
-    uploadFile: vi.fn(),
+    uploadFile: vi.fn().mockResolvedValue({
+      fileId: `sediment://file_abc123`,
+    }),
     getFileDownloadUrl: vi.fn(),
+    widgetState: null,
+    setWidgetState: vi.fn(),
   };
 
   beforeEach(() => {


### PR DESCRIPTION
Spoiler: this is not working because the OpenAI runtime is [broken](https://community.openai.com/t/window-openai-uploadfile-and-setwidgetstate-and-imageids/1372230).

I'm pushing this change nevertheless because it has no impact on the API, and at least images end up where they are supposed to.