### PR TITLE
Experimenting on CSP inspector

### DIFF
--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -43,6 +43,7 @@
     "@total-typescript/tsconfig": "^1.0.4",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
+    "@types/jsdom": "^28.0.1",
     "@types/lodash-es": "^4.17.12",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
@@ -53,6 +54,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "framer-motion": "^12.38.0",
+    "jsdom": "^29.0.1",
     "lodash-es": "^4.17.23",
     "lucide-react": "^1.7.0",
     "motion": "^12.38.0",
@@ -70,6 +72,7 @@
     "tw-animate-css": "^1.4.0",
     "typescript": "~6.0.2",
     "vite": "^8.0.3",
+    "vitest": "^4.1.2",
     "zustand": "^5.0.12"
   }
 }

--- a/packages/devtools/src/components/layout/tool-panel/csp-inspector.tsx
+++ b/packages/devtools/src/components/layout/tool-panel/csp-inspector.tsx
@@ -1,0 +1,295 @@
+import { ClipboardCopyIcon } from "lucide-react";
+import { useMemo } from "react";
+import { Button } from "@/components/ui/button.js";
+import { useSelectedTool, useSuspenseResource } from "@/lib/mcp/index.js";
+import { type CspObservedDomains, useCallToolResult } from "@/lib/store.js";
+
+type CspConfig = {
+  resourceDomains: string[];
+  connectDomains: string[];
+  frameDomains: string[];
+};
+
+const CSP_CATEGORY_MAP: Record<keyof CspObservedDomains, keyof CspConfig> = {
+  resourceDomains: "resourceDomains",
+  connectDomains: "connectDomains",
+  frameDomains: "frameDomains",
+};
+
+function extractConfiguredCsp(
+  resourceMeta: Record<string, unknown> | undefined,
+): CspConfig {
+  if (!resourceMeta) {
+    return { resourceDomains: [], connectDomains: [], frameDomains: [] };
+  }
+
+  const widgetCSP = resourceMeta["openai/widgetCSP"] as
+    | Record<string, string[]>
+    | undefined;
+  if (widgetCSP) {
+    return {
+      resourceDomains: widgetCSP.resource_domains ?? [],
+      connectDomains: widgetCSP.connect_domains ?? [],
+      frameDomains: widgetCSP.frame_domains ?? [],
+    };
+  }
+
+  const ui = resourceMeta.ui as { csp?: Record<string, string[]> } | undefined;
+  if (ui?.csp) {
+    return {
+      resourceDomains: ui.csp.resourceDomains ?? [],
+      connectDomains: ui.csp.connectDomains ?? [],
+      frameDomains: ui.csp.frameDomains ?? [],
+    };
+  }
+
+  return { resourceDomains: [], connectDomains: [], frameDomains: [] };
+}
+
+function originMatchesDomain(origin: string, domain: string): boolean {
+  try {
+    const originHost = new URL(origin).hostname;
+    const domainHost = new URL(domain).hostname;
+    return originHost === domainHost;
+  } catch {
+    return origin === domain;
+  }
+}
+
+function isDomainConfigured(origin: string, configuredDomains: string[]) {
+  return configuredDomains.some((d) => originMatchesDomain(origin, d));
+}
+
+type CategoryAnalysis = {
+  label: string;
+  configKey: string;
+  configured: string[];
+  observed: string[];
+  missing: string[];
+};
+
+function useAnalysis(
+  configuredCsp: CspConfig,
+  observedDomains: CspObservedDomains,
+): CategoryAnalysis[] {
+  return useMemo(() => {
+    const categories: {
+      key: keyof CspConfig;
+      label: string;
+      configKey: string;
+    }[] = [
+      {
+        key: "connectDomains",
+        label: "Connect (fetch / XHR)",
+        configKey: "connectDomains",
+      },
+      {
+        key: "resourceDomains",
+        label: "Resources (images, scripts, styles, fonts)",
+        configKey: "resourceDomains",
+      },
+      {
+        key: "frameDomains",
+        label: "Frames (iframe embeds)",
+        configKey: "frameDomains",
+      },
+    ];
+
+    return categories.map(({ key, label, configKey }) => {
+      const configured = configuredCsp[key];
+      const observedKey = CSP_CATEGORY_MAP[key];
+      const observed = observedDomains[observedKey];
+      const missing = observed.filter(
+        (o) => !isDomainConfigured(o, configured),
+      );
+      return { label, configKey, configured, observed, missing };
+    });
+  }, [configuredCsp, observedDomains]);
+}
+
+function buildSuggestedConfig(analysis: CategoryAnalysis[]): string | null {
+  const csp: Record<string, string[]> = {};
+  let hasMissing = false;
+
+  for (const { configKey, missing } of analysis) {
+    if (missing.length > 0) {
+      csp[configKey] = missing;
+      hasMissing = true;
+    }
+  }
+
+  if (!hasMissing) {
+    return null;
+  }
+
+  return JSON.stringify({ _meta: { ui: { csp } } }, null, 2);
+}
+
+function DomainBadge({
+  domain,
+  variant,
+}: {
+  domain: string;
+  variant: "configured" | "missing";
+}) {
+  const isMissing = variant === "missing";
+  return (
+    <span
+      className={`inline-flex items-center rounded px-1.5 py-0.5 text-[11px] font-mono leading-tight ${
+        isMissing
+          ? "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300 ring-1 ring-red-300 dark:ring-red-700"
+          : "bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300"
+      }`}
+    >
+      {domain}
+    </span>
+  );
+}
+
+function CategorySection({ analysis }: { analysis: CategoryAnalysis }) {
+  const { label, configured, observed, missing } = analysis;
+  const hasActivity = observed.length > 0 || configured.length > 0;
+
+  if (!hasActivity) {
+    return null;
+  }
+
+  const configuredOnly = configured.filter(
+    (d) => !observed.some((o) => originMatchesDomain(o, d)),
+  );
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-2">
+        <h4 className="text-xs font-semibold text-foreground">{label}</h4>
+        {missing.length > 0 && (
+          <span className="inline-flex items-center rounded-full bg-red-100 px-1.5 py-0.5 text-[10px] font-medium text-red-700 dark:bg-red-900/40 dark:text-red-300">
+            {missing.length} missing
+          </span>
+        )}
+      </div>
+      <div className="flex flex-wrap gap-1">
+        {missing.map((domain) => (
+          <DomainBadge
+            key={`missing-${domain}`}
+            domain={domain}
+            variant="missing"
+          />
+        ))}
+        {observed
+          .filter((o) => !missing.includes(o))
+          .map((domain) => (
+            <DomainBadge
+              key={`observed-${domain}`}
+              domain={domain}
+              variant="configured"
+            />
+          ))}
+        {configuredOnly.map((domain) => (
+          <DomainBadge
+            key={`configured-${domain}`}
+            domain={domain}
+            variant="configured"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function CspInspector() {
+  const tool = useSelectedTool();
+  const toolResult = useCallToolResult(tool.name);
+  const resourceUri = tool._meta?.["openai/outputTemplate"] as
+    | string
+    | undefined;
+  const { data: resource } = useSuspenseResource(resourceUri);
+
+  const resourceMeta = resource?.contents?.[0]?._meta as
+    | Record<string, unknown>
+    | undefined;
+  const configuredCsp = useMemo(
+    () => extractConfiguredCsp(resourceMeta),
+    [resourceMeta],
+  );
+  const observedDomains = toolResult?.cspObservedDomains ?? {
+    resourceDomains: [],
+    connectDomains: [],
+    frameDomains: [],
+  };
+
+  const analysis = useAnalysis(configuredCsp, observedDomains);
+  const suggestedConfig = useMemo(
+    () => buildSuggestedConfig(analysis),
+    [analysis],
+  );
+  const totalMissing = analysis.reduce((sum, a) => sum + a.missing.length, 0);
+  const totalObserved = analysis.reduce((sum, a) => sum + a.observed.length, 0);
+
+  const handleCopy = () => {
+    if (suggestedConfig) {
+      navigator.clipboard.writeText(suggestedConfig);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <h3 className="text-xs font-semibold text-foreground">CSP Inspector</h3>
+        {totalMissing > 0 ? (
+          <span className="inline-flex items-center rounded-full bg-red-100 px-2 py-0.5 text-[10px] font-medium text-red-700 dark:bg-red-900/40 dark:text-red-300">
+            {totalMissing} domain{totalMissing > 1 ? "s" : ""} missing
+          </span>
+        ) : totalObserved > 0 ? (
+          <span className="inline-flex items-center rounded-full bg-emerald-50 px-2 py-0.5 text-[10px] font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300">
+            All domains configured
+          </span>
+        ) : null}
+      </div>
+
+      <p className="text-[11px] text-muted-foreground leading-relaxed">
+        Compares observed network requests against{" "}
+        <code className="text-[10px] bg-muted px-1 py-0.5 rounded">
+          _meta.ui.csp
+        </code>{" "}
+        in your widget&apos;s resource config. Missing domains are highlighted
+        in red.
+      </p>
+
+      {totalObserved === 0 && (
+        <div className="rounded-md border border-dashed border-border p-3 text-center text-[11px] text-muted-foreground">
+          No external requests detected yet. Interact with the widget to trigger
+          network activity.
+        </div>
+      )}
+
+      <div className="space-y-3">
+        {analysis.map((a) => (
+          <CategorySection key={a.configKey} analysis={a} />
+        ))}
+      </div>
+
+      {suggestedConfig && (
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between">
+            <h4 className="text-xs font-semibold text-foreground">
+              Suggested addition to registerWidget
+            </h4>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 px-2 text-[10px]"
+              onClick={handleCopy}
+            >
+              <ClipboardCopyIcon className="w-3 h-3 mr-1" />
+              Copy
+            </Button>
+          </div>
+          <pre className="rounded-md bg-muted p-2.5 text-[11px] font-mono leading-relaxed overflow-x-auto whitespace-pre-wrap text-foreground">
+            {suggestedConfig}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/devtools/src/components/layout/tool-panel/openai-inspector.tsx
+++ b/packages/devtools/src/components/layout/tool-panel/openai-inspector.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/components/ui/tabs.js";
 import { useSelectedTool } from "@/lib/mcp/index.js";
 import { useCallToolResult, useStore } from "@/lib/store.js";
+import { CspInspector } from "./csp-inspector.js";
 import { LocaleSelector } from "./locale-selector.js";
 import { ResourceTabContent } from "./resource-tab.js";
 
@@ -59,6 +60,7 @@ export const OpenAiInspector = () => {
           <TabsTrigger value="properties">Properties</TabsTrigger>
           <TabsTrigger value="widget-state">Widget State</TabsTrigger>
           {resourceUri && <TabsTrigger value="resource">Resource</TabsTrigger>}
+          {resourceUri && <TabsTrigger value="csp">CSP</TabsTrigger>}
         </TabsList>
         <TabsContent value="properties" className="p-4">
           <FieldSet>
@@ -293,6 +295,19 @@ export const OpenAiInspector = () => {
               }
             >
               <ResourceTabContent resourceUri={resourceUri} />
+            </Suspense>
+          </TabsContent>
+        )}
+        {resourceUri && (
+          <TabsContent value="csp" className="p-4">
+            <Suspense
+              fallback={
+                <div className="text-xs text-muted-foreground">
+                  Loading CSP data...
+                </div>
+              }
+            >
+              <CspInspector />
             </Suspense>
           </TabsContent>
         )}

--- a/packages/devtools/src/components/layout/tool-panel/widget/widget.tsx
+++ b/packages/devtools/src/components/layout/tool-panel/widget/widget.tsx
@@ -1,9 +1,14 @@
 import { useCallback, useEffect, useRef } from "react";
+import { setupCspInterceptor } from "@/lib/csp-interceptor.js";
 import mcpClient, {
   useSelectedTool,
   useSuspenseResource,
 } from "@/lib/mcp/index.js";
-import { useCallToolResult, useStore } from "@/lib/store.js";
+import {
+  type CspObservedDomains,
+  useCallToolResult,
+  useStore,
+} from "@/lib/store.js";
 import { createAndInjectOpenAi } from "./create-openai-mock.js";
 import { injectWaitForOpenai } from "./utils.js";
 
@@ -14,11 +19,17 @@ export const Widget = () => {
   const { data: resource } = useSuspenseResource(
     tool._meta?.["openai/outputTemplate"] as string | undefined,
   );
-  const { setToolData, pushOpenAiLog, updateOpenaiObject, setOpenInAppUrl } =
-    useStore();
+  const {
+    setToolData,
+    pushOpenAiLog,
+    updateOpenaiObject,
+    setOpenInAppUrl,
+    addCspObservedDomain,
+  } = useStore();
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const hasLoadedRef = useRef(false);
+  const cspCleanupRef = useRef<(() => void) | null>(null);
 
   const html = (resource.contents[0] as { text: string }).text;
 
@@ -63,6 +74,20 @@ export const Widget = () => {
     iframe.contentDocument.write(injectWaitForOpenai(html));
     iframe.contentDocument.close();
 
+    const categoryMap: Record<string, keyof CspObservedDomains> = {
+      resource: "resourceDomains",
+      connect: "connectDomains",
+      frame: "frameDomains",
+    };
+
+    cspCleanupRef.current?.();
+    cspCleanupRef.current = setupCspInterceptor(
+      iframe.contentWindow as Window & typeof globalThis,
+      (origin, category) => {
+        addCspObservedDomain(tool.name, origin, categoryMap[category]);
+      },
+    );
+
     setToolData(tool.name, {
       openaiRef: iframeRef as React.RefObject<HTMLIFrameElement>,
     });
@@ -72,6 +97,7 @@ export const Widget = () => {
     setToolData,
     updateOpenaiObject,
     setOpenInAppUrl,
+    addCspObservedDomain,
     tool.name,
     html,
     resource,
@@ -80,6 +106,12 @@ export const Widget = () => {
   useEffect(() => {
     handleLoad();
   }, [handleLoad]);
+
+  useEffect(() => {
+    return () => {
+      cspCleanupRef.current?.();
+    };
+  }, []);
 
   return (
     <div

--- a/packages/devtools/src/lib/csp-interceptor.test.ts
+++ b/packages/devtools/src/lib/csp-interceptor.test.ts
@@ -1,0 +1,325 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setupCspInterceptor } from "./csp-interceptor.js";
+
+type CspCategory = "resource" | "connect" | "frame";
+type Observed = { origin: string; category: CspCategory };
+
+function collectObserved() {
+  const observed: Observed[] = [];
+  const callback = (origin: string, category: CspCategory) => {
+    observed.push({ origin, category });
+  };
+  return { observed, callback };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("setupCspInterceptor", () => {
+  describe("fetch interception", () => {
+    it("detects fetch calls to external origins", () => {
+      const originalFetch = window.fetch;
+      const mockFetch = vi.fn(async () => new Response("ok"));
+      window.fetch = mockFetch as unknown as typeof fetch;
+
+      const { observed, callback } = collectObserved();
+      const cleanup = setupCspInterceptor(window, callback);
+
+      window.fetch("https://api.example.com/data");
+
+      expect(observed).toContainEqual({
+        origin: "https://api.example.com",
+        category: "connect",
+      });
+      expect(mockFetch).toHaveBeenCalled();
+
+      cleanup();
+      window.fetch = originalFetch;
+    });
+
+    it("detects fetch with URL object", () => {
+      const originalFetch = window.fetch;
+      const mockFetch = vi.fn(async () => new Response("ok"));
+      window.fetch = mockFetch as unknown as typeof fetch;
+
+      const { observed, callback } = collectObserved();
+      const cleanup = setupCspInterceptor(window, callback);
+
+      window.fetch(new URL("https://cdn.example.com/file.json"));
+
+      expect(observed).toContainEqual({
+        origin: "https://cdn.example.com",
+        category: "connect",
+      });
+
+      cleanup();
+      window.fetch = originalFetch;
+    });
+
+    it("detects fetch with Request object", () => {
+      const originalFetch = window.fetch;
+      const mockFetch = vi.fn(async () => new Response("ok"));
+      window.fetch = mockFetch as unknown as typeof fetch;
+
+      const { observed, callback } = collectObserved();
+      const cleanup = setupCspInterceptor(window, callback);
+
+      window.fetch(new Request("https://api.example.com/users"));
+
+      expect(observed).toContainEqual({
+        origin: "https://api.example.com",
+        category: "connect",
+      });
+
+      cleanup();
+      window.fetch = originalFetch;
+    });
+
+    it("ignores data: and blob: URLs", () => {
+      const originalFetch = window.fetch;
+      const mockFetch = vi.fn(async () => new Response("ok"));
+      window.fetch = mockFetch as unknown as typeof fetch;
+
+      const { observed, callback } = collectObserved();
+      const cleanup = setupCspInterceptor(window, callback);
+
+      window.fetch("data:text/plain;base64,SGVsbG8=");
+
+      const connectObserved = observed.filter((o) => o.category === "connect");
+      expect(connectObserved).toHaveLength(0);
+
+      cleanup();
+      window.fetch = originalFetch;
+    });
+
+    it("skips patching when fetch is not available", () => {
+      const originalFetch = window.fetch;
+      (window as Partial<Window & typeof globalThis>).fetch = undefined;
+
+      const { callback } = collectObserved();
+      const cleanup = setupCspInterceptor(window, callback);
+
+      // Should not throw
+      cleanup();
+      window.fetch = originalFetch;
+    });
+
+    it("restores original fetch on cleanup", () => {
+      const originalFetch = window.fetch;
+      const mockFetch = vi.fn(async () => new Response("ok"));
+      window.fetch = mockFetch as unknown as typeof fetch;
+
+      const { callback } = collectObserved();
+      const cleanup = setupCspInterceptor(window, callback);
+
+      expect(window.fetch.name).toBe("patchedFetch");
+
+      cleanup();
+      expect(window.fetch.name).not.toBe("patchedFetch");
+
+      window.fetch = originalFetch;
+    });
+  });
+
+  describe("deduplication", () => {
+    it("reports the same origin+category only once", () => {
+      const originalFetch = window.fetch;
+      const mockFetch = vi.fn(async () => new Response("ok"));
+      window.fetch = mockFetch as unknown as typeof fetch;
+
+      const { observed, callback } = collectObserved();
+      const cleanup = setupCspInterceptor(window, callback);
+
+      window.fetch("https://api.example.com/users");
+      window.fetch("https://api.example.com/posts");
+      window.fetch("https://api.example.com/comments");
+
+      const apiEntries = observed.filter(
+        (o) => o.origin === "https://api.example.com",
+      );
+      expect(apiEntries).toHaveLength(1);
+
+      cleanup();
+      window.fetch = originalFetch;
+    });
+
+    it("reports different origins separately", () => {
+      const originalFetch = window.fetch;
+      const mockFetch = vi.fn(async () => new Response("ok"));
+      window.fetch = mockFetch as unknown as typeof fetch;
+
+      const { observed, callback } = collectObserved();
+      const cleanup = setupCspInterceptor(window, callback);
+
+      window.fetch("https://api-a.example.com/data");
+      window.fetch("https://api-b.example.com/data");
+
+      const origins = observed.map((o) => o.origin);
+      expect(origins).toContain("https://api-a.example.com");
+      expect(origins).toContain("https://api-b.example.com");
+
+      cleanup();
+      window.fetch = originalFetch;
+    });
+  });
+
+  describe("performance polling", () => {
+    it("picks up entries from performance.getEntriesByType", () => {
+      const mockEntries = [
+        { name: "https://cdn.example.com/app.js", initiatorType: "script" },
+        {
+          name: "https://fonts.googleapis.com/css2?family=Inter",
+          initiatorType: "link",
+        },
+        {
+          name: "https://api.example.com/data",
+          initiatorType: "fetch",
+        },
+        {
+          name: "https://avatars.githubusercontent.com/u/182288589",
+          initiatorType: "img",
+        },
+      ];
+
+      const originalGetEntries = window.performance.getEntriesByType;
+      window.performance.getEntriesByType = vi.fn(
+        () => mockEntries as unknown as PerformanceEntryList,
+      );
+
+      const { observed, callback } = collectObserved();
+      const cleanup = setupCspInterceptor(window, callback);
+
+      expect(observed).toContainEqual({
+        origin: "https://cdn.example.com",
+        category: "resource",
+      });
+      expect(observed).toContainEqual({
+        origin: "https://fonts.googleapis.com",
+        category: "resource",
+      });
+      expect(observed).toContainEqual({
+        origin: "https://api.example.com",
+        category: "connect",
+      });
+      expect(observed).toContainEqual({
+        origin: "https://avatars.githubusercontent.com",
+        category: "resource",
+      });
+
+      cleanup();
+      window.performance.getEntriesByType = originalGetEntries;
+    });
+
+    it("categorizes iframe initiatorType as frame", () => {
+      const mockEntries = [
+        {
+          name: "https://www.youtube.com/embed/abc",
+          initiatorType: "iframe",
+        },
+      ];
+
+      const originalGetEntries = window.performance.getEntriesByType;
+      window.performance.getEntriesByType = vi.fn(
+        () => mockEntries as unknown as PerformanceEntryList,
+      );
+
+      const { observed, callback } = collectObserved();
+      const cleanup = setupCspInterceptor(window, callback);
+
+      expect(observed).toContainEqual({
+        origin: "https://www.youtube.com",
+        category: "frame",
+      });
+
+      cleanup();
+      window.performance.getEntriesByType = originalGetEntries;
+    });
+
+    it("picks up new entries on subsequent polls", async () => {
+      vi.useFakeTimers();
+
+      let entries: unknown[] = [];
+
+      const originalGetEntries = window.performance.getEntriesByType;
+      window.performance.getEntriesByType = vi.fn(
+        () => entries as unknown as PerformanceEntryList,
+      );
+
+      const { observed, callback } = collectObserved();
+      const cleanup = setupCspInterceptor(window, callback);
+
+      expect(observed).toHaveLength(0);
+
+      entries = [
+        {
+          name: "https://lazy.example.com/image.png",
+          initiatorType: "img",
+        },
+      ];
+
+      vi.advanceTimersByTime(1100);
+
+      expect(observed).toContainEqual({
+        origin: "https://lazy.example.com",
+        category: "resource",
+      });
+
+      cleanup();
+      window.performance.getEntriesByType = originalGetEntries;
+      vi.useRealTimers();
+    });
+  });
+
+  describe("iframe context", () => {
+    function createTestIframe() {
+      const iframe = document.createElement("iframe");
+      document.body.appendChild(iframe);
+      const iframeWin = iframe.contentWindow;
+      if (!iframeWin) {
+        throw new Error("iframe contentWindow unavailable");
+      }
+      return { iframe, iframeWin };
+    }
+
+    it("detects fetch calls from iframe window", () => {
+      const { iframe, iframeWin } = createTestIframe();
+
+      const mockFetch = vi.fn(async () => new Response("ok"));
+      (iframeWin as Window & typeof globalThis).fetch =
+        mockFetch as unknown as typeof fetch;
+
+      const { observed, callback } = collectObserved();
+      const cleanup = setupCspInterceptor(
+        iframeWin as Window & typeof globalThis,
+        callback,
+      );
+
+      (iframeWin as Window & typeof globalThis).fetch(
+        "https://api.example.com/endpoint",
+      );
+
+      expect(observed).toContainEqual({
+        origin: "https://api.example.com",
+        category: "connect",
+      });
+
+      cleanup();
+      iframe.remove();
+    });
+
+    it("does not throw when iframe has limited APIs", () => {
+      const { iframe, iframeWin } = createTestIframe();
+
+      const { callback } = collectObserved();
+      // Should not throw even though iframe may lack fetch/XHR/PerformanceObserver
+      const cleanup = setupCspInterceptor(
+        iframeWin as Window & typeof globalThis,
+        callback,
+      );
+
+      cleanup();
+      iframe.remove();
+    });
+  });
+});

--- a/packages/devtools/src/lib/csp-interceptor.ts
+++ b/packages/devtools/src/lib/csp-interceptor.ts
@@ -1,0 +1,229 @@
+type CspCategory = "resource" | "connect" | "frame";
+
+type DomainObservedCallback = (origin: string, category: CspCategory) => void;
+
+const POLL_INTERVAL_MS = 1000;
+
+function extractOrigin(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol === "data:" || parsed.protocol === "blob:") {
+      return null;
+    }
+    return parsed.origin;
+  } catch {
+    return null;
+  }
+}
+
+function categorizeInitiatorType(initiatorType: string): CspCategory {
+  if (initiatorType === "fetch" || initiatorType === "xmlhttprequest") {
+    return "connect";
+  }
+  if (initiatorType === "iframe" || initiatorType === "subdocument") {
+    return "frame";
+  }
+  return "resource";
+}
+
+function deduplicatedCallback(callback: DomainObservedCallback) {
+  const seen = new Set<string>();
+  return (origin: string, category: CspCategory) => {
+    const key = `${category}:${origin}`;
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    callback(origin, category);
+  };
+}
+
+/**
+ * Primary mechanism: PerformanceObserver captures every network request
+ * (scripts, images, fonts, CSS, fetch, XHR) regardless of whether it was
+ * initiated from static HTML or dynamic JS.
+ */
+function observePerformance(
+  iframeWindow: Window & typeof globalThis,
+  report: DomainObservedCallback,
+): () => void {
+  if (!iframeWindow.PerformanceObserver) {
+    return () => {};
+  }
+
+  const processEntry = (entry: PerformanceEntry) => {
+    const origin = extractOrigin(entry.name);
+    if (origin) {
+      report(
+        origin,
+        categorizeInitiatorType(
+          (entry as PerformanceResourceTiming).initiatorType,
+        ),
+      );
+    }
+  };
+
+  try {
+    const observer = new iframeWindow.PerformanceObserver(
+      (list: PerformanceObserverEntryList) => {
+        for (const entry of list.getEntries()) {
+          processEntry(entry);
+        }
+      },
+    );
+    observer.observe({ type: "resource", buffered: true });
+    return () => observer.disconnect();
+  } catch {
+    return () => {};
+  }
+}
+
+/**
+ * Fallback: poll performance.getEntriesByType('resource') on an interval.
+ * Catches entries that PerformanceObserver might miss (e.g. if observer was
+ * set up after resources loaded and buffered mode didn't work).
+ */
+function pollPerformanceEntries(
+  iframeWindow: Window & typeof globalThis,
+  report: DomainObservedCallback,
+): () => void {
+  if (!iframeWindow.performance?.getEntriesByType) {
+    return () => {};
+  }
+
+  const poll = () => {
+    try {
+      const entries = iframeWindow.performance.getEntriesByType("resource");
+      for (const entry of entries) {
+        const origin = extractOrigin(entry.name);
+        if (origin) {
+          report(
+            origin,
+            categorizeInitiatorType(
+              (entry as PerformanceResourceTiming).initiatorType,
+            ),
+          );
+        }
+      }
+    } catch {
+      // iframe may become unavailable
+    }
+  };
+
+  poll();
+  const intervalId = setInterval(poll, POLL_INTERVAL_MS);
+  return () => clearInterval(intervalId);
+}
+
+/**
+ * Intercept fetch() calls for real-time connect-domain detection.
+ * Reports the origin before the actual request is made.
+ */
+function patchFetch(
+  iframeWindow: Window,
+  report: DomainObservedCallback,
+): () => void {
+  if (typeof iframeWindow.fetch !== "function") {
+    return () => {};
+  }
+
+  const originalFetch = iframeWindow.fetch.bind(iframeWindow);
+
+  iframeWindow.fetch = function patchedFetch(
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+    const origin = extractOrigin(url);
+    if (origin) {
+      report(origin, "connect");
+    }
+    return originalFetch(input, init);
+  };
+
+  return () => {
+    iframeWindow.fetch = originalFetch;
+  };
+}
+
+/**
+ * Intercept XMLHttpRequest.open() for real-time connect-domain detection.
+ */
+function patchXHR(
+  iframeWindow: Window & typeof globalThis,
+  report: DomainObservedCallback,
+): () => void {
+  if (!iframeWindow.XMLHttpRequest) {
+    return () => {};
+  }
+
+  const XHR = iframeWindow.XMLHttpRequest;
+  const originalOpen = XHR.prototype.open;
+
+  XHR.prototype.open = function patchedOpen(
+    method: string,
+    url: string | URL,
+    ...rest: unknown[]
+  ) {
+    const urlStr = typeof url === "string" ? url : url.href;
+    const origin = extractOrigin(urlStr);
+    if (origin) {
+      report(origin, "connect");
+    }
+    return (originalOpen as (...args: unknown[]) => void).call(
+      this,
+      method,
+      url,
+      ...rest,
+    );
+  };
+
+  return () => {
+    XHR.prototype.open = originalOpen;
+  };
+}
+
+/**
+ * Sets up interception of all network requests made by a widget iframe.
+ *
+ * Uses three complementary strategies:
+ * 1. PerformanceObserver — captures all resource loads (primary)
+ * 2. performance.getEntriesByType polling — fallback for missed entries
+ * 3. fetch/XHR monkey-patching — real-time connect-domain detection
+ *
+ * Call AFTER document.close() but before module scripts execute,
+ * so fetch/XHR patches are in place when the widget SPA boots.
+ */
+export function setupCspInterceptor(
+  iframeWindow: Window & typeof globalThis,
+  report: DomainObservedCallback,
+): () => void {
+  const cleanups: Array<() => void> = [];
+  const dedupedReport = deduplicatedCallback(report);
+
+  const layers = [
+    () => observePerformance(iframeWindow, dedupedReport),
+    () => pollPerformanceEntries(iframeWindow, dedupedReport),
+    () => patchFetch(iframeWindow, dedupedReport),
+    () => patchXHR(iframeWindow, dedupedReport),
+  ];
+
+  for (const layer of layers) {
+    try {
+      cleanups.push(layer());
+    } catch {
+      // Layer unavailable in this context
+    }
+  }
+
+  return () => {
+    for (const cleanup of cleanups) {
+      cleanup();
+    }
+  };
+}

--- a/packages/devtools/src/lib/mcp/index.ts
+++ b/packages/devtools/src/lib/mcp/index.ts
@@ -138,6 +138,11 @@ export const useCallTool = () => {
         openaiLogs: [],
         openaiObject: null,
         openInAppUrl: null,
+        cspObservedDomains: {
+          resourceDomains: [],
+          connectDomains: [],
+          frameDomains: [],
+        },
       });
       const response = await client.callTool(toolName, args);
       setToolData(toolName, {
@@ -153,6 +158,11 @@ export const useCallTool = () => {
           widgetState: null,
         },
         openInAppUrl: null,
+        cspObservedDomains: {
+          resourceDomains: [],
+          connectDomains: [],
+          frameDomains: [],
+        },
       });
       return response;
     },

--- a/packages/devtools/src/lib/store.ts
+++ b/packages/devtools/src/lib/store.ts
@@ -14,6 +14,12 @@ export type OpenAiLog = {
   type: "default" | "response";
 };
 
+export type CspObservedDomains = {
+  resourceDomains: string[];
+  connectDomains: string[];
+  frameDomains: string[];
+};
+
 type ToolData = {
   input: Record<string, unknown>;
   response: CallToolResponse;
@@ -21,6 +27,7 @@ type ToolData = {
   openaiLogs: OpenAiLog[];
   openaiObject: AppsSdkContext | null;
   openInAppUrl: string | null;
+  cspObservedDomains: CspObservedDomains;
 };
 
 export type Store = {
@@ -35,6 +42,11 @@ export type Store = {
     value: unknown,
   ) => void;
   setOpenInAppUrl: (tool: string, href: string) => void;
+  addCspObservedDomain: (
+    tool: string,
+    origin: string,
+    category: keyof CspObservedDomains,
+  ) => void;
 };
 
 export const useStore = create<Store>()((setState) => ({
@@ -73,6 +85,25 @@ export const useStore = create<Store>()((setState) => ({
     setState((state) =>
       updateNestedState(state, `tools.${tool}.openInAppUrl`, href),
     ),
+  addCspObservedDomain: (
+    tool: string,
+    origin: string,
+    category: keyof CspObservedDomains,
+  ) =>
+    setState((state) => {
+      const current = state.tools[tool]?.cspObservedDomains;
+      if (!current) {
+        return state;
+      }
+      const list = current[category];
+      if (list.includes(origin)) {
+        return state;
+      }
+      return updateNestedState(state, `tools.${tool}.cspObservedDomains`, {
+        ...current,
+        [category]: [...list, origin],
+      });
+    }),
 }));
 
 export const useCallToolResult = (toolName: string) => {

--- a/packages/devtools/vitest.config.ts
+++ b/packages/devtools/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+    exclude: ["**/node_modules/**", "**/dist/**"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1072,6 +1072,9 @@ importers:
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
+      '@types/jsdom':
+        specifier: ^28.0.1
+        version: 28.0.1
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12
@@ -1102,6 +1105,9 @@ importers:
       framer-motion:
         specifier: ^12.38.0
         version: 12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      jsdom:
+        specifier: ^29.0.1
+        version: 29.0.1(@noble/hashes@1.8.0)
       lodash-es:
         specifier: ^4.17.23
         version: 4.17.23
@@ -1153,6 +1159,9 @@ importers:
       vite:
         specifier: ^8.0.3
         version: 8.0.3(@types/node@25.5.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(@vitest/ui@4.1.2)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.4(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       zustand:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@19.2.14)(immer@9.0.21)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
@@ -8872,10 +8881,6 @@ packages:
   undici-types@7.22.0:
     resolution: {integrity: sha512-RKZvifiL60xdsIuC80UY0dq8Z7DbJUV8/l2hOVbyZAxBzEeQU4Z58+4ZzJ6WN2Lidi9KzT5EbiGX+PI/UGYuRw==}
 
-  undici@7.24.5:
-    resolution: {integrity: sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==}
-    engines: {node: '>=20.18.1'}
-
   undici@7.24.6:
     resolution: {integrity: sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==}
     engines: {node: '>=20.18.1'}
@@ -14487,7 +14492,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(@vitest/ui@4.1.2)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.4(@types/node@24.12.0)(typescript@6.0.2))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(@vitest/ui@4.1.2)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.4(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
 
   '@vitest/utils@4.1.2':
     dependencies:
@@ -15853,6 +15858,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
   fetch-blob@3.2.0:
     dependencies:
       node-domexception: 1.0.0
@@ -16998,7 +17007,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.24.5
+      undici: 7.24.6
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -20489,8 +20498,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinyqueue@1.2.3: {}
 
@@ -20696,8 +20705,6 @@ snapshots:
   undici-types@7.18.2: {}
 
   undici-types@7.22.0: {}
-
-  undici@7.24.5: {}
 
   undici@7.24.6: {}
 
@@ -21091,7 +21098,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.2
@@ -21121,7 +21128,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.2


### PR DESCRIPTION
Just a POC to demo the _meta.ui.csp metadata confirmation of ext-apps and how Skybridge can help developers inspect and correct missing/extra domains in CSPs.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This POC adds a CSP Inspector tab to the devtools panel that intercepts network activity from widget iframes (via fetch/XHR monkey-patching, PerformanceObserver, and DOM mutation observation), compares observed origins against the declared `_meta.ui.csp` config, and surfaces missing domains with a copyable suggested snippet.

- **P1 (DOM observer):** `setupCspInterceptor` is invoked before `document.open()`, so the MutationObserver is attached to a node that `document.open()` immediately detaches — the observer never fires. This silently drops all `frameDomains` detection for static `<iframe>` elements (not covered by PerformanceObserver either). The stale JSDoc on `setupCspInterceptor` references a non-existent `observeAfterWrite` return that was apparently the intended fix.
- **P2 (domain matching):** Bare-hostname CSP entries (no protocol) always fail URL parsing and fall back to an exact string match against full-origin strings, producing permanent false-positives in the "missing" list.

<h3>Confidence Score: 4/5</h3>

Safe to merge as a POC, but the DOM observer is effectively a no-op, silently missing an entire detection category (frameDomains) — worth fixing before promoting beyond an experiment.

One P1 finding (DOM observer never fires due to ordering relative to document.open) leaves a functional gap in frame-domain tracking that isn't obvious from runtime behaviour. The P2 domain-matching issue can produce misleading false-positives. Both should be resolved before this ships as a real feature.

packages/devtools/src/components/layout/tool-panel/widget/widget.tsx (CSP interceptor setup order) and packages/devtools/src/lib/csp-interceptor.ts (missing observeAfterWrite phase).

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The monkey-patching of `fetch` and `XMLHttpRequest.prototype.open` is scoped to the sandboxed iframe window and is cleaned up on unmount. No credentials, tokens, or sensitive data are captured — only request origins are recorded.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/devtools/src/components/layout/tool-panel/widget/widget.tsx
Line: 80-90

Comment:
**DOM observer set up before `document.open()` — never fires**

`setupCspInterceptor` is called at line 80 with the current `contentDocument`, but `document.open()` at line 88 detaches the `<html>` element that `observeDOM` passed to `MutationObserver.observe()`. The observer now targets a disconnected node, so no DOM mutations will fire for the actual widget content. The initial `querySelectorAll` inside `observeDOM` also runs against the blank document (no elements yet).

The practical gap: `<iframe>` elements emitted by `document.write()` (the `frameDomains` category) won't be captured, because they don't appear in PerformanceObserver resource entries either (iframes generate navigation entries, not resource entries).

The JSDoc on `setupCspInterceptor` already hints at the fix — it mentions "call the returned `observeAfterWrite` after document.close()" — but that callback is never returned. The DOM observation phase should be deferred to run after `document.close()`, e.g. by splitting the return value into `{ cleanup, observeAfterWrite }` and calling `observeAfterWrite()` at line 91.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/devtools/src/components/layout/tool-panel/csp-inspector.tsx
Line: 49-57

Comment:
**Bare-hostname CSP entries always fail to match observed origins**

`extractOrigin` in `csp-interceptor.ts` always produces full origins (`"https://api.example.com"`). If a developer configures a CSP domain as a bare hostname (`"api.example.com"` — valid in the ext-apps spec), `new URL("api.example.com")` throws and the fallback does an exact-string comparison: `"https://api.example.com" === "api.example.com"` → `false`. Every such domain will be permanently shown as "missing" regardless of configuration.

Consider normalising the `domain` side to accept bare hostnames by prepending a dummy scheme when the URL parse fails:

```ts
function originMatchesDomain(origin: string, domain: string): boolean {
  try {
    const originHost = new URL(origin).hostname;
    let domainHost: string;
    try {
      domainHost = new URL(domain).hostname;
    } catch {
      // bare hostname — no protocol
      domainHost = new URL(`https://${domain}`).hostname;
    }
    return originHost === domainHost;
  } catch {
    return origin === domain;
  }
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["wip"](https://github.com/alpic-ai/skybridge/commit/afce665524daaf0e2d1481ecba6eb29480146194) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27883611)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->