### PR TITLE
fix: remove core readme from bump pr

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,6 +88,12 @@ jobs:
         if: github.event_name == 'release'
         run: node scripts/bump.js ${{ steps.version.outputs.version }} && pnpm install --no-frozen-lockfile
 
+      # The prepublishOnly script in packages/core copies the root README into
+      # the package for npm. Clean it up so it doesn't leak into the bump PR.
+      - name: Clean up copied README
+        if: github.event_name == 'release'
+        run: rm -f packages/core/README.md
+
       - name: Open bump PR
         if: github.event_name == 'release'
         uses: peter-evans/create-pull-request@v8


### PR DESCRIPTION
The prepublishOnly script in packages/core copies the root README into the package for npm. We need to clean it up before opening bump PRs.