### PR TITLE
fix: manifest ui example app csp

### DIFF
--- a/examples/manifest-ui/server/src/index.ts
+++ b/examples/manifest-ui/server/src/index.ts
@@ -11,6 +11,13 @@ const server = new McpServer(
   "hello-world",
   {
     description: "Hello World widget",
+    _meta: {
+      ui: {
+        csp: {
+          resourceDomains: ["https://avatars.githubusercontent.com"]
+        }
+      }
+    }
   },
   {
     description: "A hero widget with customizable title and subtitle.",


### PR DESCRIPTION
alpic logo sourced from github was not displayed properly