### PR TITLE
feat: add dev:tunnel cmd

### DIFF
--- a/examples/auth-auth0/package.json
+++ b/examples/auth-auth0/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "skybridge dev",
+    "dev:tunnel": "skybridge dev --tunnel",
     "build": "skybridge build",
     "start": "skybridge start",
     "deploy": "alpic deploy",

--- a/examples/auth-clerk/package.json
+++ b/examples/auth-clerk/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "skybridge dev",
+    "dev:tunnel": "skybridge dev --tunnel",
     "build": "skybridge build",
     "start": "skybridge start",
     "deploy": "alpic deploy",

--- a/examples/auth-stytch/package.json
+++ b/examples/auth-stytch/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "skybridge dev",
+    "dev:tunnel": "skybridge dev --tunnel",
     "build": "skybridge build",
     "start": "skybridge start",
     "deploy": "alpic deploy",

--- a/examples/auth-workos/package.json
+++ b/examples/auth-workos/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "skybridge dev",
+    "dev:tunnel": "skybridge dev --tunnel",
     "build": "skybridge build",
     "start": "skybridge start",
     "deploy": "alpic deploy",

--- a/examples/capitals/package.json
+++ b/examples/capitals/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "skybridge dev",
+    "dev:tunnel": "skybridge dev --tunnel",
     "build": "skybridge build",
     "start": "skybridge start",
     "deploy": "alpic deploy",

--- a/examples/ecom-carousel/package.json
+++ b/examples/ecom-carousel/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "skybridge dev",
+    "dev:tunnel": "skybridge dev --tunnel",
     "build": "skybridge build",
     "start": "skybridge start",
     "deploy": "alpic deploy",

--- a/examples/everything/package.json
+++ b/examples/everything/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "skybridge dev",
+    "dev:tunnel": "skybridge dev --tunnel",
     "build": "skybridge build",
     "start": "skybridge start",
     "deploy": "alpic deploy",

--- a/examples/flight-booking/package.json
+++ b/examples/flight-booking/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "skybridge dev",
+    "dev:tunnel": "skybridge dev --tunnel",
     "build": "skybridge build",
     "start": "skybridge start",
     "deploy": "alpic deploy",

--- a/examples/generative-ui/package.json
+++ b/examples/generative-ui/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "skybridge dev",
+    "dev:tunnel": "skybridge dev --tunnel",
     "build": "skybridge build",
     "start": "skybridge start",
     "deploy": "alpic deploy",

--- a/examples/investigation-game/package.json
+++ b/examples/investigation-game/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "skybridge dev",
+    "dev:tunnel": "skybridge dev --tunnel",
     "build": "skybridge build",
     "start": "skybridge start",
     "deploy": "alpic deploy",

--- a/examples/manifest-ui/package.json
+++ b/examples/manifest-ui/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "skybridge dev",
+    "dev:tunnel": "skybridge dev --tunnel",
     "build": "skybridge build",
     "start": "skybridge start",
     "deploy": "alpic deploy",

--- a/examples/productivity/package.json
+++ b/examples/productivity/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "skybridge dev",
+    "dev:tunnel": "skybridge dev --tunnel",
     "build": "skybridge build",
     "start": "skybridge start",
     "deploy": "alpic deploy",

--- a/examples/times-up/package.json
+++ b/examples/times-up/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "skybridge dev",
+    "dev:tunnel": "skybridge dev --tunnel",
     "build": "skybridge build",
     "start": "skybridge start",
     "deploy": "alpic deploy"

--- a/packages/create-skybridge/template/package.json
+++ b/packages/create-skybridge/template/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "skybridge dev",
+    "dev:tunnel": "skybridge dev --tunnel",
     "build": "skybridge build",
     "start": "skybridge start",
     "deploy": "alpic deploy"


### PR DESCRIPTION
to make it clear it exists

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `dev:tunnel` npm script (`skybridge dev --tunnel`) to all 13 example projects and the `create-skybridge` template, making the tunnel feature more discoverable without requiring users to know the `--tunnel` flag.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely additive, identical one-line change across all files.

The change is a mechanical, uniform addition of a single convenience script to 14 package.json files. No logic, no new dependencies, no security surface — nothing to break.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["feat: add dev:tunnel cmd"](https://github.com/alpic-ai/skybridge/commit/d9dba3c0390bb9e75f104c227d84bc35aee62e9a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28976300)</sub>

<!-- /greptile_comment -->