### PR TITLE
fix: version view resource URIs with bundle content hash

### DIFF
--- a/packages/core/src/commands/build.tsx
+++ b/packages/core/src/commands/build.tsx
@@ -43,7 +43,7 @@ export const commandSteps: CommandStep[] = [
   {
     label: "Compiling server",
     run: () => rmSync("dist", { recursive: true, force: true }),
-    command: "tsc -b",
+    command: "tsc -b --force",
   },
   {
     label: "Building views",

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -506,10 +506,15 @@ export class McpServer<
   ): void {
     const hosts = view.hosts ?? (["apps-sdk", "mcp-app"] as const);
 
+    // Append a content-derived version param so hosts (e.g. ChatGPT) bust
+    // their cache when the bundle changes, but keep the URI stable across
+    // `tools/list` calls when the bundle hasn't changed.
+    const versionParam = this.computeViewVersionParam(view.component);
+
     if (hosts.includes("apps-sdk")) {
       const viewResource: ViewResourceConfig<OpenaiResourceMeta> = {
         hostType: "apps-sdk",
-        uri: `ui://widgets/apps-sdk/${view.component}.html`,
+        uri: `ui://widgets/apps-sdk/${view.component}.html${versionParam}`,
         mimeType: "text/html+skybridge",
         buildContentMeta: (
           { resourceDomains, connectDomains, domain },
@@ -563,7 +568,7 @@ export class McpServer<
     if (hosts.includes("mcp-app")) {
       const viewResource: ViewResourceConfig<McpAppsResourceMeta> = {
         hostType: "mcp-app",
-        uri: `ui://widgets/ext-apps/${view.component}.html`,
+        uri: `ui://widgets/ext-apps/${view.component}.html${versionParam}`,
         mimeType: "text/html;profile=mcp-app",
         buildContentMeta: (
           { resourceDomains, connectDomains, domain, baseUriDomains },
@@ -749,6 +754,26 @@ export class McpServer<
         }),
       };
     };
+  }
+
+  private computeViewVersionParam(viewName: string): string {
+    if (process.env.NODE_ENV !== "production") {
+      return "";
+    }
+    try {
+      const viewFile = this.lookupViewFile(viewName);
+      const styleFile = this.lookupDistFile("style.css") ?? "";
+      const hash = crypto
+        .createHash("sha256")
+        .update(viewFile)
+        .update("\0")
+        .update(styleFile)
+        .digest("hex")
+        .slice(0, 8);
+      return `?v=${hash}`;
+    } catch {
+      return "";
+    }
   }
 
   private lookupViewFile(viewName: string) {

--- a/packages/core/src/test/view.test.ts
+++ b/packages/core/src/test/view.test.ts
@@ -35,6 +35,19 @@ const mockManifest = {
   "style.css": { file: "style.css" },
 };
 
+// Mirrors `McpServer.computeViewVersionParam`. Tests recompute the expected
+// hash from the mocked manifest so they don't hardcode digest output.
+function expectedVersionParam(viewFile: string, styleFile: string): string {
+  const hash = crypto
+    .createHash("sha256")
+    .update(viewFile)
+    .update("\0")
+    .update(styleFile)
+    .digest("hex")
+    .slice(0, 8);
+  return `?v=${hash}`;
+}
+
 const actual = vi.hoisted(() => require("node:fs"));
 
 vi.mock("node:fs", () => {
@@ -168,15 +181,16 @@ describe("McpServer.registerTool (unified API)", () => {
       ServerRequest,
       ServerNotification
     >;
+    const versionedUri = `ui://widgets/apps-sdk/my-widget.html${expectedVersionParam("assets/my-widget-abc123.js", "style.css")}`;
     const result = await appsSdkResourceCallback(
-      new URL("ui://widgets/apps-sdk/my-widget.html"),
+      new URL(versionedUri),
       mockExtra,
     );
 
     expect(result).toEqual({
       contents: [
         {
-          uri: "ui://widgets/apps-sdk/my-widget.html",
+          uri: versionedUri,
           mimeType: "text/html+skybridge",
           text: expect.stringContaining('<div id="root"></div>'),
           _meta: {
@@ -236,7 +250,9 @@ describe("McpServer.registerTool (unified API)", () => {
       .slice(0, 32)}.claudemcpcontent.com`;
 
     const result = await extAppsResourceCallback(
-      new URL("ui://widgets/ext-apps/my-widget.html"),
+      new URL(
+        `ui://widgets/ext-apps/my-widget.html${expectedVersionParam("assets/my-widget-abc123.js", "style.css")}`,
+      ),
       createMockExtra("localhost:3000", {
         headers: {
           "user-agent": "Claude-User",
@@ -407,6 +423,122 @@ describe("McpServer.registerTool (unified API)", () => {
     expect(toolConfig._meta).not.toHaveProperty("ui");
     expect(toolConfig._meta?.["openai/outputTemplate"]).toBe(
       "ui://widgets/apps-sdk/my-widget.html",
+    );
+  });
+
+  it("should not version view URIs in development", () => {
+    server.registerTool(
+      {
+        name: "my-widget",
+        description: "Test tool",
+        view: { component: "my-widget", description: "Test view" },
+      },
+      vi.fn(),
+    );
+
+    const toolConfig = mockRegisterTool.mock.calls[0]?.[1] as {
+      _meta?: Record<string, unknown> & { ui?: { resourceUri?: string } };
+    };
+
+    expect(toolConfig._meta?.["openai/outputTemplate"]).toBe(
+      "ui://widgets/apps-sdk/my-widget.html",
+    );
+    expect(toolConfig._meta?.ui?.resourceUri).toBe(
+      "ui://widgets/ext-apps/my-widget.html",
+    );
+    // The URI registered with the resource handler must match the URI in
+    // outputTemplate exactly so the SDK can resolve `resources/read` requests.
+    expect(mockRegisterResource.mock.calls[0]?.[1]).toBe(
+      "ui://widgets/apps-sdk/my-widget.html",
+    );
+    expect(mockRegisterResource.mock.calls[1]?.[1]).toBe(
+      "ui://widgets/ext-apps/my-widget.html",
+    );
+  });
+
+  it("should append a stable content hash to view URIs in production", () => {
+    setTestEnv({ NODE_ENV: "production" });
+
+    server.registerTool(
+      {
+        name: "my-widget",
+        description: "Test tool",
+        view: { component: "my-widget", description: "Test view" },
+      },
+      vi.fn(),
+    );
+
+    const expected = expectedVersionParam(
+      "assets/my-widget-abc123.js",
+      "style.css",
+    );
+    const toolConfig = mockRegisterTool.mock.calls[0]?.[1] as {
+      _meta?: Record<string, unknown> & { ui?: { resourceUri?: string } };
+    };
+
+    expect(toolConfig._meta?.["openai/outputTemplate"]).toBe(
+      `ui://widgets/apps-sdk/my-widget.html${expected}`,
+    );
+    expect(toolConfig._meta?.ui?.resourceUri).toBe(
+      `ui://widgets/ext-apps/my-widget.html${expected}`,
+    );
+    expect(mockRegisterResource.mock.calls[0]?.[1]).toBe(
+      `ui://widgets/apps-sdk/my-widget.html${expected}`,
+    );
+    expect(mockRegisterResource.mock.calls[1]?.[1]).toBe(
+      `ui://widgets/ext-apps/my-widget.html${expected}`,
+    );
+  });
+
+  it("should produce different version params for views with different bundles", () => {
+    setTestEnv({ NODE_ENV: "production" });
+
+    server.registerTool(
+      {
+        name: "my-widget",
+        description: "First tool",
+        view: { component: "my-widget" },
+      },
+      vi.fn(),
+    );
+    server.registerTool(
+      {
+        name: "folder-widget",
+        description: "Second tool",
+        view: { component: "folder-widget" },
+      },
+      vi.fn(),
+    );
+
+    const myWidgetTemplate = (
+      mockRegisterTool.mock.calls[0]?.[1] as { _meta?: Record<string, unknown> }
+    )._meta?.["openai/outputTemplate"];
+    const folderWidgetTemplate = (
+      mockRegisterTool.mock.calls[1]?.[1] as { _meta?: Record<string, unknown> }
+    )._meta?.["openai/outputTemplate"];
+
+    expect(myWidgetTemplate).not.toEqual(folderWidgetTemplate);
+    expect(myWidgetTemplate).toMatch(/\?v=[0-9a-f]{8}$/);
+    expect(folderWidgetTemplate).toMatch(/\?v=[0-9a-f]{8}$/);
+  });
+
+  it("should fall back to bare URI in production when manifest is missing", () => {
+    setTestEnv({ NODE_ENV: "production" });
+
+    server.registerTool(
+      {
+        name: "unknown-widget",
+        description: "Test tool",
+        view: { component: "unknown-widget" },
+      },
+      vi.fn(),
+    );
+
+    const toolConfig = mockRegisterTool.mock.calls[0]?.[1] as {
+      _meta?: Record<string, unknown>;
+    };
+    expect(toolConfig._meta?.["openai/outputTemplate"]).toBe(
+      "ui://widgets/apps-sdk/unknown-widget.html",
     );
   });
 


### PR DESCRIPTION
ChatGPT keeps serving the old widget after a redeploy because the resource URI never changes. Fix: append a ?v=<hash> derived from the Vite manifest's view file + style.css to apps-sdk and mcp-app URIs in production. Bundle changes -> hash changes -> cache busts; otherwise stable so tools/list polls don't invalidate.

Drive-by: skybridge build now uses tsc -b --force, since rmSync("dist") left tsconfig.tsbuildinfo behind and a second build silently emitted nothing.

Resolves https://github.com/alpic-ai/skybridge/issues/530