### PR TITLE
feat: remove alias record

### DIFF
--- a/infrastructure/lib/constructs/SkybridgeRecords.ts
+++ b/infrastructure/lib/constructs/SkybridgeRecords.ts
@@ -1,9 +1,4 @@
-import {
-  ARecord,
-  CnameRecord,
-  PublicHostedZone,
-  RecordTarget,
-} from "aws-cdk-lib/aws-route53";
+import { CnameRecord, PublicHostedZone } from "aws-cdk-lib/aws-route53";
 import { Construct } from "constructs";
 
 type SkybridgeRecordsProps = {
@@ -16,11 +11,6 @@ export class SkybridgeRecords extends Construct {
 
     const hostedZone = new PublicHostedZone(this, "HostedZone", {
       zoneName: domain,
-    });
-
-    new ARecord(this, "Apex", {
-      zone: hostedZone,
-      target: RecordTarget.fromIpAddresses("216.150.1.1"),
     });
 
     // Showcase apps pointing to alpic.ai


### PR DESCRIPTION
to be followed by adding the [https redirect](https://github.com/alpic-ai/skybridge/pull/562)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the A record for the `skybridge.tech` apex domain (previously pointing to `216.150.1.1`) and cleans up the now-unused `ARecord` and `RecordTarget` imports. This is an intentional intermediate step — the author plans to follow up by re-adding an HTTPS redirect for the apex domain (which was removed in #559).

- The apex domain (`skybridge.tech`) will have **no DNS record** between this deploy and the follow-up PR. Subdomain CNAME records and docs records are unaffected.

<h3>Confidence Score: 4/5</h3>

- This PR is a safe, minimal infrastructure change that intentionally removes a single DNS record as part of a two-step migration.
- The change is small and well-scoped — only one construct and its imports are removed. The code is syntactically correct. The only risk is a brief period where the apex domain has no DNS record, but the author has acknowledged this is intentional. Score is 4 instead of 5 because the apex domain will be temporarily unresolvable between this deploy and the follow-up PR.
- No files require special attention. The single changed file is straightforward.

<sub>Last reviewed commit: 4e5f0c3</sub>

<!-- /greptile_comment -->