### PR TITLE
fix: type mcpMiddleware next() return per method

### DIFF
--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -11,7 +11,9 @@ export type {
   McpMethodString,
   McpMiddlewareFilter,
   McpMiddlewareFn,
+  McpResultFor,
   McpTypedMiddlewareFn,
+  McpWildcard,
 } from "./middleware.js";
 export type { McpServerTypes, ToolDef, WidgetHostType } from "./server.js";
 export { McpServer } from "./server.js";

--- a/packages/core/src/server/middleware.test-d.ts
+++ b/packages/core/src/server/middleware.test-d.ts
@@ -1,52 +1,70 @@
+import type {
+  CallToolResult,
+  ListToolsResult,
+  ServerResult,
+} from "@modelcontextprotocol/sdk/types.js";
 import { expectTypeOf, test } from "vitest";
-import type { McpExtra, McpTypedMiddlewareFn } from "./middleware.js";
+import type {
+  McpExtra,
+  McpResultFor,
+  McpTypedMiddlewareFn,
+} from "./middleware.js";
 import type { McpServer } from "./server.js";
 
 const server = null as unknown as McpServer;
 
-test("request category narrows extra to McpExtra", () => {
-  server.mcpMiddleware("request", (_request, extra, next) => {
+test("request category narrows extra and next() result", () => {
+  server.mcpMiddleware("request", async (_request, extra, next) => {
     expectTypeOf(extra).toEqualTypeOf<McpExtra>();
     extra.signal;
-    return next();
+    const result = await next();
+    expectTypeOf(result).toEqualTypeOf<ServerResult>();
+    return result;
   });
 });
 
-test("notification category narrows extra to undefined", () => {
-  server.mcpMiddleware("notification", (_request, extra, next) => {
+test("notification category narrows extra and next() result", () => {
+  server.mcpMiddleware("notification", async (_request, extra, next) => {
     expectTypeOf(extra).toEqualTypeOf<undefined>();
     // @ts-expect-error extra is undefined, cannot access .signal
     extra.signal;
-    return next();
+    const result = await next();
+    expectTypeOf(result).toEqualTypeOf<undefined>();
   });
 });
 
-test("exact method tools/call narrows params and extra", () => {
-  server.mcpMiddleware("tools/call", (request, extra, next) => {
+test("exact method tools/call narrows params, extra, and next() result", () => {
+  server.mcpMiddleware("tools/call", async (request, extra, next) => {
     expectTypeOf(request.params.name).toBeString();
     expectTypeOf(extra).toEqualTypeOf<McpExtra>();
-    return next();
+    const result = await next();
+    expectTypeOf(result).toEqualTypeOf<CallToolResult>();
+    return result;
   });
 });
 
-test("exact method tools/list narrows extra to McpExtra", () => {
-  server.mcpMiddleware("tools/list", (_request, extra, next) => {
-    expectTypeOf(extra).toEqualTypeOf<McpExtra>();
-    return next();
+test("exact method tools/list narrows next() to ListToolsResult", () => {
+  server.mcpMiddleware("tools/list", async (_request, _extra, next) => {
+    const result = await next();
+    expectTypeOf(result).toEqualTypeOf<ListToolsResult>();
+    return result;
   });
 });
 
-test("exact notification method narrows extra to undefined", () => {
-  server.mcpMiddleware("notifications/initialized", (_request, extra, next) => {
-    expectTypeOf(extra).toEqualTypeOf<undefined>();
-    // @ts-expect-error extra is undefined
-    extra.signal;
-    return next();
-  });
+test("exact notification method narrows extra and next() result", () => {
+  server.mcpMiddleware(
+    "notifications/initialized",
+    async (_request, extra, next) => {
+      expectTypeOf(extra).toEqualTypeOf<undefined>();
+      // @ts-expect-error extra is undefined
+      extra.signal;
+      const result = await next();
+      expectTypeOf(result).toEqualTypeOf<undefined>();
+    },
+  );
 });
 
-test("McpTypedMiddlewareFn narrows params and extra per method", () => {
-  expectTypeOf<McpTypedMiddlewareFn<"tools/call">>().toBeFunction();
+test("McpTypedMiddlewareFn narrows params, extra, and next() per method", () => {
   expectTypeOf<
     Parameters<McpTypedMiddlewareFn<"tools/call">>[0]["params"]["name"]
   >().toBeString();
@@ -56,6 +74,34 @@ test("McpTypedMiddlewareFn narrows params and extra per method", () => {
   expectTypeOf<
     Parameters<McpTypedMiddlewareFn<"notifications/initialized">>[1]
   >().toEqualTypeOf<undefined>();
+  expectTypeOf<
+    ReturnType<Parameters<McpTypedMiddlewareFn<"tools/list">>[2]>
+  >().toEqualTypeOf<Promise<ListToolsResult>>();
+  expectTypeOf<
+    ReturnType<Parameters<McpTypedMiddlewareFn<"notifications/initialized">>[2]>
+  >().toEqualTypeOf<Promise<undefined>>();
+});
+
+test("McpResultFor maps methods to correct result types", () => {
+  expectTypeOf<McpResultFor<"tools/list">>().toEqualTypeOf<ListToolsResult>();
+  expectTypeOf<McpResultFor<"tools/call">>().toEqualTypeOf<CallToolResult>();
+  expectTypeOf<
+    McpResultFor<"notifications/initialized">
+  >().toEqualTypeOf<undefined>();
+});
+
+test("wildcard tools/* narrows next() to union of tools result types", () => {
+  server.mcpMiddleware("tools/*", async (_request, _extra, next) => {
+    const result = await next();
+    expectTypeOf(result).toEqualTypeOf<ListToolsResult | CallToolResult>();
+    return result;
+  });
+});
+
+test("McpResultFor resolves wildcards to union of matching result types", () => {
+  expectTypeOf<McpResultFor<"tools/*">>().toEqualTypeOf<
+    ListToolsResult | CallToolResult
+  >();
 });
 
 test("catch-all middleware has no narrowing on extra or params", () => {

--- a/packages/core/src/server/middleware.ts
+++ b/packages/core/src/server/middleware.ts
@@ -1,10 +1,25 @@
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import type {
+  CallToolResult,
+  CancelTaskResult,
   ClientNotification,
   ClientRequest,
+  CompleteResult,
+  EmptyResult,
+  GetPromptResult,
+  GetTaskPayloadResult,
+  GetTaskResult,
+  InitializeResult,
+  ListPromptsResult,
+  ListResourcesResult,
+  ListResourceTemplatesResult,
+  ListTasksResult,
+  ListToolsResult,
+  ReadResourceResult,
   ServerNotification,
   ServerRequest,
+  ServerResult,
 } from "@modelcontextprotocol/sdk/types.js";
 
 /**
@@ -46,11 +61,51 @@ export type McpExtraFor<M extends string> = M extends ClientRequest["method"]
     ? undefined
     : McpExtra | undefined;
 
-/** Typed middleware fn for a specific method — narrows both params and extra. */
+/** Maps each MCP request method to its SDK result type. */
+interface McpResultMap {
+  ping: EmptyResult;
+  initialize: InitializeResult;
+  "tools/list": ListToolsResult;
+  "tools/call": CallToolResult;
+  "resources/list": ListResourcesResult;
+  "resources/templates/list": ListResourceTemplatesResult;
+  "resources/read": ReadResourceResult;
+  "resources/subscribe": EmptyResult;
+  "resources/unsubscribe": EmptyResult;
+  "prompts/list": ListPromptsResult;
+  "prompts/get": GetPromptResult;
+  "completion/complete": CompleteResult;
+  "logging/setLevel": EmptyResult;
+  "tasks/get": GetTaskResult;
+  "tasks/result": GetTaskPayloadResult;
+  "tasks/list": ListTasksResult;
+  "tasks/cancel": CancelTaskResult;
+}
+
+/**
+ * Map an MCP method string to its corresponding result type.
+ * For request methods, resolves to the specific SDK result type.
+ * For wildcard patterns (e.g. `"tools/*"`), resolves to the union of matching result types.
+ * For notification methods, resolves to `undefined`.
+ * For unknown/unmatched methods, falls back to `ServerResult`.
+ */
+export type McpResultFor<M extends string> = M extends keyof McpResultMap
+  ? McpResultMap[M]
+  : M extends `${infer Prefix}/*`
+    ? [McpResultMap[keyof McpResultMap & `${Prefix}/${string}`]] extends [never]
+      ? M extends ToWildcard<ClientNotification["method"]>
+        ? undefined
+        : ServerResult
+      : McpResultMap[keyof McpResultMap & `${Prefix}/${string}`]
+    : M extends ClientNotification["method"]
+      ? undefined
+      : ServerResult;
+
+/** Typed middleware fn for a specific method — narrows params, extra, and next() result. */
 export type McpTypedMiddlewareFn<M extends string> = (
   request: { method: M; params: McpRequestParams<M> },
   extra: McpExtraFor<M>,
-  next: () => Promise<unknown>,
+  next: () => Promise<McpResultFor<M>>,
 ) => Promise<unknown> | unknown;
 
 /** Extracts `"prefix/*"` from `"prefix/anything"` — distributive over unions. */
@@ -59,7 +114,7 @@ type ToWildcard<T extends string> = T extends `${infer Prefix}/${string}`
   : never;
 
 /** Wildcard prefixes derived from method strings (e.g. `"tools/*"` from `"tools/call"`). */
-type McpWildcard = ToWildcard<McpMethodString>;
+export type McpWildcard = ToWildcard<McpMethodString>;
 
 /** Category keywords matching all requests or all notifications. */
 type McpCategory = "request" | "notification";

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -22,6 +22,7 @@ import type {
   Resource,
   ServerNotification,
   ServerRequest,
+  ServerResult,
   ToolAnnotations,
 } from "@modelcontextprotocol/sdk/types.js";
 import { mergeWith, union } from "es-toolkit";
@@ -30,11 +31,14 @@ import { DEFAULT_HMR_PORT } from "./const.js";
 import { createServer } from "./express.js";
 import type {
   McpExtra,
+  McpExtraFor,
   McpMethodString,
   McpMiddlewareEntry,
   McpMiddlewareFilter,
   McpMiddlewareFn,
+  McpResultFor,
   McpTypedMiddlewareFn,
+  McpWildcard,
 } from "./middleware.js";
 import { buildMiddlewareChain, getHandlerMaps } from "./middleware.js";
 import { templateHelper } from "./templateHelper.js";
@@ -270,7 +274,7 @@ export class McpServer<
     handler: (
       request: { method: string; params: Record<string, unknown> },
       extra: McpExtra,
-      next: () => Promise<unknown>,
+      next: () => Promise<ServerResult>,
     ) => Promise<unknown> | unknown,
   ): this;
   /**
@@ -281,16 +285,28 @@ export class McpServer<
     handler: (
       request: { method: string; params: Record<string, unknown> },
       extra: undefined,
-      next: () => Promise<unknown>,
+      next: () => Promise<undefined>,
     ) => Promise<unknown> | unknown,
   ): this;
   /**
    * Register MCP protocol-level middleware for an exact method.
-   * Narrows both `params` and `extra` based on the method string.
+   * Narrows `params`, `extra`, and `next()` result based on the method string.
    */
   mcpMiddleware<M extends McpMethodString>(
     filter: M,
     handler: McpTypedMiddlewareFn<M>,
+  ): this;
+  /**
+   * Register MCP protocol-level middleware for a wildcard pattern (e.g. `"tools/*"`).
+   * `next()` returns the union of result types for matching methods.
+   */
+  mcpMiddleware<W extends McpWildcard>(
+    filter: W,
+    handler: (
+      request: { method: string; params: Record<string, unknown> },
+      extra: McpExtraFor<W>,
+      next: () => Promise<McpResultFor<W>>,
+    ) => Promise<unknown> | unknown,
   ): this;
   /**
    * Register MCP protocol-level middleware with a method filter.


### PR DESCRIPTION
next() was typed as Promise<unknown>, requiring manual casts. Now resolves to the specific SDK result type based on the method filter: exact methods (e.g. tools/call → CallToolResult), wildcards (e.g. tools/* → ListToolsResult | CallToolResult), request category (→ ServerResult), and notification category (→ undefined).

Fixes #553

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds strongly-typed `next()` return values to MCP middleware, so that `next()` resolves to the specific SDK result type (e.g., `CallToolResult` for `"tools/call"`) instead of `Promise<unknown>`. This is achieved via a new `McpResultMap` interface mapping method strings to result types, a `McpResultFor<M>` conditional type, updated overload signatures on `mcpMiddleware()`, and a new wildcard overload for patterns like `"tools/*"`.

- The core type mapping (`McpResultMap`, `McpResultFor`) is well-designed and handles exact methods, wildcards, and notification methods correctly for the common cases
- Overload ordering in `McpServer.mcpMiddleware()` is correct — TypeScript resolves exact methods, wildcards, and categories to the right overload
- Comprehensive type-level tests (`middleware.test-d.ts`) cover exact methods, wildcards, categories, and the `McpResultFor` utility type
- **Issue found**: The notification wildcard `"notifications/*"` resolves to `never` via `McpResultFor` (since `McpResultMap` has no notification entries), and the wildcard overload hardcodes `extra: McpExtra` which is incorrect for notifications — this combination means using `"notifications/*"` would produce incorrect types for both `extra` and `next()`

<h3>Confidence Score: 3/5</h3>

- This PR is type-level only (no runtime changes) so it cannot break existing behavior, but has a type-correctness gap for notification wildcards.
- Score of 3 reflects that the core feature works well for the common use cases (exact methods, request wildcards, categories), but the notification wildcard edge case (`"notifications/*"`) produces incorrect types (`never` instead of `undefined`, and `McpExtra` instead of `undefined`). Since this is purely a type-level change with no runtime impact, it cannot break existing functionality, but shipping an incorrect type for a valid input pattern could confuse users.
- `packages/core/src/server/middleware.ts` (McpResultFor type) and `packages/core/src/server/server.ts` (wildcard overload) need attention for the notification wildcard edge case.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/core/src/server/middleware.ts
Line: 92-98

Comment:
**`McpResultFor` resolves to `never` for notification wildcards**

`McpResultFor<"notifications/*">` falls into the wildcard branch (line 94), which looks up `McpResultMap[keyof McpResultMap & "notifications/${string}"]`. Since no notification methods exist in `McpResultMap`, this evaluates to `McpResultMap[never]` = `never` — instead of the expected `undefined`.

This means the wildcard overload in `server.ts:302-309` would type `next()` as `Promise<never>` for `"notifications/*"`, making it impossible to call `next()` and use its return value correctly at the type level. The `extra` parameter would also be incorrectly typed as `McpExtra` instead of `undefined`.

Consider adding a check for notification wildcards before the generic wildcard branch:

```suggestion
export type McpResultFor<M extends string> = M extends keyof McpResultMap
  ? McpResultMap[M]
  : M extends `${infer Prefix}/*`
    ? [McpResultMap[keyof McpResultMap & `${Prefix}/${string}`]] extends [never]
      ? M extends `notifications/*` ? undefined : ServerResult
      : McpResultMap[keyof McpResultMap & `${Prefix}/${string}`]
    : M extends ClientNotification["method"]
      ? undefined
      : ServerResult;
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/core/src/server/server.ts
Line: 302-309

Comment:
**Wildcard overload hardcodes `extra: McpExtra`, incorrect for `"notifications/*"`**

`McpWildcard` includes `"notifications/*"` (derived from `"notifications/initialized"` etc.), but this overload always types `extra` as `McpExtra`. For notification wildcards, `extra` should be `undefined` since the SDK does not provide extra context for notifications.

Combined with the `McpResultFor<"notifications/*">` resolving to `never` (see comment on `middleware.ts`), a user calling `server.mcpMiddleware("notifications/*", handler)` would get both `extra` and `next()` typed incorrectly.

Consider either:
1. Splitting this into separate request-wildcard and notification-wildcard overloads, or
2. Using a conditional type for `extra` similar to `McpExtraFor` (e.g., `extra: McpExtraFor<W>`)

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 1a26e56</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->