### PR TITLE
docs(readme): update intro image with new Skybrdige logo and added values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 <div align="center">
 
-<img alt="Skybridge" src="docs/images/Skybridgewhite(1).svg" width="100%">
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/images/Skybridgewhite(1).svg">
+  <source media="(prefers-color-scheme: light)" srcset="docs/images/Skybridgemidnight.svg">
+  <img alt="Skybridge" src="docs/images/Skybridgemidnight.svg" width="100%">
+</picture>
 
 <br />
 


### PR DESCRIPTION
Completes https://github.com/alpic-ai/skybridge/issues/468

### Changes
1. Replaces old SB logo with new one
2. Update SB values

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the `README.md` with a new Skybridge logo (switching from an absolute `raw.githubusercontent.com` URL to a relative SVG path) and refreshes two entries in the values table to better highlight cross-platform compatibility.

- The new logo file `docs/images/Skybridgewhite(1).svg` exists in the repo, so the image renders correctly on GitHub — but the `(1)` suffix in the filename looks like an auto-numbered download artifact and should ideally be renamed to a cleaner canonical name (e.g. `Skybridgewhite.svg`).
- The trailing newline at the end of the file was accidentally removed.
- The switch from an absolute URL to a relative path is fine for GitHub rendering, but external platforms that embed READMEs (e.g. npm) may not resolve relative image paths — worth keeping in mind if the file is ever published there.

<h3>Confidence Score: 5/5</h3>

Safe to merge — only docs changes with minor cosmetic issues.

All findings are P2 (style/cleanup). The image renders correctly on GitHub, the value table text is coherent, and no functional code is affected.

No files require special attention beyond the two minor P2 notes on README.md.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Replaces the old banner image with a new SVG logo (relative path), updates two value-table entries, and removes the trailing newline. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: README.md
Line: 3

Comment:
**Suspicious `(1)` suffix in filename**

The file `Skybridgewhite(1).svg` looks like it was auto-numbered on download (e.g., when a file with the same base name already existed locally). This naming artifact could cause confusion and makes it harder to reference the canonical logo asset. Consider renaming it to something cleaner like `Skybridgewhite.svg` or `skybridge-logo-white.svg`.

```suggestion
<img alt="Skybridge" src="docs/images/Skybridgewhite.svg" width="100%">
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: README.md
Line: 149

Comment:
**Missing newline at end of file**

The file no longer ends with a newline character. Most editors and linters expect a trailing newline; this can cause noisy diffs and minor issues with some tooling.

```suggestion
</div>
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["SB new logo and update values"](https://github.com/alpic-ai/skybridge/commit/5438d96e5a4c22e4a340f6bb6325fbe783700f39) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26662943)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->