### PR TITLE
feat: ignore pnpm overrides in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,12 @@
   ],
   "prConcurrentLimit": 5,
   "timezone": "Europe/Paris",
-  "rangeStrategy": "bump"
+  "rangeStrategy": "bump",
+  "packageRules": [
+    {
+      "description": "Ignore pnpm overrides (security floor pins managed manually)",
+      "matchDepTypes": ["pnpm.overrides"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `packageRules` entry to `renovate.json` that disables automated Renovate updates for `pnpm.overrides` dependencies, with a clear comment explaining that these security-floor pins are managed manually.

- The `matchDepTypes: ["pnpm.overrides"]` value is the correct Renovate dep type for targeting `pnpm.overrides` entries in `package.json`.
- Setting `enabled: false` correctly opts those pins out of automated bump PRs without affecting any other dependency type.
- The descriptive comment makes the intent clear for future maintainers.

No issues found — the change is minimal, well-scoped, and syntactically valid.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — single-line config addition with no risk to application code.
- The change is a one-block addition to a Renovate configuration file. It uses the correct `matchDepTypes` value (`pnpm.overrides`), the JSON is valid, and the intent is clearly documented. There are no logic concerns, no application code is touched, and the change is straightforwardly reversible if needed.
- No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["feat: ignore pnpm overrides in renovate"](https://github.com/alpic-ai/skybridge/commit/03fb8fe9dc54677f5e33dd302559375dc6f8156d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26036412)</sub>

<!-- /greptile_comment -->