### PR TITLE
feat: add https redirect

### DIFF
--- a/infrastructure/lib/constructs/SkybridgeRecords.ts
+++ b/infrastructure/lib/constructs/SkybridgeRecords.ts
@@ -1,4 +1,5 @@
 import { CnameRecord, PublicHostedZone } from "aws-cdk-lib/aws-route53";
+import { HttpsRedirect } from "aws-cdk-lib/aws-route53-patterns";
 import { Construct } from "constructs";
 
 type SkybridgeRecordsProps = {
@@ -11,6 +12,12 @@ export class SkybridgeRecords extends Construct {
 
     const hostedZone = new PublicHostedZone(this, "HostedZone", {
       zoneName: domain,
+    });
+
+    // Redirect apex to docs
+    new HttpsRedirect(this, "ApexRedirect", {
+      zone: hostedZone,
+      targetDomain: `docs.${domain}`,
     });
 
     // Showcase apps pointing to alpic.ai


### PR DESCRIPTION
so skybridge.tech redirects to docs

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Re-introduces the `HttpsRedirect` CDK construct to redirect the apex domain (`skybridge.tech`) to `docs.skybridge.tech` via CloudFront and S3. This was previously added and reverted in #559; the two-step approach (first removing the A record in the base branch, then adding the redirect) avoids DNS record conflicts during deployment.

- Adds `HttpsRedirect` from `aws-cdk-lib/aws-route53-patterns` to `SkybridgeRecords`, which provisions a CloudFront distribution, S3 redirect bucket, Route53 A/AAAA alias records, and an auto-generated ACM certificate in `us-east-1`
- No `recordNames` specified, which correctly defaults to the zone apex (`skybridge.tech`)
- Stack is deployed in `us-east-1`, so no cross-region certificate issues

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it correctly re-introduces a well-understood CDK pattern with no code issues.
- The change is minimal (6 lines added), uses a standard AWS CDK construct correctly, the stack region aligns with ACM requirements, and the two-step deployment approach (removing the old A record first) avoids DNS conflicts. This is also an exact re-introduction of a previously deployed configuration.
- No files require special attention.

<sub>Last reviewed commit: 46f8dac</sub>

<!-- /greptile_comment -->