### PR TITLE
fix: use shared message queue for chronological dev logs

### DIFF
--- a/packages/core/src/cli/types.ts
+++ b/packages/core/src/cli/types.ts
@@ -2,5 +2,4 @@ export type Message = {
   id: string;
   text: string;
   type: "log" | "restart" | "error";
-  ts: number;
 };

--- a/packages/core/src/cli/use-messages.ts
+++ b/packages/core/src/cli/use-messages.ts
@@ -1,0 +1,19 @@
+import { randomUUID } from "node:crypto";
+import { useCallback, useState } from "react";
+import type { Message } from "./types.js";
+
+const MAX_MESSAGES = 10;
+
+export type PushMessage = (text: string, type: Message["type"]) => void;
+
+export function useMessages(): [Array<Message>, PushMessage] {
+  const [messages, setMessages] = useState<Array<Message>>([]);
+
+  const push = useCallback<PushMessage>((text, type) => {
+    setMessages((prev) =>
+      [...prev, { id: randomUUID(), text, type }].slice(-MAX_MESSAGES),
+    );
+  }, []);
+
+  return [messages, push];
+}

--- a/packages/core/src/cli/use-nodemon.ts
+++ b/packages/core/src/cli/use-nodemon.ts
@@ -1,16 +1,16 @@
-import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import nodemonOriginal from "nodemon";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import type { ExtendedNodemon } from "./nodemon.d.ts";
-import type { Message } from "./types.js";
+import type { PushMessage } from "./use-messages.js";
 
 const nodemon = nodemonOriginal as ExtendedNodemon;
 
-export function useNodemon(env: NodeJS.ProcessEnv): Array<Message> {
-  const [messages, setMessages] = useState<Array<Message>>([]);
-
+export function useNodemon(
+  env: NodeJS.ProcessEnv,
+  pushMessage: PushMessage,
+): void {
   useEffect(() => {
     const configFile = resolve(process.cwd(), "nodemon.json");
 
@@ -29,34 +29,14 @@ export function useNodemon(env: NodeJS.ProcessEnv): Array<Message> {
     const handleStdoutData = (chunk: Buffer) => {
       const message = chunk.toString().trim();
       if (message) {
-        setMessages((prev) =>
-          [
-            ...prev,
-            {
-              id: randomUUID(),
-              text: message,
-              type: "log",
-              ts: Date.now(),
-            } satisfies Message,
-          ].slice(-10),
-        );
+        pushMessage(message, "log");
       }
     };
 
     const handleStderrData = (chunk: Buffer) => {
       const message = chunk.toString().trim();
       if (message) {
-        setMessages((prev) =>
-          [
-            ...prev,
-            {
-              id: randomUUID(),
-              text: message,
-              type: "error",
-              ts: Date.now(),
-            } satisfies Message,
-          ].slice(-10),
-        );
+        pushMessage(message, "error");
       }
     };
 
@@ -81,15 +61,7 @@ export function useNodemon(env: NodeJS.ProcessEnv): Array<Message> {
 
     nodemon.on("restart", (files: string[]) => {
       const restartMessage = `Server restarted due to file changes: ${files.join(", ")}`;
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: randomUUID(),
-          text: restartMessage,
-          type: "restart",
-          ts: Date.now(),
-        },
-      ]);
+      pushMessage(restartMessage, "restart");
       setupStdoutListener();
       setupStderrListener();
     });
@@ -103,7 +75,5 @@ export function useNodemon(env: NodeJS.ProcessEnv): Array<Message> {
       }
       nodemon.emit("quit");
     };
-  }, [env]);
-
-  return messages;
+  }, [env, pushMessage]);
 }

--- a/packages/core/src/cli/use-tunnel.ts
+++ b/packages/core/src/cli/use-tunnel.ts
@@ -1,15 +1,16 @@
 import { spawn } from "node:child_process";
-import { randomUUID } from "node:crypto";
 import { useEffect, useState } from "react";
-import type { Message } from "./types.js";
+import type { PushMessage } from "./use-messages.js";
 
 type TunnelState = {
   label: string;
   labelColor: "yellow" | "white" | "red";
-  logs: Message[];
 };
 
-export function useTunnel(port: number | null): TunnelState {
+export function useTunnel(
+  port: number | null,
+  pushMessage: PushMessage,
+): TunnelState {
   const [label, setLabel] = useState<{
     text: string;
     color: "yellow" | "white" | "red";
@@ -17,7 +18,6 @@ export function useTunnel(port: number | null): TunnelState {
     text: "Starting...",
     color: "yellow",
   });
-  const [logs, setLogs] = useState<Message[]>([]);
 
   useEffect(() => {
     if (port === null) {
@@ -52,17 +52,7 @@ export function useTunnel(port: number | null): TunnelState {
         second: "2-digit",
         hour12: true,
       });
-      setLogs((prev) =>
-        [
-          ...prev,
-          {
-            id: randomUUID(),
-            text: `${time} [tunnel] ${text}`,
-            type,
-            ts: Date.now(),
-          },
-        ].slice(-10),
-      );
+      pushMessage(`${time} [tunnel] ${text}`, type);
     };
 
     const handleStdout = (data: Buffer) => {
@@ -124,7 +114,7 @@ export function useTunnel(port: number | null): TunnelState {
       clearTimeout(timeout);
       tunnelProcess.kill();
     };
-  }, [port]);
+  }, [port, pushMessage]);
 
-  return { label: label.text, labelColor: label.color, logs };
+  return { label: label.text, labelColor: label.color };
 }

--- a/packages/core/src/commands/dev.tsx
+++ b/packages/core/src/commands/dev.tsx
@@ -1,8 +1,8 @@
 import { Command, Flags } from "@oclif/core";
 import { Box, render, Text } from "ink";
-import { useMemo } from "react";
 import { resolvePort } from "../cli/detect-port.js";
 import { Header } from "../cli/header.js";
+import { useMessages } from "../cli/use-messages.js";
 import { useNodemon } from "../cli/use-nodemon.js";
 import { useTunnel } from "../cli/use-tunnel.js";
 import { useTypeScriptCheck } from "../cli/use-typescript-check.js";
@@ -37,16 +37,9 @@ export default class Dev extends Command {
 
     const App = () => {
       const tsErrors = useTypeScriptCheck();
-      const nodemonMessages = useNodemon(env);
-      const tunnelState = useTunnel(flags.tunnel ? port : null);
-
-      const messages = useMemo(
-        () =>
-          [...nodemonMessages, ...tunnelState.logs]
-            .sort((a, b) => a.ts - b.ts)
-            .slice(-10),
-        [nodemonMessages, tunnelState.logs],
-      );
+      const [messages, pushMessage] = useMessages();
+      useNodemon(env, pushMessage);
+      const tunnelState = useTunnel(flags.tunnel ? port : null, pushMessage);
 
       return (
         <Box flexDirection="column" padding={1} marginLeft={1}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
@paulleseute, your PR #683 got me thinking on the API for log messages in skybridge CLI.
I've come up (with the help of my dear Cursor) with this alternative API where message display complexity is bundled in a dedicated hook exposing a push API.
Messages do not need to be sorted on each push by datetime.
It "looks" cleaner overall IMHO.

WDYT?

<div><a href="https://cursor.com/agents/bc-c0f532ec-88e5-4094-8f4f-fccdada7c18e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0f532ec-88e5-4094-8f4f-fccdada7c18e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the dev command's log handling by introducing a single shared `useMessages` hook that owns a unified message queue, replacing the per-hook state arrays and the `useMemo` merge-and-sort in `dev.tsx`. The `ts` timestamp field is removed from `Message` since natural insertion order in the shared queue now provides chronological ordering.

<h3>Confidence Score: 5/5</h3>

Safe to merge — clean refactor with no functional regressions.

The change correctly centralizes message state into a single shared hook using `useCallback` for a stable push reference and functional state updates for safe concurrent pushes. Insertion order in the shared queue correctly reflects Node.js event-loop arrival order, fixing the original chronological-ordering problem more reliably than timestamp-based sorting. No P0/P1 issues found.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix: use shared message queue for chrono..."](https://github.com/alpic-ai/skybridge/commit/f381d90089ad27e8d9b408c97787806cc943a9d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28623202)</sub>

<!-- /greptile_comment -->