### PR TITLE
Fix start command serving assets

### DIFF
--- a/packages/core/src/server/express.ts
+++ b/packages/core/src/server/express.ts
@@ -1,5 +1,4 @@
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import cors from "cors";
 import express from "express";
@@ -22,11 +21,10 @@ export async function createServer({
   }
 
   if (env === "production") {
-    const __filename = fileURLToPath(import.meta.url);
-    const __dirname = path.dirname(__filename);
+    const assetsPath = path.join(process.cwd(), "dist", "assets");
 
     app.use("/assets", cors());
-    app.use("/assets", express.static(path.join(__dirname, "assets")));
+    app.use("/assets", express.static(assetsPath));
   }
 
   app.use("/mcp", mcpMiddleware(server));


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed the production assets serving path by replacing `__dirname` calculation (which incorrectly resolved to `dist/server`) with `process.cwd()` based path construction that correctly points to `dist/assets` where the build command places static files.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The change correctly fixes a bug where assets were being served from the wrong path (`dist/server/assets` instead of `dist/assets`). The new implementation using `process.cwd()` aligns with how the build command works (copies assets to `dist/assets`) and how the start command runs (from the project root). Also removes an unnecessary import.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->