### PR TITLE
fix(devtools): persist inspector preferences across refreshes

### DIFF
--- a/packages/devtools/src/components/layout/tool-panel/openai-inspector.tsx
+++ b/packages/devtools/src/components/layout/tool-panel/openai-inspector.tsx
@@ -20,10 +20,23 @@ import {
   TabsList,
   TabsTrigger,
 } from "@/components/ui/tabs.js";
+import {
+  type InspectorPreferences,
+  useInspectorPreferencesStore,
+} from "@/lib/inspector-preferences-store.js";
 import { useSelectedTool } from "@/lib/mcp/index.js";
 import { useCallToolResult, useStore } from "@/lib/store.js";
 import { LocaleSelector } from "./locale-selector.js";
 import { ResourceTabContent } from "./resource-tab.js";
+
+const PERSISTED_KEYS = new Set<keyof InspectorPreferences>([
+  "theme",
+  "locale",
+  "displayMode",
+  "maxHeight",
+  "safeArea",
+  "userAgent",
+]);
 
 export const OpenAiInspector = () => {
   const tool = useSelectedTool();
@@ -31,6 +44,7 @@ export const OpenAiInspector = () => {
     tool.name,
   );
   const { setToolData } = useStore();
+  const setPreference = useInspectorPreferencesStore((s) => s.setPreference);
   const resourceUri = tool._meta?.["openai/outputTemplate"] as
     | string
     | undefined;
@@ -45,6 +59,12 @@ export const OpenAiInspector = () => {
           [key]: value,
         },
       });
+      if (PERSISTED_KEYS.has(key as keyof InspectorPreferences)) {
+        setPreference(
+          key as keyof InspectorPreferences,
+          value as InspectorPreferences[keyof InspectorPreferences],
+        );
+      }
     }
   };
 

--- a/packages/devtools/src/components/layout/tool-panel/openai-inspector.tsx
+++ b/packages/devtools/src/components/layout/tool-panel/openai-inspector.tsx
@@ -21,6 +21,7 @@ import {
   TabsTrigger,
 } from "@/components/ui/tabs.js";
 import {
+  defaultInspectorPreferences,
   type InspectorPreferences,
   useInspectorPreferencesStore,
 } from "@/lib/inspector-preferences-store.js";
@@ -28,15 +29,6 @@ import { useSelectedTool } from "@/lib/mcp/index.js";
 import { useCallToolResult, useStore } from "@/lib/store.js";
 import { LocaleSelector } from "./locale-selector.js";
 import { ResourceTabContent } from "./resource-tab.js";
-
-const PERSISTED_KEYS = new Set<keyof InspectorPreferences>([
-  "theme",
-  "locale",
-  "displayMode",
-  "maxHeight",
-  "safeArea",
-  "userAgent",
-]);
 
 export const OpenAiInspector = () => {
   const tool = useSelectedTool();
@@ -59,7 +51,7 @@ export const OpenAiInspector = () => {
           [key]: value,
         },
       });
-      if (PERSISTED_KEYS.has(key as keyof InspectorPreferences)) {
+      if (key in defaultInspectorPreferences) {
         setPreference(
           key as keyof InspectorPreferences,
           value as InspectorPreferences[keyof InspectorPreferences],

--- a/packages/devtools/src/lib/inspector-preferences-store.ts
+++ b/packages/devtools/src/lib/inspector-preferences-store.ts
@@ -1,0 +1,54 @@
+import type { AppsSdkContext } from "skybridge/web";
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type InspectorPreferences = Pick<
+  AppsSdkContext,
+  "theme" | "locale" | "displayMode" | "maxHeight" | "safeArea" | "userAgent"
+>;
+
+type InspectorPreferencesStore = InspectorPreferences & {
+  setPreference: <K extends keyof InspectorPreferences>(
+    key: K,
+    value: InspectorPreferences[K],
+  ) => void;
+};
+
+export const defaultInspectorPreferences: InspectorPreferences = {
+  theme: "light",
+  locale: "en-US",
+  displayMode: "inline",
+  maxHeight: undefined,
+  safeArea: {
+    insets: {
+      top: 0,
+      bottom: 0,
+      left: 0,
+      right: 0,
+    },
+  },
+  userAgent: {
+    device: { type: "desktop" },
+    capabilities: { hover: true, touch: false },
+  },
+};
+
+export const useInspectorPreferencesStore = create<InspectorPreferencesStore>()(
+  persist(
+    (set) => ({
+      ...defaultInspectorPreferences,
+      setPreference: (key, value) =>
+        set({ [key]: value } as Partial<InspectorPreferences>),
+    }),
+    {
+      name: "skybridge-devtools-inspector-preferences",
+      version: 1,
+    },
+  ),
+);
+
+export const getInspectorPreferences = (): InspectorPreferences => {
+  const { setPreference: _setPreference, ...preferences } =
+    useInspectorPreferencesStore.getState();
+  return preferences;
+};

--- a/packages/devtools/src/lib/mcp/index.ts
+++ b/packages/devtools/src/lib/mcp/index.ts
@@ -7,6 +7,7 @@ import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import type { AppsSdkContext, CallToolArgs } from "skybridge/web";
 import { useAuthStore } from "@/lib/auth-store.js";
+import { getInspectorPreferences } from "@/lib/inspector-preferences-store.js";
 import { useStore } from "@/lib/store.js";
 import { useSelectedToolName } from "../nuqs.js";
 import { queryClient } from "../query-client.js";
@@ -80,28 +81,16 @@ export async function logout(): Promise<void> {
   queryClient.invalidateQueries({ queryKey: ["list-tools"] });
 }
 
-const defaultOpenaiObject: AppsSdkContext = {
-  theme: "light",
-  userAgent: {
-    device: { type: "desktop" },
-    capabilities: { hover: true, touch: false },
-  },
-  locale: "en-US",
-  maxHeight: undefined,
-  displayMode: "inline",
-  safeArea: {
-    insets: {
-      top: 0,
-      bottom: 0,
-      left: 0,
-      right: 0,
-    },
-  },
-  toolInput: {},
-  toolOutput: null,
-  toolResponseMetadata: null,
-  view: { mode: "inline" },
-  widgetState: null,
+const buildInitialOpenaiObject = (): AppsSdkContext => {
+  const preferences = getInspectorPreferences();
+  return {
+    ...preferences,
+    view: { mode: preferences.displayMode },
+    toolInput: {},
+    toolOutput: null,
+    toolResponseMetadata: null,
+    widgetState: null,
+  };
 };
 
 export const useSuspenseTools = () => {
@@ -146,7 +135,7 @@ export const useCallTool = () => {
         openaiRef: null,
         openaiLogs: [],
         openaiObject: {
-          ...defaultOpenaiObject,
+          ...buildInitialOpenaiObject(),
           toolInput: args ?? {},
           toolOutput: response.structuredContent,
           toolResponseMetadata: response.meta ?? null,


### PR DESCRIPTION
## Summary

- Adds a zustand `persist` store (`inspector-preferences-store.ts`) that keeps inspector settings in `localStorage`: theme, locale, display mode, max height, safe area insets, device type, and capabilities.
- Seeds each new `openaiObject` (on tool calls) from the persisted store so the chosen device / theme / etc. stick across refreshes and tool re-runs.
- Writes updates from the OpenAI inspector UI back into the store for the subset of keys that should be remembered (mutation of tool-derived fields like `widgetState` is unaffected).

Panel resizing was already persisted via `react-resizable-panels`' `useDefaultLayout({ storage: localStorage })` — this PR covers the remaining inspector settings that were resetting on every refresh and every tool call.

Fixes #702

## Test plan

- [ ] Change theme / device / locale / display mode / max height / safe area in the inspector
- [ ] Trigger another tool call — settings stay the same
- [ ] Refresh the page — settings stay the same
- [ ] Clear `localStorage` key `skybridge-devtools-inspector-preferences` — defaults restore on next load

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a zustand `persist` store (`inspector-preferences-store.ts`) to keep inspector settings (theme, locale, displayMode, maxHeight, safeArea, userAgent) in `localStorage`, and seeds each new `openaiObject` from those persisted values instead of a hard-coded static default. The implementation is straightforward and the previous thread comments on `PERSISTED_KEYS` → `key in defaultInspectorPreferences` and the missing `migrate` function have already been incorporated or flagged.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no P0 or P1 issues introduced; the implementation is correct and well-scoped.

All changes are additive and isolated to the devtools package. The logic for seeding openaiObject from persisted preferences and writing back on change is correct. The previous thread comments (PERSISTED_KEYS / migrate) have already been flagged; no new P0/P1 issues are present.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["refactor: use in-operator check instead ..."](https://github.com/alpic-ai/skybridge/commit/a29aa1029000f844d5a93b1c3c203a2b0c3a25d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29591171)</sub>

<!-- /greptile_comment -->