### PR TITLE
fix: remove false positive malicious url from skill

### DIFF
--- a/skills/chatgpt-app-builder/references/open-external-links.md
+++ b/skills/chatgpt-app-builder/references/open-external-links.md
@@ -60,7 +60,7 @@ server.registerWidget(
     _meta: {
       ui: {
         csp: {
-          redirectDomains: ["https://some-airline.com"],
+          redirectDomains: ["https://airline.example.com"],
         },
       },
     },


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates a single documentation reference file by replacing a real-looking placeholder domain (`https://some-airline.com`) in a code example with the RFC 2606-reserved `https://airline.example.com`, which is the standard domain intended for documentation and examples. This resolves a false-positive malicious URL detection. The change is consistent with how all other example URLs in the same file already use `example.com`-based domains.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — it is a one-line documentation-only change with no logic impact.

The change only affects a markdown reference file, replacing a placeholder URL with the RFC 2606-reserved example.com subdomain. No code logic, configuration, or runtime behavior is affected. No issues were found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| skills/chatgpt-app-builder/references/open-external-links.md | One-line change replacing a real-looking placeholder domain with the RFC 2606-reserved airline.example.com in a code example, making it consistent with all other example URLs in the file. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: remove false positive malicious url..."](https://github.com/alpic-ai/skybridge/commit/22b50d466163911730e2a3a96b8abec79139023b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26550146)</sub>

<!-- /greptile_comment -->