### PR TITLE
chroe/stip slash forwarded url

### DIFF
--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -706,8 +706,11 @@ export class McpServer<
         let contentMetaOverrides: { domain?: string } = {};
         if (isClaude) {
           const pathname = extra?.requestInfo?.url?.pathname ?? "";
-          const url =
+          const rawUrl =
             header("x-alpic-forwarded-url") ?? `${serverUrl}${pathname}`;
+          // Strip a lone trailing slash so the hash matches the connector URL
+          // as registered with Claude (which has no trailing slash on bare origins).
+          const url = rawUrl.endsWith("/") ? rawUrl.slice(0, -1) : rawUrl;
           const hash = crypto
             .createHash("sha256")
             .update(url)


### PR DESCRIPTION
- **chore: use x-alpic-forwarded-url for claude hash**
- **chore: fix formatting**
- **fix: strip trailiong slash for claude connector hash**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two targeted fixes to the Claude connector hash computation in `McpServer.registerWidget`: it now reads the `x-alpic-forwarded-url` request header as the authoritative URL for hashing instead of constructing one from `serverUrl + pathname`, and strips a trailing slash from that URL before hashing to match the connector URL as registered with Claude. A new test and a `createMockExtra` helper are added to cover the forwarded-URL behaviour.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the logic change is small and correctly scoped to the Claude hash path.

The only finding is a missing test case for the trailing-slash branch (P2). No correctness or security issues were found in the implementation.

No files require special attention.

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/core/src/test/widget.test.ts`, line 201-254 ([link](https://github.com/alpic-ai/skybridge/blob/898a4d328462637962cde0f06a419b77cad31707/packages/core/src/test/widget.test.ts#L201-L254)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **No test for the trailing-slash stripping**

   The new test exercises `x-alpic-forwarded-url` preference but uses a URL without a trailing slash (`/mcp?foo=bar`), so the `rawUrl.endsWith("/")` branch in `server.ts` is never exercised. A second scenario — where the forwarded URL ends with `/` — would confirm the slash is stripped before hashing and that the resulting domain matches what Claude has registered.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/core/src/test/widget.test.ts
   Line: 201-254

   Comment:
   **No test for the trailing-slash stripping**

   The new test exercises `x-alpic-forwarded-url` preference but uses a URL without a trailing slash (`/mcp?foo=bar`), so the `rawUrl.endsWith("/")` branch in `server.ts` is never exercised. A second scenario — where the forwarded URL ends with `/` — would confirm the slash is stripped before hashing and that the resulting domain matches what Claude has registered.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/core/src/test/widget.test.ts
Line: 201-254

Comment:
**No test for the trailing-slash stripping**

The new test exercises `x-alpic-forwarded-url` preference but uses a URL without a trailing slash (`/mcp?foo=bar`), so the `rawUrl.endsWith("/")` branch in `server.ts` is never exercised. A second scenario — where the forwarded URL ends with `/` — would confirm the slash is stripped before hashing and that the resulting domain matches what Claude has registered.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: strip trailiong slash for claude co..."](https://github.com/alpic-ai/skybridge/commit/898a4d328462637962cde0f06a419b77cad31707) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28994027)</sub>

<!-- /greptile_comment -->