### PR TITLE
fix: include mimeType in widget resource definition

### DIFF
--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -455,7 +455,7 @@ export class McpServer<
     this.registerResource(
       name,
       widgetUri,
-      { ...resourceConfig, _meta: resourceConfig._meta },
+      { ...resourceConfig, mimeType, _meta: resourceConfig._meta },
       async (uri, extra) => {
         const isProduction = process.env.NODE_ENV === "production";
         const useForwardedHost =


### PR DESCRIPTION
## Summary
- `registerWidgetResource` was omitting `mimeType` from the resource definition passed to `registerResource`, so `resources/list` returned resources without `mimeType`
- MCP extended apps compatibility checkers validate `mimeType` on the resource definition, causing failures
- `mimeType` was already available as a destructured local — just needed to be spread into the definition object

## Test plan
- [ ] Verify `resources/list` now includes `mimeType` on widget resource definitions
- [ ] Confirm MCP extended apps compatibility checks pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where `mimeType` was missing from widget resource definitions returned by `resources/list`. The `mimeType` field was already being destructured from `widgetConfig` in `registerWidgetResource` but was not being spread into the resource definition passed to `registerResource`. This caused MCP extended apps compatibility checkers to fail validation since they expect `mimeType` to be present on resource definitions.

The fix is minimal and correct:
- Adds `mimeType` to the spread when calling `registerResource` (line 458)
- No breaking changes or side effects
- Aligns with the base SDK's `Resource` type which includes `mimeType`
- The existing test suite expects resources to have `mimeType` fields

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple one-line fix that adds a missing field to an object spread. The `mimeType` variable was already being destructured and is guaranteed to be present from the `WidgetResourceConfig` type. The fix directly addresses the described issue without introducing any breaking changes or side effects. The existing test suite validates that resources should include `mimeType` fields, confirming this change is correct.
- No files require special attention

<sub>Last reviewed commit: 331dc59</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->