### PR TITLE
fix: sort dev logs chronologically across sources

### DIFF
--- a/packages/core/src/cli/types.ts
+++ b/packages/core/src/cli/types.ts
@@ -2,4 +2,5 @@ export type Message = {
   id: string;
   text: string;
   type: "log" | "restart" | "error";
+  ts: number;
 };

--- a/packages/core/src/cli/use-nodemon.ts
+++ b/packages/core/src/cli/use-nodemon.ts
@@ -32,7 +32,12 @@ export function useNodemon(env: NodeJS.ProcessEnv): Array<Message> {
         setMessages((prev) =>
           [
             ...prev,
-            { id: randomUUID(), text: message, type: "log" } satisfies Message,
+            {
+              id: randomUUID(),
+              text: message,
+              type: "log",
+              ts: Date.now(),
+            } satisfies Message,
           ].slice(-10),
         );
       }
@@ -48,6 +53,7 @@ export function useNodemon(env: NodeJS.ProcessEnv): Array<Message> {
               id: randomUUID(),
               text: message,
               type: "error",
+              ts: Date.now(),
             } satisfies Message,
           ].slice(-10),
         );
@@ -77,7 +83,12 @@ export function useNodemon(env: NodeJS.ProcessEnv): Array<Message> {
       const restartMessage = `Server restarted due to file changes: ${files.join(", ")}`;
       setMessages((prev) => [
         ...prev,
-        { id: randomUUID(), text: restartMessage, type: "restart" },
+        {
+          id: randomUUID(),
+          text: restartMessage,
+          type: "restart",
+          ts: Date.now(),
+        },
       ]);
       setupStdoutListener();
       setupStderrListener();

--- a/packages/core/src/cli/use-tunnel.ts
+++ b/packages/core/src/cli/use-tunnel.ts
@@ -59,6 +59,7 @@ export function useTunnel(port: number | null): TunnelState {
             id: randomUUID(),
             text: `${time} [tunnel] ${text}`,
             type,
+            ts: Date.now(),
           },
         ].slice(-10),
       );

--- a/packages/core/src/commands/dev.tsx
+++ b/packages/core/src/commands/dev.tsx
@@ -41,7 +41,10 @@ export default class Dev extends Command {
       const tunnelState = useTunnel(flags.tunnel ? port : null);
 
       const messages = useMemo(
-        () => [...nodemonMessages, ...tunnelState.logs].slice(-10),
+        () =>
+          [...nodemonMessages, ...tunnelState.logs]
+            .sort((a, b) => a.ts - b.ts)
+            .slice(-10),
         [nodemonMessages, tunnelState.logs],
       );
 


### PR DESCRIPTION
nodemon and tunnel messages were interleaved by source rather than by time, favoring tunnel logs