### PR TITLE
feat: support scrollToBottom in useSendFollowUpMessage

### DIFF
--- a/docs/api-reference/use-send-follow-up-message.mdx
+++ b/docs/api-reference/use-send-follow-up-message.mdx
@@ -24,7 +24,10 @@ function FollowUpButton() {
 ## Returns
 
 ```tsx
-sendFollowUpMessage: (prompt: string) => Promise<void>
+sendFollowUpMessage: (
+  prompt: string,
+  options?: { scrollToBottom?: boolean },
+) => Promise<void>
 ```
 
 An async function that sends a follow-up message to continue the conversation.
@@ -34,6 +37,9 @@ An async function that sends a follow-up message to continue the conversation.
 - `prompt: string`
   - **Required**
   - The message to send as a follow-up prompt
+- `options?: { scrollToBottom?: boolean }`
+  - **Optional**
+  - Pass `scrollToBottom: false` to avoid auto-scrolling the host conversation after sending the follow-up message when supported by the Apps SDK host
 
 ## Examples
 
@@ -81,7 +87,9 @@ function SearchResults({ results }: { results: SearchResult[] }) {
   const sendFollowUpMessage = useSendFollowUpMessage();
 
   const handleLearnMore = (result: SearchResult) => {
-    sendFollowUpMessage(`Tell me more about "${result.title}"`);
+    sendFollowUpMessage(`Tell me more about "${result.title}"`, {
+      scrollToBottom: false,
+    });
   };
 
   return (

--- a/packages/core/src/web/bridges/apps-sdk/adaptor.ts
+++ b/packages/core/src/web/bridges/apps-sdk/adaptor.ts
@@ -6,6 +6,7 @@ import type {
   OpenExternalOptions,
   RequestDisplayMode,
   RequestModalOptions,
+  SendFollowUpMessageOptions,
   SetWidgetStateAction,
 } from "../types.js";
 import { AppsSdkBridge } from "./bridge.js";
@@ -60,8 +61,11 @@ export class AppsSdkAdaptor implements Adaptor {
     return window.openai.requestDisplayMode({ mode });
   };
 
-  public sendFollowUpMessage = (prompt: string): Promise<void> => {
-    return window.openai.sendFollowUpMessage({ prompt });
+  public sendFollowUpMessage = (
+    prompt: string,
+    options: SendFollowUpMessageOptions = {},
+  ): Promise<void> => {
+    return window.openai.sendFollowUpMessage({ prompt, ...options });
   };
 
   public openExternal(href: string, options: OpenExternalOptions = {}): void {

--- a/packages/core/src/web/bridges/apps-sdk/types.ts
+++ b/packages/core/src/web/bridges/apps-sdk/types.ts
@@ -4,6 +4,7 @@ import type {
   CallToolResponse,
   FileMetadata,
   RequestModalOptions,
+  SendFollowUpMessageOptions,
 } from "../types.js";
 
 type DisplayMode = "pip" | "inline" | "fullscreen" | "modal";
@@ -67,7 +68,10 @@ export type AppsSdkMethods<WS extends AppsSdkWidgetState = AppsSdkWidgetState> =
     ) => Promise<ToolResponse>;
 
     /** Triggers a followup turn in the ChatGPT conversation */
-    sendFollowUpMessage: (args: { prompt: string }) => Promise<void>;
+    sendFollowUpMessage: (args: {
+      prompt: string;
+      scrollToBottom?: SendFollowUpMessageOptions["scrollToBottom"];
+    }) => Promise<void>;
 
     /** Opens an external link, redirects web page or mobile app */
     openExternal(args: { href: string; redirectUrl?: false }): void;

--- a/packages/core/src/web/bridges/mcp-app/adaptor.ts
+++ b/packages/core/src/web/bridges/mcp-app/adaptor.ts
@@ -7,6 +7,7 @@ import type {
   OpenExternalOptions,
   RequestDisplayMode,
   RequestModalOptions,
+  SendFollowUpMessageOptions,
   SetWidgetStateAction,
 } from "../types.js";
 import { McpAppBridge } from "./bridge.js";
@@ -85,7 +86,10 @@ export class McpAppAdaptor implements Adaptor {
     return app.requestDisplayMode({ mode });
   };
 
-  public sendFollowUpMessage = async (prompt: string) => {
+  public sendFollowUpMessage = async (
+    prompt: string,
+    _options?: SendFollowUpMessageOptions,
+  ) => {
     const app = await McpAppBridge.getInstance().getApp();
     await app.sendMessage({
       role: "user",

--- a/packages/core/src/web/bridges/types.ts
+++ b/packages/core/src/web/bridges/types.ts
@@ -99,6 +99,10 @@ export type OpenExternalOptions = {
   redirectUrl?: false;
 };
 
+export type SendFollowUpMessageOptions = {
+  scrollToBottom?: boolean;
+};
+
 export interface Adaptor {
   getHostContextStore<K extends keyof HostContext>(key: K): HostContextStore<K>;
   callTool<
@@ -108,7 +112,10 @@ export interface Adaptor {
   requestDisplayMode(mode: RequestDisplayMode): Promise<{
     mode: RequestDisplayMode;
   }>;
-  sendFollowUpMessage(prompt: string): Promise<void>;
+  sendFollowUpMessage(
+    prompt: string,
+    options?: SendFollowUpMessageOptions,
+  ): Promise<void>;
   openExternal(href: string, options?: OpenExternalOptions): void;
   setWidgetState(stateOrUpdater: SetWidgetStateAction): Promise<void>;
   uploadFile(file: File): Promise<FileMetadata>;

--- a/packages/core/src/web/hooks/use-send-follow-up-message.test-d.ts
+++ b/packages/core/src/web/hooks/use-send-follow-up-message.test-d.ts
@@ -1,0 +1,12 @@
+import { expectTypeOf, test } from "vitest";
+import type { SendFollowUpMessageOptions } from "../bridges/types.js";
+import type { useSendFollowUpMessage } from "./use-send-follow-up-message.js";
+
+test("useSendFollowUpMessage accepts optional follow-up options", () => {
+  type SendFollowUpMessage = ReturnType<typeof useSendFollowUpMessage>;
+
+  expectTypeOf<Parameters<SendFollowUpMessage>[0]>().toEqualTypeOf<string>();
+  expectTypeOf<Parameters<SendFollowUpMessage>[1]>().toEqualTypeOf<
+    SendFollowUpMessageOptions | undefined
+  >();
+});

--- a/packages/core/src/web/hooks/use-send-follow-up-message.test.ts
+++ b/packages/core/src/web/hooks/use-send-follow-up-message.test.ts
@@ -1,0 +1,49 @@
+import { renderHook } from "@testing-library/react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  vi,
+} from "vitest";
+import { useSendFollowUpMessage } from "./use-send-follow-up-message.js";
+
+describe("useSendFollowUpMessage", () => {
+  let OpenaiMock: { sendFollowUpMessage: Mock };
+
+  beforeEach(() => {
+    OpenaiMock = {
+      sendFollowUpMessage: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.stubGlobal("openai", OpenaiMock);
+    vi.stubGlobal("skybridge", { hostType: "apps-sdk" });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetAllMocks();
+  });
+
+  it("should call window.openai.sendFollowUpMessage with the prompt", () => {
+    const { result } = renderHook(() => useSendFollowUpMessage());
+
+    result.current("Tell me more");
+
+    expect(OpenaiMock.sendFollowUpMessage).toHaveBeenCalledWith({
+      prompt: "Tell me more",
+    });
+  });
+
+  it("should forward scrollToBottom when provided", () => {
+    const { result } = renderHook(() => useSendFollowUpMessage());
+
+    result.current("Tell me more", { scrollToBottom: false });
+
+    expect(OpenaiMock.sendFollowUpMessage).toHaveBeenCalledWith({
+      prompt: "Tell me more",
+      scrollToBottom: false,
+    });
+  });
+});

--- a/packages/core/src/web/hooks/use-send-follow-up-message.ts
+++ b/packages/core/src/web/hooks/use-send-follow-up-message.ts
@@ -1,10 +1,12 @@
 import { useCallback } from "react";
 import { getAdaptor } from "../bridges/index.js";
+import type { SendFollowUpMessageOptions } from "../bridges/types.js";
 
 export function useSendFollowUpMessage() {
   const adaptor = getAdaptor();
   const sendFollowUpMessage = useCallback(
-    (prompt: string) => adaptor.sendFollowUpMessage(prompt),
+    (prompt: string, options?: SendFollowUpMessageOptions) =>
+      adaptor.sendFollowUpMessage(prompt, options),
     [adaptor],
   );
 


### PR DESCRIPTION
## Summary
- add optional `scrollToBottom` support to `useSendFollowUpMessage`
- thread the option through the shared bridge types and Apps SDK adaptor
- keep the MCP app adaptor API-compatible by accepting and ignoring the option there
- document the new hook signature and add targeted tests

## Changes
- add `SendFollowUpMessageOptions` with `scrollToBottom?: boolean`
- update `Adaptor.sendFollowUpMessage(prompt, options?)`
- update Apps SDK types so `window.openai.sendFollowUpMessage` can receive `scrollToBottom`
- update `useSendFollowUpMessage` to accept optional options
- add hook runtime/type tests
- update API docs examples

## Testing
- `pnpm exec vitest run src/web/hooks/use-send-follow-up-message.test.ts`
- `pnpm --filter skybridge test:type`
- `pnpm --filter skybridge test:format`

## Notes
- The repo advertises Node 24.x, while this machine is currently on Node 22.22.1.
- The targeted checks above passed locally on this change set.

Fixes #512
