### PR TITLE
feat: make tunnel logs optional

### DIFF
--- a/packages/core/src/cli/use-tunnel.ts
+++ b/packages/core/src/cli/use-tunnel.ts
@@ -10,6 +10,7 @@ type TunnelState = {
 export function useTunnel(
   port: number | null,
   pushMessage: PushMessage,
+  verbose: boolean,
 ): TunnelState {
   const [label, setLabel] = useState<{
     text: string;
@@ -59,7 +60,9 @@ export function useTunnel(
       const lines = data.toString().trim().split("\n").filter(Boolean);
       for (const line of lines) {
         if (connected) {
-          pushLog(line, "log");
+          if (verbose) {
+            pushLog(line, "log");
+          }
         } else {
           const match = line.match(
             /Forwarding:\s+(https:\/\/\S+)\s*->\s*(\S+)/,
@@ -79,9 +82,11 @@ export function useTunnel(
       const text = data.toString().trim();
       if (text) {
         stderrBuffer = (stderrBuffer + text).slice(-1024);
-        for (const line of text.split("\n").filter(Boolean)) {
-          if (connected) {
-            pushLog(line, "error");
+        if (verbose) {
+          for (const line of text.split("\n").filter(Boolean)) {
+            if (connected) {
+              pushLog(line, "error");
+            }
           }
         }
       }
@@ -103,8 +108,11 @@ export function useTunnel(
       clearTimeout(timeout);
       if (code !== 0 && code !== null) {
         const detail = stderrBuffer.trim() || `exited with code ${code}`;
+        const hint = verbose
+          ? `Try manually: npx alpic tunnel --port ${port}`
+          : "Re-run with --verbose to see full tunnel logs";
         setLabel({
-          text: `${detail}. Try manually: npx alpic tunnel --port ${port}`,
+          text: `${detail}. ${hint}`,
           color: "red",
         });
       }
@@ -114,7 +122,7 @@ export function useTunnel(
       clearTimeout(timeout);
       tunnelProcess.kill();
     };
-  }, [port, pushMessage]);
+  }, [port, pushMessage, verbose]);
 
   return { label: label.text, labelColor: label.color };
 }

--- a/packages/core/src/commands/dev.tsx
+++ b/packages/core/src/commands/dev.tsx
@@ -20,6 +20,11 @@ export default class Dev extends Command {
       description: "Open an Alpic tunnel for remote testing",
       default: false,
     }),
+    verbose: Flags.boolean({
+      char: "v",
+      description: "Show tunnel logs",
+      default: false,
+    }),
   };
 
   public async run(): Promise<void> {
@@ -39,7 +44,11 @@ export default class Dev extends Command {
       const tsErrors = useTypeScriptCheck();
       const [messages, pushMessage] = useMessages();
       useNodemon(env, pushMessage);
-      const tunnelState = useTunnel(flags.tunnel ? port : null, pushMessage);
+      const tunnelState = useTunnel(
+        flags.tunnel ? port : null,
+        pushMessage,
+        flags.verbose,
+      );
 
       return (
         <Box flexDirection="column" padding={1} marginLeft={1}>


### PR DESCRIPTION
with the verbose flag, that can be re-used for other subsystems.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `--verbose` / `-v` flag to the `dev` command that gates tunnel log streaming. When omitted, stdout/stderr from the tunnel process are silently buffered (the buffer is still used for error details on non-zero exit), and the exit-error hint directs users to re-run with `--verbose`. The `verbose` parameter is correctly threaded through to `useTunnel` and added to the `useEffect` dependency array.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are minimal, well-scoped, and introduce no logic regressions.

Both changed files are straightforward: a new boolean parameter guards log-push calls, the stderr buffer is still populated for error reporting, the dependency array is updated correctly, and the flag is wired up cleanly in the command. No P0/P1 issues found.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["feat: make tunnel logs optional"](https://github.com/alpic-ai/skybridge/commit/4a61d13349aebe4e75d45bb2fe45f7c58946b330) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28975604)</sub>

<!-- /greptile_comment -->