### PR TITLE
chore: 0 mixed auth

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -151,13 +151,13 @@
         "tab": "Showcase",
         "pages": [
           "showcase",
-          "showcase/auth",
           "showcase/capitals",
           "showcase/ecommerce-carousel",
           "showcase/everything",
           "showcase/investigation-game",
           "showcase/productivity",
-          "showcase/times-up"
+          "showcase/times-up",
+          "showcase/auth"
         ]
       }
     ]

--- a/docs/showcase.mdx
+++ b/docs/showcase.mdx
@@ -79,4 +79,14 @@ Explore real-world examples built with Skybridge. Each app demonstrates differen
   <a href="https://github.com/alpic-ai/skybridge/tree/main/examples/times-up" target="_blank" onClick={(e) => e.stopPropagation()}><Icon icon="github" iconType="brands" /> View code on GitHub</a>
 </Card>
 
+<Card
+  title="Auth"
+  img="/images/showcase-auth.png"
+  href="/showcase/auth"
+>
+  Full OAuth authentication with WorkOS AuthKit and personalized coffee shop search.
+
+  <a href="https://github.com/alpic-ai/skybridge/tree/main/examples/auth" target="_blank" onClick={(e) => e.stopPropagation()}><Icon icon="github" iconType="brands" /> View code on GitHub</a>
+</Card>
+
 </CardGroup>

--- a/docs/showcase/auth.mdx
+++ b/docs/showcase/auth.mdx
@@ -5,6 +5,12 @@ description: Full OAuth authentication with WorkOS AuthKit and personalized coff
 
 Auth is an example that demonstrates full OAuth authentication using WorkOS AuthKit, with a personalized coffee shop finder widget that displays user-specific favorites.
 
+<img
+  src="/images/showcase-auth.png"
+  alt="Auth"
+  style={{ width: "100%", maxWidth: "960px", borderRadius: "12px" }}
+/>
+
 ## Links
 
 <CardGroup cols={2}>

--- a/examples/auth/README.md
+++ b/examples/auth/README.md
@@ -4,6 +4,7 @@ An example MCP app built with [Skybridge](https://docs.skybridge.tech/home): a p
 
 ## What This Example Showcases
 
+- **Transport-Level Auth**: Auth is enforced at the `/mcp` transport level via the MCP SDK's `requireBearerAuth` middleware — unauthenticated requests receive HTTP 401 before reaching any tool handler
 - **OAuth Authentication**: Full OAuth2 setup with WorkOS AuthKit for user sign-in
 - **JWT Verification**: Server-side token validation using JWKS for secure identity extraction
 - **Personalized Results**: Authenticated users see favorites highlighted and sorted first
@@ -71,7 +72,7 @@ This command starts:
 ├── server/
 │   └── src/
 │       ├── index.ts        # Server entry: McpServer + OAuth + widget + run()
-│       ├── auth.ts          # JWT verification & WorkOS user lookup
+│       ├── auth.ts          # verifyAccessToken for requireBearerAuth
 │       ├── env.ts           # Env validation
 │       └── coffee-data.ts   # Mock coffee shop data & search
 ├── web/

--- a/examples/auth/server/src/auth.ts
+++ b/examples/auth/server/src/auth.ts
@@ -1,13 +1,7 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import { WorkOS } from "@workos-inc/node";
 import * as jose from "jose";
 import { env } from "./env.js";
-
-type Extra = RequestHandlerExtra<ServerRequest, ServerNotification>;
 
 // Initialize JWKS client for AuthKit public key verification
 const jwks = jose.createRemoteJWKSet(
@@ -17,54 +11,29 @@ const jwks = jose.createRemoteJWKSet(
 // Initialize WorkOS client
 const workos = new WorkOS(env.WORKOS_API_KEY);
 
-interface AuthResult {
-  userId: string;
-  email: string;
-  firstName: string | null;
-  lastName: string | null;
-}
+/**
+ * Verify a Bearer JWT and return AuthInfo for the MCP SDK.
+ * Used with `requireBearerAuth({ verifier: { verifyAccessToken } })`.
+ */
+export async function verifyAccessToken(token: string): Promise<AuthInfo> {
+  const { payload } = await jose.jwtVerify(token, jwks, {
+    issuer: `https://${env.AUTHKIT_DOMAIN}`,
+  });
 
-export async function tryGetAuth(
-  extra: Extra,
-): Promise<AuthResult | undefined> {
-  const authHeader = extra.requestInfo?.headers?.authorization;
-  if (!authHeader) {
-    return undefined;
+  if (!payload.sub || typeof payload.sub !== "string") {
+    throw new Error("Invalid token: missing sub claim");
   }
 
-  const headerValue = Array.isArray(authHeader) ? authHeader[0] : authHeader;
-  if (!headerValue?.toLowerCase().startsWith("bearer ")) {
-    return undefined;
-  }
+  const user = await workos.userManagement.getUser(payload.sub);
 
-  const token = headerValue.slice(7).trim();
-  if (!token) {
-    return undefined;
-  }
-
-  try {
-    const { payload } = await jose.jwtVerify(token, jwks, {
-      issuer: `https://${env.AUTHKIT_DOMAIN}`,
-    });
-
-    if (!payload.sub || typeof payload.sub !== "string") {
-      return undefined;
-    }
-
-    const user = await workos.userManagement.getUser(payload.sub);
-
-    return {
-      userId: user.id,
+  return {
+    token,
+    clientId: user.id,
+    scopes: [],
+    extra: {
       email: user.email,
       firstName: user.firstName,
       lastName: user.lastName,
-    };
-  } catch {
-    return undefined;
-  }
-}
-
-export async function getUserId(extra: Extra): Promise<string | undefined> {
-  const auth = await tryGetAuth(extra);
-  return auth?.userId;
+    },
+  };
 }

--- a/examples/auth/server/src/index.ts
+++ b/examples/auth/server/src/index.ts
@@ -1,7 +1,9 @@
+import { requireBearerAuth } from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js";
 import { mcpAuthMetadataRouter } from "@modelcontextprotocol/sdk/server/auth/router.js";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import { McpServer } from "skybridge/server";
 import * as z from "zod";
-import { tryGetAuth } from "./auth.js";
+import { verifyAccessToken } from "./auth.js";
 import { searchCoffeeShops } from "./coffee-data.js";
 import { env } from "./env.js";
 
@@ -9,14 +11,15 @@ import { env } from "./env.js";
  * Auth Example - Full OAuth Authentication with WorkOS AuthKit
  *
  * This example demonstrates a fully authenticated MCP server where users
- * must sign in via OAuth before using any tools. All tools have access
- * to the authenticated user's identity.
+ * must sign in via OAuth before using any tools. Auth is enforced at the
+ * transport level — unauthenticated requests to /mcp receive HTTP 401.
  *
  * Auth flow:
- * 1. ChatGPT discovers OAuth metadata via /.well-known/oauth-authorization-server
+ * 1. MCP client discovers OAuth metadata via /.well-known/oauth-authorization-server
  * 2. User is prompted to sign in via WorkOS AuthKit
- * 3. All subsequent tool calls include a Bearer JWT token
- * 4. The server verifies the token and extracts user identity
+ * 3. MCP client connects to /mcp with a Bearer JWT token
+ * 4. requireBearerAuth verifies the token via verifyAccessToken
+ * 5. Tool handlers read user identity via extra.authInfo
  */
 
 const server = new McpServer(
@@ -26,7 +29,7 @@ const server = new McpServer(
   },
   { capabilities: {} },
 )
-  // Mount OAuth metadata so ChatGPT can discover auth endpoints
+  // Mount OAuth metadata so MCP clients can discover auth endpoints
   .use(
     mcpAuthMetadataRouter({
       oauthMetadata: {
@@ -44,6 +47,7 @@ const server = new McpServer(
       resourceServerUrl: new URL(env.SERVER_URL),
     }),
   )
+  .use("/mcp", requireBearerAuth({ verifier: { verifyAccessToken } }))
   .registerWidget(
     "search-coffee-paris",
     {
@@ -83,34 +87,19 @@ const server = new McpServer(
         "openai/widgetAccessible": true,
       },
     },
-    async ({ query, minRating }, extra) => {
-      const auth = await tryGetAuth(extra);
+    ({ query, minRating }, extra) => {
+      const auth = extra.authInfo as AuthInfo;
 
-      if (!auth) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: "Authentication required. Please sign in to search coffee shops.",
-            },
-          ],
-          isError: true,
-          _meta: {
-            "mcp/www_authenticate": [
-              `Bearer resource_metadata="${env.SERVER_URL}/.well-known/oauth-protected-resource"`,
-            ],
-          },
-        };
-      }
+      const email = auth.extra?.email as string | undefined;
+      const firstName = auth.extra?.firstName as string | null | undefined;
 
       const results = searchCoffeeShops({
         query,
         minRating,
-        userId: auth.userId,
+        userId: auth.clientId,
       });
 
-      const displayName =
-        auth.firstName ?? auth.email.split("@")[0];
+      const displayName = firstName ?? email?.split("@")[0] ?? "User";
 
       return {
         structuredContent: {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactored authentication to use MCP SDK's `requireBearerAuth` middleware for transport-level auth enforcement. The previous approach handled auth manually within each tool handler — now unauthenticated requests receive HTTP 401 at the `/mcp` endpoint before reaching tool handlers.

**Key changes:**
- Simplified `auth.ts` from ~54 lines to ~41 by replacing `tryGetAuth()` with `verifyAccessToken()` that returns `AuthInfo`
- Added `.use("/mcp", requireBearerAuth({ verifier: { verifyAccessToken } }))` middleware at line 50
- Removed manual auth checking and error responses from tool handlers
- Tool handlers now read user identity via `extra.authInfo` instead of calling `tryGetAuth()`
- Updated documentation to reflect transport-level authentication model

**Issues found:**
- Critical: Line 102 will crash if `email` is undefined (type assertions on lines 93-94 bypass null safety)
- Minor: Redundant variable assignment in `auth.ts:19-23`

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing the critical null-safety issue on line 102
- The refactoring properly moves auth from tool-level to transport-level using the MCP SDK's middleware, which is architecturally sound. However, the code has a critical bug where `email` can be undefined but is used without null-checking in `.split()`, which will cause runtime errors. The type assertions also bypass TypeScript's safety checks.
- Pay close attention to `examples/auth/server/src/index.ts` lines 93-94 and 102 for null-safety issues

<sub>Last reviewed commit: 1e0d23f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->