### PR TITLE
[SKY-235] fix: remove unnecessary checks from setOpenInAppUrl

### DIFF
--- a/docs/api-reference/use-set-open-in-app-url.mdx
+++ b/docs/api-reference/use-set-open-in-app-url.mdx
@@ -48,16 +48,15 @@ An async function that sets the URL to be opened when the user clicks the "open 
 
 - `href: string`
   - **Required**
-  - The URL to set. Must be a valid URL with the same origin as the widget's server URL.
-  - The URL will be opened in the host application when the user clicks the "open in app" button.
+  - The URL to set.
+  - If the origin matches the widget's server URL, ChatGPT navigates to the full `href`.
+  - If the origin differs from the widget's server URL, ChatGPT ignores the `href` and falls back to the widget's server URL.
 
 ### Errors
 
 The function may throw errors in the following cases:
 
 - If `href` is empty or only whitespace: `"The href parameter is required."`
-- If the widget domain is not set: `"The widgetDomain property has not been set on the widget resource meta object."`
-- If the `href` origin differs from the widget's server URL origin: `"Provided href is not compatible with widget domain: origin differs"`
 
 ## Examples
 

--- a/packages/core/src/web/bridges/apps-sdk/adaptor.ts
+++ b/packages/core/src/web/bridges/apps-sdk/adaptor.ts
@@ -107,22 +107,6 @@ export class AppsSdkAdaptor implements Adaptor {
       throw new Error("The href parameter is required.");
     }
 
-    const serverUrl = window.skybridge.serverUrl;
-    if (!serverUrl) {
-      throw new Error(
-        "The widgetDomain property has not been set on the widget resource meta object.",
-      );
-    }
-
-    const domainUrl = new URL(serverUrl);
-    const hrefUrl = new URL(href, serverUrl);
-
-    if (domainUrl.origin !== hrefUrl.origin) {
-      throw new Error(
-        "Provided href is not compatible with widget domain: origin differs",
-      );
-    }
-
     return window.openai.setOpenInAppUrl({ href });
   }
 }

--- a/packages/core/src/web/hooks/use-set-open-in-app-url.test.ts
+++ b/packages/core/src/web/hooks/use-set-open-in-app-url.test.ts
@@ -42,26 +42,14 @@ describe("useSetOpenInAppUrl", () => {
       );
     });
 
-    it("should throw an error when serverUrl is not set", () => {
-      vi.stubGlobal("skybridge", {
-        hostType: "apps-sdk",
-        serverUrl: undefined,
-      });
-      AppsSdkAdaptor.resetInstance();
-
+    it("should call setOpenInAppUrl when href origin differs from serverUrl origin", async () => {
       const { result } = renderHook(() => useSetOpenInAppUrl());
 
-      expect(() => result.current("https://example.com/path")).toThrow(
-        "The widgetDomain property has not been set on the widget resource meta object.",
-      );
-    });
+      const href = "https://different-domain.com/path";
+      await result.current(href);
 
-    it("should throw an error when href origin differs from serverUrl origin", () => {
-      const { result } = renderHook(() => useSetOpenInAppUrl());
-
-      expect(() => result.current("https://different-domain.com/path")).toThrow(
-        "Provided href is not compatible with widget domain: origin differs",
-      );
+      expect(setOpenInAppUrlMock).toHaveBeenCalledTimes(1);
+      expect(setOpenInAppUrlMock).toHaveBeenCalledWith({ href });
     });
   });
 });

--- a/skills/chatgpt-app-builder/references/open-external-links.md
+++ b/skills/chatgpt-app-builder/references/open-external-links.md
@@ -5,7 +5,7 @@
 
 ## "Open in App" button
 
-Top right corner in fullscreen mode. Must have same origin as widget server (default). Set programmatically.
+Top right corner in fullscreen mode. Set programmatically. If the origin matches the widget server URL, ChatGPT navigates to the full href (any path). If the origin differs, ChatGPT falls back to the widget server URL.
 
 **Example**:
 ```tsx


### PR DESCRIPTION
Allows using openai fullscreen button to redirect to a different url than the mcp server

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed origin validation from `setOpenInAppUrl` to allow redirecting to URLs with different origins than the widget server.

- Changed behavior aligns with PR description ("Allows using openai fullscreen button to redirect to a different url than the mcp server")
- Tests in `use-set-open-in-app-url.test.ts` will fail (lines 45-56 and 59-65) - they expect the removed validation errors
- Documentation in `docs/api-reference/use-set-open-in-app-url.mdx` is now outdated (line 51 states "Must be a valid URL with the same origin" and line 60 lists the removed error)
- Reference docs in `skills/chatgpt-app-builder/references/open-external-links.md` line 8 states "Must have same origin as widget server"

<h3>Confidence Score: 2/5</h3>

- Breaking change that removes security validation - tests will fail and documentation needs updates
- The code change itself is simple and clean, but it breaks existing tests that verify the removed validation logic. The failing tests indicate this is a breaking behavioral change that needs accompanying test updates and documentation revisions.
- Update tests in `packages/core/src/web/hooks/use-set-open-in-app-url.test.ts` and documentation in `docs/api-reference/use-set-open-in-app-url.mdx`

<sub>Last reviewed commit: 1856904</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->