### PR TITLE
fix: add version note for port flag

### DIFF
--- a/docs/api-reference/cli.mdx
+++ b/docs/api-reference/cli.mdx
@@ -39,6 +39,8 @@ PORT=8080 skybridge dev
 
 The flag takes precedence over the environment variable.
 
+<Note>The `-p, --port` flag and `PORT` environment variable are available since **v0.33.0**. If you're on an older version, upgrade your `skybridge` dependency first.</Note>
+
 The `--use-forwarded-host`  allows your widgets to work on any device connected to the internet, not just on your local machine. Useful when developing on multiple devices or when you need to test your app from different devices.
 
 **Important limitation:** Hot Module Reloading (HMR) is not available when using `--use-forwarded-host` because HMR uses a different port than the dev server and requires the WebSocket Secure (WSS) protocol, which most tunnel solutions don't support. To see your changes during development, simply reopen the conversation in ChatGPT to refresh the widget.


### PR DESCRIPTION
<img width="784" height="426" alt="image" src="https://github.com/user-attachments/assets/8c723530-51a7-45ed-a1eb-390118ecf5c7" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a version note to document when the `-p, --port` flag and `PORT` environment variable became available. The note aims to help users understand version compatibility, but **the version number v0.33.0 is incorrect** - this version doesn't exist in the repository. The latest tag is v0.12.0, and the port feature was added 363 commits after that release, meaning it hasn't been published yet.

- Added version availability note for port configuration options
- **Critical issue**: References non-existent version v0.33.0
- The correct version needs to be determined before merging

<h3>Confidence Score: 1/5</h3>

- This PR should not be merged as-is due to incorrect version information
- The documentation references a non-existent version (v0.33.0), which would confuse users. This is a critical factual error that must be corrected before merging. While the documentation change itself is a good addition, the incorrect version number makes this unsafe to merge.
- `docs/api-reference/cli.mdx` requires correction of the version number

<sub>Last reviewed commit: 39c6ad3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->