### PR TITLE
chore: add app examples subdomains

### DIFF
--- a/infrastructure/lib/constructs/SkybridgeRecords.ts
+++ b/infrastructure/lib/constructs/SkybridgeRecords.ts
@@ -31,6 +31,9 @@ export class SkybridgeRecords extends Construct {
       "productivity",
       "times-up",
       "auth0",
+      "clerk",
+      "stytch",
+      "workos",
     ]) {
       new CnameRecord(this, `${subdomain}App`, {
         zone: hostedZone,


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds three new subdomain CNAME records (`clerk`, `stytch`, `workos`) to the `SkybridgeRecords` CDK construct, following the same pattern as existing auth-related showcase app subdomains (e.g. `auth0`). Each new entry points to `cname.alpic.ai`, consistent with all other showcase app subdomains in the loop.

- Added `clerk`, `stytch`, and `workos` to the showcase apps subdomain list in `SkybridgeRecords.ts`
- No logic changes — purely additive infrastructure configuration
- No issues found; the change is minimal, correct, and follows established patterns

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a purely additive, low-risk DNS configuration change.
- The change adds three entries to an existing loop, generating valid CNAME records with unique CDK construct IDs (`clerkApp`, `stytchApp`, `workosApp`). There are no logic changes, no regressions, and the pattern is identical to the pre-existing entries.
- No files require special attention.

<sub>Last reviewed commit: 4e76954</sub>

<!-- /greptile_comment -->