### PR TITLE
chore: use x-alpic-forwarded-url for claude hash

### DIFF
--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -706,7 +706,7 @@ export class McpServer<
         let contentMetaOverrides: { domain?: string } = {};
         if (isClaude) {
           const pathname = extra?.requestInfo?.url?.pathname ?? "";
-          const url = `${serverUrl}${pathname}`;
+          const url = header("x-alpic-forwarded-url") ?? `${serverUrl}${pathname}`;
           const hash = crypto
             .createHash("sha256")
             .update(url)

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -706,7 +706,8 @@ export class McpServer<
         let contentMetaOverrides: { domain?: string } = {};
         if (isClaude) {
           const pathname = extra?.requestInfo?.url?.pathname ?? "";
-          const url = header("x-alpic-forwarded-url") ?? `${serverUrl}${pathname}`;
+          const url =
+            header("x-alpic-forwarded-url") ?? `${serverUrl}${pathname}`;
           const hash = crypto
             .createHash("sha256")
             .update(url)

--- a/packages/core/src/test/utils.ts
+++ b/packages/core/src/test/utils.ts
@@ -315,10 +315,17 @@ export function createInterfaceTestServer() {
 /**
  * Mock extra parameter for resource callback
  */
-export function createMockExtra(host: string) {
+export function createMockExtra(
+  host: string,
+  options?: {
+    headers?: Record<string, string | string[]>;
+    url?: URL | string;
+  },
+) {
   return {
     requestInfo: {
-      headers: { host },
+      headers: { host, ...(options?.headers ?? {}) },
+      ...(options?.url ? { url: options.url } : {}),
     },
   };
 }

--- a/packages/core/src/test/widget.test.ts
+++ b/packages/core/src/test/widget.test.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import type {
   ServerNotification,
@@ -195,6 +196,61 @@ describe("McpServer.registerWidget", () => {
       `${serverUrl}/assets/my-widget.js`,
     );
     expect(result.contents[0]?.text).toContain(`${serverUrl}/assets/style.css`);
+  });
+
+  it("should prefer x-alpic-forwarded-url when hashing Claude widget domains", async () => {
+    setTestEnv({ NODE_ENV: "production" });
+
+    const mockToolCallback = vi.fn();
+    server.registerWidget(
+      "my-widget",
+      { description: "Test widget" },
+      { description: "Test tool" },
+      mockToolCallback,
+    );
+
+    const extAppsResourceCallback = mockRegisterResource.mock
+      .calls[1]?.[3] as unknown as (
+      uri: URL,
+      extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
+    ) => Promise<{
+      contents: Array<{
+        uri: URL | string;
+        mimeType: string;
+        text?: string;
+        _meta?: Record<string, unknown>;
+      }>;
+    }>;
+    expect(extAppsResourceCallback).toBeDefined();
+
+    const forwardedUrl =
+      "https://everything-3a2c1264.staging.alpic.live/mcp?foo=bar";
+    const expectedDomain = `${crypto
+      .createHash("sha256")
+      .update(forwardedUrl)
+      .digest("hex")
+      .slice(0, 32)}.claudemcpcontent.com`;
+
+    const result = await extAppsResourceCallback(
+      new URL("ui://widgets/ext-apps/my-widget.html"),
+      createMockExtra("localhost:3000", {
+        headers: {
+          "user-agent": "Claude-User",
+          "x-alpic-forwarded-url": forwardedUrl,
+        },
+        url: "http://localhost:3000/mcp",
+      }) as unknown as RequestHandlerExtra<ServerRequest, ServerNotification>,
+    );
+
+    expect(result.contents[0]?._meta).toEqual({
+      ui: {
+        csp: {
+          resourceDomains: ["http://localhost:3000"],
+          connectDomains: ["http://localhost:3000"],
+        },
+        domain: expectedDomain,
+      },
+    });
   });
 
   it("should resolve folder-based widgets (barrel files) in production mode", async () => {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes the Claude widget domain hash to prefer the `x-alpic-forwarded-url` request header over the constructed `${serverUrl}${pathname}` fallback, and extends `createMockExtra` to support injecting custom headers and a `url` field for testing.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the production change is a one-liner with correct fallback, and the only finding is a P2 type looseness in test utility code.

No P0/P1 issues. The core server change correctly prefers the forwarded URL header with a sound fallback. The new test validates the happy path. The sole finding (accepting `string` for a field that needs a `URL` object) is test-only, currently harmless, and does not affect any production path.

packages/core/src/test/utils.ts — minor type looseness on the `url` option

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/core/src/test/utils.ts
Line: 322

Comment:
**`string` accepted but `.pathname` will be `undefined`**

The server accesses `extra?.requestInfo?.url?.pathname`, which is only defined on a `URL` object — plain strings have no `.pathname`. Passing a string silently produces an empty pathname (the `?? ""` fallback fires), which is the same as omitting `url` entirely. The current test is unaffected because `x-alpic-forwarded-url` takes precedence, but future tests that omit the header and pass a string URL expecting pathname-based hashing will silently get the wrong hash.

```suggestion
    url?: URL;
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: use x-alpic-forwarded-url for cla..."](https://github.com/alpic-ai/skybridge/commit/bad05f46a964d8ad6a4d7508d5342839bbe96f92) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28776771)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->