### PR TITLE
feat: add release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,19 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+version-resolver:
+  major:
+    labels:
+      - major
+  minor:
+    labels:
+      - minor
+  patch:
+    labels:
+      - patch
+  default: patch
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-title-escapes: '\<*_&'
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,3 +92,14 @@ jobs:
 
       - name: Build
         run: pnpm run build
+
+  draft-release:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces automated release draft generation using the `release-drafter` GitHub Action. It adds a `release-drafter.yml` configuration file and a new `draft-release` job to the CI workflow that runs on pushes to `main`. The configuration uses label-based versioning (`major`, `minor`, `patch`) and generates a changelog from merged PRs. The implementation integrates cleanly with the existing `publish.yml` workflow which triggers on `release: [published]` events.

- New `.github/release-drafter.yml` config with label-based semantic version resolution and changelog templating
- New `draft-release` job in `ci.yml` correctly gated to push events only (`if: github.event_name == 'push'`), since the workflow also triggers on `pull_request` events
- Required `contents: write` and `pull-requests: write` permissions are properly scoped to the `draft-release` job
- The action is pinned to a floating major version tag (`release-drafter/release-drafter@v6`) rather than a specific commit SHA, which is a minor security best practice concern

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a non-breaking CI automation job and config file with no effect on application code.
- The changes are confined to GitHub Actions workflow and config files. The logic is correct: the `draft-release` job is properly gated to push events, permissions are minimally scoped to the job level, and the release-drafter config is standard. The only minor concern is the use of a floating `@v6` tag rather than a pinned SHA, but this is a best practice issue rather than a functional or security defect.
- No files require special attention.

<sub>Last reviewed commit: ef50c3d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->