### PR TITLE
fix: release port on SIGTERM/SIGINT in McpServer.run()

### DIFF
--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -434,7 +434,7 @@ export class McpServer<
     }
 
     httpServer.on("request", this.express);
-    return new Promise((resolve, reject) => {
+    await new Promise<void>((resolve, reject) => {
       httpServer.on("error", (error: Error) => {
         console.error("Failed to start server:", error);
         reject(error);
@@ -444,6 +444,15 @@ export class McpServer<
         resolve();
       });
     });
+
+    const shutdown = () => {
+      httpServer.close(() => process.exit(0));
+      // Force exit if connections don't drain in time so the port is still
+      // released promptly (e.g. for nodemon restarts).
+      setTimeout(() => process.exit(1), 3000).unref();
+    };
+    process.once("SIGTERM", shutdown);
+    process.once("SIGINT", shutdown);
   }
 
   registerWidget<

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -446,13 +446,17 @@ export class McpServer<
     });
 
     const shutdown = () => {
+      // Drop both handlers so a second signal falls through to Node's default
+      // (force-quit on a second Ctrl+C while drain is hanging).
+      process.off("SIGTERM", shutdown);
+      process.off("SIGINT", shutdown);
       httpServer.close(() => process.exit(0));
       // Force exit if connections don't drain in time so the port is still
       // released promptly (e.g. for nodemon restarts).
-      setTimeout(() => process.exit(1), 3000).unref();
+      setTimeout(() => process.exit(0), 3000).unref();
     };
-    process.once("SIGTERM", shutdown);
-    process.once("SIGINT", shutdown);
+    process.on("SIGTERM", shutdown);
+    process.on("SIGINT", shutdown);
   }
 
   registerWidget<


### PR DESCRIPTION
Restarting via nodemon (or any process manager that sends SIGTERM) leaves the port held because McpServer.run() never closes the HTTP server before the process exits, so the next start fails with EADDRINUSE. Folks have been working around it with signal: SIGKILL in nodemon.json, which is brittle and shouldn't be necessary.

The fix registers SIGTERM/SIGINT handlers inside run() that call httpServer.close() so in-flight requests drain and the port is released cleanly. A 3s setTimeout falls through to a hard exit if connections don't drain in time, the fallback timer is unref'd so it doesn't keep the loop alive on its own, and handlers are registered with process.once so a second signal falls through to Node's default terminate (force-quit on a second Ctrl+C).

Closes [SKY-226.](https://github.com/alpic-ai/skybridge/issues/481)