### PR TITLE
fix: allow vite 8.0 as peerDepencies in skybridge chore

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,7 @@
     "nodemon": ">=3.0.0",
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0",
-    "vite": "^7.3.1"
+    "vite": ">=7.3.1"
   },
   "dependencies": {
     "@babel/core": "^7.29.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -753,7 +753,7 @@ importers:
         specifier: ^2.2.6
         version: 2.2.6
       vite:
-        specifier: ^7.3.1
+        specifier: '>=7.3.1'
         version: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
       zustand:
         specifier: ^5.0.12


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR relaxes the `vite` peer dependency constraint in `packages/core/package.json` from `^7.3.1` (which caps at `<8.0.0`) to `>=7.3.1`, allowing Vite 8.x (and beyond) to satisfy the requirement. The lock file is updated to reflect the new specifier.

- The change makes the `vite` peer dependency consistent with the existing `>=` pattern used by all other peer dependencies in the file (`react`, `nodemon`, `@modelcontextprotocol/sdk`, etc.).
- The installed version in `pnpm-lock.yaml` remains `7.3.1`, so no runtime behavior changes are introduced.
- The constraint is unbounded from above (no `<9.0.0` ceiling), which matches the project's deliberate policy for peer deps but does mean future Vite major versions with breaking changes could be silently accepted.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — minimal, intentional change that aligns with the project's existing peer dependency strategy.
- The change is a single-line constraint relaxation that is consistent with every other peer dependency in the file. There are no logic, syntax, or security concerns introduced.
- No files require special attention.

<sub>Last reviewed commit: 797861d</sub>

<!-- /greptile_comment -->