### PR TITLE
feat: warn when widget is not exported or mounted

### DIFF
--- a/packages/core/src/web/plugin/plugin.ts
+++ b/packages/core/src/web/plugin/plugin.ts
@@ -1,5 +1,10 @@
 import type { Plugin } from "vite";
 import { transform as dataLlmTransform } from "./transform-data-llm.js";
+import { validateWidget } from "./validate-widget.js";
+
+// Matches widget entry files (e.g. src/widgets/foo.tsx, src/widgets/foo/index.tsx) with optional Vite query strings
+const WIDGET_ENTRY_RE =
+  /\/src\/widgets\/(?:[^/]+\.(?:jsx|tsx)|[^/]+\/index\.tsx)(?:\?.*)?$/;
 
 export function skybridge(): Plugin {
   return {
@@ -48,6 +53,12 @@ export function skybridge(): Plugin {
     },
     enforce: "pre",
     async transform(code, id) {
+      if (WIDGET_ENTRY_RE.test(id)) {
+        for (const warning of validateWidget(code, id)) {
+          this.warn(warning.message);
+        }
+      }
+
       return await dataLlmTransform(code, id);
     },
   };

--- a/packages/core/src/web/plugin/validate-widget.test.ts
+++ b/packages/core/src/web/plugin/validate-widget.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { validateWidget } from "./validate-widget.js";
+
+describe("validateWidget", () => {
+  it("returns no warnings for a valid widget", () => {
+    expect(
+      validateWidget(
+        "export default MyWidget;\nmountWidget(<MyWidget />);",
+        "src/widgets/my-widget.tsx",
+      ),
+    ).toEqual([]);
+  });
+
+  it("accepts all default export syntaxes", () => {
+    for (const exportLine of [
+      "export default MyWidget;",
+      "export default function MyWidget() {}",
+      "export { Foo as default };",
+    ]) {
+      expect(
+        validateWidget(
+          `${exportLine}\nmountWidget(<MyWidget />);`,
+          "src/widgets/my-widget.tsx",
+        ),
+      ).toEqual([]);
+    }
+  });
+
+  it("warns when export default is missing", () => {
+    const warnings = validateWidget(
+      "mountWidget(<MyWidget />);",
+      "src/widgets/my-widget.tsx",
+    );
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.message).toContain("missing a default export");
+    expect(warnings[0]?.message).toContain("my-widget.tsx");
+  });
+
+  it("warns when mountWidget() call is missing", () => {
+    const warnings = validateWidget(
+      "export default MyWidget;",
+      "src/widgets/my-widget.tsx",
+    );
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.message).toContain("missing a mountWidget() call");
+    expect(warnings[0]?.message).toContain("my-widget.tsx");
+  });
+
+  it("ignores commented-out code", () => {
+    const code = `
+      // export default MyWidget;
+      // mountWidget(<MyWidget />);
+      /* export default MyWidget; */
+      /* mountWidget(<MyWidget />); */
+    `;
+    expect(validateWidget(code, "src/widgets/my-widget.tsx")).toHaveLength(2);
+  });
+
+  it("uses filename from path for directory widgets", () => {
+    const warnings = validateWidget("", "src/widgets/foo/index.tsx");
+    expect(warnings[0]?.message).toContain("index.tsx");
+  });
+});

--- a/packages/core/src/web/plugin/validate-widget.ts
+++ b/packages/core/src/web/plugin/validate-widget.ts
@@ -1,0 +1,38 @@
+interface Warning {
+  message: string;
+}
+
+function hasExportDefault(code: string): boolean {
+  return (
+    /export\s+default\s/.test(code) ||
+    /export\s*\{[^}]*\bas\s+default\b[^}]*}/.test(code)
+  );
+}
+
+function hasMountWidgetCall(code: string): boolean {
+  return /mountWidget\s*\(/.test(code);
+}
+
+function stripComments(code: string): string {
+  return code.replace(/\/\/.*$/gm, "").replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+export function validateWidget(code: string, filePath: string): Warning[] {
+  code = stripComments(code);
+  const warnings: Warning[] = [];
+  const fileName = filePath.split("/").pop() ?? filePath;
+
+  if (!hasExportDefault(code)) {
+    warnings.push({
+      message: `Widget file "${fileName}" is missing a default export. Add "export default <ComponentName>" to ensure the widget is properly registered.`,
+    });
+  }
+
+  if (!hasMountWidgetCall(code)) {
+    warnings.push({
+      message: `Widget file "${fileName}" is missing a mountWidget() call. Add "mountWidget(<Component />)" to mount the component to the DOM.`,
+    });
+  }
+
+  return warnings;
+}


### PR DESCRIPTION
Widget files need both an export default and a mountWidget() call to work properly, but forgetting one leads to confusing runtime errors. This adds a warning during dev and build when either is missing.

dev:
<img width="692" height="123" alt="Screenshot 2026-02-21 at 09 23 19" src="https://github.com/user-attachments/assets/5ebdf36a-2b30-43cd-9ced-8d63da6a439a" />

build:
<img width="704" height="83" alt="Screenshot 2026-02-21 at 09 24 01" src="https://github.com/user-attachments/assets/4bbdf074-e079-4327-aa4a-027ecfb6e18e" />