### PR TITLE
fix(web): normalize locale to BCP 47 in useUser

### DIFF
--- a/packages/core/src/web/hooks/use-user.test.ts
+++ b/packages/core/src/web/hooks/use-user.test.ts
@@ -60,6 +60,27 @@ describe("useUser", () => {
 
       expect(result.current.locale).toBe("es-ES");
     });
+
+    it("should normalize underscore locale to BCP 47 hyphen format", () => {
+      OpenaiMock.locale = "fr_FR";
+      const { result } = renderHook(() => useUser());
+
+      expect(result.current.locale).toBe("fr-FR");
+    });
+
+    it("should canonicalize locale casing", () => {
+      OpenaiMock.locale = "en-us";
+      const { result } = renderHook(() => useUser());
+
+      expect(result.current.locale).toBe("en-US");
+    });
+
+    it("should fall back to en-US for invalid locale", () => {
+      OpenaiMock.locale = "not-a-locale-!!";
+      const { result } = renderHook(() => useUser());
+
+      expect(result.current.locale).toBe("en-US");
+    });
   });
 
   describe("mcp-app host type", () => {
@@ -91,6 +112,21 @@ describe("useUser", () => {
           device: { type: "desktop" },
           capabilities: { hover: true, touch: false },
         });
+      });
+    });
+
+    it("should normalize underscore locale to BCP 47 hyphen format", async () => {
+      vi.stubGlobal("parent", {
+        postMessage: getMcpAppHostPostMessageMock({
+          locale: "fr_FR",
+          platform: "web",
+          deviceCapabilities: { hover: true, touch: false },
+        }),
+      });
+      const { result } = renderHook(() => useUser());
+
+      await waitFor(() => {
+        expect(result.current.locale).toBe("fr-FR");
       });
     });
 

--- a/packages/core/src/web/hooks/use-user.ts
+++ b/packages/core/src/web/hooks/use-user.ts
@@ -5,6 +5,23 @@ export type UserState = {
   userAgent: UserAgent;
 };
 
+const DEFAULT_LOCALE = "en-US";
+
+/**
+ * Normalizes a locale string to canonical BCP 47 format using {@link Intl.Locale}.
+ *
+ * Handles underscored identifiers returned by the ChatGPT mobile app (e.g. "fr_FR" → "fr-FR"),
+ * incorrect casing (e.g. "en-us" → "en-US"), and complex subtags (e.g. "zh_Hans_CN" → "zh-Hans-CN").
+ * Falls back to "en-US" if the locale is invalid.
+ */
+function normalizeLocale(locale: string): string {
+  try {
+    return new Intl.Locale(locale.replace(/_/g, "-")).toString();
+  } catch {
+    return DEFAULT_LOCALE;
+  }
+}
+
 /**
  * Hook for accessing session-stable user information.
  * These values are set once at initialization and do not change during the session.
@@ -18,8 +35,8 @@ export type UserState = {
  * ```
  */
 export function useUser(): UserState {
-  const locale = useHostContext("locale");
+  const rawLocale = useHostContext("locale");
   const userAgent = useHostContext("userAgent");
 
-  return { locale, userAgent };
+  return { locale: normalizeLocale(rawLocale), userAgent };
 }


### PR DESCRIPTION
## Summary

- The ChatGPT mobile app returns locale identifiers with underscores (e.g. `fr_FR`) instead of BCP 47 hyphens (`fr-FR`)
- This causes `Intl.NumberFormat`, `Intl.DateTimeFormat`, and libraries like `react-intl`'s `<IntlProvider>` to throw `"Incorrect locale information provided"`, crashing the widget on mobile
- `useUser()` now canonicalizes the locale via `Intl.Locale`, which handles underscores, incorrect casing (`en-us` → `en-US`), and complex subtags (`zh_Hans_CN` → `zh-Hans-CN`)
- Falls back to `en-US` on completely invalid input

## Test plan

- [x] Added test for underscore locale normalization (apps-sdk)
- [x] Added test for underscore locale normalization (mcp-app)
- [x] Added test for casing canonicalization
- [x] Added test for invalid locale fallback
- [x] All 144 existing tests pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a mobile crash caused by the ChatGPT app supplying locale strings with underscores (e.g. `fr_FR`) instead of the BCP 47 hyphen format (`fr-FR`) expected by `Intl.NumberFormat`, `Intl.DateTimeFormat`, and `react-intl`. The fix introduces a `normalizeLocale` helper in `use-user.ts` that leverages `Intl.Locale` to canonicalize the raw locale (underscore → hyphen, casing normalisation) with a safe `en-US` fallback on completely invalid input.

- **`normalizeLocale`** correctly pre-processes the string with `replace(/_/g, "-")` before passing to `Intl.Locale`, which is the right approach since `Intl.Locale` itself rejects underscored tags.
- All edge cases (empty string, runtime `null`/`undefined`, garbled tags like `"not-a-locale-!!"`) throw inside the `try` block and fall back gracefully to `DEFAULT_LOCALE`.
- New tests cover the three normalization scenarios in the `apps-sdk` path and the underscore case in the `mcp-app` path; the shared function means full edge-case coverage is achieved without redundant async tests.
- Minor observation: `normalizeLocale` is invoked on every render of `useUser` without `useMemo`. Given the session-stable nature of the locale value (as noted in the JSDoc), the overhead is negligible, but a `useMemo(() => normalizeLocale(rawLocale), [rawLocale])` would make the intent explicit.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a well-scoped, well-tested bug fix with no regressions risk.
- The change is minimal and surgical (one pure helper function + pipe it through the hook), all error paths are caught, test coverage is thorough, and the existing 144 tests pass. The only note is an optional `useMemo` for explicitness, which does not affect correctness.
- No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix(web): normalize locale to BCP 47 in ..."](https://github.com/alpic-ai/skybridge/commit/0b7479cdeb3fa9b6a9a1fee53e8ef3717de3279f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26329206)</sub>

<!-- /greptile_comment -->