### PR TITLE
fix(create-skybridge): scope skills install to claude-code in CI

### DIFF
--- a/packages/create-skybridge/src/index.ts
+++ b/packages/create-skybridge/src/index.ts
@@ -195,7 +195,7 @@ export async function init(args: string[] = process.argv.slice(2)) {
         "alpic-ai/skybridge",
         "-s",
         "chatgpt-app-builder",
-        ...(interactive ? [] : ["--yes"]),
+        ...(interactive ? [] : ["--yes", "-a", "claude-code"]),
       ],
       {
         stdio: "inherit",


### PR DESCRIPTION
## Summary
- In non-interactive mode (CI), the `skills` CLI defaults to installing for all 42 agents when none are detected, cluttering repos with unnecessary directories (`.windsurf/`, `.roo/`, `.trae/`, etc.)
- Pass `-a claude-code` in non-interactive mode to only install for Claude Code (+ universal `.agents/` dir)
- Interactive mode is unchanged — users still get prompted to choose agents

<img width="899" height="1221" alt="image" src="https://github.com/user-attachments/assets/945b3f29-c133-44ec-bf90-cd74a6ed896c" />

## Test plan
- [ ] Run `npm create skybridge@latest . --overwrite` in non-interactive mode and verify only `.agents/` and `.claude/` skill dirs are created
- [ ] Run interactively and verify the agent selection prompt still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes a small, targeted fix to `packages/create-skybridge/src/index.ts`: when running in non-interactive (CI) mode, `-a claude-code` is now appended to the `skills add` command, scoping the skills installation to only Claude Code and the universal `.agents/` directory rather than all 42 agents.

- The `interactive` flag is correctly derived from `process.stdin.isTTY`, which is the standard way to detect a non-TTY/CI context.
- `--yes` (auto-confirm) was already present for non-interactive mode; only `-a claude-code` is new.
- Interactive mode is unaffected — users still get the `skills` CLI's own agent selection prompt.
- The change is minimal, well-scoped, and consistent with the rest of the file's interactive/non-interactive branching pattern.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-line change with no logic issues, correct use of existing non-interactive flag pattern.

The change is a one-line addition of `-a claude-code` to a spread array used only in non-interactive mode. No new control flow, no new dependencies, and no breaking changes to interactive mode. All existing guard conditions (`process.stdin.isTTY`, `--yes`) are used correctly.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/create-skybridge/src/index.ts | Adds `-a claude-code` flag in non-interactive mode to scope skills installation to Claude Code only, preventing unnecessary agent directories from being created in CI. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(create-skybridge): only install skil..."](https://github.com/alpic-ai/skybridge/commit/71fba48a3b8f0a242779d7f338b6c4fbc96ed07a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26785456)</sub>

<!-- /greptile_comment -->