### PR TITLE
fix: resolve asset URLs at runtime to support tunnels

### DIFF
--- a/packages/core/src/server/asset-base-url-transform-plugin.test.ts
+++ b/packages/core/src/server/asset-base-url-transform-plugin.test.ts
@@ -2,29 +2,27 @@ import { describe, expect, it } from "vitest";
 import { assetBaseUrlTransform } from "./asset-base-url-transform-plugin.js";
 
 describe("assetBaseUrlTransform", () => {
-  const devServerOrigin = "http://localhost:3000";
-
-  it("should transform asset paths in single, double, and backtick quotes", () => {
+  it("should transform asset paths to use window.skybridge.serverUrl", () => {
     const cases = [
       {
         desc: "single-quoted",
         code: `const image = '/assets/logo.png';`,
-        expected: `const image = '${devServerOrigin}/assets/logo.png';`,
+        expected: `const image = (window.skybridge?.serverUrl ?? "") + "/assets/logo.png";`,
       },
       {
         desc: "double-quoted",
         code: `const image = "/assets/logo.png";`,
-        expected: `const image = "${devServerOrigin}/assets/logo.png";`,
+        expected: `const image = (window.skybridge?.serverUrl ?? "") + "/assets/logo.png";`,
       },
       {
         desc: "backtick-quoted",
         code: "const image = `/assets/logo.png`;",
-        expected: `const image = \`${devServerOrigin}/assets/logo.png\`;`,
+        expected: `const image = (window.skybridge?.serverUrl ?? "") + "/assets/logo.png";`,
       },
     ];
 
     for (const { code, expected } of cases) {
-      const result = assetBaseUrlTransform(code, devServerOrigin);
+      const result = assetBaseUrlTransform(code);
       expect(result).toBe(expected);
     }
   });
@@ -35,11 +33,17 @@ describe("assetBaseUrlTransform", () => {
       const icon = '/assets/icon.svg';
       const font = '/assets/font.woff2';
     `;
-    const result = assetBaseUrlTransform(code, devServerOrigin);
+    const result = assetBaseUrlTransform(code);
 
-    expect(result).toContain(`${devServerOrigin}/assets/logo.png`);
-    expect(result).toContain(`${devServerOrigin}/assets/icon.svg`);
-    expect(result).toContain(`${devServerOrigin}/assets/font.woff2`);
+    expect(result).toContain(
+      `(window.skybridge?.serverUrl ?? "") + "/assets/logo.png"`,
+    );
+    expect(result).toContain(
+      `(window.skybridge?.serverUrl ?? "") + "/assets/icon.svg"`,
+    );
+    expect(result).toContain(
+      `(window.skybridge?.serverUrl ?? "") + "/assets/font.woff2"`,
+    );
   });
 
   it("should not transform already absolute URLs", () => {
@@ -48,16 +52,18 @@ describe("assetBaseUrlTransform", () => {
       const http = 'http://example.com/image.png';
       const https = 'https://example.com/image.png';
     `;
-    const result = assetBaseUrlTransform(code, devServerOrigin);
+    const result = assetBaseUrlTransform(code);
 
-    expect(result).toContain(`${devServerOrigin}/assets/logo.png`);
+    expect(result).toContain(
+      `(window.skybridge?.serverUrl ?? "") + "/assets/logo.png"`,
+    );
     expect(result).toContain("http://example.com/image.png");
     expect(result).toContain("https://example.com/image.png");
   });
 
   it("should not transform code without asset paths", () => {
     const code = `const text = "Hello World";`;
-    const result = assetBaseUrlTransform(code, devServerOrigin);
+    const result = assetBaseUrlTransform(code);
 
     expect(result).toBe(code);
   });

--- a/packages/core/src/server/asset-base-url-transform-plugin.ts
+++ b/packages/core/src/server/asset-base-url-transform-plugin.ts
@@ -1,30 +1,24 @@
 import type { Plugin } from "vite";
 
 /**
- * Transforms asset import paths to use the development server base URL.
+ * Transforms asset import paths to resolve at runtime via `window.skybridge.serverUrl`,
+ * so they work both locally and behind tunnels.
  */
-export function assetBaseUrlTransform(
-  code: string,
-  devServerOrigin: string,
-): string {
+export function assetBaseUrlTransform(code: string): string {
   const assetStringPattern =
     /(?<!https?:\/\/)(["'`])(\/[^"'`]+\.(svg|png|jpeg|jpg|gif|webp|mp3|mp4|woff|woff2|ttf|eot))\1/g;
 
-  code = code.replace(assetStringPattern, (_match, quote, assetPath) => {
-    return `${quote}${devServerOrigin}${assetPath}${quote}`;
+  code = code.replace(assetStringPattern, (_match, _quote, assetPath) => {
+    return `(window.skybridge?.serverUrl ?? "") + "${assetPath}"`;
   });
 
   return code;
 }
 
 /**
- * Vite plugin that transforms asset import paths to use the development server base URL.
+ * Vite plugin that transforms asset import paths to resolve at runtime via `window.skybridge.serverUrl`.
  */
-export function assetBaseUrlTransformPlugin(options: {
-  devServerOrigin: string;
-}): Plugin {
-  const { devServerOrigin } = options;
-
+export function assetBaseUrlTransformPlugin(): Plugin {
   return {
     name: "asset-base-url-transform",
     enforce: "pre",
@@ -33,7 +27,7 @@ export function assetBaseUrlTransformPlugin(options: {
         return null;
       }
 
-      const transformedCode = assetBaseUrlTransform(code, devServerOrigin);
+      const transformedCode = assetBaseUrlTransform(code);
 
       if (transformedCode === code) {
         return null;

--- a/packages/core/src/server/asset-base-url-transform-plugin.ts
+++ b/packages/core/src/server/asset-base-url-transform-plugin.ts
@@ -21,7 +21,6 @@ export function assetBaseUrlTransform(code: string): string {
 export function assetBaseUrlTransformPlugin(): Plugin {
   return {
     name: "asset-base-url-transform",
-    enforce: "pre",
     transform(code) {
       if (!code) {
         return null;

--- a/packages/core/src/server/widgetsDevServer.ts
+++ b/packages/core/src/server/widgetsDevServer.ts
@@ -63,12 +63,7 @@ export const widgetsDevServer = async (
     optimizeDeps: {
       include: ["react", "react-dom/client"],
     },
-    plugins: [
-      ...userPlugins,
-      assetBaseUrlTransformPlugin({
-        devServerOrigin: `http://localhost:${process.env.__PORT ?? "3000"}`,
-      }),
-    ],
+    plugins: [...userPlugins, assetBaseUrlTransformPlugin()],
   });
 
   router.use(cors());


### PR DESCRIPTION
Static assets (images, fonts, etc.) imported in widgets were not available to clients other than the machine running the tunnel. The Vite transform plugin hardcoded `http://localhost:${port}` as the asset origin, so only localhost could reach them.

Asset paths are now rewritten as expressions that read `window.skybridge.serverUrl` at runtime, which already contains the correct origin (tunnel or localhost). We can't use `import.meta.url` because widget iframes render on a sandbox domain (e.g. `web-sandbox.oaiusercontent.com` on ChatGPT), so the module origin doesn't point back to the tunnel.