### PR TITLE
fix: make bump script use argv version for devtools

### DIFF
--- a/scripts/bump.js
+++ b/scripts/bump.js
@@ -32,7 +32,7 @@ if (!skybridgeVersion) {
   process.exit(1);
 }
 
-const devtoolsVersion = fetchLatestVersion("@skybridge/devtools");
+const devtoolsVersion = process.argv[2] || fetchLatestVersion("@skybridge/devtools");
 const alpicVersion = fetchLatestVersion("alpic");
 
 const skybridgeRange = `>=${skybridgeVersion} <1.0.0`;


### PR DESCRIPTION
since it's the same as core

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the `bump.js` script use the CLI argument (`process.argv[2]`) as the version for `@skybridge/devtools` — the same way it already works for `skybridge` — since both packages are versioned in sync. The change is minimal and the logic is sound.

- The `devtoolsVersion` line is updated from always fetching the latest npm version to preferring `process.argv[2]` first, falling back to `fetchLatestVersion("@skybridge/devtools")` when no argument is provided.
- The usage comment at the top of the file (line 8) should be updated to reflect that `process.argv[2]` now sets the version for both `skybridge` **and** `@skybridge/devtools`, not just `skybridge`.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — the change is correct, intentional, and consistent with the existing pattern in the script.
- The fix is a single-line, low-risk change that aligns `devtoolsVersion` resolution with `skybridgeVersion`. Both packages are version-synced per the PR description, making this the correct behaviour. The only gap is a minor documentation inaccuracy in the usage comment.
- No files require special attention.

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `scripts/bump.js`, line 7-9 ([link](https://github.com/alpic-ai/skybridge/blob/8810c2d20303839645abfab7d392c1c98cf09ce2/scripts/bump.js#L7-L9)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Outdated usage comment**

   Now that `process.argv[2]` is used for both `skybridge` and `@skybridge/devtools`, the usage comment should be updated to reflect that the argument sets the version for both packages, not just `skybridge`.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: scripts/bump.js
   Line: 7-9

   Comment:
   **Outdated usage comment**

   Now that `process.argv[2]` is used for both `skybridge` and `@skybridge/devtools`, the usage comment should be updated to reflect that the argument sets the version for both packages, not just `skybridge`.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: scripts/bump.js
Line: 7-9

Comment:
**Outdated usage comment**

Now that `process.argv[2]` is used for both `skybridge` and `@skybridge/devtools`, the usage comment should be updated to reflect that the argument sets the version for both packages, not just `skybridge`.

```suggestion
 * Usage:
 *   node scripts/bump.js          # Uses latest published versions
 *   node scripts/bump.js 0.30.0   # Uses specific version for skybridge and @skybridge/devtools
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix: make bump scrip..."](https://github.com/alpic-ai/skybridge/commit/8810c2d20303839645abfab7d392c1c98cf09ce2)</sub>

<!-- /greptile_comment -->