### PR TITLE
feat: persist widget state across re-renders in MCP Apps via localStorage

### DIFF
--- a/docs/api-reference/register-widget.mdx
+++ b/docs/api-reference/register-widget.mdx
@@ -124,6 +124,10 @@ return {
 };
 ```
 
+<Info>
+**viewUUID**: Skybridge automatically injects a unique `viewUUID` into `_meta` for every widget tool call. This enables `useWidgetState` and `createStore` to persist state across re-renders in MCP Apps via `localStorage`. You don't need to generate it yourself — any `_meta` you return is preserved alongside the injected `viewUUID`.
+</Info>
+
 ## Input Schema
 
 Define expected inputs with Zod:

--- a/docs/api-reference/use-widget-state.mdx
+++ b/docs/api-reference/use-widget-state.mdx
@@ -3,10 +3,6 @@ title: useWidgetState
 description: "React hook for persistent widget state that survives re-renders and display mode changes."
 ---
 
-<Warning>
-**Runtime Support**: In MCP Apps, `useWidgetState` is polyfilled. State does **not** persist across widget renders.
-</Warning>
-
 The `useWidgetState` hook provides persistent state management for your widget. Unlike React's `useState`, this state is persisted by the host and survives across widget re-renders and display mode changes.
 
 ## Basic usage

--- a/docs/guides/managing-state.mdx
+++ b/docs/guides/managing-state.mdx
@@ -158,13 +158,9 @@ function CartWidget() {
 ### Automatic Persistence
 
 `createStore` automatically:
-- Syncs state to the host's persistent storage (Apps SDK: `window.openai.setWidgetState()`, MCP Apps: polyfilled)
-- Restores state from the host on load (Apps SDK: `window.openai.widgetState`, MCP Apps: polyfilled)
+- Syncs state to the host's persistent storage
+- Restores state from the host on load
 - Filters out functions (actions) during serialization
-
-<Note>
-**MCP Apps Limitation**: In MCP Apps, state persistence is polyfilled and does not survive widget re-renders. State is only maintained within the current widget render cycle.
-</Note>
 
 ## Comparison Table
 
@@ -212,14 +208,7 @@ function ProductListWidget() {
 
 ## When State Persists
 
-**In Apps SDK (ChatGPT)**, widget state persists:
-- When the widget re-renders (component update)
-- When the user scrolls away and back
-- When the display mode changes
-
-**In MCP Apps**, widget state only persists:
-- Within the current widget render cycle (component updates)
-- State is lost when the widget is re-mounted or the tool is called again
+Widget state persists across re-renders, re-mounts, and display mode changes. Skybridge handles the storage mechanism automatically.
 
 Widget state **resets** when:
 - A new conversation starts

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -559,13 +559,27 @@ export class McpServer<
       toolMeta.ui = { resourceUri: widgetConfig.uri };
     }
 
+    const wrappedToolCallback: ToolHandler<TInput, TReturn> = async (
+      args,
+      extra,
+    ) => {
+      const result = await toolCallback(args, extra);
+      return {
+        ...result,
+        _meta: {
+          ...(result as { _meta?: Record<string, unknown> })._meta,
+          viewUUID: crypto.randomUUID(),
+        },
+      };
+    };
+
     this.registerTool(
       name,
       {
         ...toolConfig,
         _meta: toolMeta,
       },
-      toolCallback,
+      wrappedToolCallback,
     );
 
     return this as AddTool<

--- a/packages/core/src/test/widget.test.ts
+++ b/packages/core/src/test/widget.test.ts
@@ -455,6 +455,82 @@ describe("McpServer.registerWidget", () => {
     expect(toolConfig._meta?.["openai/outputTemplate"]).to.be.undefined;
   });
 
+  it("should inject viewUUID into _meta of tool callback results", async () => {
+    const mockToolCallback = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "result" }],
+      structuredContent: { data: "test" },
+    });
+
+    server.registerWidget(
+      "my-widget",
+      { description: "Test widget" },
+      { description: "Test tool" },
+      mockToolCallback,
+    );
+
+    // The registerTool should have been called with a wrapped callback
+    const wrappedCallback = mockRegisterTool.mock.calls[0]?.[2] as (
+      ...args: unknown[]
+    ) => Promise<{ _meta?: Record<string, unknown> }>;
+    expect(wrappedCallback).toBeDefined();
+
+    const result = await wrappedCallback({}, {});
+
+    expect(result._meta).toBeDefined();
+    expect(result._meta?.viewUUID).toBeDefined();
+    expect(typeof result._meta?.viewUUID).toBe("string");
+    // UUID v4 format
+    expect(result._meta?.viewUUID).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("should preserve existing _meta when injecting viewUUID", async () => {
+    const mockToolCallback = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "result" }],
+      structuredContent: { data: "test" },
+      _meta: { requestId: "req-123", cached: true },
+    });
+
+    server.registerWidget(
+      "my-widget",
+      { description: "Test widget" },
+      { description: "Test tool" },
+      mockToolCallback,
+    );
+
+    const wrappedCallback = mockRegisterTool.mock.calls[0]?.[2] as (
+      ...args: unknown[]
+    ) => Promise<{ _meta?: Record<string, unknown> }>;
+    const result = await wrappedCallback({}, {});
+
+    expect(result._meta?.requestId).toBe("req-123");
+    expect(result._meta?.cached).toBe(true);
+    expect(result._meta?.viewUUID).toBeDefined();
+  });
+
+  it("should generate unique viewUUIDs across calls", async () => {
+    const mockToolCallback = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "result" }],
+      structuredContent: {},
+    });
+
+    server.registerWidget(
+      "my-widget",
+      { description: "Test widget" },
+      { description: "Test tool" },
+      mockToolCallback,
+    );
+
+    const wrappedCallback = mockRegisterTool.mock.calls[0]?.[2] as (
+      ...args: unknown[]
+    ) => Promise<{ _meta?: Record<string, unknown> }>;
+    const result1 = await wrappedCallback({}, {});
+    const result2 = await wrappedCallback({}, {});
+
+    expect(result1._meta?.viewUUID).not.toBe(result2._meta?.viewUUID);
+  });
+
   it("should register tool with uopenai/outputTemplate metadata only", async () => {
     const mockToolCallback = vi.fn();
     server.registerWidget(

--- a/packages/core/src/web/bridges/mcp-app/adaptor.ts
+++ b/packages/core/src/web/bridges/mcp-app/adaptor.ts
@@ -16,6 +16,20 @@ type PickContext<K extends readonly McpAppContextKey[]> = {
   [P in K[number]]: McpAppContext[P];
 };
 
+const STORAGE_PREFIX = "sb:";
+const MAX_STORAGE_ENTRIES = 200;
+
+function findStorageKey(viewUUID: string): string | undefined {
+  const suffix = `:${viewUUID}`;
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key?.startsWith(STORAGE_PREFIX) && key.endsWith(suffix)) {
+      return key;
+    }
+  }
+  return undefined;
+}
+
 export class McpAppAdaptor implements Adaptor {
   private static instance: McpAppAdaptor | null = null;
   private stores: {
@@ -268,15 +282,19 @@ export class McpAppAdaptor implements Adaptor {
     });
   }
 
+  // localStorage keys: sb:{unix_ms}:{viewUUID}
+  // Timestamp is updated on every write (LRU); eviction drops the least recently used entries.
   private restoreFromLocalStorage(viewUUID: string): void {
     try {
-      const stored = localStorage.getItem(viewUUID);
-      if (stored !== null) {
-        const state = JSON.parse(stored) as Record<string, unknown>;
-        this._widgetState = state;
-        this.widgetStateListeners.forEach((listener) => {
-          listener();
-        });
+      const existingKey = findStorageKey(viewUUID);
+      if (existingKey) {
+        const stored = localStorage.getItem(existingKey);
+        if (stored !== null) {
+          this._widgetState = JSON.parse(stored);
+          this.widgetStateListeners.forEach((listener) => {
+            listener();
+          });
+        }
       }
     } catch (err) {
       console.error(err);
@@ -288,7 +306,30 @@ export class McpAppAdaptor implements Adaptor {
       return;
     }
     try {
-      localStorage.setItem(this._viewUUID, JSON.stringify(state));
+      // Remove old key for this view, write with fresh timestamp (LRU)
+      const oldKey = findStorageKey(this._viewUUID);
+      if (oldKey) {
+        localStorage.removeItem(oldKey);
+      }
+      const newKey = `${STORAGE_PREFIX}${Date.now()}:${this._viewUUID}`;
+      localStorage.setItem(newKey, JSON.stringify(state));
+
+      // lru cleanup
+      const keys: string[] = [];
+      for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (key?.startsWith(STORAGE_PREFIX)) {
+          keys.push(key);
+        }
+      }
+      if (keys.length <= MAX_STORAGE_ENTRIES) {
+        return;
+      }
+      keys.sort();
+      const toRemove = keys.slice(0, keys.length - MAX_STORAGE_ENTRIES);
+      for (const key of toRemove) {
+        localStorage.removeItem(key);
+      }
     } catch (err) {
       console.error(err);
     }

--- a/packages/core/src/web/bridges/mcp-app/adaptor.ts
+++ b/packages/core/src/web/bridges/mcp-app/adaptor.ts
@@ -23,6 +23,7 @@ export class McpAppAdaptor implements Adaptor {
   };
   private _widgetState: HostContext["widgetState"] = null;
   private widgetStateListeners = new Set<() => void>();
+  private _viewUUID: string | null = null;
 
   private _viewState: HostContext["view"] = {
     mode: "inline",
@@ -31,6 +32,7 @@ export class McpAppAdaptor implements Adaptor {
 
   private constructor() {
     this.stores = this.initializeStores();
+    this.subscribeToViewUUID();
   }
 
   public static getInstance(): McpAppAdaptor {
@@ -206,6 +208,8 @@ export class McpAppAdaptor implements Adaptor {
       listener();
     });
 
+    this.persistToLocalStorage(newState);
+
     try {
       const app = await McpAppBridge.getInstance().getApp();
       await app.updateModelContext({
@@ -247,6 +251,47 @@ export class McpAppAdaptor implements Adaptor {
 
   public setOpenInAppUrl(_href: string): Promise<void> {
     throw new Error("setOpenInAppUrl is not implemented in MCP App.");
+  }
+
+  private subscribeToViewUUID(): void {
+    const bridge = McpAppBridge.getInstance();
+    bridge.subscribe("toolResult")(() => {
+      const toolResult = bridge.getSnapshot("toolResult");
+      const viewUUID = (
+        toolResult?._meta as Record<string, unknown> | undefined
+      )?.viewUUID as string | undefined;
+
+      if (viewUUID && viewUUID !== this._viewUUID) {
+        this._viewUUID = viewUUID;
+        this.restoreFromLocalStorage(viewUUID);
+      }
+    });
+  }
+
+  private restoreFromLocalStorage(viewUUID: string): void {
+    try {
+      const stored = localStorage.getItem(viewUUID);
+      if (stored !== null) {
+        const state = JSON.parse(stored) as Record<string, unknown>;
+        this._widgetState = state;
+        this.widgetStateListeners.forEach((listener) => {
+          listener();
+        });
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  private persistToLocalStorage(state: Record<string, unknown> | null): void {
+    if (!this._viewUUID || state === null) {
+      return;
+    }
+    try {
+      localStorage.setItem(this._viewUUID, JSON.stringify(state));
+    } catch (err) {
+      console.error(err);
+    }
   }
 
   private createHostContextStore<

--- a/packages/core/src/web/create-store.ts
+++ b/packages/core/src/web/create-store.ts
@@ -1,6 +1,8 @@
+import { dequal } from "dequal/lite";
 import { create, type StateCreator } from "zustand";
 import { getAdaptor } from "./bridges/index.js";
 import {
+  filterWidgetContext,
   getInitialState,
   injectWidgetContext,
   serializeState,
@@ -25,12 +27,26 @@ export function createStore<State extends UnknownObject>(
     },
   );
 
+  // Bidirectional sync between the Zustand store and the adaptor's widgetState.
+  // Store changes persist to the host; external widgetState changes rehydrate the store.
   store.subscribe((state: State) => {
     const serializedState = serializeState(state);
     if (serializedState !== null && serializedState !== undefined) {
       const stateToPersist = injectWidgetContext(serializedState as State);
       if (stateToPersist !== null) {
         getAdaptor().setWidgetState(stateToPersist);
+      }
+    }
+  });
+
+  const widgetStateStore = getAdaptor().getHostContextStore("widgetState");
+  widgetStateStore.subscribe(() => {
+    const externalState = widgetStateStore.getSnapshot();
+    if (externalState !== null) {
+      const filtered = filterWidgetContext(externalState) as State;
+      const current = serializeState(store.getState()) as State;
+      if (!dequal(filtered, current)) {
+        store.setState(filtered);
       }
     }
   });

--- a/packages/core/src/web/hooks/use-widget-state.test.ts
+++ b/packages/core/src/web/hooks/use-widget-state.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import {
   afterEach,
   beforeEach,
@@ -8,6 +8,12 @@ import {
   type Mock,
   vi,
 } from "vitest";
+import { McpAppAdaptor, McpAppBridge } from "../bridges/mcp-app/index.js";
+import {
+  fireToolResultNotification,
+  getMcpAppHostPostMessageMock,
+  MockResizeObserver,
+} from "./test/utils.js";
 import { useWidgetState } from "./use-widget-state.js";
 
 describe("useWidgetState", () => {
@@ -85,5 +91,94 @@ describe("useWidgetState", () => {
     rerender();
 
     expect(result.current[0]).toEqual(windowState);
+  });
+});
+
+describe("useWidgetState (mcp-app host — localStorage persistence)", () => {
+  beforeEach(() => {
+    vi.stubGlobal("parent", { postMessage: getMcpAppHostPostMessageMock() });
+    vi.stubGlobal("skybridge", { hostType: "mcp-app" });
+    vi.stubGlobal("ResizeObserver", MockResizeObserver);
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetAllMocks();
+    McpAppBridge.resetInstance();
+    McpAppAdaptor.resetInstance();
+    localStorage.clear();
+  });
+
+  it("should persist state to localStorage when viewUUID is available", async () => {
+    const viewUUID = "test-uuid-123";
+    const { result } = renderHook(() => useWidgetState({ page: 1, zoom: 100 }));
+
+    await act(async () => {
+      fireToolResultNotification({
+        content: [{ type: "text", text: "result" }],
+        structuredContent: {},
+        _meta: { viewUUID },
+      });
+    });
+
+    act(() => {
+      result.current[1]({ page: 3, zoom: 150 });
+    });
+
+    expect(result.current[0]).toEqual({ page: 3, zoom: 150 });
+    expect(localStorage.getItem(viewUUID)).toBe(
+      JSON.stringify({ page: 3, zoom: 150 }),
+    );
+  });
+
+  it("should restore state from localStorage when viewUUID arrives", async () => {
+    const viewUUID = "test-uuid-456";
+    localStorage.setItem(viewUUID, JSON.stringify({ page: 5, zoom: 200 }));
+
+    const { result } = renderHook(() => useWidgetState({ page: 1, zoom: 100 }));
+
+    act(() => {
+      fireToolResultNotification({
+        content: [{ type: "text", text: "result" }],
+        structuredContent: {},
+        _meta: { viewUUID },
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current[0]).toEqual({ page: 5, zoom: 200 });
+    });
+  });
+
+  it("should not persist when no viewUUID is available", () => {
+    const { result } = renderHook(() => useWidgetState({ page: 1 }));
+
+    act(() => {
+      result.current[1]({ page: 2 });
+    });
+
+    expect(result.current[0]).toEqual({ page: 2 });
+    expect(localStorage.length).toBe(0);
+  });
+
+  it("should handle corrupted localStorage data gracefully", async () => {
+    const viewUUID = "test-uuid-corrupt";
+    localStorage.setItem(viewUUID, "not valid json{{{");
+
+    const { result } = renderHook(() => useWidgetState({ page: 1 }));
+
+    act(() => {
+      fireToolResultNotification({
+        content: [{ type: "text", text: "result" }],
+        structuredContent: {},
+        _meta: { viewUUID },
+      });
+    });
+
+    await waitFor(() => {
+      // Should keep default state when localStorage data is corrupted
+      expect(result.current[0]).toEqual({ page: 1 });
+    });
   });
 });

--- a/packages/core/src/web/hooks/use-widget-state.test.ts
+++ b/packages/core/src/web/hooks/use-widget-state.test.ts
@@ -127,14 +127,16 @@ describe("useWidgetState (mcp-app host — localStorage persistence)", () => {
     });
 
     expect(result.current[0]).toEqual({ page: 3, zoom: 150 });
-    expect(localStorage.getItem(viewUUID)).toBe(
-      JSON.stringify({ page: 3, zoom: 150 }),
-    );
+    expect(localStorage.length).toBe(1);
   });
 
   it("should restore state from localStorage when viewUUID arrives", async () => {
     const viewUUID = "test-uuid-456";
-    localStorage.setItem(viewUUID, JSON.stringify({ page: 5, zoom: 200 }));
+    // Pre-seed with the sb:{timestamp}:{viewUUID} format
+    localStorage.setItem(
+      `sb:1700000000000:${viewUUID}`,
+      JSON.stringify({ page: 5, zoom: 200 }),
+    );
 
     const { result } = renderHook(() => useWidgetState({ page: 1, zoom: 100 }));
 
@@ -164,7 +166,7 @@ describe("useWidgetState (mcp-app host — localStorage persistence)", () => {
 
   it("should handle corrupted localStorage data gracefully", async () => {
     const viewUUID = "test-uuid-corrupt";
-    localStorage.setItem(viewUUID, "not valid json{{{");
+    localStorage.setItem(`sb:1700000000000:${viewUUID}`, "not valid json{{{");
 
     const { result } = renderHook(() => useWidgetState({ page: 1 }));
 
@@ -177,8 +179,61 @@ describe("useWidgetState (mcp-app host — localStorage persistence)", () => {
     });
 
     await waitFor(() => {
-      // Should keep default state when localStorage data is corrupted
       expect(result.current[0]).toEqual({ page: 1 });
     });
+  });
+
+  it("should refresh localStorage timestamp on each persist (LRU)", async () => {
+    const viewUUID = "lru-test-uuid";
+    const oldKey = `sb:1000000000000:${viewUUID}`;
+    localStorage.setItem(oldKey, JSON.stringify({ page: 1 }));
+
+    const { result } = renderHook(() => useWidgetState({ page: 1 }));
+
+    await act(async () => {
+      fireToolResultNotification({
+        content: [{ type: "text", text: "result" }],
+        structuredContent: {},
+        _meta: { viewUUID },
+      });
+    });
+
+    act(() => {
+      result.current[1]({ page: 2 });
+    });
+
+    // Old key removed, replaced with a new one (still just 1 entry)
+    expect(localStorage.getItem(oldKey)).toBeNull();
+    expect(localStorage.length).toBe(1);
+  });
+
+  it("should evict oldest entries when exceeding max storage entries", async () => {
+    // Fill localStorage with 200 entries (the max)
+    for (let i = 0; i < 200; i++) {
+      localStorage.setItem(
+        `sb:${String(1000000000000 + i)}:old-uuid-${String(i).padStart(4, "0")}`,
+        JSON.stringify({ i }),
+      );
+    }
+    expect(localStorage.length).toBe(200);
+
+    const viewUUID = "eviction-test-uuid";
+    const { result } = renderHook(() => useWidgetState({ page: 1 }));
+
+    await act(async () => {
+      fireToolResultNotification({
+        content: [{ type: "text", text: "result" }],
+        structuredContent: {},
+        _meta: { viewUUID },
+      });
+    });
+
+    act(() => {
+      result.current[1]({ page: 99 });
+    });
+
+    // Should have evicted the oldest entry to stay at 200
+    expect(localStorage.length).toBe(200);
+    expect(localStorage.getItem("sb:1000000000000:old-uuid-0000")).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #663

MCP Apps widgets lost all UI state on every re-render — useWidgetState and createStore only persisted within a single render cycle because the MCP Apps host doesn't replay updateModelContext on remount.

The root cause is that there was no client-side persistence layer for MCP Apps. The Apps SDK host handles this natively, but MCP Apps had nothing.

registerWidget now wraps tool callbacks to inject a unique viewUUID into every tool result _meta. The MCP App adaptor captures that UUID from the tool result notification, uses it as a localStorage key to persist widget state on every setWidgetState call, and restores from localStorage when the host re-delivers the tool result on remount. createStore also gained a reverse subscription to the widgetState store (with dequal to prevent round-trip loops) so Zustand stores rehydrate too — same pattern useWidgetState already had via useHostContext. No new public API, both runtimes work transparently.