### PR TITLE
fix: handle ui/notifications/tool-input-partial notification to fix u…

### DIFF
--- a/packages/core/src/web/bridges/mcp-app/bridge.ts
+++ b/packages/core/src/web/bridges/mcp-app/bridge.ts
@@ -9,6 +9,7 @@ import type {
   McpUiSizeChangedNotification,
   McpUiToolCancelledNotification,
   McpUiToolInputNotification,
+  McpUiToolInputPartialNotification,
   McpUiToolResultNotification,
 } from "@modelcontextprotocol/ext-apps";
 import type { Bridge, Subscribe } from "../types.js";
@@ -54,6 +55,7 @@ type McpAppRequest = {
 
 type McpAppNotification = { jsonrpc: "2.0" } & (
   | McpUiToolInputNotification
+  | McpUiToolInputPartialNotification
   | McpUiToolResultNotification
   | McpUiToolCancelledNotification
   | McpUiHostContextChangedNotification
@@ -240,6 +242,11 @@ export class McpAppBridge implements Bridge<McpUiHostContext> {
     switch (notification.method) {
       case "ui/notifications/host-context-changed":
         this.updateContext(notification.params);
+        return;
+      case "ui/notifications/tool-input-partial":
+        this.updateContext({
+          toolInput: notification.params.arguments ?? {},
+        });
         return;
       case "ui/notifications/tool-input":
         this.updateContext({


### PR DESCRIPTION
https://mcpui.dev/guide/protocol-details

Claude sends ui/notifications/tool-input only once the server has responded
ui/notifications/tool-input-partial is sent while the response streaming as soon as the tool call is started

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds handling for the `ui/notifications/tool-input-partial` MCP UI protocol notification in `McpAppBridge`, which is sent during streaming as soon as a tool call starts (before the server responds). Previously, only `ui/notifications/tool-input` was handled, meaning `toolInput` remained `null` during streaming, causing `useToolInfo().isPending` to incorrectly return `false` (status was `"idle"` instead of `"pending"`).

- Imports `McpUiToolInputPartialNotification` type and adds it to the `McpAppNotification` union
- Adds a switch case in `handleNotification()` for `"ui/notifications/tool-input-partial"` that updates `toolInput` identically to the existing `"ui/notifications/tool-input"` handler
- Clean, minimal fix that correctly addresses the gap in notification handling per the [MCP UI protocol spec](https://mcpui.dev/guide/protocol-details)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-scoped bug fix that adds handling for a previously unhandled protocol notification.
- The change is small (3 additions across one file), follows existing patterns exactly, adds proper type safety via the imported type and union addition, and correctly fixes the documented bug where useToolInfo().isPending was not set during streaming. No logic, security, or correctness concerns.
- No files require special attention.

<sub>Last reviewed commit: 2734a50</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->