### PR TITLE
chore: remove declaration true on skybridge examples

### DIFF
--- a/examples/auth/tsconfig.server.json
+++ b/examples/auth/tsconfig.server.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "noEmit": false,
     "outDir": "dist",
-    "sourceMap": true,
-    "declaration": true
+    "sourceMap": true
   },
   "include": ["server/src"],
   "exclude": ["dist", "node_modules"]

--- a/examples/capitals/tsconfig.server.json
+++ b/examples/capitals/tsconfig.server.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "noEmit": false,
     "outDir": "dist",
-    "sourceMap": true,
-    "declaration": true
+    "sourceMap": true
   },
   "include": ["server/src"],
   "exclude": ["dist", "node_modules"]

--- a/examples/ecom-carousel/tsconfig.server.json
+++ b/examples/ecom-carousel/tsconfig.server.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "noEmit": false,
     "outDir": "dist",
-    "sourceMap": true,
-    "declaration": true
+    "sourceMap": true
   },
   "include": ["server/src"],
   "exclude": ["dist", "node_modules"]

--- a/examples/everything/tsconfig.server.json
+++ b/examples/everything/tsconfig.server.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "noEmit": false,
     "outDir": "dist",
-    "sourceMap": true,
-    "declaration": true
+    "sourceMap": true
   },
   "include": ["server/src"],
   "exclude": ["dist", "node_modules"]

--- a/examples/investigation-game/tsconfig.server.json
+++ b/examples/investigation-game/tsconfig.server.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "noEmit": false,
     "outDir": "dist",
-    "sourceMap": true,
-    "declaration": true
+    "sourceMap": true
   },
   "include": ["server/src"],
   "exclude": ["dist", "node_modules"]

--- a/examples/manifest-ui/tsconfig.server.json
+++ b/examples/manifest-ui/tsconfig.server.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "noEmit": false,
     "outDir": "dist",
-    "sourceMap": true,
-    "declaration": true
+    "sourceMap": true
   },
   "include": ["server/src"],
   "exclude": ["dist", "node_modules"]

--- a/examples/productivity/tsconfig.server.json
+++ b/examples/productivity/tsconfig.server.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "noEmit": false,
     "outDir": "dist",
-    "sourceMap": true,
-    "declaration": true
+    "sourceMap": true
   },
   "include": ["server/src"],
   "exclude": ["dist", "node_modules"]


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes `"declaration": true` from all 7 example `tsconfig.server.json` files. Since examples are standalone applications (not libraries consumed by other packages), generating `.d.ts` declaration files is unnecessary. The resulting configs now match the project template at `packages/create-skybridge/template/tsconfig.server.json`.

- Consistent change across all example projects: `auth`, `capitals`, `ecom-carousel`, `everything`, `investigation-game`, `manifest-ui`, `productivity`
- No functional impact on example server builds — only stops emitting unused `.d.ts` files

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only removes an unnecessary TypeScript compiler option from example project configs.
- The change is purely a config cleanup across example projects. All 7 files have an identical, minimal change (removing one JSON property). The resulting files match the existing project template. No logic, runtime behavior, or build output is affected beyond stopping the emission of unused declaration files.
- No files require special attention.

<sub>Last reviewed commit: 98a674d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->