### PR TITLE
feat: add IAM user for CloudWatch read access

### DIFF
--- a/infrastructure/lib/constructs/CloudWatchReader.ts
+++ b/infrastructure/lib/constructs/CloudWatchReader.ts
@@ -1,0 +1,44 @@
+import { CfnOutput } from "aws-cdk-lib";
+import {
+  AccessKey,
+  Effect,
+  PolicyStatement,
+  User,
+} from "aws-cdk-lib/aws-iam";
+import { Secret } from "aws-cdk-lib/aws-secretsmanager";
+import { Construct } from "constructs";
+
+export class CloudWatchReader extends Construct {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    const user = new User(this, "User", {
+      userName: "skybridge-cloudwatch-reader",
+    });
+
+    user.addToPolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: [
+          "cloudwatch:GetMetricData",
+          "cloudwatch:GetMetricStatistics",
+          "cloudwatch:ListMetrics",
+        ],
+        resources: ["*"],
+      }),
+    );
+
+    const accessKey = new AccessKey(this, "AccessKey", { user });
+
+    new Secret(this, "AccessKeySecret", {
+      secretName: "skybridge/cloudwatch-reader",
+      secretStringValue: accessKey.secretAccessKey,
+      description: "AWS secret access key for the skybridge-cloudwatch-reader IAM user",
+    });
+
+    new CfnOutput(this, "AccessKeyId", {
+      value: accessKey.accessKeyId,
+      description: "AWS_ACCESS_KEY_ID for CloudWatch reader",
+    });
+  }
+}

--- a/infrastructure/lib/constructs/CloudWatchReader.ts
+++ b/infrastructure/lib/constructs/CloudWatchReader.ts
@@ -1,4 +1,4 @@
-import { CfnOutput } from "aws-cdk-lib";
+import { SecretValue } from "aws-cdk-lib";
 import {
   AccessKey,
   Effect,
@@ -32,13 +32,11 @@ export class CloudWatchReader extends Construct {
 
     new Secret(this, "AccessKeySecret", {
       secretName: "skybridge/cloudwatch-reader",
-      secretStringValue: accessKey.secretAccessKey,
-      description: "AWS secret access key for the skybridge-cloudwatch-reader IAM user",
-    });
-
-    new CfnOutput(this, "AccessKeyId", {
-      value: accessKey.accessKeyId,
-      description: "AWS_ACCESS_KEY_ID for CloudWatch reader",
+      secretObjectValue: {
+        accessKeyId: SecretValue.unsafePlainText(accessKey.accessKeyId),
+        secretAccessKey: accessKey.secretAccessKey,
+      },
+      description: "AWS credentials for the skybridge-cloudwatch-reader IAM user",
     });
   }
 }

--- a/infrastructure/lib/constructs/CloudWatchReader.ts
+++ b/infrastructure/lib/constructs/CloudWatchReader.ts
@@ -1,10 +1,5 @@
 import { SecretValue } from "aws-cdk-lib";
-import {
-  AccessKey,
-  Effect,
-  PolicyStatement,
-  User,
-} from "aws-cdk-lib/aws-iam";
+import { AccessKey, Effect, PolicyStatement, User } from "aws-cdk-lib/aws-iam";
 import { Secret } from "aws-cdk-lib/aws-secretsmanager";
 import { Construct } from "constructs";
 
@@ -36,7 +31,8 @@ export class CloudWatchReader extends Construct {
         accessKeyId: SecretValue.unsafePlainText(accessKey.accessKeyId),
         secretAccessKey: accessKey.secretAccessKey,
       },
-      description: "AWS credentials for the skybridge-cloudwatch-reader IAM user",
+      description:
+        "AWS credentials for the skybridge-cloudwatch-reader IAM user",
     });
   }
 }

--- a/infrastructure/lib/infrastructure-stack.ts
+++ b/infrastructure/lib/infrastructure-stack.ts
@@ -1,5 +1,6 @@
 import { Stack, type StackProps } from "aws-cdk-lib";
 import type { Construct } from "constructs";
+import { CloudWatchReader } from "./constructs/CloudWatchReader";
 import { Metrics } from "./constructs/Metrics";
 import { SkybridgeRecords } from "./constructs/SkybridgeRecords";
 
@@ -12,5 +13,7 @@ export class InfrastructureStack extends Stack {
     });
 
     new Metrics(this, "Metrics");
+
+    new CloudWatchReader(this, "CloudWatchReader");
   }
 }


### PR DESCRIPTION
Provision a scoped-down IAM user with CloudWatch read permissions and store its secret access key in Secrets Manager for use in Railway.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a CDK construct that provisions a scoped-down IAM user with CloudWatch Metrics read permissions, creates a long-lived access key, and stores the credential material in AWS Secrets Manager for use in Railway.

- The Secrets Manager secret only stores the IAM secret key value, while the corresponding key ID is emitted as a CloudFormation output. Authenticating with AWS requires both values, so they should be co-located in one secret (via `secretObjectValue`) rather than split across Secrets Manager and stack outputs.

<h3>Confidence Score: 4/5</h3>

Merge after resolving the split-credential issue — the current implementation requires fetching from two separate sources to get a usable credential pair.

One P1 finding: the secret stores only the IAM secret key while the access key ID lives in a CloudFormation output, making it impossible to retrieve a complete credential pair from Secrets Manager alone. This directly undermines the stated goal of Railway integration. All other aspects (IAM scoping, permissions breadth) are reasonable.

infrastructure/lib/constructs/CloudWatchReader.ts — credential storage split between Secrets Manager and CfnOutput

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: infrastructure/lib/constructs/CloudWatchReader.ts
Line: 33-42

Comment:
**Credentials split across two locations**

The Secrets Manager secret contains only one half of the credential pair (`AWS_SECRET_ACCESS_KEY`), while the key ID needed for `AWS_ACCESS_KEY_ID` is only available as a CloudFormation output. Anyone configuring Railway must retrieve both halves from separate sources — this can't be resolved with a single secret fetch and is easy to miss.

The fix is to store both fields in the same secret using `secretObjectValue`, then remove the `CfnOutput`. CDK's `Secret` supports mixing a plain-text token (for the non-sensitive key ID, wrapped in `SecretValue.unsafePlainText`) with a `SecretValue` token (for the actual key) under a single `secretObjectValue` map. That way the complete credential pair is retrieved atomically from one Secrets Manager path.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add IAM user for CloudWatch read a..."](https://github.com/alpic-ai/skybridge/commit/defd82ed69a56b5f9e53a276712951444d1fc501) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28225512)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->