### PR TITLE
feat: add support for custom Express error middleware

### DIFF
--- a/docs/api-reference/mcp-server.mdx
+++ b/docs/api-reference/mcp-server.mdx
@@ -67,6 +67,42 @@ server.use(cors());
 server.use("/api", authMiddleware);
 ```
 
+### useOnError
+Register [Express error handler](https://expressjs.com/en/guide/error-handling.html) on the underlying HTTP server. Supports optional path filtering.
+
+```typescript
+// Global error handler
+server.useOnError((err, req, res, next) => {
+  console.error(err);
+  res.status(500).send('Something broke!');
+})
+
+// Path-scoped error handler
+server.useOnError('/api', (err, req, res, next) => {
+  console.error(err);
+  res.status(500).send('Something broke!');
+})
+```
+
+There is a default error handler already registered, defined as:
+```typescript
+function defaultErrorHandler(
+  err: unknown,
+  _req: express.Request,
+  res: express.Response,
+  _next: express.NextFunction,
+) {
+  console.error("Error handling MCP request:", err);
+  if (!res.headersSent) {
+    res.status(500).json({
+      jsonrpc: "2.0",
+      error: { code: -32603, message: "Internal server error" },
+      id: null,
+    });
+  }
+}
+```
+
 ### mcpMiddleware
 
 Register MCP protocol-level middleware using an onion model. Middleware wraps request/notification handlers and can inspect, modify, or short-circuit them.

--- a/packages/core/src/server/express.test.ts
+++ b/packages/core/src/server/express.test.ts
@@ -1,5 +1,5 @@
 import http from "node:http";
-import type { RequestHandler } from "express";
+import type { ErrorRequestHandler, RequestHandler } from "express";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { McpServer } from "./server";
 
@@ -33,6 +33,10 @@ async function postMcp(port: number) {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 1 }),
   });
+}
+
+async function postApi(port: number) {
+  return fetch(`http://localhost:${port}/api/test`, { method: "POST" });
 }
 
 describe("createApp", () => {
@@ -84,8 +88,10 @@ describe("createApp", () => {
 
   it("allows middleware to short-circuit with 401", async () => {
     const { createApp } = await import("./express.js");
+    const calls: string[] = [];
 
     const reject: RequestHandler = (_req, res) => {
+      calls.push("reject");
       res.status(401).json({ error: "Unauthorized" });
     };
 
@@ -100,6 +106,7 @@ describe("createApp", () => {
     openServer = server;
 
     const res = await postMcp(port);
+    expect(calls).toEqual(["reject"]);
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual({ error: "Unauthorized" });
   });
@@ -228,5 +235,87 @@ describe("createApp", () => {
     // Server process did not crash — it still accepts connections
     const followUp = await fetch(`http://localhost:${port}/explode`);
     expect(followUp.status).toBe(500);
+  });
+
+  it("returns 500 JSON-RPC error when the MCP handler throws and no error middleware is registered", async () => {
+    const { createApp } = await import("./express.js");
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const httpServer = http.createServer();
+    const app = await createApp({ mcpServer: fakeServer, httpServer });
+    const { port, server } = await listen(app);
+    openServer = server;
+
+    const res = await postMcp(port);
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({
+      jsonrpc: "2.0",
+      error: { code: -32603, message: "Internal server error" },
+      id: null,
+    });
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Error handling MCP request:",
+      expect.any(Error),
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it("invokes a custom error handler when the MCP handler throws", async () => {
+    const { createApp } = await import("./express.js");
+    const calls: string[] = [];
+
+    const errorHandler: ErrorRequestHandler = (_err, _req, res, _next) => {
+      calls.push("error-handler");
+      res.status(503).json({ custom: true });
+    };
+
+    const httpServer = http.createServer();
+    const app = await createApp({
+      mcpServer: fakeServer,
+      httpServer,
+      errorMiddleware: [{ handlers: [errorHandler] }],
+    });
+    const { port, server } = await listen(app);
+    openServer = server;
+
+    const res = await postMcp(port);
+    expect(calls).toEqual(["error-handler"]);
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ custom: true });
+  });
+
+  it("invokes a path-scoped error handler only for matching routes", async () => {
+    const { createApp } = await import("./express.js");
+    const calls: string[] = [];
+
+    const mcpErrorHandler: ErrorRequestHandler = (_err, _req, res, _next) => {
+      calls.push("mcp-error-handler");
+      res.status(503).json({ from: "mcp-error-handler" });
+    };
+
+    const throwingApiRoute: RequestHandler = (_req, _res, next) => {
+      next(new Error("api error"));
+    };
+
+    const httpServer = http.createServer();
+    const app = await createApp({
+      mcpServer: fakeServer,
+      httpServer,
+      customMiddleware: [{ path: "/api/test", handlers: [throwingApiRoute] }],
+      errorMiddleware: [{ path: "/mcp", handlers: [mcpErrorHandler] }],
+    });
+    const { port, server } = await listen(app);
+    openServer = server;
+
+    const mcpRes = await postMcp(port);
+    expect(calls).toEqual(["mcp-error-handler"]);
+    expect(mcpRes.status).toBe(503);
+    expect(await mcpRes.json()).toEqual({ from: "mcp-error-handler" });
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const apiRes = await postApi(port);
+    expect(calls).toEqual(["mcp-error-handler"]);
+    expect(apiRes.status).toBe(500);
+    consoleSpy.mockRestore();
   });
 });

--- a/packages/core/src/server/express.ts
+++ b/packages/core/src/server/express.ts
@@ -5,26 +5,57 @@ import cors from "cors";
 import express from "express";
 import type { McpServer } from "./server";
 
-export async function createApp({
-  mcpServer,
-  httpServer,
-  customMiddleware = [],
-}: {
-  mcpServer: McpServer;
-  httpServer: http.Server;
-  customMiddleware?: { path?: string; handlers: express.RequestHandler[] }[];
-}): Promise<express.Express> {
-  const app = express();
-  app.use(express.json());
-  const env = process.env.NODE_ENV || "development";
-
-  for (const middleware of customMiddleware) {
+function applyMiddlewares(
+  app: express.Express,
+  middlewares: Array<{
+    path?: string;
+    handlers: Array<express.RequestHandler | express.ErrorRequestHandler>;
+  }>,
+): void {
+  for (const middleware of middlewares) {
     if (middleware.path) {
       app.use(middleware.path, ...middleware.handlers);
     } else {
       app.use(...middleware.handlers);
     }
   }
+}
+
+function defaultErrorHandler(
+  err: unknown,
+  _req: express.Request,
+  res: express.Response,
+  _next: express.NextFunction,
+) {
+  console.error("Error handling MCP request:", err);
+  if (!res.headersSent) {
+    res.status(500).json({
+      jsonrpc: "2.0",
+      error: { code: -32603, message: "Internal server error" },
+      id: null,
+    });
+  }
+}
+
+export async function createApp({
+  mcpServer,
+  httpServer,
+  customMiddleware = [],
+  errorMiddleware = [],
+}: {
+  mcpServer: McpServer;
+  httpServer: http.Server;
+  customMiddleware?: { path?: string; handlers: express.RequestHandler[] }[];
+  errorMiddleware?: {
+    path?: string;
+    handlers: express.ErrorRequestHandler[];
+  }[];
+}): Promise<express.Express> {
+  const app = express();
+  app.use(express.json());
+  const env = process.env.NODE_ENV || "development";
+
+  applyMiddlewares(app, customMiddleware);
 
   if (env !== "production") {
     const { devtoolsStaticServer } = await import("@skybridge/devtools");
@@ -42,6 +73,10 @@ export async function createApp({
 
   app.use("/mcp", mcpMiddleware(mcpServer));
 
+  applyMiddlewares(app, errorMiddleware);
+
+  app.use("/mcp", defaultErrorHandler);
+
   return app;
 }
 
@@ -49,7 +84,7 @@ const mcpMiddleware = (server: McpServer): express.RequestHandler => {
   return async (
     req: express.Request,
     res: express.Response,
-    _next: express.NextFunction,
+    next: express.NextFunction,
   ) => {
     if (req.method !== "POST") {
       res.writeHead(405).end(
@@ -80,17 +115,7 @@ const mcpMiddleware = (server: McpServer): express.RequestHandler => {
       req.url = req.originalUrl;
       await transport.handleRequest(req, res, req.body);
     } catch (error) {
-      console.error("Error handling MCP request:", error);
-      if (!res.headersSent) {
-        res.status(500).json({
-          jsonrpc: "2.0",
-          error: {
-            code: -32603,
-            message: "Internal server error",
-          },
-          id: null,
-        });
-      }
+      next(error);
     }
   };
 };

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -26,7 +26,7 @@ import type {
   ToolAnnotations,
 } from "@modelcontextprotocol/sdk/types.js";
 import { mergeWith, union } from "es-toolkit";
-import type { Express, RequestHandler } from "express";
+import type { ErrorRequestHandler, Express, RequestHandler } from "express";
 import { createApp } from "./express.js";
 import type {
   McpExtra,
@@ -232,12 +232,18 @@ type MiddlewareConfig = {
   handlers: RequestHandler[];
 };
 
+type ErrorMiddlewareConfig = {
+  path?: string;
+  handlers: ErrorRequestHandler[];
+};
+
 export class McpServer<
   TTools extends Record<string, ToolDef> = Record<never, ToolDef>,
 > extends McpServerBase {
   declare readonly $types: McpServerTypes<TTools>;
   private express?: Express;
   private customMiddleware: MiddlewareConfig[] = [];
+  private customErrorMiddleware: ErrorMiddlewareConfig[] = [];
   private mcpMiddlewareEntries: McpMiddlewareEntry[] = [];
   private mcpMiddlewareApplied = false;
 
@@ -258,6 +264,22 @@ export class McpServer<
       });
     }
 
+    return this;
+  }
+
+  useOnError(...handlers: ErrorRequestHandler[]): this;
+  useOnError(path: string, ...handlers: ErrorRequestHandler[]): this;
+  useOnError(
+    pathOrHandler: string | ErrorRequestHandler,
+    ...handlers: ErrorRequestHandler[]
+  ): this {
+    if (typeof pathOrHandler === "string") {
+      this.customErrorMiddleware.push({ path: pathOrHandler, handlers });
+    } else {
+      this.customErrorMiddleware.push({
+        handlers: [pathOrHandler, ...handlers],
+      });
+    }
     return this;
   }
 
@@ -402,6 +424,7 @@ export class McpServer<
         mcpServer: this,
         httpServer,
         customMiddleware: this.customMiddleware,
+        errorMiddleware: this.customErrorMiddleware,
       });
     }
 


### PR DESCRIPTION
Hi, while working, I found that I needed to register an Express error handler, but I realized that it cannot be registered via `use()` because it doesn’t accept a handler of type `ErrorRequestHandler`. Furthermore, error handlers should be registered last, after all other `use` calls and routes, so expanding the current `use()` API was not an option.

Summary

  - Adds `useError()` method to `McpServer`, mirroring the existing use() API, so users can register [Express
  error-handling middleware](https://expressjs.com/en/guide/error-handling.html) directly on the server instance.
  - Accepts an optional path prefix so error handlers can be scoped to specific routes (e.g. only `/mcp`).
  - Propagates errors from the MCP handler via next(error) instead of swallowing them inline, so registered error
  middleware actually fires.
  - Falls back to a built-in `defaultErrorHandler` that returns a JSON-RPC 500 response when no custom error
  middleware is registered for backward compatibility

  Usage
```ts
  // Global error handler
  server.useError((err, req, res, next) => {
    res.status(503).json({ error: "unavailable" });
  });

  // Scoped to /mcp only
  server.useError("/mcp", (err, req, res, next) => {
    res.status(401).json({ error: "Unauthorized" });
  });
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `useError()` method to `McpServer` that lets users register Express error-handling middleware, and refactors the MCP handler to propagate errors via `next(error)` rather than swallowing them inline. A `defaultErrorHandler` (scoped to `/mcp`) is always registered after user-supplied handlers as a JSON-RPC 500 fallback, preserving backward compatibility.

**Key changes:**
- `useError(path?, ...handlers)` in `server.ts` mirrors the existing `use()` API and stores handlers in `customErrorMiddleware`, which is forwarded to `createApp` at startup.
- In `express.ts`, registration order is: custom middleware → MCP route → user error handlers → `defaultErrorHandler`. This correctly ensures user-supplied handlers have priority over the fallback.
- `defaultErrorHandler` guards with `!res.headersSent` to avoid double-response issues if a preceding handler has already sent a response but still called `next(err)`.
- Three new tests cover: (1) the fallback 500 JSON-RPC path, (2) a global custom error handler overriding the response, and (3) path-scoped error handlers firing only for matching routes.
- Minor: `applyMiddlewares` returns `express.Express` but the return value is never used by callers — `void` would better reflect the intent.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — the feature is well-scoped, backward-compatible, and covered by targeted tests.
- The implementation is logically sound: middleware registration order (custom → fallback) is correct, the `!res.headersSent` guard prevents double-response bugs, and the `useError()` API is consistent with the existing `use()` pattern. Tests cover the three critical paths (no handler, global handler, path-scoped handler). The only finding is a minor style issue (`applyMiddlewares` returning an unused `express.Express` instead of `void`), which does not affect runtime behaviour.
- No files require special attention.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/core/src/server/express.ts
Line: 8-23

Comment:
**`applyMiddlewares` return value is unused**

The function returns `express.Express` but neither call site captures the return value — it's invoked purely for its side effects. Returning `void` would make the intent clearer and avoid any confusion that the caller needs to use the returned app instance.

```suggestion
function applyMiddlewares(
  app: express.Express,
  middlewares: Array<{
    path?: string;
    handlers: Array<express.RequestHandler | express.ErrorRequestHandler>;
  }>,
): void {
  for (const middleware of middlewares) {
    if (middleware.path) {
      app.use(middleware.path, ...middleware.handlers);
    } else {
      app.use(...middleware.handlers);
    }
  }
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add support for custom Express err..."](https://github.com/alpic-ai/skybridge/commit/ab7cea0e68cc8e36b7d2f5cd547470b0436fcacc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26223877)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->