### PR TITLE
Update skill to improve data-llm and useWidgetState usage

### DIFF
--- a/skills/chatgpt-app-builder/references/state-and-context.md
+++ b/skills/chatgpt-app-builder/references/state-and-context.md
@@ -93,12 +93,30 @@ const [selected, setSelected] = useState(null);
 const [{ selected }, setState] = useWidgetState({ selected: null });
 ```
 
+Rule of thumb:
+- useWidgetState for data that needs to persist
+- useState for data that is ephemeral (e.g. ui state, animation)
+
 ```tsx
 // DON'T: Complex object in data-llm
 <div data-llm={JSON.stringify(cart)}>
 
 // DO: Human-readable summary
 <div data-llm={`Cart: ${cart.length} items, $${total}`}>
+```
+
+```tsx
+// DON'T: data-llm on every item in a list
+{products.map(product => (
+  <div key={product.id} data-llm={`Product: ${product.name}`}>
+    <ProductCard product={product} />
+  </div>
+))}
+
+// DO: One data-llm on the parent summarising the list
+<div data-llm={`Browsing ${products.length} products`}>
+  {products.map(product => <ProductCard key={product.id} product={product} />)}
+</div>
 ```
 
 ## Combined example


### PR DESCRIPTION
Adds usage precision in the skill around data-llm and useWidgetState

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates `skills/chatgpt-app-builder/references/state-and-context.md` with two additions: a short rule-of-thumb bullet list clarifying when to use `useWidgetState` versus `useState`, and a new DON'T/DO example showing that `data-llm` should be placed on a single parent element summarising a list rather than on each individual item. The guidance is accurate and aligns with the rest of the document.

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation-only change with no runtime impact.

Only a single markdown file is modified with no code logic changes. The one finding is a P2 style nit (missing backticks on API names in the new bullets), which does not block merging.

No files require special attention.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: skills/chatgpt-app-builder/references/state-and-context.md
Line: 97-98

Comment:
**Inconsistent code formatting in rule-of-thumb bullets**

`useWidgetState` and `useState` are rendered as plain text here, while every other mention in the document wraps them in backticks. "ui state" should also be capitalised to "UI state" for consistency.

```suggestion
- `useWidgetState` for data that needs to persist
- `useState` for data that is ephemeral (e.g. UI state, animation)
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Update skill to fix hanh feedback"](https://github.com/alpic-ai/skybridge/commit/44248b21a977dc00e6d9b2c2cc40dc3cb567e980) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30036661)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->