### PR TITLE
feat: put the custom middlewares up in the server creation

### DIFF
--- a/packages/core/src/server/express.ts
+++ b/packages/core/src/server/express.ts
@@ -14,7 +14,7 @@ export async function createServer({
   const app = express();
   app.use(express.json());
   const env = process.env.NODE_ENV || "development";
-  
+
   for (const middleware of customMiddleware) {
     if (middleware.path) {
       app.use(middleware.path, ...middleware.handlers);


### PR DESCRIPTION
In order to apply middlewares (like assets resolution from the root in dev mode..) before launching the other middlewares.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Moves custom middleware registration earlier in the Express app setup — from after devtools/static-asset middleware to immediately after `express.json()`. This is a follow-up to PR #476 which first introduced custom middleware support before the `/mcp` handler.

- Custom middleware now runs before devtools and static asset middleware, giving it full control over all routes
- The middleware loop code itself is unchanged — only its position in the `createServer` function moved
- Path-scoped middleware (e.g., `{ path: "/mcp", handlers: [...] }`) still works as expected for users who want narrower scope
- Existing tests in `express.test.ts` cover the key ordering guarantee (custom middleware runs before `/mcp`)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only relocates existing code without changing any logic.
- The change is a straightforward code relocation within a single file. The middleware registration loop is identical before and after; only its position changed. The intent is clear and aligns with the previous fix in PR #476. Existing tests validate the core behavior (custom middleware executes before `/mcp`).
- No files require special attention.

<sub>Last reviewed commit: 14e1a6a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->