### PR TITLE
fix: limit file type in file picker in everything app

### DIFF
--- a/examples/everything/web/src/widgets/tabs/use-files-tab.tsx
+++ b/examples/everything/web/src/widgets/tabs/use-files-tab.tsx
@@ -55,6 +55,7 @@ export function UseFilesTab() {
         <input
           ref={inputRef}
           type="file"
+          accept="image/png,image/jpeg,image/webp"
           onChange={handleUpload}
           disabled={isUploading}
         />

--- a/packages/core/src/web/hooks/index.ts
+++ b/packages/core/src/web/hooks/index.ts
@@ -6,7 +6,11 @@ export {
   useCallTool,
 } from "./use-call-tool.js";
 export { useDisplayMode } from "./use-display-mode.js";
-export { useFiles } from "./use-files.js";
+export {
+  SUPPORTED_FILE_EXTENSIONS,
+  SUPPORTED_FILE_TYPES_ACCEPT,
+  useFiles,
+} from "./use-files.js";
 export { type LayoutState, useLayout } from "./use-layout.js";
 export { type OpenExternalFn, useOpenExternal } from "./use-open-external.js";
 export { useRequestModal } from "./use-request-modal.js";

--- a/packages/core/src/web/hooks/use-files.test.ts
+++ b/packages/core/src/web/hooks/use-files.test.ts
@@ -1,33 +1,41 @@
 import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useFiles } from "./use-files.js";
+import { AppsSdkAdaptor } from "../bridges/apps-sdk/adaptor.js";
+import { SUPPORTED_FILE_TYPES_ACCEPT, useFiles } from "./use-files.js";
 
 describe("useFiles", () => {
-  const OpenaiMock = {
-    uploadFile: vi.fn().mockResolvedValue({
-      fileId: `sediment://file_abc123`,
-    }),
-    getFileDownloadUrl: vi.fn(),
-    widgetState: null,
-    setWidgetState: vi.fn(),
+  let OpenaiMock: {
+    uploadFile: ReturnType<typeof vi.fn>;
+    getFileDownloadUrl: ReturnType<typeof vi.fn>;
+    widgetState: null;
+    setWidgetState: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(() => {
+    OpenaiMock = {
+      uploadFile: vi.fn().mockResolvedValue({
+        fileId: `sediment://file_abc123`,
+      }),
+      getFileDownloadUrl: vi.fn(),
+      widgetState: null,
+      setWidgetState: vi.fn(),
+    };
     vi.stubGlobal("skybridge", { hostType: "apps-sdk" });
     vi.stubGlobal("openai", OpenaiMock);
+    AppsSdkAdaptor.resetInstance();
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.resetAllMocks();
+    AppsSdkAdaptor.resetInstance();
   });
 
-  const dummyFile = new File([], "test.txt");
-
-  it("should upload a file to ChatGPT", () => {
+  it("should upload a file to ChatGPT", async () => {
     const { result } = renderHook(() => useFiles());
+    const dummyFile = new File([], "test.png");
 
-    result.current.upload(dummyFile);
+    await result.current.upload(dummyFile);
     expect(OpenaiMock.uploadFile).toHaveBeenCalledWith(dummyFile);
   });
 
@@ -37,5 +45,43 @@ describe("useFiles", () => {
 
     result.current.getDownloadUrl({ fileId });
     expect(OpenaiMock.getFileDownloadUrl).toHaveBeenCalledWith({ fileId });
+  });
+
+  it("should reject unsupported file types", async () => {
+    const { result } = renderHook(() => useFiles());
+    const unsupportedFile = new File([], "test.exe");
+
+    await expect(result.current.upload(unsupportedFile)).rejects.toThrow(
+      /Unsupported file type/,
+    );
+    expect(OpenaiMock.uploadFile).not.toHaveBeenCalled();
+  });
+
+  it("should accept all supported file extensions", async () => {
+    const { result } = renderHook(() => useFiles());
+
+    // Test all supported image extensions
+    const supportedExtensions = [".png", ".jpg", ".jpeg", ".webp"];
+
+    for (const ext of supportedExtensions) {
+      const file = new File([], `test${ext}`);
+      await expect(result.current.upload(file)).resolves.toBeDefined();
+    }
+
+    expect(OpenaiMock.uploadFile).toHaveBeenCalledTimes(
+      supportedExtensions.length,
+    );
+  });
+
+  it("should be case-insensitive for file extensions", async () => {
+    const { result } = renderHook(() => useFiles());
+    const upperCaseFile = new File([], "test.PNG");
+
+    await result.current.upload(upperCaseFile);
+    expect(OpenaiMock.uploadFile).toHaveBeenCalledWith(upperCaseFile);
+  });
+
+  it("should export SUPPORTED_FILE_TYPES_ACCEPT constant", () => {
+    expect(SUPPORTED_FILE_TYPES_ACCEPT).toBe("image/png,image/jpeg,image/webp");
   });
 });

--- a/packages/core/src/web/hooks/use-files.ts
+++ b/packages/core/src/web/hooks/use-files.ts
@@ -1,9 +1,47 @@
 import { getAdaptor } from "../bridges/index.js";
 
+/**
+ * Supported file extensions for ChatGPT file uploads
+ * ChatGPT currently supports only image formats: PNG, JPEG, and WebP
+ * @see https://developers.openai.com/apps-sdk/build/chatgpt-ui#upload-files-from-the-widget
+ */
+export const SUPPORTED_FILE_EXTENSIONS = [
+  ".jpg",
+  ".jpeg",
+  ".png",
+  ".webp",
+] as const;
+
+/**
+ * Accept attribute value for file input elements
+ * Matches the MIME types: image/png, image/jpeg, image/webp
+ */
+export const SUPPORTED_FILE_TYPES_ACCEPT = "image/png,image/jpeg,image/webp";
+
+/**
+ * Validates if a file has a supported extension
+ */
+function validateFileType(file: File): void {
+  const fileName = file.name.toLowerCase();
+  const hasValidExtension = SUPPORTED_FILE_EXTENSIONS.some((ext) =>
+    fileName.endsWith(ext),
+  );
+
+  if (!hasValidExtension) {
+    throw new Error(
+      `Unsupported file type. Supported file types are: ${SUPPORTED_FILE_EXTENSIONS.join(", ")}`,
+    );
+  }
+}
+
 export function useFiles() {
   const adaptor = getAdaptor();
+
   return {
-    upload: adaptor.uploadFile,
+    upload: async (file: File) => {
+      validateFileType(file);
+      return adaptor.uploadFile(file);
+    },
     getDownloadUrl: adaptor.getFileDownloadUrl,
   };
 }


### PR DESCRIPTION
## Description

This pull request addresses issue #368 by implementing proper file type validation for the file upload functionality in both the Everything app and the useFiles hook. The changes restrict file uploads to only the **3 image file types** supported by ChatGPT's file upload API, preventing cryptic backend errors and improving user experience.

According to the ChatGPT UI documentation, `window.openai.uploadFile()` currently supports only:
- `image/png`
- `image/jpeg` 
- `image/webp`

The implementation adds:
1. A list of supported file extensions as a constant (SUPPORTED_FILE_EXTENSIONS: .jpg, .jpeg, .png, .webp)
2. An accept attribute value for HTML file inputs (SUPPORTED_FILE_TYPES_ACCEPT: "image/png,image/jpeg,image/webp")
3. Client-side validation in the useFiles hook that throws descriptive errors when unsupported file types are attempted
4. Updated file picker in the Everything app to visually limit file selection to supported image types

The validation is case-insensitive and covers all image format variations that ChatGPT supports (.jpg, .jpeg, .png, .webp).

Closes #368.

**The code in this pull request was generated by GitHub Copilot with the Claude Sonnet 4.5 model.**

## Checklist if Applicable

- [x] The tests passed – `pnpm test` executed successfully in packages/core
- [x] Linting passed – biome ci check completed with no new errors
- [x] Documentation has been added – JSDoc comments added for exported constants
- [ ] CHANGELOG.md has been updated

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restricts file uploads to the three image types supported by ChatGPT's `window.openai.uploadFile()` API (`image/png`, `image/jpeg`, `image/webp`) by adding a `validateFileType` helper in `useFiles` and an `accept` attribute to the Everything-app file picker. The tests are well-structured and cover the full range of validation cases.

**One maintenance concern:**
- The `accept` attribute in `use-files-tab.tsx` (line 58) hardcodes `"image/png,image/jpeg,image/webp"` verbatim instead of importing the newly-exported `SUPPORTED_FILE_TYPES_ACCEPT` constant. If the supported types are extended in `use-files.ts`, the file picker's filter won't update automatically, silently allowing the UI restriction to drift from the server-side validation.

**Positive notes:**
- The mock is now correctly reset per-test via `beforeEach`/`afterEach` and `AppsSdkAdaptor.resetInstance()`, eliminating shared state between tests.
- The extension check is case-insensitive and correctly uses the dot prefix (e.g., `.png`) avoiding false-positive suffix matches.
- The new `upload` wrapper calls `adaptor.uploadFile(file)` as a method invocation (preserving `this` context), which is a subtle improvement over the prior bare method reference.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; the only issue is a minor maintainability concern in the example app where a constant is duplicated instead of reused.
- The core logic in `use-files.ts` is correct, well-tested, and cleanly separated. The sole concern is that `use-files-tab.tsx` hardcodes the accept MIME-type string rather than using the exported `SUPPORTED_FILE_TYPES_ACCEPT` constant, creating a potential drift risk. This is a style-level issue in an example app and does not affect correctness or security today.
- examples/everything/web/src/widgets/tabs/use-files-tab.tsx — the hardcoded `accept` string should use the exported constant.

<sub>Last reviewed commit: bcdae51</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->