### PR TITLE
fix: widget state rendering order mcp-apps

### DIFF
--- a/packages/core/src/web/bridges/mcp-app/adaptor.ts
+++ b/packages/core/src/web/bridges/mcp-app/adaptor.ts
@@ -220,6 +220,13 @@ export class McpAppAdaptor implements Adaptor {
         ? stateOrUpdater(this._widgetState)
         : stateOrUpdater;
 
+    // must happen before the async bridge call to ensure the state is updated immediately for the UI,
+    // otherwise successive calls to setWidgetState may have stale state
+    this._widgetState = newState;
+    this.widgetStateListeners.forEach((listener) => {
+      listener();
+    });
+
     const bridge = McpAppBridge.getInstance();
     await bridge.request<McpUiUpdateModelContextRequest, unknown>({
       method: "ui/update-model-context",
@@ -227,10 +234,6 @@ export class McpAppAdaptor implements Adaptor {
         structuredContent: newState,
         content: [{ type: "text", text: JSON.stringify(newState) }],
       },
-    });
-    this._widgetState = newState;
-    this.widgetStateListeners.forEach((listener) => {
-      listener();
     });
   };
 


### PR DESCRIPTION
fixes #473 

 setWidgetState updated _widgetState only after await bridge.request(). This created an async gap where concurrent callers would read stale state.

so the widget's useEffect (setting full data) and DataLLM's useEffect (spreading prevState to add __widget_context) both call setWidgetState in the same tick. The second call reads _widgetState before the first call's await resolves, gets null, and produces {__widget_context: "..." } without the actual widget data. 
When this overwrites the full state, the widget crashes trying to iterate missing arrays.