### PR TITLE
Avoid relying on requestInfo.url.href

### DIFF
--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -497,7 +497,7 @@ export class McpServer<
           connectDomains.push(VITE_HMR_WEBSOCKET_DEFAULT_URL);
         }
 
-        const pathname = extra?.requestInfo?.url?.pathname;
+        const pathname = extra?.requestInfo?.url?.pathname ?? "";
         const url = `https://${hostFromHeaders}${pathname}`;
         const hash = crypto
           .createHash("sha256")


### PR DESCRIPTION
## Motivation

Claude changes on the fly the protocol of `requestInfo.url.href` resulting in a mismatch between the calculated and expected hashes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced use of `requestInfo.url.href` with manually constructed URL from `hostFromHeaders` and `pathname` to avoid protocol mismatch issues caused by Claude modifying the protocol. This change addresses hash calculation mismatches.

**Key changes:**
- Extracted `pathname` from `requestInfo.url` separately
- Constructed URL using `https://` protocol explicitly with `hostFromHeaders` and `pathname`
- Moved hash calculation out of inline expression for better readability

**Issue found:**
- Missing fallback for `pathname` when `undefined` - will result in malformed URL with literal "undefined" string

<h3>Confidence Score: 2/5</h3>

- This PR has a critical bug that must be fixed before merging
- The change correctly addresses the protocol mismatch issue, but introduces a critical bug where `pathname` can be `undefined`, resulting in a malformed URL string containing the literal text "undefined". This would break the hash calculation and content domain generation for Claude requests when `pathname` is not provided.
- packages/core/src/server/server.ts needs attention for the undefined pathname handling

<sub>Last reviewed commit: 19b40f4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->