### PR TITLE
feat: add claude code start hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ \"$CLAUDE_CODE_REMOTE\" = \"true\" ] && npx --yes skills add obra/superpowers -a claude-code -s brainstorming dispatching-parallel-agents executing-plans finishing-a-development-branch receiving-code-review requesting-code-review subagent-driven-development systematic-debugging test-driven-development using-git-worktrees using-superpowers verification-before-completion writing-plans writing-skills -y || true"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
I'm experimenting with claude code cloud, and update setup script directly in the web interface does not seem to work. Having the SessionStart hook defined seems to do the trick.

This is only run in Claude Code web env. Not impacting other setups.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a SessionStart hook in `.claude/settings.json` to automatically install Claude Code skills package (`obra/superpowers`) when running in the cloud environment. The hook checks for `$CLAUDE_CODE_REMOTE` environment variable to ensure it only runs in the web interface, not affecting local setups.

- New configuration file with SessionStart hook that installs multiple skills including brainstorming, parallel agents, git worktrees, and TDD
- Command is safely gated with environment check and includes `|| true` fallback to prevent session startup failures
- Addresses the issue where updating setup scripts directly in the web interface wasn't working

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risks
- The change is well-contained, adds a single configuration file with proper error handling, and is gated to only run in the cloud environment. No logical or syntactic errors found, and the implementation correctly addresses the stated problem.
- No files require special attention

<sub>Last reviewed commit: 3f8c69c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->