### PR TITLE
Put nodemon config in dev command

### DIFF
--- a/packages/core/src/cli/use-nodemon.ts
+++ b/packages/core/src/cli/use-nodemon.ts
@@ -15,7 +15,9 @@ export function useNodemon(env: NodeJS.ProcessEnv): Array<Message> {
   useEffect(() => {
     nodemon({
       env,
-      configFile: "nodemon.json",
+      watch: ["server/src"],
+      ext: "ts,json",
+      exec: "tsx server/src/index.ts",
       stdout: false,
     });
 


### PR DESCRIPTION
Preliminary to removing nodemon config files in template and examples folders

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change moves nodemon configuration into the core CLI’s `dev` command implementation (via `use-nodemon.ts`), likely to avoid requiring per-template/example nodemon config files. In practice, this centralizes nodemon watch/ignore settings in the CLI so templates can remain simpler while still getting consistent hot-reload behavior during development.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to the CLI’s nodemon integration and appears intended to centralize config. No additional files or cross-cutting behavior changes are introduced in the PR as provided.
- packages/core/src/cli/use-nodemon.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - test ([source](https://app.greptile.com/review/custom-context?memory=79a7ae1f-ecf0-49fd-99c6-e267baf0a6b8))

<!-- /greptile_comment -->