### PR TITLE
feat: support OpenAI file library APIs

### DIFF
--- a/docs/api-reference/use-files.mdx
+++ b/docs/api-reference/use-files.mdx
@@ -1,6 +1,6 @@
 ---
 title: useFiles
-description: "Upload and download files within widgets, with host-managed storage across tool calls."
+description: "Upload, select, and download files within widgets, with host-managed storage across tool calls."
 tag: "ChatGPT"
 ---
 
@@ -10,7 +10,7 @@ tag: "ChatGPT"
 This hook is not available in MCP Apps. Calling it in an MCP Apps environment will throw an error.
 </Warning>
 
-The `useFiles` hook provides methods for uploading and downloading files within your widget. Files are managed by the host and can be referenced across tool calls.
+The `useFiles` hook provides methods for uploading, selecting, and downloading files within your widget. Files are managed by the host and can be referenced across tool calls.
 
 ## Basic usage
 
@@ -44,13 +44,23 @@ function FileUploader() {
 ### `upload`
 
 ```tsx
-upload: (file: File) => Promise<{ fileId: string }>
+upload: (file: File, options?: { library?: boolean }) => Promise<{ fileId: string }>
 ```
 
 Uploads a file to the host. Returns a promise that resolves with the file metadata containing a unique `fileId`.
 
 - `file: File`
   - The file object to upload
+- `options?: { library?: boolean }`
+  - Pass `{ library: true }` to also save the upload into the user's ChatGPT file library (when available)
+
+### `selectFiles`
+
+```tsx
+selectFiles: () => Promise<Array<{ fileId: string; fileName?: string; mimeType?: string }>>
+```
+
+Opens ChatGPT's file library picker and returns app-authorized files selected by the user. Feature-detect before using — this method may not be available on all host versions.
 
 ### `getDownloadUrl`
 
@@ -58,13 +68,13 @@ Uploads a file to the host. Returns a promise that resolves with the file metada
 getDownloadUrl: (file: { fileId: string }) => Promise<{ downloadUrl: string }>
 ```
 
-Get the download URL of a file that was previously uploaded. Returns a promise that resolves with a `downloadUrl` that can be used to fetch the file content.
+Get the download URL of a file. Returns a promise that resolves with a `downloadUrl` that can be used to fetch the file content.
 
 - `file: { fileId: string }`
   - An object containing the `fileId` of the file to download
 
 <Note>
-Only files uploaded by the same connector instance can be downloaded.
+Works for files uploaded by the widget, files selected via `selectFiles()`, or files provided via tool/file params.
 </Note>
 
 ## Examples
@@ -106,6 +116,74 @@ function ImageUploader() {
       />
       {isUploading && <p>Uploading...</p>}
       {previewUrl && <img src={previewUrl} alt="Preview" />}
+    </div>
+  );
+}
+```
+
+### Upload to File Library
+
+```tsx
+import { useFiles } from "skybridge/web";
+import { useState } from "react";
+
+function LibraryUploader() {
+  const { upload } = useFiles();
+  const [fileId, setFileId] = useState<string | null>(null);
+
+  const handleUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    // Save to the user's ChatGPT file library
+    const { fileId } = await upload(file, { library: true });
+    setFileId(fileId);
+  };
+
+  return (
+    <div>
+      <input type="file" onChange={handleUpload} />
+      {fileId && <p>Saved to library: {fileId}</p>}
+    </div>
+  );
+}
+```
+
+### Select Files from Library
+
+```tsx
+import { useFiles } from "skybridge/web";
+import type { FileMetadata } from "skybridge/web";
+import { useState } from "react";
+
+function FileSelector() {
+  const { selectFiles, getDownloadUrl } = useFiles();
+  const [files, setFiles] = useState<FileMetadata[]>([]);
+
+  const handleSelect = async () => {
+    const selected = await selectFiles();
+    setFiles(selected);
+  };
+
+  const handleDownload = async (fileId: string) => {
+    const { downloadUrl } = await getDownloadUrl({ fileId });
+    window.open(downloadUrl, "_blank");
+  };
+
+  return (
+    <div>
+      <button onClick={handleSelect}>Select from Library</button>
+      <ul>
+        {files.map((file) => (
+          <li key={file.fileId}>
+            {file.fileName ?? file.fileId}
+            {file.mimeType && <span> ({file.mimeType})</span>}
+            <button onClick={() => handleDownload(file.fileId)}>
+              Download
+            </button>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/examples/everything/web/src/widgets/tabs/use-files-tab.tsx
+++ b/examples/everything/web/src/widgets/tabs/use-files-tab.tsx
@@ -1,13 +1,10 @@
 import { useRef, useState } from "react";
-import type { FileMetadata } from "skybridge/web";
 import { useFiles } from "skybridge/web";
 
 export function UseFilesTab() {
-  const { upload, getDownloadUrl, selectFiles } = useFiles();
+  const { upload, getDownloadUrl } = useFiles();
   const [fileId, setFileId] = useState<string | null>(null);
-  const [selectedFiles, setSelectedFiles] = useState<FileMetadata[]>([]);
   const [isUploading, setIsUploading] = useState(false);
-  const [saveToLibrary, setSaveToLibrary] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -19,8 +16,7 @@ export function UseFilesTab() {
     setIsUploading(true);
     setError(null);
     try {
-      const options = saveToLibrary ? { library: true as const } : undefined;
-      const { fileId } = await upload(file, options);
+      const { fileId } = await upload(file);
       setFileId(fileId);
     } catch (error) {
       setError(error instanceof Error ? error.message : "Upload failed");
@@ -29,21 +25,12 @@ export function UseFilesTab() {
     }
   }
 
-  async function handleSelectFiles() {
-    setError(null);
-    try {
-      const files = await selectFiles();
-      setSelectedFiles(files);
-    } catch (error) {
-      setError(
-        error instanceof Error ? error.message : "File selection failed",
-      );
+  async function handleDownload() {
+    if (!fileId) {
+      return;
     }
-  }
-
-  async function handleDownload(id: string) {
     try {
-      const { downloadUrl } = await getDownloadUrl({ fileId: id });
+      const { downloadUrl } = await getDownloadUrl({ fileId });
       window.open(downloadUrl, "_blank");
     } catch (error) {
       console.error("Download failed:", error);
@@ -52,7 +39,6 @@ export function UseFilesTab() {
 
   function handleClear() {
     setFileId(null);
-    setSelectedFiles([]);
     if (inputRef.current) {
       inputRef.current.value = "";
     }
@@ -61,7 +47,7 @@ export function UseFilesTab() {
   return (
     <div className="tab-content">
       <p className="description">
-        Upload, select, and download files via the host application.
+        Upload and download files via the host application.
       </p>
 
       <div className="field">
@@ -74,22 +60,11 @@ export function UseFilesTab() {
         />
       </div>
 
-      <div className="field">
-        <label>
-          <input
-            type="checkbox"
-            checked={saveToLibrary}
-            onChange={(e) => setSaveToLibrary(e.target.checked)}
-          />{" "}
-          Save to ChatGPT file library
-        </label>
-      </div>
-
       {error && <p className="error">{error}</p>}
 
       {fileId && (
         <div className="field">
-          <span className="field-label">Uploaded File ID</span>
+          <span className="field-label">File ID</span>
           <code>{fileId}</code>
         </div>
       )}
@@ -98,51 +73,20 @@ export function UseFilesTab() {
         <button
           type="button"
           className="btn"
-          onClick={() => fileId && handleDownload(fileId)}
+          onClick={handleDownload}
           disabled={!fileId}
         >
-          Download Uploaded
-        </button>
-        <button
-          type="button"
-          className="btn"
-          onClick={handleSelectFiles}
-        >
-          Select Files
+          Download
         </button>
         <button
           type="button"
           className="btn btn-outline"
           onClick={handleClear}
-          disabled={!fileId && selectedFiles.length === 0}
+          disabled={!fileId}
         >
           Clear
         </button>
       </div>
-
-      {selectedFiles.length > 0 && (
-        <div className="field">
-          <span className="field-label">Selected Files</span>
-          <ul>
-            {selectedFiles.map((file) => (
-              <li key={file.fileId}>
-                <code>{file.fileName ?? file.fileId}</code>
-                {file.mimeType && (
-                  <span style={{ opacity: 0.6 }}> ({file.mimeType})</span>
-                )}
-                <button
-                  type="button"
-                  className="btn"
-                  style={{ marginLeft: 8 }}
-                  onClick={() => handleDownload(file.fileId)}
-                >
-                  Download
-                </button>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
     </div>
   );
 }

--- a/examples/everything/web/src/widgets/tabs/use-files-tab.tsx
+++ b/examples/everything/web/src/widgets/tabs/use-files-tab.tsx
@@ -1,10 +1,13 @@
 import { useRef, useState } from "react";
+import type { FileMetadata } from "skybridge/web";
 import { useFiles } from "skybridge/web";
 
 export function UseFilesTab() {
-  const { upload, getDownloadUrl } = useFiles();
+  const { upload, getDownloadUrl, selectFiles } = useFiles();
   const [fileId, setFileId] = useState<string | null>(null);
+  const [selectedFiles, setSelectedFiles] = useState<FileMetadata[]>([]);
   const [isUploading, setIsUploading] = useState(false);
+  const [saveToLibrary, setSaveToLibrary] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -16,7 +19,8 @@ export function UseFilesTab() {
     setIsUploading(true);
     setError(null);
     try {
-      const { fileId } = await upload(file);
+      const options = saveToLibrary ? { library: true as const } : undefined;
+      const { fileId } = await upload(file, options);
       setFileId(fileId);
     } catch (error) {
       setError(error instanceof Error ? error.message : "Upload failed");
@@ -25,12 +29,21 @@ export function UseFilesTab() {
     }
   }
 
-  async function handleDownload() {
-    if (!fileId) {
-      return;
-    }
+  async function handleSelectFiles() {
+    setError(null);
     try {
-      const { downloadUrl } = await getDownloadUrl({ fileId });
+      const files = await selectFiles();
+      setSelectedFiles(files);
+    } catch (error) {
+      setError(
+        error instanceof Error ? error.message : "File selection failed",
+      );
+    }
+  }
+
+  async function handleDownload(id: string) {
+    try {
+      const { downloadUrl } = await getDownloadUrl({ fileId: id });
       window.open(downloadUrl, "_blank");
     } catch (error) {
       console.error("Download failed:", error);
@@ -39,6 +52,7 @@ export function UseFilesTab() {
 
   function handleClear() {
     setFileId(null);
+    setSelectedFiles([]);
     if (inputRef.current) {
       inputRef.current.value = "";
     }
@@ -47,7 +61,7 @@ export function UseFilesTab() {
   return (
     <div className="tab-content">
       <p className="description">
-        Upload and download files via the host application.
+        Upload, select, and download files via the host application.
       </p>
 
       <div className="field">
@@ -60,11 +74,22 @@ export function UseFilesTab() {
         />
       </div>
 
+      <div className="field">
+        <label>
+          <input
+            type="checkbox"
+            checked={saveToLibrary}
+            onChange={(e) => setSaveToLibrary(e.target.checked)}
+          />{" "}
+          Save to ChatGPT file library
+        </label>
+      </div>
+
       {error && <p className="error">{error}</p>}
 
       {fileId && (
         <div className="field">
-          <span className="field-label">File ID</span>
+          <span className="field-label">Uploaded File ID</span>
           <code>{fileId}</code>
         </div>
       )}
@@ -73,20 +98,51 @@ export function UseFilesTab() {
         <button
           type="button"
           className="btn"
-          onClick={handleDownload}
+          onClick={() => fileId && handleDownload(fileId)}
           disabled={!fileId}
         >
-          Download
+          Download Uploaded
+        </button>
+        <button
+          type="button"
+          className="btn"
+          onClick={handleSelectFiles}
+        >
+          Select Files
         </button>
         <button
           type="button"
           className="btn btn-outline"
           onClick={handleClear}
-          disabled={!fileId}
+          disabled={!fileId && selectedFiles.length === 0}
         >
           Clear
         </button>
       </div>
+
+      {selectedFiles.length > 0 && (
+        <div className="field">
+          <span className="field-label">Selected Files</span>
+          <ul>
+            {selectedFiles.map((file) => (
+              <li key={file.fileId}>
+                <code>{file.fileName ?? file.fileId}</code>
+                {file.mimeType && (
+                  <span style={{ opacity: 0.6 }}> ({file.mimeType})</span>
+                )}
+                <button
+                  type="button"
+                  className="btn"
+                  style={{ marginLeft: 8 }}
+                  onClick={() => handleDownload(file.fileId)}
+                >
+                  Download
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/core/src/web/bridges/apps-sdk/adaptor.ts
+++ b/packages/core/src/web/bridges/apps-sdk/adaptor.ts
@@ -1,12 +1,14 @@
 import type {
   Adaptor,
   CallToolResponse,
+  FileMetadata,
   HostContext,
   HostContextStore,
   OpenExternalOptions,
   RequestDisplayMode,
   RequestModalOptions,
   SetWidgetStateAction,
+  UploadFileOptions,
 } from "../types.js";
 import { AppsSdkBridge } from "./bridge.js";
 import type { AppsSdkWidgetState } from "./types.js";
@@ -83,23 +85,39 @@ export class AppsSdkAdaptor implements Adaptor {
     });
   };
 
-  public uploadFile = (file: File) => {
-    return window.openai.uploadFile(file).then(async (metadata) => {
-      const state: AppsSdkWidgetState = window.openai.widgetState
-        ? { ...window.openai.widgetState }
-        : { modelContent: {}, privateContent: {} };
-      if (!state.imageIds) {
-        state.imageIds = [];
-      }
-      state.imageIds.push(metadata.fileId);
-      await window.openai.setWidgetState(state);
-      return metadata;
-    });
+  public uploadFile = async (file: File, options?: UploadFileOptions) => {
+    const metadata = await window.openai.uploadFile(file, options);
+    await this.trackFileIds(metadata.fileId);
+    return metadata;
   };
 
   public getFileDownloadUrl = (file: { fileId: string }) => {
     return window.openai.getFileDownloadUrl(file);
   };
+
+  public selectFiles = async (): Promise<FileMetadata[]> => {
+    if (!window.openai.selectFiles) {
+      throw new Error(
+        "selectFiles is not supported by the current host version.",
+      );
+    }
+    const files = await window.openai.selectFiles();
+    if (files.length > 0) {
+      await this.trackFileIds(...files.map((f) => f.fileId));
+    }
+    return files;
+  };
+
+  private async trackFileIds(...fileIds: string[]): Promise<void> {
+    const state: AppsSdkWidgetState = window.openai.widgetState
+      ? { ...window.openai.widgetState }
+      : { modelContent: {}, privateContent: {} };
+    if (!state.imageIds) {
+      state.imageIds = [];
+    }
+    state.imageIds.push(...fileIds);
+    await window.openai.setWidgetState(state);
+  }
 
   public openModal(options: RequestModalOptions) {
     return window.openai.requestModal(options);

--- a/packages/core/src/web/bridges/apps-sdk/types.ts
+++ b/packages/core/src/web/bridges/apps-sdk/types.ts
@@ -4,6 +4,7 @@ import type {
   CallToolResponse,
   FileMetadata,
   RequestModalOptions,
+  UploadFileOptions,
 } from "../types.js";
 
 type DisplayMode = "pip" | "inline" | "fullscreen" | "modal";
@@ -93,12 +94,21 @@ export type AppsSdkMethods<WS extends AppsSdkWidgetState = AppsSdkWidgetState> =
      */
     requestModal: (args: RequestModalOptions) => Promise<void>;
 
-    /** Uploads a new file to the host */
-    uploadFile: (file: File) => Promise<FileMetadata>;
+    /** Uploads a new file to the host. Pass `{ library: true }` to also save to the user's ChatGPT file library. */
+    uploadFile: (
+      file: File,
+      options?: UploadFileOptions,
+    ) => Promise<FileMetadata>;
 
     /**
-     * Downloads a file from the host that was previously uploaded.
-     * Only files uploaded by the same connector instance can be downloaded.
+     * Opens ChatGPT's file library picker and returns app-authorized files.
+     * Feature-detect before using: this method may not be available on all host versions.
+     */
+    selectFiles?: () => Promise<FileMetadata[]>;
+
+    /**
+     * Downloads a file from the host. Works for files uploaded by the widget,
+     * files selected via selectFiles(), or files provided via tool/file params.
      */
     getFileDownloadUrl: (
       file: FileMetadata,

--- a/packages/core/src/web/bridges/mcp-app/adaptor.ts
+++ b/packages/core/src/web/bridges/mcp-app/adaptor.ts
@@ -231,6 +231,13 @@ export class McpAppAdaptor implements Adaptor {
     throw new Error("File download is not supported in MCP App.");
   }
 
+  /**
+   * @throws File selection is not supported in MCP App.
+   */
+  public selectFiles(): Promise<{ fileId: string }[]> {
+    throw new Error("File selection is not supported in MCP App.");
+  }
+
   public openModal(options: RequestModalOptions) {
     this._viewState = { mode: "modal", params: options.params };
     this.viewListeners.forEach((listener) => {

--- a/packages/core/src/web/bridges/types.ts
+++ b/packages/core/src/web/bridges/types.ts
@@ -87,7 +87,13 @@ export type SetWidgetStateAction =
   | WidgetState
   | ((prevState: WidgetState | null) => WidgetState);
 
-export type FileMetadata = { fileId: string };
+export type FileMetadata = {
+  fileId: string;
+  fileName?: string;
+  mimeType?: string;
+};
+
+export type UploadFileOptions = { library?: boolean };
 
 export type RequestModalOptions = {
   title?: string;
@@ -112,8 +118,9 @@ export interface Adaptor {
   sendFollowUpMessage(prompt: string): Promise<void>;
   openExternal(href: string, options?: OpenExternalOptions): void;
   setWidgetState(stateOrUpdater: SetWidgetStateAction): Promise<void>;
-  uploadFile(file: File): Promise<FileMetadata>;
+  uploadFile(file: File, options?: UploadFileOptions): Promise<FileMetadata>;
   getFileDownloadUrl(file: FileMetadata): Promise<{ downloadUrl: string }>;
+  selectFiles(): Promise<FileMetadata[]>;
   openModal(options: RequestModalOptions): void;
   setOpenInAppUrl(href: string): Promise<void>;
 }

--- a/packages/core/src/web/hooks/use-files.test.ts
+++ b/packages/core/src/web/hooks/use-files.test.ts
@@ -53,6 +53,8 @@ describe("useFiles", () => {
     const files = await result.current.selectFiles();
     expect(OpenaiMock.selectFiles).toHaveBeenCalled();
     expect(files).toEqual(selectedFiles);
+
+    delete OpenaiMock.selectFiles;
   });
 
   it("should download a file from ChatGPT", () => {

--- a/packages/core/src/web/hooks/use-files.test.ts
+++ b/packages/core/src/web/hooks/use-files.test.ts
@@ -1,9 +1,10 @@
 import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppsSdkAdaptor } from "../bridges/apps-sdk/adaptor.js";
 import { useFiles } from "./use-files.js";
 
 describe("useFiles", () => {
-  const OpenaiMock = {
+  const OpenaiMock: Record<string, unknown> = {
     uploadFile: vi.fn().mockResolvedValue({
       fileId: `sediment://file_abc123`,
     }),
@@ -19,7 +20,8 @@ describe("useFiles", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
-    vi.resetAllMocks();
+    vi.clearAllMocks();
+    AppsSdkAdaptor.resetInstance();
   });
 
   const dummyFile = new File([], "test.txt");
@@ -28,7 +30,29 @@ describe("useFiles", () => {
     const { result } = renderHook(() => useFiles());
 
     result.current.upload(dummyFile);
-    expect(OpenaiMock.uploadFile).toHaveBeenCalledWith(dummyFile);
+    expect(OpenaiMock.uploadFile).toHaveBeenCalledWith(dummyFile, undefined);
+  });
+
+  it("should upload a file with library option", () => {
+    const { result } = renderHook(() => useFiles());
+
+    result.current.upload(dummyFile, { library: true });
+    expect(OpenaiMock.uploadFile).toHaveBeenCalledWith(dummyFile, {
+      library: true,
+    });
+  });
+
+  it("should select files from ChatGPT", async () => {
+    const selectedFiles = [
+      { fileId: "file_1", fileName: "doc.pdf", mimeType: "application/pdf" },
+    ];
+    OpenaiMock.selectFiles = vi.fn().mockResolvedValue(selectedFiles);
+
+    const { result } = renderHook(() => useFiles());
+
+    const files = await result.current.selectFiles();
+    expect(OpenaiMock.selectFiles).toHaveBeenCalled();
+    expect(files).toEqual(selectedFiles);
   });
 
   it("should download a file from ChatGPT", () => {

--- a/packages/core/src/web/hooks/use-files.ts
+++ b/packages/core/src/web/hooks/use-files.ts
@@ -5,5 +5,6 @@ export function useFiles() {
   return {
     upload: adaptor.uploadFile,
     getDownloadUrl: adaptor.getFileDownloadUrl,
+    selectFiles: adaptor.selectFiles,
   };
 }


### PR DESCRIPTION
## Summary

- Add `selectFiles()` to `useFiles()` hook — opens ChatGPT's file library picker (with feature detection for hosts that don't support it yet)
- Add `{ library?: boolean }` option to `upload()` — saves uploads to the user's ChatGPT file library
- Extend `FileMetadata` type with optional `fileName` and `mimeType` fields
- Update `getFileDownloadUrl` to document expanded scope (uploads, selected files, tool/file params)
- Extract `trackFileIds` helper in `AppsSdkAdaptor` to DRY widget state updates

Closes #605

## Test plan

- [x] Unit tests pass (`pnpm test`)
- [x] Build passes (`pnpm build`)
- [ ] Manual test in everything example app on ChatGPT (note: `selectFiles` is documented but not yet available in the host runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends `useFiles()` with two new capabilities: a `selectFiles()` method that opens ChatGPT's file library picker (with proper feature detection for older host versions) and a `{ library?: boolean }` option on `upload()` to persist files to the user's library. `FileMetadata` is also enriched with optional `fileName` and `mimeType` fields.

Key changes:
- `AppsSdkAdaptor` extracts the repeated widgetState `imageIds` update into a private `trackFileIds` helper used by both `uploadFile` and the new `selectFiles` — a clean DRY improvement
- `McpAppAdaptor` adds a correctly-throwing `selectFiles` stub, consistent with the existing pattern for other unsupported file methods
- New unit tests cover the `library` upload option and `selectFiles` success path; the switch from `vi.resetAllMocks()` to `vi.clearAllMocks()` leaves a dynamically-added `OpenaiMock.selectFiles` property alive across subsequent tests, which could interfere with testing the unsupported-host code path in the future
- Documentation and example app are updated thoroughly

<h3>Confidence Score: 4/5</h3>

- PR is safe to merge; the one minor concern is a test isolation issue that doesn't affect production behavior.
- The implementation is clean, feature detection is correctly applied, the `trackFileIds` refactor is a net improvement, and the MCP stub follows the established pattern. The only flag is a P2 test hygiene issue: `vi.clearAllMocks()` doesn't remove the `selectFiles` property added in one test, leaving it visible to subsequent tests and making the unsupported-host path untestable without a cleanup step.
- packages/core/src/web/hooks/use-files.test.ts — mock cleanup for the dynamically-added `selectFiles` property

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/core/src/web/hooks/use-files.test.ts
Line: 45-56

Comment:
**Test mock leaks to sibling tests**

`OpenaiMock.selectFiles` is assigned inside this test body, but `vi.clearAllMocks()` (changed from `vi.resetAllMocks()`) only clears call history — it does not remove properties added to `OpenaiMock`. Because `OpenaiMock` is shared across all tests in the suite, any test that runs *after* this one will observe `window.openai.selectFiles` as defined, even if the test doesn't expect it to be.

In practice this means the "unsupported host" code path in `AppsSdkAdaptor.selectFiles` (the `!window.openai.selectFiles` guard) can never be exercised by a future test without an explicit cleanup step. Consider either:

1. Deleting the property in `afterEach` (or resetting it to `undefined`), or
2. Moving the assignment into `beforeEach` alongside the other mock setup and using `vi.resetAllMocks()` (which would clear the mock implementation) combined with a per-test override.

```suggestion
  it("should select files from ChatGPT", async () => {
    const selectedFiles = [
      { fileId: "file_1", fileName: "doc.pdf", mimeType: "application/pdf" },
    ];
    OpenaiMock.selectFiles = vi.fn().mockResolvedValue(selectedFiles);

    const { result } = renderHook(() => useFiles());

    const files = await result.current.selectFiles();
    expect(OpenaiMock.selectFiles).toHaveBeenCalled();
    expect(files).toEqual(selectedFiles);

    delete OpenaiMock.selectFiles;
  });
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: support OpenAI file library APIs (..."](https://github.com/alpic-ai/skybridge/commit/916ff75a21217bc169a1dca003abcbd91cb8fe7b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26282275)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->