### PR TITLE
refactor(ecom-carousel): Rename ecom-carousel tool to browse-catalog in the ecom example app

### DIFF
--- a/examples/ecom-carousel/server/src/index.ts
+++ b/examples/ecom-carousel/server/src/index.ts
@@ -17,7 +17,7 @@ interface Product {
 
 const server = new McpServer(
   {
-    name: "browse-catalog-app",
+    name: "ecom-carousel-app",
     version: "0.0.1",
   },
   { capabilities: {} },

--- a/examples/ecom-carousel/web/src/widgets/browse-catalog.tsx
+++ b/examples/ecom-carousel/web/src/widgets/browse-catalog.tsx
@@ -188,6 +188,6 @@ function BrowseCatalog() {
   );
 }
 
-export default EcomCarousel;
+export default BrowseCatalog;
 
 mountWidget(<BrowseCatalog />);


### PR DESCRIPTION
Closes #365 

# Changes

1. Rename `ecom-carousel` to `browse-catalog`
2. Replace `EcomCarousel` function with `BrowseCatalog`

The example and MCP server name is kept same i.e ecom-carousel and ecom-carousel-app respectively.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames the `ecom-carousel` MCP widget to `browse-catalog` in the ecom-carousel example app, updating both the server registration and the React widget component accordingly while intentionally keeping the example folder name and MCP server name (`ecom-carousel`/`ecom-carousel-app`) unchanged.

**Changes:**
- `examples/ecom-carousel/server/src/index.ts`: Widget name updated from `"ecom-carousel"` to `"browse-catalog"` in `registerWidget`
- `examples/ecom-carousel/web/src/widgets/ecom-carousel.tsx` → `browse-catalog.tsx`: File renamed, function renamed from `EcomCarousel` to `BrowseCatalog`, and `useToolInfo<"ecom-carousel">()` generic updated to `useToolInfo<"browse-catalog">()`

All references are consistent: the Vite `skybridge()` plugin derives the bundle entry key directly from the widget filename (via `parse(file).name`), so the renamed file `browse-catalog.tsx` correctly maps to the `browse-catalog` widget registered on the server. TypeScript types via `generateHelpers<AppType>()` are also correctly updated.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — it is a clean, self-contained rename with no inconsistencies.

All references are consistently updated across server registration, widget filename, component function name, TypeScript generic, default export, and mountWidget call. No stale references to the old name remain in the web or server code. The Vite plugin build key derivation (filename → entry key) aligns correctly with the new name.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| examples/ecom-carousel/server/src/index.ts | Widget registration name updated from 'ecom-carousel' to 'browse-catalog'; no other changes. |
| examples/ecom-carousel/web/src/widgets/browse-catalog.tsx | File renamed from ecom-carousel.tsx; component function, export, mountWidget call, and useToolInfo generic all consistently updated to BrowseCatalog/'browse-catalog'. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix minor bug"](https://github.com/alpic-ai/skybridge/commit/e9886dc7964174ce50da493674509aab9a688d7f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26692629)</sub>

<!-- /greptile_comment -->