### PR TITLE
fix: HttpsRedirect recordNames

### DIFF
--- a/infrastructure/lib/constructs/SkybridgeRecords.ts
+++ b/infrastructure/lib/constructs/SkybridgeRecords.ts
@@ -17,7 +17,7 @@ export class SkybridgeRecords extends Construct {
     // Redirect apex and www to docs
     new HttpsRedirect(this, "ApexRedirect", {
       zone: hostedZone,
-      recordNames: ["www"],
+      recordNames: [domain, `www.${domain}`],
       targetDomain: `docs.${domain}`,
     });
 


### PR DESCRIPTION
they must be whole list of the full domain redirecting to docs.skybridge.tech

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the `HttpsRedirect` `recordNames` to use fully qualified domain names as required by the AWS CDK construct. Previously, only `["www"]` was specified, which is not a valid FQDN. The fix changes it to `[domain, \`www.${domain}\`]` (i.e., `["skybridge.tech", "www.skybridge.tech"]`), correctly redirecting both the apex domain and the `www` subdomain to `docs.skybridge.tech`. This aligns with the [official AWS CDK documentation](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_route53_patterns.HttpsRedirect.html) which shows `recordNames` expecting FQDNs (e.g., `foo.example.com`).

<h3>Confidence Score: 5/5</h3>

- This PR is a straightforward infrastructure fix that correctly aligns the HttpsRedirect configuration with AWS CDK requirements.
- Single-line change that corrects recordNames to use FQDNs as required by the AWS CDK HttpsRedirect construct. The fix matches official documentation examples and addresses a clear configuration bug from the previous commit.
- No files require special attention.

<sub>Last reviewed commit: 9d49d8f</sub>

<!-- /greptile_comment -->