### PR TITLE
fix: add missing base branch for PR creation on create PR to bump skybridge on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,4 +96,5 @@ jobs:
           title: "chore: bump skybridge versions to ${{ steps.version.outputs.version }}"
           body: "Automated version bump of skybridge dependencies in templates and examples."
           branch: chore/bump-versions
+          base: main
           delete-branch: true


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds explicit `base: main` parameter to the automated PR creation step in the release workflow. This ensures version bump PRs consistently target the main branch, preventing potential failures when the workflow runs from a release tag context where the base branch might be ambiguous.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change adds a single, explicit configuration parameter that improves reliability. It's a defensive fix that prevents potential edge cases in automated PR creation during releases. The parameter value (`main`) is correct and aligns with the repository's branch structure. No breaking changes or side effects are introduced.
- No files require special attention

<sub>Last reviewed commit: 762857f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->