### PR TITLE
fix(auth-clerk): exclude openid scope from PRM to fix Clerk DCR auth

### DIFF
--- a/examples/auth-clerk/server/src/index.ts
+++ b/examples/auth-clerk/server/src/index.ts
@@ -27,7 +27,10 @@ const server = new McpServer(
   { capabilities: {} },
 )
   .use(clerkMiddleware())
-  .use("/.well-known/oauth-protected-resource", protectedResourceHandlerClerk())
+  .use(
+    "/.well-known/oauth-protected-resource",
+    protectedResourceHandlerClerk({ scopes_supported: ["profile", "email"] }),
+  )
   .use("/mcp", mcpAuthClerk)
   .registerWidget(
     "search-coffee-paris",


### PR DESCRIPTION
## Summary

- Clerk rejects the `openid` scope for dynamically registered OAuth clients (DCR)
- The MCP SDK resolves scopes in priority order: WWW-Authenticate → PRM `scopes_supported` → auth server metadata
- Since the PRM had no `scopes_supported`, the SDK fell through to Clerk's FAPI metadata which advertises `openid`, triggering the rejection
- Fix: pass `scopes_supported: ["profile", "email"]` to `protectedResourceHandlerClerk` so the SDK uses those scopes instead

Closes #694.

## Test plan

- [ ] Run the `auth-clerk` example and connect via Alpic
- [ ] Verify OAuth flow completes without `invalid_scope` error
- [ ] Verify authenticated tool calls still return user identity correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `scopes_supported: ["profile", "email"]` to the `protectedResourceHandlerClerk` call in the `auth-clerk` example to prevent the MCP SDK from falling back to Clerk's FAPI metadata (which advertises `openid`) when resolving scopes for dynamically registered OAuth clients — a scope Clerk rejects for DCR flows.

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted one-line fix in an example file with no side effects on other code paths.

The change is minimal, well-explained, and directly addresses the root cause (MCP SDK scope resolution order). No logic errors, security concerns, or regressions introduced.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["fix(auth-clerk): exclude openid scope fr..."](https://github.com/alpic-ai/skybridge/commit/9309ea28857293cbb3f2ac2495539567a03e0b67) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29008645)</sub>

<!-- /greptile_comment -->