### PR TITLE
feat: add tunnel to docs

### DIFF
--- a/docs/quickstart/create-new-app.mdx
+++ b/docs/quickstart/create-new-app.mdx
@@ -44,7 +44,6 @@ deno init --npm skybridge my-app
 
 Make sure you have:
 - **Node.js 24+**
-- **[Alpic tunnel](https://docs.alpic.ai/cli/tunnel)** for exposing your local server
 - Basic knowledge of **React** and **TypeScript**
 - Familiarity with **Zod** for schema validation (we'll use it for type-safe tool definitions)
 </Info>
@@ -95,6 +94,30 @@ When you run `skybridge`:
 3. The **MCP server** is available at `http://localhost:3000/mcp`
 4. **File watching** is enabled - changes to server code will automatically restart the server
 5. **Hot Module Reload (HMR)** is active for Widgets components - changes appear instantly in the host without reconnecting
+
+### Exposing a public URL
+
+When you need to connect a remote client like ChatGPT or Claude, pass the `--tunnel` flag:
+
+<CodeGroup>
+```bash npm
+npm run dev -- --tunnel
+```
+```bash pnpm
+pnpm dev --tunnel
+```
+```bash yarn
+yarn dev --tunnel
+```
+```bash bun
+bun dev --tunnel
+```
+```bash deno
+deno task dev --tunnel
+```
+</CodeGroup>
+
+Skybridge downloads and runs [Alpic tunnel](https://docs.alpic.ai/cli/tunnel) automatically, then prints a public `/mcp` URL and an LLM Playground `/try` URL. Add `--verbose` to stream tunnel logs.
 
 ## Next steps
 

--- a/docs/quickstart/test-your-app.mdx
+++ b/docs/quickstart/test-your-app.mdx
@@ -47,18 +47,32 @@ ChatGPT uses the Apps SDK runtime and requires a public URL to connect to your a
 
 #### 1. Expose your server
 
-ChatGPT needs a public URL to access your AI App. Use the [Alpic tunnel](https://docs.alpic.ai/cli/tunnel) to expose your local server:
+ChatGPT needs a public URL to access your AI App. Start the dev server with the `--tunnel` flag:
 
-```bash
-alpic tunnel --port 3000
+<CodeGroup>
+```bash npm
+npm run dev -- --tunnel
 ```
+```bash pnpm
+pnpm dev --tunnel
+```
+```bash yarn
+yarn dev --tunnel
+```
+```bash bun
+bun dev --tunnel
+```
+```bash deno
+deno task dev --tunnel
+```
+</CodeGroup>
 
-Copy the forwarding URL (e.g., `https://cool-marmot-fondue-420.alpic.dev`).
+Skybridge downloads and runs [Alpic tunnel](https://docs.alpic.ai/cli/tunnel) automatically, then prints a public URL (e.g., `https://cool-marmot-fondue-420.alpic.dev/mcp`).
 
 #### 2. Connect to ChatGPT
 
 1. In ChatGPT, go to **Profile → Apps → Create app**
-2. Enter your tunnel URL with `/mcp` at the end:
+2. Enter the printed `/mcp` URL:
    ```
    https://cool-marmot-fondue-420.alpic.dev/mcp
    ```
@@ -82,18 +96,32 @@ Claude uses the MCP Apps runtime and requires a public URL to connect to your ap
 
 #### 1. Expose your server
 
-Claude needs a public URL to access your AI App. Use [Alpic tunnel](https://docs.alpic.ai/cli/tunnel) to expose your local server:
+Claude needs a public URL to access your AI App. Start the dev server with the `--tunnel` flag:
 
-```bash
-alpic tunnel --port 3000
+<CodeGroup>
+```bash npm
+npm run dev -- --tunnel
 ```
+```bash pnpm
+pnpm dev --tunnel
+```
+```bash yarn
+yarn dev --tunnel
+```
+```bash bun
+bun dev --tunnel
+```
+```bash deno
+deno task dev --tunnel
+```
+</CodeGroup>
 
-Copy the forwarding URL (e.g., `https://cool-marmot-fondue-420.alpic.dev`).
+Skybridge downloads and runs [Alpic tunnel](https://docs.alpic.ai/cli/tunnel) automatically, then prints a public URL (e.g., `https://cool-marmot-fondue-420.alpic.dev/mcp`).
 
 #### 2. Connect to Claude
 
 1. In Claude, go to **Settings → Connectors → Add Custom Connector** and configure your MCP server connection
-2. Enter your App name and Alpic tunnel URL with `/mcp` at the end:
+2. Enter your App name and the printed `/mcp` URL:
    ```
    https://cool-marmot-fondue-420.alpic.dev/mcp
    ```


### PR DESCRIPTION
because it was missing

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the quickstart documentation to replace the separate `alpic tunnel` CLI step with the new built-in `--tunnel` flag for the dev server. Both `create-new-app.mdx` and `test-your-app.mdx` are updated consistently, including multi-package-manager code groups and clarified instructions for connecting ChatGPT and Claude.

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation-only changes with no logic or security implications.

All changes are documentation updates that consistently reflect the new --tunnel flag UX across both files. No code is modified and no P0/P1 issues were found.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["feat: add tunnel to docs"](https://github.com/alpic-ai/skybridge/commit/b62a016e0d7e910268c5369c7bdf86b8d526dd2c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29420300)</sub>

<!-- /greptile_comment -->