### PR TITLE
fix(showcase.mdx): add Cottages.com App as a showcase app into our documentation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -144,20 +144,30 @@
         "tab": "Showcase",
         "pages": [
           "showcase",
-          "showcase/generative-ui",
-          "showcase/capitals",
-          "showcase/flight-booking",
-          "showcase/ecommerce-carousel",
-          "showcase/everything",
-          "showcase/investigation-game",
-          "showcase/productivity",
-          "showcase/times-up",
-          "showcase/awaze",
-          "showcase/lumo",
-          "showcase/auth-clerk",
-          "showcase/auth-workos",
-          "showcase/auth-stytch",
-          "showcase/auth-auth0"
+          {
+            "group": "Examples",
+            "pages": [
+              "showcase/generative-ui",
+              "showcase/capitals",
+              "showcase/flight-booking",
+              "showcase/ecommerce-carousel",
+              "showcase/everything",
+              "showcase/investigation-game",
+              "showcase/productivity",
+              "showcase/times-up",
+              "showcase/auth-clerk",
+              "showcase/auth-workos",
+              "showcase/auth-stytch",
+              "showcase/auth-auth0"
+            ]
+          },
+          {
+            "group": "3rd Party Apps",
+            "pages": [
+              "showcase/awaze",
+              "showcase/lumo"
+            ]
+          }
         ]
       }
     ]

--- a/docs/showcase.mdx
+++ b/docs/showcase.mdx
@@ -5,6 +5,10 @@ description: Example apps built with Skybridge
 
 Explore real-world examples built with Skybridge. Each app demonstrates different features and integrations. Click an app to see a full-page walkthrough.
 
+## Examples
+
+Open-source apps with source code available on GitHub.
+
 <CardGroup cols={2}>
 
 <Card
@@ -104,28 +108,6 @@ Explore real-world examples built with Skybridge. Each app demonstrates differen
 </Card>
 
 <Card
-  title="Awaze — Cottage Search"
-  img="/images/showcase-awaze.png"
-  href="/showcase/awaze"
->
-  Holiday cottage search and booking experience — browse properties, filter by location, and explore availability.
-
-  <a href="https://mcp.cottages.com/try" target="_blank" onClick={(e) => e.stopPropagation()}><Icon icon="play" /> Try Demo</a>
-</Card>
-
-<Card
-  title="Lumo — Interactive AI Tutor"
-  img="/images/showcase-lumo.png"
-  href="/showcase/lumo"
->
-  Adaptive educational tutor with Mermaid.js diagrams, mind maps, quizzes, and fill-in-the-blank exercises. Built at the Claude Code London Hack Night.
-
-  <a href="https://lumo-mcp-app-39519fdd.alpic.live/try" target="_blank" onClick={(e) => e.stopPropagation()}><Icon icon="play" /> Try Demo</a>
-  <br />
-  <a href="https://github.com/connorads/lumo-mcp-app" target="_blank" onClick={(e) => e.stopPropagation()}><Icon icon="github" iconType="brands" /> View code on GitHub</a>
-</Card>
-
-<Card
   title="Auth — Clerk"
   img="/images/showcase-clerk.png"
   href="/showcase/auth-clerk"
@@ -163,6 +145,36 @@ Explore real-world examples built with Skybridge. Each app demonstrates differen
   Full OAuth authentication with Auth0 and personalized coffee shop search.
 
   <a href="https://github.com/alpic-ai/skybridge/tree/main/examples/auth-auth0" target="_blank" onClick={(e) => e.stopPropagation()}><Icon icon="github" iconType="brands" /> View code on GitHub</a>
+</Card>
+
+</CardGroup>
+
+## 3rd Party Apps
+
+Apps built by customers and the community using Skybridge.
+
+<CardGroup cols={2}>
+
+<Card
+  title="Awaze — Cottage Search"
+  img="/images/showcase-awaze.png"
+  href="/showcase/awaze"
+>
+  Holiday cottage search and booking experience — browse properties, filter by location, and explore availability.
+
+  <a href="https://mcp.cottages.com/try" target="_blank" onClick={(e) => e.stopPropagation()}><Icon icon="play" /> Try Demo</a>
+</Card>
+
+<Card
+  title="Lumo — Interactive AI Tutor"
+  img="/images/showcase-lumo.png"
+  href="/showcase/lumo"
+>
+  Adaptive educational tutor with Mermaid.js diagrams, mind maps, quizzes, and fill-in-the-blank exercises. Built at the Claude Code London Hack Night.
+
+  <a href="https://lumo-mcp-app-39519fdd.alpic.live/try" target="_blank" onClick={(e) => e.stopPropagation()}><Icon icon="play" /> Try Demo</a>
+  <br />
+  <a href="https://github.com/connorads/lumo-mcp-app" target="_blank" onClick={(e) => e.stopPropagation()}><Icon icon="github" iconType="brands" /> View code on GitHub</a>
 </Card>
 
 </CardGroup>

--- a/docs/showcase/awaze.mdx
+++ b/docs/showcase/awaze.mdx
@@ -13,12 +13,19 @@ Awaze brings holiday cottage search into the AI conversation — browse properti
 
 ## Links
 
-<CardGroup cols={1}>
+<CardGroup cols={2}>
   <Card
     title="Try the demo"
     icon="play"
     href="https://mcp.cottages.com/try"
   >
     Launch the live widget experience.
+  </Card>
+  <Card
+    title="Try on ChatGPT"
+    icon="robot"
+    href="https://chatgpt.com/apps/cottages/asdk_app_6945254ad31c81919d07ba1c357a1a57"
+  >
+    Open the Cottages.com app in ChatGPT.
   </Card>
 </CardGroup>


### PR DESCRIPTION
Completes https://github.com/alpic-ai/skybridge/issues/517

### Changes

1. Added ChatGPT Link to _Awaze — Cottage Search_
2. Categorized showcase into two section: Examples (internal with source code) and 3rd Party Apps
3. Added _Awaze — Cottage Search_ and _Lumo — Interactive AI Tutor_ to 3rd Party Apps subsection.

### Result
<img width="1920" height="1080" alt="Screenshot (133)" src="https://github.com/user-attachments/assets/a12ab6e1-4137-4e23-af3f-02ef8fd3fe70" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reorganizes the Skybridge showcase documentation by splitting the flat app list into two clearly labelled sections — **Examples** (internal, open-source apps with GitHub links) and **3rd Party Apps** (community-built apps) — and adds a "Try on ChatGPT" link for the Awaze Cottage Search app. The navigation in `docs.json` is updated consistently to mirror the same grouping.

- `docs/docs.json`: flat page list replaced with two named groups (`Examples` and `3rd Party Apps`); `awaze` and `lumo` correctly placed in the 3rd-party group.
- `docs/showcase.mdx`: two `## ` section headers added with descriptive subtitles; Awaze and Lumo cards moved into a dedicated `<CardGroup>` under the new section.
- `docs/showcase/awaze.mdx`: `CardGroup` widened from `cols={1}` to `cols={2}` to accommodate the new "Try on ChatGPT" card, which links to the public ChatGPT store entry for Cottages.com.

No logic or data issues found. All three files are internally consistent and the structural change is clean.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely documentation restructuring with no logic or data-integrity concerns.

All changes are documentation-only (MDX and JSON navigation config). The reorganisation is internally consistent across all three files, the new ChatGPT link is a valid public URL, and no existing content was dropped or broken. No P0/P1 findings.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/docs.json | Navigation restructured into 'Examples' and '3rd Party Apps' groups; awaze and lumo correctly moved to the new 3rd-party section. |
| docs/showcase.mdx | Page split into two clearly labelled sections with matching CardGroups; Awaze and Lumo cards moved to the new '3rd Party Apps' section. |
| docs/showcase/awaze.mdx | CardGroup widened to cols=2 and a 'Try on ChatGPT' card added with a valid ChatGPT store link. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Categorized showcase into examples (inte..."](https://github.com/alpic-ai/skybridge/commit/0a8c7e81f2d217b1a5094d4ebdddf1f7ed8e02d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26683567)</sub>

<!-- /greptile_comment -->