### PR TITLE
Make nodemon config optional

### DIFF
--- a/packages/core/src/cli/use-nodemon.ts
+++ b/packages/core/src/cli/use-nodemon.ts
@@ -1,3 +1,5 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
 import nodemonOriginal from "nodemon";
 import { useEffect, useState } from "react";
 import type { ExtendedNodemon } from "./nodemon.d.ts";
@@ -13,13 +15,19 @@ export function useNodemon(env: NodeJS.ProcessEnv): Array<Message> {
   const [messages, setMessages] = useState<Array<Message>>([]);
 
   useEffect(() => {
-    nodemon({
-      env,
-      watch: ["server/src"],
-      ext: "ts,json",
-      exec: "tsx server/src/index.ts",
-      stdout: false,
-    });
+    const configFile = resolve(process.cwd(), "nodemon.json");
+
+    const config = existsSync(configFile)
+      ? {
+          configFile,
+        }
+      : {
+          watch: ["server/src"],
+          ext: "ts,json",
+          exec: "tsx server/src/index.ts",
+        };
+
+    nodemon({ ...config, env, stdout: false });
 
     const handleStdoutData = (chunk: Buffer) => {
       const message = chunk.toString().trim();


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Made nodemon configuration file optional by checking if `nodemon.json` exists before using it. If the config file exists, nodemon uses it via the `configFile` option; otherwise, it falls back to hardcoded defaults (`watch: ["server/src"]`, `ext: "ts,json"`, `exec: "tsx server/src/index.ts"`). The `env` and `stdout: false` options are still passed in both cases.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is straightforward and well-implemented. It adds a simple conditional check for the existence of a config file before deciding whether to use it or fall back to defaults. The spread operator ensures that `env` and `stdout: false` are always passed regardless of which path is taken. The logic is clear and matches the existing pattern used throughout the codebase.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->