### PR TITLE
fix: remove duplicate Skybridge title from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 
 <br />
 
-# Skybridge
-
 **Build ChatGPT & MCP Apps. The Modern TypeScript Way.**
 
 The fullstack TypeScript framework for AI-embedded widgets.<br />


### PR DESCRIPTION
## Summary
- Remove the `# Skybridge` heading that duplicated the text already in the SVG logo banner

## Test plan
- [ ] Verify README renders without the duplicate title on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the redundant `# Skybridge` heading from `README.md` that appeared immediately after the SVG logo banner, which already displays the "Skybridge" title. The change is a minor documentation cleanup with no functional impact.

- Removes one duplicated `# Skybridge` heading below the logo `<picture>` block
- No logic, configuration, or code changes involved

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — it is a one-line documentation-only cleanup with no risk.

The change removes a single redundant heading from the README. No code, logic, or configuration is affected. There are no issues of any severity.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Removes the redundant `# Skybridge` heading that duplicated the SVG logo banner title. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: remove duplicate Skybridge title fr..."](https://github.com/alpic-ai/skybridge/commit/b275a76514f9c6ce368aa0b4efe83561ad8cacda) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26912316)</sub>

<!-- /greptile_comment -->