### PR TITLE
feat: add scrollToBottom parameter

### DIFF
--- a/docs/api-reference/use-send-follow-up-message.mdx
+++ b/docs/api-reference/use-send-follow-up-message.mdx
@@ -24,7 +24,10 @@ function FollowUpButton() {
 ## Returns
 
 ```tsx
-sendFollowUpMessage: (prompt: string) => Promise<void>
+sendFollowUpMessage: (
+  prompt: string,
+  options?: { scrollToBottom?: boolean }
+) => Promise<void>
 ```
 
 An async function that sends a follow-up message to continue the conversation.
@@ -34,6 +37,11 @@ An async function that sends a follow-up message to continue the conversation.
 - `prompt: string`
   - **Required**
   - The message to send as a follow-up prompt
+
+- `options?: { scrollToBottom?: boolean }`
+  - **Optional**
+  - Configuration options for the follow-up message
+  - `scrollToBottom`: When `true` (default), automatically scrolls to the bottom of the conversation after posting the message. Set to `false` to prevent auto-scroll.
 
 ## Examples
 
@@ -61,6 +69,39 @@ function QuickActions() {
           {action.label}
         </button>
       ))}
+    </div>
+  );
+}
+```
+
+### Custom Scroll Behavior
+
+```tsx
+import { useSendFollowUpMessage } from "skybridge/web";
+
+function CustomScrollExample() {
+  const sendFollowUpMessage = useSendFollowUpMessage();
+
+  const handleBackgroundUpdate = () => {
+    // Send a follow-up without scrolling to keep the user's current position
+    sendFollowUpMessage("Update the data in the background", {
+      scrollToBottom: false,
+    });
+  };
+
+  const handleInteractivePrompt = () => {
+    // Send a follow-up with automatic scroll (default behavior)
+    sendFollowUpMessage("Tell me more about this topic");
+  };
+
+  return (
+    <div>
+      <button onClick={handleBackgroundUpdate}>
+        Update Data (No Scroll)
+      </button>
+      <button onClick={handleInteractivePrompt}>
+        Ask Question (Auto-scroll)
+      </button>
     </div>
   );
 }

--- a/docs/api-reference/use-send-follow-up-message.mdx
+++ b/docs/api-reference/use-send-follow-up-message.mdx
@@ -41,7 +41,8 @@ An async function that sends a follow-up message to continue the conversation.
 - `options?: { scrollToBottom?: boolean }`
   - **Optional**
   - Configuration options for the follow-up message
-  - `scrollToBottom`: When `true` (default), automatically scrolls to the bottom of the conversation after posting the message. Set to `false` to prevent auto-scroll.
+  - `scrollToBottom`: When `true`, automatically scrolls to the bottom of the conversation after posting the message. Set to `false` to prevent auto-scroll. Defaults to the host platform's default behavior when not specified.
+  - **Note**: This option is only supported in Apps SDK hosts. In MCP app hosts, this option will be ignored with a warning.
 
 ## Examples
 

--- a/packages/core/src/web/bridges/apps-sdk/adaptor.ts
+++ b/packages/core/src/web/bridges/apps-sdk/adaptor.ts
@@ -60,8 +60,14 @@ export class AppsSdkAdaptor implements Adaptor {
     return window.openai.requestDisplayMode({ mode });
   };
 
-  public sendFollowUpMessage = (prompt: string): Promise<void> => {
-    return window.openai.sendFollowUpMessage({ prompt });
+  public sendFollowUpMessage = (
+    prompt: string,
+    options?: { scrollToBottom?: boolean },
+  ): Promise<void> => {
+    return window.openai.sendFollowUpMessage({
+      prompt,
+      ...options,
+    });
   };
 
   public openExternal(href: string, options: OpenExternalOptions = {}): void {

--- a/packages/core/src/web/bridges/apps-sdk/types.ts
+++ b/packages/core/src/web/bridges/apps-sdk/types.ts
@@ -65,7 +65,10 @@ export type AppsSdkMethods<WS extends WidgetState = WidgetState> = {
   ) => Promise<ToolResponse>;
 
   /** Triggers a followup turn in the ChatGPT conversation */
-  sendFollowUpMessage: (args: { prompt: string }) => Promise<void>;
+  sendFollowUpMessage: (args: {
+    prompt: string;
+    scrollToBottom?: boolean;
+  }) => Promise<void>;
 
   /** Opens an external link, redirects web page or mobile app */
   openExternal(args: { href: string; redirectUrl?: false }): void;

--- a/packages/core/src/web/bridges/mcp-app/adaptor.ts
+++ b/packages/core/src/web/bridges/mcp-app/adaptor.ts
@@ -107,7 +107,10 @@ export class McpAppAdaptor implements Adaptor {
     });
   };
 
-  public sendFollowUpMessage = async (prompt: string) => {
+  public sendFollowUpMessage = async (
+    prompt: string,
+    options?: { scrollToBottom?: boolean },
+  ) => {
     const bridge = McpAppBridge.getInstance();
     await bridge.request<McpUiMessageRequest, McpUiMessageResult>({
       method: "ui/message",

--- a/packages/core/src/web/bridges/mcp-app/adaptor.ts
+++ b/packages/core/src/web/bridges/mcp-app/adaptor.ts
@@ -111,6 +111,11 @@ export class McpAppAdaptor implements Adaptor {
     prompt: string,
     options?: { scrollToBottom?: boolean },
   ) => {
+    if (options?.scrollToBottom !== undefined) {
+      console.warn(
+        "[skybridge] scrollToBottom option is not supported by the MCP ui/message protocol and will be ignored.",
+      );
+    }
     const bridge = McpAppBridge.getInstance();
     await bridge.request<McpUiMessageRequest, McpUiMessageResult>({
       method: "ui/message",

--- a/packages/core/src/web/bridges/types.ts
+++ b/packages/core/src/web/bridges/types.ts
@@ -108,7 +108,10 @@ export interface Adaptor {
   requestDisplayMode(mode: RequestDisplayMode): Promise<{
     mode: RequestDisplayMode;
   }>;
-  sendFollowUpMessage(prompt: string): Promise<void>;
+  sendFollowUpMessage(
+    prompt: string,
+    options?: { scrollToBottom?: boolean },
+  ): Promise<void>;
   openExternal(href: string, options?: OpenExternalOptions): void;
   setWidgetState(stateOrUpdater: SetWidgetStateAction): Promise<void>;
   uploadFile(file: File): Promise<FileMetadata>;

--- a/packages/core/src/web/hooks/use-send-follow-up-message.test.ts
+++ b/packages/core/src/web/hooks/use-send-follow-up-message.test.ts
@@ -94,5 +94,21 @@ describe("useSendFollowUpMessage", () => {
         "*",
       );
     });
+
+    it("should warn when scrollToBottom option is used in MCP host", () => {
+      const consoleWarnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+      const { result } = renderHook(() => useSendFollowUpMessage());
+
+      const prompt = "Test message";
+      result.current(prompt, { scrollToBottom: false });
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "[skybridge] scrollToBottom option is not supported by the MCP ui/message protocol and will be ignored.",
+      );
+
+      consoleWarnSpy.mockRestore();
+    });
   });
 });

--- a/packages/core/src/web/hooks/use-send-follow-up-message.test.ts
+++ b/packages/core/src/web/hooks/use-send-follow-up-message.test.ts
@@ -1,0 +1,98 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { McpAppBridge } from "../bridges/mcp-app/bridge.js";
+import { useSendFollowUpMessage } from "./use-send-follow-up-message.js";
+
+describe("useSendFollowUpMessage", () => {
+  describe("apps-sdk host", () => {
+    let sendFollowUpMessageMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      sendFollowUpMessageMock = vi.fn();
+      vi.stubGlobal("openai", {
+        sendFollowUpMessage: sendFollowUpMessageMock,
+      });
+      vi.stubGlobal("skybridge", { hostType: "apps-sdk" });
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      vi.resetAllMocks();
+    });
+
+    it("should return a function that calls window.openai.sendFollowUpMessage with the prompt", () => {
+      const { result } = renderHook(() => useSendFollowUpMessage());
+
+      const prompt = "Test message";
+      result.current(prompt);
+
+      expect(sendFollowUpMessageMock).toHaveBeenCalledTimes(1);
+      expect(sendFollowUpMessageMock).toHaveBeenCalledWith({ prompt });
+    });
+
+    it("should forward scrollToBottom option to window.openai.sendFollowUpMessage", () => {
+      const { result } = renderHook(() => useSendFollowUpMessage());
+
+      const prompt = "Test message";
+      result.current(prompt, { scrollToBottom: false });
+
+      expect(sendFollowUpMessageMock).toHaveBeenCalledTimes(1);
+      expect(sendFollowUpMessageMock).toHaveBeenCalledWith({
+        prompt,
+        scrollToBottom: false,
+      });
+    });
+
+    it("should send follow-up message with scrollToBottom set to true", () => {
+      const { result } = renderHook(() => useSendFollowUpMessage());
+
+      const prompt = "Test message with scroll";
+      result.current(prompt, { scrollToBottom: true });
+
+      expect(sendFollowUpMessageMock).toHaveBeenCalledTimes(1);
+      expect(sendFollowUpMessageMock).toHaveBeenCalledWith({
+        prompt,
+        scrollToBottom: true,
+      });
+    });
+  });
+
+  describe("mcp-app host", () => {
+    const mockPostMessage = vi.fn();
+
+    beforeEach(() => {
+      vi.stubGlobal("parent", { postMessage: mockPostMessage });
+      vi.stubGlobal("skybridge", { hostType: "mcp-app" });
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      vi.resetAllMocks();
+      McpAppBridge.resetInstance();
+    });
+
+    it("should return a function that sends ui/message request to the MCP host", () => {
+      const { result } = renderHook(() => useSendFollowUpMessage());
+
+      const prompt = "Test message";
+      result.current(prompt);
+
+      expect(mockPostMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jsonrpc: "2.0",
+          method: "ui/message",
+          params: expect.objectContaining({
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: prompt,
+              },
+            ],
+          }),
+        }),
+        "*",
+      );
+    });
+  });
+});

--- a/packages/core/src/web/hooks/use-send-follow-up-message.ts
+++ b/packages/core/src/web/hooks/use-send-follow-up-message.ts
@@ -4,7 +4,8 @@ import { getAdaptor } from "../bridges/index.js";
 export function useSendFollowUpMessage() {
   const adaptor = getAdaptor();
   const sendFollowUpMessage = useCallback(
-    (prompt: string) => adaptor.sendFollowUpMessage(prompt),
+    (prompt: string, options?: { scrollToBottom?: boolean }) =>
+      adaptor.sendFollowUpMessage(prompt, options),
     [adaptor],
   );
 


### PR DESCRIPTION
## Description

Extended the `useSendFollowUpMessage` hook to support an optional `scrollToBottom` parameter, aligning with the Apps SDK API update. This parameter allows developers to control whether the conversation view automatically scrolls to the bottom after sending a follow-up message.

The implementation:
- Updated the Apps SDK type definition to include the optional `scrollToBottom` parameter
- Modified the `Adaptor` interface to accept the new options parameter
- Updated both `AppsSdkAdaptor` and `McpAppAdaptor` implementations to handle the parameter
- Enhanced the `useSendFollowUpMessage` hook to pass through the options to the underlying adaptor
- Added comprehensive test coverage with 4 test cases covering both Apps SDK and MCP app hosts
- Updated documentation with usage examples demonstrating the new parameter

Closes #512.

**The code in this pull request was generated by GitHub Copilot with the Claude Sonnet 4.5 model.**

## Checklist if Applicable

- [x] The tests passed – `pnpm test src/web/hooks/use-send-follow-up-message.test.ts` 
- [x] Linting passed – `pnpm biome ci` on modified files
- [x] Documentation has been added – Updated API reference with parameter documentation and usage example
- [ ] CHANGELOG.md has been updated

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends `useSendFollowUpMessage` with an optional `scrollToBottom` parameter, updating the `Adaptor` interface, both adaptor implementations, the hook itself, tests, and documentation. The Apps SDK path is implemented correctly, but the MCP app adaptor accepts the parameter and silently discards it — unlike the existing pattern in the same file where unsupported options emit a `console.warn`. The test suite has good coverage for the Apps SDK host but misses a test for the MCP host with `scrollToBottom`, which would have exposed this gap. The documentation also claims `true` is the default value, but no explicit default is set in code.

- **Silent no-op in `McpAppAdaptor`**: `scrollToBottom` is accepted but never forwarded to the `ui/message` bridge request. No warning is emitted (contrast with `openExternal`'s handling of `redirectUrl`).
- **Missing MCP host test**: The MCP app describe block only covers the no-options path; a `scrollToBottom` test case is absent.
- **Inaccurate documentation default**: Docs state `scrollToBottom` defaults to `true`, but the code relies on the underlying `window.openai` API's default rather than enforcing one explicitly.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is — the `scrollToBottom` option is silently ignored for MCP app hosts, making the feature incomplete and potentially misleading for that platform.
- The Apps SDK implementation is correct, but the MCP app adaptor accepts `scrollToBottom` without forwarding it or warning the caller. The PR description says both adaptors "handle the parameter", which is inaccurate. This constitutes a broken contract for MCP app consumers and should be resolved before merging.
- `packages/core/src/web/bridges/mcp-app/adaptor.ts` requires a fix — either forward `scrollToBottom` to the bridge request (if the MCP protocol supports it) or emit a `console.warn` that it is unsupported (matching the existing `openExternal` pattern).

<sub>Last reviewed commit: 1d07428</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->