### PR TITLE
feat: adapt cli message + claude doc to not limit to chatgpt in message

### DIFF
--- a/docs/quickstart/test-your-app.mdx
+++ b/docs/quickstart/test-your-app.mdx
@@ -82,22 +82,22 @@ Claude uses the MCP Apps runtime and requires a public URL to connect to your ap
 
 #### 1. Expose your server
 
-Claude needs a public URL to access your AI App. Use [ngrok](https://ngrok.com/) to expose your local server:
+Claude needs a public URL to access your AI App. Use [cloudflared](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/get-started/create-local-tunnel/) to expose your local server:
 
 ```bash
-ngrok http 3000
+cloudflared tunnel --url http://localhost:3000
 ```
 
-Copy the forwarding URL (e.g., `https://abc123.ngrok-free.app`).
+Copy the generated URL (e.g., `https://abc123.trycloudflare.com`).
 
 #### 2. Connect to Claude
 
 1. In Claude, go to **Settings → Connectors → Add Custom Connector** and configure your MCP server connection
-2. Enter your App name and ngrok URL with `/mcp` at the end:
+2. Enter your App name and cloudflared URL with `/mcp` at the end:
    ```
-   https://abc123.ngrok-free.app/mcp
+   https://abc123.trycloudflare.com/mcp
    ```
-3. Click on **Add** 
+3. Click on **Add**
 
 #### 3. Test your app
 

--- a/packages/core/src/commands/dev.tsx
+++ b/packages/core/src/commands/dev.tsx
@@ -50,7 +50,7 @@ export default class Dev extends Command {
               </Text>
             </Box>
           )}
-          <Box>
+          <Box marginBottom={1}>
             <Text color="green">→{"  "}</Text>
             <Text color="white" bold>
               Open DevTools to test your app locally:{" "}
@@ -64,31 +64,14 @@ export default class Dev extends Command {
               {`http://localhost:${port}/mcp`}
             </Text>
           </Box>
-          <Text color="white" underline>
-            To test on ChatGPT:
-          </Text>
           <Box>
-            <Text color="#20a832">→{"  "}</Text>
-            <Text color="grey">Make your local server accessible with </Text>
-            <Text color="white" bold>
-              {`ngrok http ${port}`}
-            </Text>
-          </Box>
-          <Box marginBottom={1}>
             <Text>
               <Text color="#20a832">→{"  "}</Text>
-              <Text color="grey">Connect to ChatGPT with URL </Text>
-              <Text color="white" bold>
-                https://xxxxxx.ngrok-free.app/mcp
+              <Text color="grey">
+                Test on ChatGPT, Claude, or any MCP client:{" "}
               </Text>
-            </Text>
-          </Box>
-          <Box>
-            <Text>
-              <Text color="#20a832">→{"  "}</Text>
-              <Text>Documentation: </Text>
               <Text color="white" bold>
-                https://docs.skybridge.tech/
+                https://docs.skybridge.tech/quickstart/test-your-app
               </Text>
             </Text>
           </Box>


### PR DESCRIPTION
<img width="647" height="595" alt="image" src="https://github.com/user-attachments/assets/6c50bc67-22e8-4d4e-9c62-c6ab65a95b29" />

<img width="649" height="132" alt="image" src="https://github.com/user-attachments/assets/2aee846c-5247-47d0-b837-988c3561bc47" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated CLI and documentation to be more generic and not ChatGPT-specific. The dev command now displays a simplified message directing users to documentation for testing on any MCP client (ChatGPT, Claude, etc.), and the documentation now recommends `cloudflared` for Claude testing instead of `ngrok`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward documentation and UI text updates that improve the user experience by making the CLI more platform-agnostic. No functional code changes or logic modifications were made.
- No files require special attention

<sub>Last reviewed commit: 38e29cb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->