### PR TITLE
fix: register custom middleware before /mcp handler

### DIFF
--- a/packages/core/src/server/express.test.ts
+++ b/packages/core/src/server/express.test.ts
@@ -1,0 +1,100 @@
+import http from "node:http";
+import type { RequestHandler } from "express";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { McpServer } from "./server";
+
+vi.mock("@skybridge/devtools", () => ({
+  devtoolsStaticServer: () =>
+    ((_req: unknown, _res: unknown, next: () => void) =>
+      next()) as RequestHandler,
+}));
+
+vi.mock("./widgetsDevServer.js", () => ({
+  widgetsDevServer: () =>
+    ((_req: unknown, _res: unknown, next: () => void) =>
+      next()) as RequestHandler,
+}));
+
+const fakeServer = {} as McpServer;
+
+async function listen(app: Parameters<typeof http.createServer>[1]) {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const port = (server.address() as { port: number }).port;
+  return { port, server };
+}
+
+let openServer: http.Server | undefined;
+afterEach(() => openServer?.close());
+
+async function postMcp(port: number) {
+  return fetch(`http://localhost:${port}/mcp`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 1 }),
+  });
+}
+
+describe("createServer", () => {
+  it("runs global custom middleware before the /mcp handler", async () => {
+    const { createServer } = await import("./express.js");
+    const calls: string[] = [];
+
+    const mw: RequestHandler = (_req, _res, next) => {
+      calls.push("custom");
+      next();
+    };
+
+    const app = await createServer({
+      server: fakeServer,
+      customMiddleware: [{ handlers: [mw] }],
+    });
+
+    const { port, server } = await listen(app);
+    openServer = server;
+
+    await postMcp(port);
+    expect(calls).toEqual(["custom"]);
+  });
+
+  it("runs path-scoped middleware on /mcp", async () => {
+    const { createServer } = await import("./express.js");
+    const calls: string[] = [];
+
+    const mw: RequestHandler = (_req, _res, next) => {
+      calls.push("auth");
+      next();
+    };
+
+    const app = await createServer({
+      server: fakeServer,
+      customMiddleware: [{ path: "/mcp", handlers: [mw] }],
+    });
+
+    const { port, server } = await listen(app);
+    openServer = server;
+
+    await postMcp(port);
+    expect(calls).toEqual(["auth"]);
+  });
+
+  it("allows middleware to short-circuit with 401", async () => {
+    const { createServer } = await import("./express.js");
+
+    const reject: RequestHandler = (_req, res) => {
+      res.status(401).json({ error: "Unauthorized" });
+    };
+
+    const app = await createServer({
+      server: fakeServer,
+      customMiddleware: [{ path: "/mcp", handlers: [reject] }],
+    });
+
+    const { port, server } = await listen(app);
+    openServer = server;
+
+    const res = await postMcp(port);
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Unauthorized" });
+  });
+});

--- a/packages/core/src/server/express.ts
+++ b/packages/core/src/server/express.ts
@@ -6,8 +6,10 @@ import type { McpServer } from "./server";
 
 export async function createServer({
   server,
+  customMiddleware = [],
 }: {
   server: McpServer;
+  customMiddleware?: { path?: string; handlers: express.RequestHandler[] }[];
 }): Promise<express.Express> {
   const app = express();
   app.use(express.json());
@@ -25,6 +27,14 @@ export async function createServer({
 
     app.use("/assets", cors());
     app.use("/assets", express.static(assetsPath));
+  }
+
+  for (const middleware of customMiddleware) {
+    if (middleware.path) {
+      app.use(middleware.path, ...middleware.handlers);
+    } else {
+      app.use(...middleware.handlers);
+    }
   }
 
   app.use("/mcp", mcpMiddleware(server));

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -256,15 +256,8 @@ export class McpServer<
     if (!this.express) {
       this.express = await createServer({
         server: this,
+        customMiddleware: this.customMiddleware,
       });
-
-      for (const middleware of this.customMiddleware) {
-        if (middleware.path) {
-          this.express.use(middleware.path, ...middleware.handlers);
-        } else {
-          this.express.use(...middleware.handlers);
-        }
-      }
     }
 
     const express = this.express;


### PR DESCRIPTION
## Summary

- Fixes #474
- Custom middleware registered via `.use()` now runs **before** the `/mcp` route handler, allowing auth middleware (e.g. MCP OAuth) to intercept requests

## Changes

- `createServer()` in `express.ts` accepts an optional `customMiddleware` array and registers it before `app.use("/mcp", ...)`
- `run()` in `server.ts` passes `this.customMiddleware` into `createServer()` instead of applying it after

## Test plan

- [x] Added 3 tests in `express.test.ts` covering: global middleware, path-scoped middleware, and 401 short-circuit
- [x] Verified tests **fail** against the original code (middleware never runs)
- [x] Verified tests **pass** with the fix
- [x] All 97 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes middleware ordering issue where custom middleware registered via `.use()` was being applied after the `/mcp` route handler, preventing auth middleware from intercepting MCP requests.

**Key changes:**
- Moved middleware registration logic from `server.ts` to `createServer()` in `express.ts`
- Custom middleware now runs before `app.use("/mcp", ...)`, enabling proper request interception
- Added comprehensive test coverage for global middleware, path-scoped middleware, and auth short-circuiting

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is straightforward and well-tested. It simply moves middleware registration to execute before the `/mcp` handler rather than after. The change is minimal, focused, and includes comprehensive test coverage that validates the fix works correctly for all use cases (global middleware, path-scoped middleware, and auth rejection).
- No files require special attention

<sub>Last reviewed commit: beb60f5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->