### PR TITLE
feat: add state generation on devtools oauth provider

### DIFF
--- a/packages/devtools/src/lib/mcp/browser-oauth-provider.ts
+++ b/packages/devtools/src/lib/mcp/browser-oauth-provider.ts
@@ -11,6 +11,7 @@ const KEYS = {
   clientInfo: `${PREFIX}:client-info`,
   tokens: `${PREFIX}:tokens`,
   codeVerifier: `${PREFIX}:code-verifier`,
+  state: `${PREFIX}:state`,
 } as const;
 
 export class BrowserOAuthProvider implements OAuthClientProvider {
@@ -50,7 +51,13 @@ export class BrowserOAuthProvider implements OAuthClientProvider {
   }
 
   state(): string {
-    return crypto.randomUUID();
+    const stored = localStorage.getItem(KEYS.state);
+    if (stored) {
+      return stored;
+    }
+    const generated = crypto.randomUUID();
+    localStorage.setItem(KEYS.state, generated);
+    return generated;
   }
 
   redirectToAuthorization(authorizationUrl: URL): void {
@@ -74,6 +81,7 @@ export class BrowserOAuthProvider implements OAuthClientProvider {
     }
     if (scope === "all" || scope === "verifier") {
       localStorage.removeItem(KEYS.codeVerifier);
+      localStorage.removeItem(KEYS.state);
     }
   }
 }


### PR DESCRIPTION
- Currently we are not sending a state to the oauth provider
- Some providers (like SuperTokens) are expecting a state when calling the authorize endpoints

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds OAuth `state` parameter support to `BrowserOAuthProvider`, which is required by certain OAuth providers (e.g. SuperTokens) that enforce the presence of a `state` during the authorization flow.

- A `state` key is added to the `KEYS` constant for localStorage.
- A `state(): string` method is implemented that lazily generates a `crypto.randomUUID()`, persists it in `localStorage` on first call, and returns the same value on subsequent calls — correctly surviving the full-page redirect and a fresh `BrowserOAuthProvider` instantiation in `finishOAuthCallback`.
- The `state` value is cleared in `invalidateCredentials` under the `"verifier"` and `"all"` scopes, consistent with the code-verifier lifecycle.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — the implementation is correct, well-scoped, and directly addresses the stated OAuth compatibility issue.
- The `state()` method correctly persists the generated UUID in `localStorage`, ensuring the same value is returned both when building the authorization URL and when the callback creates a fresh `BrowserOAuthProvider`. Cleanup is tied to the `"verifier"` scope alongside `codeVerifier`, which is semantically appropriate. No regressions are introduced.
- No files require special attention.

<sub>Last reviewed commit: 52d77d0</sub>

<!-- /greptile_comment -->