### PR TITLE
[SKY-215] Update documentation to explain sb structure

### DIFF
--- a/examples/capitals/README.md
+++ b/examples/capitals/README.md
@@ -74,9 +74,7 @@ This command starts:
 ```
 ├── server/
 │   └── src/
-│       ├── index.ts      # Entry point
-│       ├── middleware.ts # MCP middleware
-│       ├── server.ts     # Widget registry & tool handlers
+│       ├── index.ts      # Server entry point
 │       ├── capitals.ts   # Capitals data & logic
 │       └── env.ts        # Env validation
 ├── web/

--- a/examples/ecom-carousel/README.md
+++ b/examples/ecom-carousel/README.md
@@ -65,9 +65,7 @@ This command starts:
 ```
 ├── server/
 │   └── src/
-│       ├── index.ts      # Entry point
-│       ├── middleware.ts # MCP middleware
-│       ├── server.ts     # Widget registry & tool handlers
+│       ├── index.ts      # Server entry point
 │       └── products.ts   # Product data
 ├── web/
 │   ├── src/

--- a/examples/everything/README.md
+++ b/examples/everything/README.md
@@ -70,9 +70,7 @@ This command starts:
 ```
 ├── server/
 │   └── src/
-│       ├── index.ts      # Entry point
-│       ├── middleware.ts # MCP middleware
-│       └── server.ts     # Widget registry & routes
+│       └── index.ts      # Server entry point
 ├── web/
 │   ├── src/
 │   │   ├── widgets/

--- a/examples/investigation-game/README.md
+++ b/examples/investigation-game/README.md
@@ -59,9 +59,7 @@ This command starts:
 ```
 ├── server/
 │   └── src/
-│       ├── index.ts        # Entry point
-│       ├── middleware.ts   # MCP middleware
-│       └── server.ts       # Widget registry & game story
+│       └── index.ts        # Server entry point
 ├── web/
 │   ├── src/
 │   │   ├── data/           # Suspects, puzzle, and image data

--- a/examples/productivity/README.md
+++ b/examples/productivity/README.md
@@ -71,9 +71,7 @@ This command starts:
 ```
 ├── server/
 │   └── src/
-│       ├── index.ts      # Entry point
-│       ├── middleware.ts # MCP middleware
-│       └── server.ts     # Widget registry & tool handlers
+│       └── index.ts      # Server entry point
 ├── web/
 │   ├── src/
 │   │   ├── components/   # Chart UI

--- a/packages/create-skybridge/template/README.md
+++ b/packages/create-skybridge/template/README.md
@@ -46,9 +46,7 @@ This command starts:
 ```
 ├── server/
 │   └── src/
-│       ├── index.ts      # Entry point
-│       ├── middleware.ts # MCP middleware
-│       └── server.ts     # Widget registry & routes
+│       └── index.ts      # Server entry point
 ├── web/
 │   ├── src/
 │   │   ├── widgets/      # React components (one per widget)


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates README documentation across all examples and the starter template to reflect a simplified server file structure (single `index.ts` instead of separate `middleware.ts` and `server.ts` files). However, while the template has actually been refactored to this new structure, all five examples (`capitals`, `ecom-carousel`, `everything`, `investigation-game`, `productivity`) still contain the old three-file structure with `middleware.ts` and `server.ts` that are actively imported and used in their `index.ts` files.

- The documentation changes create a mismatch between what the READMEs describe and what the actual code structure contains for all examples
- Only the template README accurately reflects its actual file structure
- Previous review thread identified this issue for the capitals example, but it applies to all examples in this PR

<h3>Confidence Score: 2/5</h3>

- Documentation changes are inaccurate for all examples
- The PR contains a critical documentation accuracy issue: all five example READMEs were updated to show a simplified server structure that doesn't match their actual code. The examples still use `middleware.ts` and `server.ts` files that are imported in `index.ts`, but the documentation removed these from the project structure diagrams. This will confuse developers trying to understand or work with the examples.
- All example README files need their server structure documentation reverted or the actual code needs to be refactored to match

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->