### PR TITLE
fix: add www to https redirect

### DIFF
--- a/infrastructure/lib/constructs/SkybridgeRecords.ts
+++ b/infrastructure/lib/constructs/SkybridgeRecords.ts
@@ -14,9 +14,10 @@ export class SkybridgeRecords extends Construct {
       zoneName: domain,
     });
 
-    // Redirect apex to docs
+    // Redirect apex and www to docs
     new HttpsRedirect(this, "ApexRedirect", {
       zone: hostedZone,
+      recordNames: ["www"],
       targetDomain: `docs.${domain}`,
     });
 


### PR DESCRIPTION
so www.skybridge.tech actually leads to docs.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR intends to add a `www` subdomain redirect alongside the existing apex domain redirect to `docs.${domain}`. However, specifying `recordNames: ["www"]` on the `HttpsRedirect` construct **overrides** the default apex redirect rather than adding to it. The result is that `www.${domain}` will redirect correctly, but the apex domain (`${domain}`) will stop redirecting — a regression from the current behavior.

- **Bug**: `recordNames: ["www"]` replaces the default apex redirect instead of supplementing it. The apex domain must be explicitly included in the `recordNames` array to preserve the existing behavior.

<h3>Confidence Score: 1/5</h3>

- This PR will break the existing apex domain redirect, causing a production regression.
- The single changed line introduces a regression by removing the apex domain redirect. The CDK `HttpsRedirect` `recordNames` property replaces the default (apex) rather than adding to it, so the current change loses the apex redirect while only adding `www`.
- `infrastructure/lib/constructs/SkybridgeRecords.ts` — the `recordNames` configuration needs to include the apex domain to preserve existing behavior.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: infrastructure/lib/constructs/SkybridgeRecords.ts
Line: 20

Comment:
**Apex redirect lost by overriding `recordNames`**

Setting `recordNames: ["www"]` replaces the default behavior, which redirects the apex domain (`domain`). According to the [CDK docs](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_route53_patterns.HttpsRedirect.html), `recordNames` defaults to the hosted zone's domain name when omitted. By explicitly providing only `["www"]`, the apex domain will no longer redirect to `docs.${domain}`.

To redirect **both** the apex and `www`, include the apex domain in the array:

```suggestion
      recordNames: [`${domain}`, "www"],
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: a4647c5</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->