### PR TITLE
[CAPITALS] feat: add use effect to react of new capital selected

### DIFF
--- a/examples/capitals/web/src/widgets/explore-capitals.tsx
+++ b/examples/capitals/web/src/widgets/explore-capitals.tsx
@@ -14,9 +14,9 @@ function CapitalExplorer() {
   const [displayMode, setDisplayMode] = useDisplayMode();
   const isFullscreen = displayMode === "fullscreen";
 
-  const { input, output, responseMetadata, isPending } =
+  const { output, responseMetadata, isPending } =
     useToolInfo<"explore-capitals">();
-  const [selectedCapital, setSelectedCapital] = useState(input?.name);
+  const [selectedCapital, setSelectedCapital] = useState<string | null>(null);
   const [pendingCapital, setPendingCapital] = useState<string | null>(null);
   const allCapitals = responseMetadata?.allCapitals || [];
 
@@ -25,6 +25,12 @@ function CapitalExplorer() {
     isPending: isTraveling,
     data,
   } = useCallTool("explore-capitals");
+
+  useEffect(() => {
+    if (output?.capital.name) {
+      setSelectedCapital(output.capital.name);
+    }
+  }, [output?.capital.name]);
 
   useEffect(() => {
     if (isFullscreen && pendingCapital) {


### PR DESCRIPTION
- Currently when the user ask to see another capital, it does not center again on the capital -> Nice wahoo effect I think

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added a `useEffect` hook that automatically updates `selectedCapital` whenever `output?.capital.name` changes, ensuring the map re-centers on newly selected capitals for a smooth transition effect. The initial state of `selectedCapital` was changed from `input?.name` to `null`, and the unused `input` destructuring was removed.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is straightforward and implements the desired behavior correctly. The new `useEffect` hook properly syncs state with output, the dependency array is correct, and the removal of unused code is appropriate. The implementation follows React best practices and achieves the intended "wahoo effect" of re-centering the map on capital changes.
- No files require special attention

<sub>Last reviewed commit: a12552c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->