### PR TITLE
fix: handle graceful shutdown in McpServer.run()

### DIFF
--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -267,6 +267,15 @@ export class McpServer<
         console.error("Failed to start server:", error);
         reject(error);
       });
+
+      const shutdown = () => {
+        server.close(() => process.exit(0));
+        setTimeout(() => process.exit(1), 3000);
+      };
+
+      process.on("SIGTERM", shutdown);
+      process.on("SIGINT", shutdown);
+
       server.listen(3000, () => {
         resolve();
       });


### PR DESCRIPTION
## Summary

- Register `SIGTERM` and `SIGINT` signal handlers in `McpServer.run()` to gracefully close the HTTP server before process exit
- Prevents `EADDRINUSE` errors when using `nodemon` or other process managers that restart the server
- Adds a 3-second forced exit timeout as a safety net if `server.close()` hangs

Fixes #481

## Test plan

- [ ] Start a Skybridge server with `nodemon`, verify restarts no longer cause `EADDRINUSE`
- [ ] Send `SIGTERM` to a running server, verify it exits cleanly
- [ ] Send `SIGINT` (Ctrl+C) to a running server, verify it exits cleanly
- [ ] Verify the build passes (`pnpm --filter skybridge build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds graceful shutdown handling to `McpServer.run()` by registering `SIGTERM` and `SIGINT` signal handlers that close the HTTP server before process exit. This prevents `EADDRINUSE` errors when using process managers like `nodemon` that restart the server. A 3-second forced-exit timeout acts as a safety net if `server.close()` hangs.

- Registers `SIGTERM` and `SIGINT` handlers that call `server.close()` followed by `process.exit(0)`
- Adds a 3-second `setTimeout` fallback that calls `process.exit(1)` if `server.close()` doesn't complete
- The change is small, focused, and follows a well-established Node.js graceful shutdown pattern

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds a standard graceful shutdown pattern with minimal risk.
- The change is small (8 lines), follows a well-known Node.js pattern for graceful shutdown, and only affects the `run()` method's lifecycle behavior. The logic is straightforward: close the server on signal, force-exit after 3 seconds if it hangs. One minor style suggestion (`.unref()` on the timer) but no functional issues.
- No files require special attention.

<sub>Last reviewed commit: 75daca4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->