### PR TITLE
fix(create-skybridge): increase test timeout for repo download

### DIFF
--- a/packages/create-skybridge/src/index.test.ts
+++ b/packages/create-skybridge/src/index.test.ts
@@ -29,7 +29,7 @@ describe("create-skybridge", () => {
     ).rejects.toThrowError();
   });
 
-  it("should download template from repo", async () => {
+  it("should download template from repo", { timeout: 10_000 }, async () => {
     const name = `../../${tempDirName}//project$`;
     await init([
       name,


### PR DESCRIPTION
## Summary
- Increase timeout for "should download template from repo" test from 5s (default) to 10s
- Test clones from GitHub and was timing out on CI runners (5497ms > 5000ms)

## Test plan
- [x] Verify the test passes in CI with the increased timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR increases the per-test timeout for the `"should download template from repo"` test in `packages/create-skybridge/src/index.test.ts` from the Vitest default (5 000 ms) to 10 000 ms, because the test clones a GitHub repository at runtime and was intermittently exceeding the default budget on CI runners.

- The Vitest options-object syntax (`{ timeout: 10_000 }`) is correct and targets only the affected test, leaving other tests unchanged.
- No logic, implementation, or configuration files were modified; the change is purely a test-infrastructure fix.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-line test configuration change with no impact on production code.

The change is minimal, syntactically correct, and directly addresses the observed CI flakiness. No logic is altered, no new dependencies are introduced, and the timeout value is scoped to the one test that performs a real network operation.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/create-skybridge/src/index.test.ts | Adds a 10 000 ms per-test timeout to the GitHub repo-download test, correctly using Vitest's options-object API. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(create-skybridge): increase timeout ..."](https://github.com/alpic-ai/skybridge/commit/61e525d6133e1e50742ba98ac81629541b27c25b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26746634)</sub>

<!-- /greptile_comment -->