### PR TITLE
fix: enforce .js import extensions via biome project domain

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -57,8 +57,12 @@
     {
       "includes": ["packages/core/**"],
       "linter": {
+        "domains": {
+          "project": "all"
+        },
         "rules": {
           "correctness": {
+            "noUnresolvedImports": "off",
             "useImportExtensions": {
               "level": "error",
               "options": {

--- a/packages/core/src/server/express.test.ts
+++ b/packages/core/src/server/express.test.ts
@@ -1,7 +1,7 @@
 import http from "node:http";
 import type { ErrorRequestHandler, RequestHandler } from "express";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { McpServer } from "./server";
+import type { McpServer } from "./server.js";
 
 vi.mock("@skybridge/devtools", () => ({
   devtoolsStaticServer: () =>

--- a/packages/core/src/server/express.ts
+++ b/packages/core/src/server/express.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import cors from "cors";
 import express from "express";
-import type { McpServer } from "./server";
+import type { McpServer } from "./server.js";
 
 function applyMiddlewares(
   app: express.Express,

--- a/packages/core/src/web/components/modal-provider.tsx
+++ b/packages/core/src/web/components/modal-provider.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useEffect, useSyncExternalStore } from "react";
-import { McpAppAdaptor } from "../bridges";
+import { McpAppAdaptor } from "../bridges/index.js";
 
 const modalStyles = `
 .sb-modal-backdrop {


### PR DESCRIPTION
### Summary

- Enable biome's `project` domain for `packages/core/**` so the `useImportExtensions` rule actually runs during lint/CI.
- Fix 3 existing extensionless relative imports that slipped through
  (`express.ts`, `express.test.ts`, `modal-provider.tsx`).
- Suppress false positive on `version.ts` where biome misflags
  a `createRequire`-based `require("../package.json")` call.

### Architecture Notes

- **`nodenext` not viable yet** — `@modelcontextprotocol/ext-apps` ships `.d.ts` files
  with extensionless specifiers, breaking TypeScript's `nodenext` resolution.
  Biome lint is the enforcement layer until that dependency is fixed upstream.
- **`noUnresolvedImports` disabled** — enabling the `project` domain also activates
  this rule, which produces false positives on third-party package imports;
  turned off inside the same override.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the root cause of `useImportExtensions` silently not running: the rule belongs to biome's `project` domain, which was never enabled. Adding `domains: { project: "all" }` activates it, and the three extensionless relative imports it surfaces (`express.ts`, `express.test.ts`, `modal-provider.tsx`) are corrected. `noUnresolvedImports` is disabled alongside to suppress false positives on third-party packages, and the `createRequire`-based JSON load in `version.ts` gets an inline suppress comment.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a targeted lint enforcement fix with no behavioural changes.
- All changes are mechanical: enabling a biome domain, correcting three extensionless imports, and suppressing one justified false positive. No logic is altered, the rule fixes are additive, and no P0/P1 issues were found across the changed files.
- No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix: enforce .js import extensions via b..."](https://github.com/alpic-ai/skybridge/commit/4ae8ff887da942dd15b46dd9bacc48394ef076d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28379246)</sub>

<!-- /greptile_comment -->