### PR TITLE
Add discord notification on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,12 +117,11 @@ jobs:
           RELEASE_URL: ${{ github.event.release.html_url }}
           RELEASE_BODY: ${{ github.event.release.body }}
         run: |
-          BODY=$(echo "$RELEASE_BODY" | head -c 1500)
-          curl -f -H "Content-Type: application/json" -d "{
-            \"embeds\": [{
-              \"title\": \"Skybridge $RELEASE_VERSION released\",
-              \"url\": \"$RELEASE_URL\",
-              \"description\": $(echo "$BODY" | jq -Rs .),
-              \"color\": 5814783
-            }]
-          }" "$DISCORD_WEBHOOK_URL"
+          BODY=$(echo "$RELEASE_BODY" | cut -c 1-1500)
+          PAYLOAD=$(jq -n \
+            --arg title "Skybridge $RELEASE_VERSION released" \
+            --arg url "$RELEASE_URL" \
+            --arg description "$BODY" \
+            --argjson color 5814783 \
+            '{embeds: [{title: $title, url: $url, description: $description, color: $color}]}')
+          curl -f -H "Content-Type: application/json" -d "$PAYLOAD" "$DISCORD_WEBHOOK_URL"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -104,3 +104,25 @@ jobs:
           branch: chore/bump-versions
           base: main
           delete-branch: true
+
+  notify-discord:
+    if: github.event_name == 'release'
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          RELEASE_VERSION: ${{ github.event.release.tag_name }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+        run: |
+          BODY=$(echo "$RELEASE_BODY" | head -c 1500)
+          curl -f -H "Content-Type: application/json" -d "{
+            \"embeds\": [{
+              \"title\": \"Skybridge $RELEASE_VERSION released\",
+              \"url\": \"$RELEASE_URL\",
+              \"description\": $(echo "$BODY" | jq -Rs .),
+              \"color\": 5814783
+            }]
+          }" "$DISCORD_WEBHOOK_URL"


### PR DESCRIPTION
## Summary

- Adds a `notify-discord` job to the publish workflow that posts a release embed to Discord after a successful publish
- Runs only on `release` events and depends on the `publish` job succeeding
- Uses `DISCORD_WEBHOOK_URL` GitHub secret (already configured)

## Details

The notification sends a Discord embed containing the release version, a link to the GitHub release, and the release notes body (truncated to 1500 chars). All GitHub context expressions are passed via environment variables to avoid command injection.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `notify-discord` job to the publish workflow that fires a Discord embed notification via webhook after a successful release. The implementation is sound: it correctly gates on `release` events, uses `needs: publish` so the notification only fires after all publish steps succeed, and safely passes GitHub expression values through the `env:` block rather than inlining them in the shell script. Two minor style improvements are suggested in inline comments: building the full JSON payload with `jq` to avoid the unescaped `$RELEASE_VERSION`/`$RELEASE_URL` interpolation, and using `cut -c` instead of `head -c` for proper UTF-8 character boundary truncation.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are minor style suggestions with no practical runtime risk.

Both comments are P2 — low-probability edge cases (tag names and GitHub-generated URLs don't contain `"`, and release notes without multi-byte chars won't trigger the `head -c` issue). No P0/P1 defects found.

No files require special attention.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/publish.yml
Line: 121-128

Comment:
**Unescaped variables in JSON payload**

`$RELEASE_VERSION` and `$RELEASE_URL` are interpolated directly into the JSON string without escaping, while `$BODY` is correctly piped through `jq -Rs .`. In practice, GitHub tag names and URLs won't contain `"`, but if they ever did (e.g., a specially crafted tag) the `curl` payload would be malformed JSON and the notification would fail silently. Building the full payload with `jq` makes this robust.

```suggestion
          PAYLOAD=$(jq -n \
            --arg title "Skybridge $RELEASE_VERSION released" \
            --arg url "$RELEASE_URL" \
            --arg description "$BODY" \
            --argjson color 5814783 \
            '{embeds: [{title: $title, url: $url, description: $description, color: $color}]}')
          curl -f -H "Content-Type: application/json" -d "$PAYLOAD" "$DISCORD_WEBHOOK_URL"
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/publish.yml
Line: 120

Comment:
**`head -c` truncates bytes, not characters**

`head -c 1500` counts bytes, so for release notes with multi-byte UTF-8 characters (e.g. emoji, non-ASCII) it can cut in the middle of a character, producing invalid UTF-8 in the Discord payload. Use `cut -c` to truncate at proper character boundaries instead.

```suggestion
          BODY=$(echo "$RELEASE_BODY" | cut -c 1-1500)
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add discord notification on release"](https://github.com/alpic-ai/skybridge/commit/882f111b53d03e7a6d6978520c79a97cb7a3301e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28220595)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->