### PR TITLE
chore: bump examples

### DIFF
--- a/examples/auth/package.json
+++ b/examples/auth/package.json
@@ -18,18 +18,18 @@
     "jose": "^6.0.11",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "skybridge": ">=0.31.3 <1.0.0",
+    "skybridge": ">=0.31.4 <1.0.0",
     "vite": "^7.3.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@skybridge/devtools": ">=0.31.1 <1.0.0",
+    "@skybridge/devtools": ">=0.31.4 <1.0.0",
     "@types/express": "^5.0.6",
     "@types/node": "^22.15.30",
     "@types/react": "^19.2.13",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.4",
-    "alpic": "^1.85.0",
+    "alpic": "^1.89.0",
     "nodemon": "^3.1.11",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"

--- a/examples/capitals/package.json
+++ b/examples/capitals/package.json
@@ -22,11 +22,11 @@
     "react-dom": "^19.1.1",
     "react-map-gl": "^7.1.8",
     "react-router-dom": "^7.11.0",
-    "skybridge": ">=0.31.3 <1.0.0",
+    "skybridge": ">=0.31.4 <1.0.0",
     "tailwindcss": "^4.1.14"
   },
   "devDependencies": {
-    "@skybridge/devtools": ">=0.31.3 <1.0.0",
+    "@skybridge/devtools": ">=0.31.4 <1.0.0",
     "@tailwindcss/vite": "^4.1.14",
     "@types/express": "^5.0.3",
     "@types/mapbox-gl": "^3.4.1",
@@ -34,7 +34,7 @@
     "@types/react": "^19.1.16",
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.1.4",
-    "alpic": "^1.85.0",
+    "alpic": "^1.89.0",
     "tsx": "^4.19.4",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.7.2",

--- a/examples/ecom-carousel/package.json
+++ b/examples/ecom-carousel/package.json
@@ -14,17 +14,17 @@
     "@modelcontextprotocol/sdk": "^1.26.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
-    "skybridge": ">=0.31.3 <1.0.0",
+    "skybridge": ">=0.31.4 <1.0.0",
     "vite": "^7.3.1",
     "zod": "^4.3.5"
   },
   "devDependencies": {
-    "@skybridge/devtools": ">=0.31.3 <1.0.0",
+    "@skybridge/devtools": ">=0.31.4 <1.0.0",
     "@types/node": "^22.19.3",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.2",
-    "alpic": "^1.85.0",
+    "alpic": "^1.89.0",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   }

--- a/examples/everything/package.json
+++ b/examples/everything/package.json
@@ -14,16 +14,16 @@
     "@modelcontextprotocol/sdk": "^1.26.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
-    "skybridge": ">=0.31.3 <1.0.0",
+    "skybridge": ">=0.31.4 <1.0.0",
     "vite": "^7.3.0",
     "zod": "^4.3.5"
   },
   "devDependencies": {
-    "@skybridge/devtools": ">=0.31.3 <1.0.0",
+    "@skybridge/devtools": ">=0.31.4 <1.0.0",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.2",
-    "alpic": "^1.85.0",
+    "alpic": "^1.89.0",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   },

--- a/examples/investigation-game/package.json
+++ b/examples/investigation-game/package.json
@@ -15,7 +15,7 @@
     "clsx": "^2.1.1",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
-    "skybridge": ">=0.31.3 <1.0.0",
+    "skybridge": ">=0.31.4 <1.0.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.14",
     "tw-animate-css": "^1.4.0",
@@ -23,12 +23,12 @@
     "zod": "^4.3.5"
   },
   "devDependencies": {
-    "@skybridge/devtools": ">=0.31.3 <1.0.0",
+    "@skybridge/devtools": ">=0.31.4 <1.0.0",
     "@types/react": "^19.2.8",
     "@types/react-dom": "^19.2.3",
     "@tailwindcss/vite": "^4.1.14",
     "@vitejs/plugin-react": "^5.1.2",
-    "alpic": "^1.85.0",
+    "alpic": "^1.89.0",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   },

--- a/examples/manifest-ui/package.json
+++ b/examples/manifest-ui/package.json
@@ -20,7 +20,7 @@
     "radix-ui": "^1.4.3",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
-    "skybridge": ">=0.31.3 <1.0.0",
+    "skybridge": ">=0.31.4 <1.0.0",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.18",
     "tw-animate-css": "^1.4.0",
@@ -28,12 +28,12 @@
     "zod": "^4.3.5"
   },
   "devDependencies": {
-    "@skybridge/devtools": ">=0.31.3 <1.0.0",
+    "@skybridge/devtools": ">=0.31.4 <1.0.0",
     "@types/node": "^25.0.10",
     "@types/react": "^19.2.8",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.2",
-    "alpic": "^1.85.0",
+    "alpic": "^1.89.0",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   },

--- a/examples/productivity/package.json
+++ b/examples/productivity/package.json
@@ -14,16 +14,16 @@
     "@modelcontextprotocol/sdk": "^1.26.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
-    "skybridge": ">=0.31.3 <1.0.0",
+    "skybridge": ">=0.31.4 <1.0.0",
     "vite": "^7.3.1",
     "zod": "^4.3.5"
   },
   "devDependencies": {
-    "@skybridge/devtools": ">=0.31.3 <1.0.0",
+    "@skybridge/devtools": ">=0.31.4 <1.0.0",
     "@types/react": "^19.2.8",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.2",
-    "alpic": "^1.85.0",
+    "alpic": "^1.89.0",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   },

--- a/packages/create-skybridge/template/package.json
+++ b/packages/create-skybridge/template/package.json
@@ -14,16 +14,16 @@
     "@modelcontextprotocol/sdk": "^1.26.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "skybridge": ">=0.31.2 <1.0.0",
+    "skybridge": ">=0.31.4 <1.0.0",
     "vite": "^7.3.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@skybridge/devtools": ">=0.31.3 <1.0.0",
+    "@skybridge/devtools": ">=0.31.4 <1.0.0",
     "@types/react": "^19.2.13",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.4",
-    "alpic": "^1.85.0",
+    "alpic": "^1.89.0",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
       skybridge:
-        specifier: '>=0.31.3 <1.0.0'
-        version: 0.31.3(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(@skybridge/devtools@0.31.3)(@types/node@22.19.3)(@types/react@19.2.13)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(nodemon@3.1.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.4))(yaml@2.8.2)
+        specifier: '>=0.31.4 <1.0.0'
+        version: 0.31.4(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(@skybridge/devtools@0.31.4)(@types/react@19.2.13)(immer@9.0.21)(nodemon@3.1.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       vite:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
@@ -61,8 +61,8 @@ importers:
         version: 4.3.6
     devDependencies:
       '@skybridge/devtools':
-        specifier: '>=0.31.1 <1.0.0'
-        version: 0.31.3
+        specifier: '>=0.31.4 <1.0.0'
+        version: 0.31.4
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
@@ -79,8 +79,8 @@ importers:
         specifier: ^5.1.4
         version: 5.1.4(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       alpic:
-        specifier: ^1.85.0
-        version: 1.85.0(@opentelemetry/api@1.9.0)
+        specifier: ^1.89.0
+        version: 1.89.0(@opentelemetry/api@1.9.0)
       nodemon:
         specifier: ^3.1.11
         version: 3.1.11
@@ -127,15 +127,15 @@ importers:
         specifier: ^7.11.0
         version: 7.11.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       skybridge:
-        specifier: '>=0.31.3 <1.0.0'
-        version: 0.31.3(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(@skybridge/devtools@0.31.3)(@types/node@22.19.3)(@types/react@19.2.7)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(nodemon@3.1.11)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.0))(yaml@2.8.2)
+        specifier: '>=0.31.4 <1.0.0'
+        version: 0.31.4(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(@skybridge/devtools@0.31.4)(@types/react@19.2.7)(immer@9.0.21)(nodemon@3.1.11)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       tailwindcss:
         specifier: ^4.1.14
         version: 4.1.18
     devDependencies:
       '@skybridge/devtools':
-        specifier: '>=0.31.3 <1.0.0'
-        version: 0.31.3
+        specifier: '>=0.31.4 <1.0.0'
+        version: 0.31.4
       '@tailwindcss/vite':
         specifier: ^4.1.14
         version: 4.1.18(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
@@ -158,8 +158,8 @@ importers:
         specifier: ^5.1.4
         version: 5.1.4(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       alpic:
-        specifier: ^1.85.0
-        version: 1.85.0(@opentelemetry/api@1.9.0)
+        specifier: ^1.89.0
+        version: 1.89.0(@opentelemetry/api@1.9.0)
       tsx:
         specifier: ^4.19.4
         version: 4.21.0
@@ -185,8 +185,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
       skybridge:
-        specifier: '>=0.31.3 <1.0.0'
-        version: 0.31.3(@modelcontextprotocol/sdk@1.26.0(zod@4.3.5))(@skybridge/devtools@0.31.3)(@types/node@22.19.3)(@types/react@19.2.7)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(nodemon@3.1.11)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.3))(yaml@2.8.2)
+        specifier: '>=0.31.4 <1.0.0'
+        version: 0.31.4(@modelcontextprotocol/sdk@1.26.0(zod@4.3.5))(@skybridge/devtools@0.31.4)(@types/react@19.2.7)(immer@9.0.21)(nodemon@3.1.11)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       vite:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
@@ -195,8 +195,8 @@ importers:
         version: 4.3.5
     devDependencies:
       '@skybridge/devtools':
-        specifier: '>=0.31.3 <1.0.0'
-        version: 0.31.3
+        specifier: '>=0.31.4 <1.0.0'
+        version: 0.31.4
       '@types/node':
         specifier: ^22.19.3
         version: 22.19.3
@@ -210,8 +210,8 @@ importers:
         specifier: ^5.1.2
         version: 5.1.2(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       alpic:
-        specifier: ^1.85.0
-        version: 1.85.0(@opentelemetry/api@1.9.0)
+        specifier: ^1.89.0
+        version: 1.89.0(@opentelemetry/api@1.9.0)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -231,8 +231,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
       skybridge:
-        specifier: '>=0.31.3 <1.0.0'
-        version: 0.31.3(@modelcontextprotocol/sdk@1.26.0(zod@4.3.5))(@skybridge/devtools@0.31.3)(@types/node@25.2.3)(@types/react@19.2.7)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(nodemon@3.1.11)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.3))(yaml@2.8.2)
+        specifier: '>=0.31.4 <1.0.0'
+        version: 0.31.4(@modelcontextprotocol/sdk@1.26.0(zod@4.3.5))(@skybridge/devtools@0.31.4)(@types/react@19.2.7)(immer@9.0.21)(nodemon@3.1.11)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       vite:
         specifier: ^7.3.0
         version: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
@@ -241,8 +241,8 @@ importers:
         version: 4.3.5
     devDependencies:
       '@skybridge/devtools':
-        specifier: '>=0.31.3 <1.0.0'
-        version: 0.31.3
+        specifier: '>=0.31.4 <1.0.0'
+        version: 0.31.4
       '@types/react':
         specifier: ^19.2.7
         version: 19.2.7
@@ -253,8 +253,8 @@ importers:
         specifier: ^5.1.2
         version: 5.1.2(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       alpic:
-        specifier: ^1.85.0
-        version: 1.85.0(@opentelemetry/api@1.9.0)
+        specifier: ^1.89.0
+        version: 1.89.0(@opentelemetry/api@1.9.0)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -277,8 +277,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.4(react@19.2.4)
       skybridge:
-        specifier: '>=0.31.3 <1.0.0'
-        version: 0.31.3(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(@skybridge/devtools@0.31.3)(@types/node@25.2.3)(@types/react@19.2.13)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(nodemon@3.1.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.4))(yaml@2.8.2)
+        specifier: '>=0.31.4 <1.0.0'
+        version: 0.31.4(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(@skybridge/devtools@0.31.4)(@types/react@19.2.13)(immer@9.0.21)(nodemon@3.1.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.4.0
@@ -296,8 +296,8 @@ importers:
         version: 4.3.6
     devDependencies:
       '@skybridge/devtools':
-        specifier: '>=0.31.3 <1.0.0'
-        version: 0.31.3
+        specifier: '>=0.31.4 <1.0.0'
+        version: 0.31.4
       '@tailwindcss/vite':
         specifier: ^4.1.14
         version: 4.1.18(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
@@ -311,8 +311,8 @@ importers:
         specifier: ^5.1.2
         version: 5.1.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       alpic:
-        specifier: ^1.85.0
-        version: 1.85.0(@opentelemetry/api@1.9.0)
+        specifier: ^1.89.0
+        version: 1.89.0(@opentelemetry/api@1.9.0)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -350,8 +350,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.4(react@19.2.4)
       skybridge:
-        specifier: '>=0.31.3 <1.0.0'
-        version: 0.31.3(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(@skybridge/devtools@0.31.3)(@types/node@25.2.3)(@types/react@19.2.13)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(nodemon@3.1.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.4))(yaml@2.8.2)
+        specifier: '>=0.31.4 <1.0.0'
+        version: 0.31.4(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(@skybridge/devtools@0.31.4)(@types/react@19.2.13)(immer@9.0.21)(nodemon@3.1.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -369,8 +369,8 @@ importers:
         version: 4.3.6
     devDependencies:
       '@skybridge/devtools':
-        specifier: '>=0.31.3 <1.0.0'
-        version: 0.31.3
+        specifier: '>=0.31.4 <1.0.0'
+        version: 0.31.4
       '@types/node':
         specifier: ^25.0.10
         version: 25.2.3
@@ -384,8 +384,8 @@ importers:
         specifier: ^5.1.2
         version: 5.1.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       alpic:
-        specifier: ^1.85.0
-        version: 1.85.0(@opentelemetry/api@1.9.0)
+        specifier: ^1.89.0
+        version: 1.89.0(@opentelemetry/api@1.9.0)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -405,8 +405,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
       skybridge:
-        specifier: '>=0.31.3 <1.0.0'
-        version: 0.31.3(@modelcontextprotocol/sdk@1.26.0(zod@4.3.5))(@skybridge/devtools@0.31.3)(@types/node@25.2.3)(@types/react@19.2.8)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(nodemon@3.1.11)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.3))(yaml@2.8.2)
+        specifier: '>=0.31.4 <1.0.0'
+        version: 0.31.4(@modelcontextprotocol/sdk@1.26.0(zod@4.3.5))(@skybridge/devtools@0.31.4)(@types/react@19.2.8)(immer@9.0.21)(nodemon@3.1.11)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       vite:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
@@ -415,8 +415,8 @@ importers:
         version: 4.3.5
     devDependencies:
       '@skybridge/devtools':
-        specifier: '>=0.31.3 <1.0.0'
-        version: 0.31.3
+        specifier: '>=0.31.4 <1.0.0'
+        version: 0.31.4
       '@types/react':
         specifier: ^19.2.8
         version: 19.2.8
@@ -427,8 +427,8 @@ importers:
         specifier: ^5.1.2
         version: 5.1.2(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       alpic:
-        specifier: ^1.85.0
-        version: 1.85.0(@opentelemetry/api@1.9.0)
+        specifier: ^1.89.0
+        version: 1.89.0(@opentelemetry/api@1.9.0)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -579,8 +579,8 @@ importers:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
       skybridge:
-        specifier: '>=0.31.2 <1.0.0'
-        version: 0.31.3(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(@skybridge/devtools@0.31.3)(@types/node@25.2.3)(@types/react@19.2.13)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(nodemon@3.1.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.4))(yaml@2.8.2)
+        specifier: '>=0.31.4 <1.0.0'
+        version: 0.31.4(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(@skybridge/devtools@0.31.4)(@types/react@19.2.13)(immer@9.0.21)(nodemon@3.1.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       vite:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
@@ -589,8 +589,8 @@ importers:
         version: 4.3.6
     devDependencies:
       '@skybridge/devtools':
-        specifier: '>=0.31.3 <1.0.0'
-        version: 0.31.3
+        specifier: '>=0.31.4 <1.0.0'
+        version: 0.31.4
       '@types/react':
         specifier: ^19.2.13
         version: 19.2.13
@@ -601,8 +601,8 @@ importers:
         specifier: ^5.1.4
         version: 5.1.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       alpic:
-        specifier: ^1.85.0
-        version: 1.85.0(@opentelemetry/api@1.9.0)
+        specifier: ^1.89.0
+        version: 1.89.0(@opentelemetry/api@1.9.0)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -756,8 +756,8 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@alpic-ai/api@1.85.0':
-    resolution: {integrity: sha512-Kh4W7AfhYsCHMSb5X8E85ZpJm0Mug56UhKZGTA2wHpKzn/F8tzqI4lWbcdJgm38b80uEbEChsJZODWLBxJHIag==}
+  '@alpic-ai/api@1.89.0':
+    resolution: {integrity: sha512-7XqsSgbr2wAwk23Dm2DkrQ8RgGBGkM8bjulPGgivI6yIXpJdcjgfPdUWulUG0Cs7Iey3X8PThvMDkArqfgOGAA==}
 
   '@antfu/ni@25.0.0':
     resolution: {integrity: sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA==}
@@ -2900,6 +2900,9 @@ packages:
   '@skybridge/devtools@0.31.3':
     resolution: {integrity: sha512-qnHgoVePQh6MQi+s9ml8l71xuOQ237GeqH3qLf6dH9yFwU6U/OWq19+DN41YVX+fmZDXKzu1XxDA9PK94R2zUQ==}
 
+  '@skybridge/devtools@0.31.4':
+    resolution: {integrity: sha512-hg6ywyyIqWkVLtTFS2k7EXQyHxfDuDOpjbf1WEL2DmrJ5oIgKsFgkNX0G8SP6nrVigA3chdexwU+KlPR/lBiyg==}
+
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
@@ -3499,8 +3502,8 @@ packages:
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
-  alpic@1.85.0:
-    resolution: {integrity: sha512-dll2FnahfXFp4fPTq6/OGXhEzf1JXlGHckhtAZ+OaixbVUswHMvojrorIFGd3cMdE0ehtkeg9RRSPZOX+nlXPw==}
+  alpic@1.89.0:
+    resolution: {integrity: sha512-W8wNhCmSsdTZgOz/lnrOroMqwVjKBh8S6F0LIWcyd+AOk6rSYJnxmSjp4SI0UZYZwUV0+VLTfeMrXG2ipZbAWA==}
     engines: {node: '>= 18.20.8'}
     hasBin: true
 
@@ -6983,8 +6986,8 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
-  skybridge@0.31.3:
-    resolution: {integrity: sha512-cPMPR7oA32tGNWR35iqtvNy6dPOfr4gJ/teA9HZef9e9cs90Jk4UX9OoKbV2QUFPHjOiZyTbJNSL8yuq8d7ADg==}
+  skybridge@0.31.4:
+    resolution: {integrity: sha512-uMJR7dPn327iguEaW4IfYZEyeR9LY/EO7P4ceiQ3yEspyi771o1mnCEPJytXsG1n1OrLggnxQydO3bHj4AV6tg==}
     hasBin: true
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.0.0'
@@ -6992,6 +6995,7 @@ packages:
       nodemon: '>=3.0.0'
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
+      vite: ^7.3.1
 
   slice-ansi@5.0.0:
     resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
@@ -7225,6 +7229,7 @@ packages:
   tar@7.5.7:
     resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   terser@5.44.1:
     resolution: {integrity: sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==}
@@ -7936,7 +7941,7 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@alpic-ai/api@1.85.0(@opentelemetry/api@1.9.0)':
+  '@alpic-ai/api@1.89.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@orpc/contract': 1.13.4(@opentelemetry/api@1.9.0)
       zod: 4.3.6
@@ -10829,6 +10834,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@skybridge/devtools@0.31.4':
+    dependencies:
+      cors: 2.8.6
+      express: 5.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@socket.io/component-emitter@3.1.2': {}
 
   '@standard-schema/spec@1.0.0': {}
@@ -11583,9 +11595,9 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  alpic@1.85.0(@opentelemetry/api@1.9.0):
+  alpic@1.89.0(@opentelemetry/api@1.9.0):
     dependencies:
-      '@alpic-ai/api': 1.85.0(@opentelemetry/api@1.9.0)
+      '@alpic-ai/api': 1.89.0(@opentelemetry/api@1.9.0)
       '@clack/prompts': 1.0.0
       '@oclif/core': 4.8.0
       '@orpc/client': 1.13.4(@opentelemetry/api@1.9.0)
@@ -16143,12 +16155,12 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
-  skybridge@0.31.3(@modelcontextprotocol/sdk@1.26.0(zod@4.3.5))(@skybridge/devtools@0.31.3)(@types/node@22.19.3)(@types/react@19.2.7)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(nodemon@3.1.11)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.3))(yaml@2.8.2):
+  skybridge@0.31.4(@modelcontextprotocol/sdk@1.26.0(zod@4.3.5))(@skybridge/devtools@0.31.4)(@types/react@19.2.7)(immer@9.0.21)(nodemon@3.1.11)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@babel/core': 7.29.0
       '@modelcontextprotocol/sdk': 1.26.0(zod@4.3.5)
       '@oclif/core': 4.8.0
-      '@skybridge/devtools': 0.31.3
+      '@skybridge/devtools': 0.31.4
       ci-info: 4.4.0
       cors: 2.8.6
       dequal: 2.0.3
@@ -16164,31 +16176,20 @@ snapshots:
       vite: 7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
       zustand: 5.0.11(@types/react@19.2.7)(immer@9.0.21)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
     transitivePeerDependencies:
-      - '@types/node'
       - '@types/react'
       - bufferutil
       - immer
-      - jiti
-      - less
-      - lightningcss
       - react-devtools-core
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
       - supports-color
-      - terser
-      - tsx
       - use-sync-external-store
       - utf-8-validate
-      - yaml
 
-  skybridge@0.31.3(@modelcontextprotocol/sdk@1.26.0(zod@4.3.5))(@skybridge/devtools@0.31.3)(@types/node@25.2.3)(@types/react@19.2.7)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(nodemon@3.1.11)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.3))(yaml@2.8.2):
+  skybridge@0.31.4(@modelcontextprotocol/sdk@1.26.0(zod@4.3.5))(@skybridge/devtools@0.31.4)(@types/react@19.2.7)(immer@9.0.21)(nodemon@3.1.11)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@babel/core': 7.29.0
       '@modelcontextprotocol/sdk': 1.26.0(zod@4.3.5)
       '@oclif/core': 4.8.0
-      '@skybridge/devtools': 0.31.3
+      '@skybridge/devtools': 0.31.4
       ci-info: 4.4.0
       cors: 2.8.6
       dequal: 2.0.3
@@ -16204,31 +16205,20 @@ snapshots:
       vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
       zustand: 5.0.11(@types/react@19.2.7)(immer@9.0.21)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
     transitivePeerDependencies:
-      - '@types/node'
       - '@types/react'
       - bufferutil
       - immer
-      - jiti
-      - less
-      - lightningcss
       - react-devtools-core
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
       - supports-color
-      - terser
-      - tsx
       - use-sync-external-store
       - utf-8-validate
-      - yaml
 
-  skybridge@0.31.3(@modelcontextprotocol/sdk@1.26.0(zod@4.3.5))(@skybridge/devtools@0.31.3)(@types/node@25.2.3)(@types/react@19.2.8)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(nodemon@3.1.11)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.3))(yaml@2.8.2):
+  skybridge@0.31.4(@modelcontextprotocol/sdk@1.26.0(zod@4.3.5))(@skybridge/devtools@0.31.4)(@types/react@19.2.8)(immer@9.0.21)(nodemon@3.1.11)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@babel/core': 7.29.0
       '@modelcontextprotocol/sdk': 1.26.0(zod@4.3.5)
       '@oclif/core': 4.8.0
-      '@skybridge/devtools': 0.31.3
+      '@skybridge/devtools': 0.31.4
       ci-info: 4.4.0
       cors: 2.8.6
       dequal: 2.0.3
@@ -16244,31 +16234,20 @@ snapshots:
       vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
       zustand: 5.0.11(@types/react@19.2.8)(immer@9.0.21)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
     transitivePeerDependencies:
-      - '@types/node'
       - '@types/react'
       - bufferutil
       - immer
-      - jiti
-      - less
-      - lightningcss
       - react-devtools-core
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
       - supports-color
-      - terser
-      - tsx
       - use-sync-external-store
       - utf-8-validate
-      - yaml
 
-  skybridge@0.31.3(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(@skybridge/devtools@0.31.3)(@types/node@22.19.3)(@types/react@19.2.13)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(nodemon@3.1.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.4))(yaml@2.8.2):
+  skybridge@0.31.4(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(@skybridge/devtools@0.31.4)(@types/react@19.2.13)(immer@9.0.21)(nodemon@3.1.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@babel/core': 7.29.0
       '@modelcontextprotocol/sdk': 1.26.0(zod@4.3.6)
       '@oclif/core': 4.8.0
-      '@skybridge/devtools': 0.31.3
+      '@skybridge/devtools': 0.31.4
       ci-info: 4.4.0
       cors: 2.8.6
       dequal: 2.0.3
@@ -16284,71 +16263,20 @@ snapshots:
       vite: 7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
       zustand: 5.0.11(@types/react@19.2.13)(immer@9.0.21)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
     transitivePeerDependencies:
-      - '@types/node'
       - '@types/react'
       - bufferutil
       - immer
-      - jiti
-      - less
-      - lightningcss
       - react-devtools-core
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
       - supports-color
-      - terser
-      - tsx
       - use-sync-external-store
       - utf-8-validate
-      - yaml
 
-  skybridge@0.31.3(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(@skybridge/devtools@0.31.3)(@types/node@22.19.3)(@types/react@19.2.7)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(nodemon@3.1.11)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.0))(yaml@2.8.2):
+  skybridge@0.31.4(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(@skybridge/devtools@0.31.4)(@types/react@19.2.13)(immer@9.0.21)(nodemon@3.1.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@babel/core': 7.29.0
       '@modelcontextprotocol/sdk': 1.26.0(zod@4.3.6)
       '@oclif/core': 4.8.0
-      '@skybridge/devtools': 0.31.3
-      ci-info: 4.4.0
-      cors: 2.8.6
-      dequal: 2.0.3
-      es-toolkit: 1.44.0
-      express: 5.2.1
-      handlebars: 4.7.8
-      ink: 6.6.0(@types/react@19.2.7)(react@19.2.0)
-      nodemon: 3.1.11
-      posthog-node: 5.24.14
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      superjson: 2.2.6
-      vite: 7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
-      zustand: 5.0.11(@types/react@19.2.7)(immer@9.0.21)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))
-    transitivePeerDependencies:
-      - '@types/node'
-      - '@types/react'
-      - bufferutil
-      - immer
-      - jiti
-      - less
-      - lightningcss
-      - react-devtools-core
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - use-sync-external-store
-      - utf-8-validate
-      - yaml
-
-  skybridge@0.31.3(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(@skybridge/devtools@0.31.3)(@types/node@25.2.3)(@types/react@19.2.13)(immer@9.0.21)(jiti@2.6.1)(lightningcss@1.30.2)(nodemon@3.1.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(terser@5.44.1)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.2.4))(yaml@2.8.2):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@modelcontextprotocol/sdk': 1.26.0(zod@4.3.6)
-      '@oclif/core': 4.8.0
-      '@skybridge/devtools': 0.31.3
+      '@skybridge/devtools': 0.31.4
       ci-info: 4.4.0
       cors: 2.8.6
       dequal: 2.0.3
@@ -16364,24 +16292,42 @@ snapshots:
       vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
       zustand: 5.0.11(@types/react@19.2.13)(immer@9.0.21)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
     transitivePeerDependencies:
-      - '@types/node'
       - '@types/react'
       - bufferutil
       - immer
-      - jiti
-      - less
-      - lightningcss
       - react-devtools-core
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
       - supports-color
-      - terser
-      - tsx
       - use-sync-external-store
       - utf-8-validate
-      - yaml
+
+  skybridge@0.31.4(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(@skybridge/devtools@0.31.4)(@types/react@19.2.7)(immer@9.0.21)(nodemon@3.1.11)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@modelcontextprotocol/sdk': 1.26.0(zod@4.3.6)
+      '@oclif/core': 4.8.0
+      '@skybridge/devtools': 0.31.4
+      ci-info: 4.4.0
+      cors: 2.8.6
+      dequal: 2.0.3
+      es-toolkit: 1.44.0
+      express: 5.2.1
+      handlebars: 4.7.8
+      ink: 6.6.0(@types/react@19.2.7)(react@19.2.0)
+      nodemon: 3.1.11
+      posthog-node: 5.24.14
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      superjson: 2.2.6
+      vite: 7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      zustand: 5.0.11(@types/react@19.2.7)(immer@9.0.21)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))
+    transitivePeerDependencies:
+      - '@types/react'
+      - bufferutil
+      - immer
+      - react-devtools-core
+      - supports-color
+      - use-sync-external-store
+      - utf-8-validate
 
   slice-ansi@5.0.0:
     dependencies:


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Bumps dependency versions across all example apps and the `create-skybridge` template:
- `skybridge`: `>=0.31.3` → `>=0.31.4` (and `>=0.31.2` → `>=0.31.4` for the template)
- `@skybridge/devtools`: `>=0.31.1`/`>=0.31.3` → `>=0.31.4`
- `alpic`: `^1.85.0` → `^1.89.0`

The `pnpm-lock.yaml` is updated accordingly, reflecting the new `vite` peer dependency added in `skybridge@0.31.4` and the reduced set of transitive peer dependencies. No code changes — purely version bumps to keep examples aligned with the latest published packages.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only bumps dependency versions in example apps and the project template with a matching lockfile update.
- All changes are mechanical version bumps of three dependencies (skybridge, @skybridge/devtools, alpic) across example package.json files and the create-skybridge template, with a consistent pnpm-lock.yaml update. No application code, configuration logic, or build scripts are modified.
- No files require special attention.

<sub>Last reviewed commit: fefabd5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->