### PR TITLE
fix: bump script

### DIFF
--- a/scripts/bump.js
+++ b/scripts/bump.js
@@ -66,11 +66,13 @@ const targets = [
 // Update @skybridge/devtools peer dependency in core package
 if (devtoolsRange) {
   const corePackagePath = join(rootDir, "packages/core/package.json");
-  const corePkg = JSON.parse(readFileSync(corePackagePath, "utf8"));
-  if (corePkg.peerDependencies?.["@skybridge/devtools"]) {
-    console.log("Updating: packages/core/package.json (peerDependencies)");
-    corePkg.peerDependencies["@skybridge/devtools"] = devtoolsRange;
-    writeFileSync(corePackagePath, JSON.stringify(corePkg, null, 2) + "\n");
+  if (existsSync(corePackagePath)) {
+    const corePkg = JSON.parse(readFileSync(corePackagePath, "utf8"));
+    if (corePkg.peerDependencies?.["@skybridge/devtools"]) {
+      console.log("Updating: packages/core/package.json (peerDependencies)");
+      corePkg.peerDependencies["@skybridge/devtools"] = devtoolsRange;
+      writeFileSync(corePackagePath, JSON.stringify(corePkg, null, 2) + "\n");
+    }
   }
 }
 


### PR DESCRIPTION
so core's "@skybridge/devtools" is updated as well.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends `scripts/bump.js` so that when a new `@skybridge/devtools` version is resolved, its peer-dependency entry in `packages/core/package.json` is updated in addition to the existing template and example targets. The logic is correct and the JSON serialisation matches the rest of the script.

- The new block correctly checks `devtoolsRange` before proceeding and only writes if the `peerDependencies["@skybridge/devtools"]` key already exists in the file, avoiding spurious additions.
- A minor inconsistency: every other file read in the script is guarded by an `existsSync` check, but the new `readFileSync` call on `packages/core/package.json` is not — if the file is absent the script will throw an unhandled error rather than skipping gracefully.

<h3>Confidence Score: 4/5</h3>

- Safe to merge; the change is small, focused, and correct with one minor robustness gap.
- The new block is logically sound and consistent with the script's intent. The only issue is a missing `existsSync` guard that could cause an unhandled exception in edge cases, but in normal repo usage `packages/core/package.json` will always be present.
- scripts/bump.js — add an `existsSync` check before the `readFileSync` call for consistency and robustness.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: scripts/bump.js
Line: 67-75

Comment:
**Missing existence check before reading core package.json**

Every other file read in this script is guarded by an `existsSync` check (see the loop at line 80-83). The new block calls `readFileSync` on `packages/core/package.json` unconditionally — if that file is ever absent (e.g., in a trimmed checkout or a future repo restructure), the script will throw an unhandled exception instead of printing a friendly skip message.

```suggestion
// Update @skybridge/devtools peer dependency in core package
if (devtoolsRange) {
  const corePackagePath = join(rootDir, "packages/core/package.json");
  if (!existsSync(corePackagePath)) {
    console.log("Skipping (not found): packages/core/package.json");
  } else {
    const corePkg = JSON.parse(readFileSync(corePackagePath, "utf8"));
    if (corePkg.peerDependencies?.["@skybridge/devtools"]) {
      console.log("Updating: packages/core/package.json (peerDependencies)");
      corePkg.peerDependencies["@skybridge/devtools"] = devtoolsRange;
      writeFileSync(corePackagePath, JSON.stringify(corePkg, null, 2) + "\n");
    }
  }
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix: bump script"](https://github.com/alpic-ai/skybridge/commit/7274a3d52f45c3595bcabffb3560520ab5e81bda)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->