### PR TITLE
fix: log error when view is missing default export

### DIFF
--- a/packages/core/src/web/plugin/plugin.ts
+++ b/packages/core/src/web/plugin/plugin.ts
@@ -1,6 +1,7 @@
 import { isAbsolute, relative, resolve } from "node:path";
 import type { Plugin, ViteDevServer } from "vite";
 import {
+  assertUniqueViewNames,
   type DiscoveredView,
   discoverViewsSync,
   scanViewsSync,
@@ -145,7 +146,7 @@ export function skybridge(options?: SkybridgePluginOptions): Plugin {
           // Surface broken view files. Without this, files lacking a
           // default export are silently dropped from the input and the
           // user has no idea why their widget never mounts.
-          const { invalid } = scanViewsSync(resolvedViewsDir);
+          const { valid, invalid } = scanViewsSync(resolvedViewsDir);
           const nextInvalid = new Set(invalid.map((v) => v.filePath));
 
           for (const filePath of nextInvalid) {
@@ -164,11 +165,11 @@ export function skybridge(options?: SkybridgePluginOptions): Plugin {
           }
           knownInvalid = nextInvalid;
 
-          const views = discoverViewsSync(resolvedViewsDir);
-          viewMap = new Map(views.map((v) => [v.name, v]));
-          writeViewsDts(projectRoot, views);
+          assertUniqueViewNames(valid);
+          viewMap = new Map(valid.map((v) => [v.name, v]));
+          writeViewsDts(projectRoot, valid);
         } catch (err) {
-          // discoverViewsSync throws on duplicate view names. Catch so
+          // assertUniqueViewNames throws on duplicate view names. Catch so
           // chokidar's listener chain doesn't surface it as unhandled and
           // crash the dev server — previous viewMap stays active until
           // the user fixes the conflict.

--- a/packages/core/src/web/plugin/plugin.ts
+++ b/packages/core/src/web/plugin/plugin.ts
@@ -1,8 +1,9 @@
-import { isAbsolute, resolve } from "node:path";
+import { isAbsolute, relative, resolve } from "node:path";
 import type { Plugin, ViteDevServer } from "vite";
 import {
   type DiscoveredView,
   discoverViewsSync,
+  scanViewsSync,
   writeViewsDts,
 } from "./scan-views.js";
 import { transform as dataLlmTransform } from "./transform-data-llm.js";
@@ -136,8 +137,33 @@ export function skybridge(options?: SkybridgePluginOptions): Plugin {
       }
 
       server.watcher.add(resolvedViewsDir);
+      // Track which view files we've already warned about so a rescan
+      // triggered by an unrelated edit doesn't re-emit the same warning.
+      let knownInvalid = new Set<string>();
       const rescan = () => {
         try {
+          // Surface broken view files. Without this, files lacking a
+          // default export are silently dropped from the input and the
+          // user has no idea why their widget never mounts.
+          const { invalid } = scanViewsSync(resolvedViewsDir);
+          const nextInvalid = new Set(invalid.map((v) => v.filePath));
+
+          for (const filePath of nextInvalid) {
+            if (!knownInvalid.has(filePath)) {
+              server.config.logger.warn(
+                `[skybridge] view file "${relative(projectRoot, filePath)}" is missing a default export — it won't be served until fixed.`,
+              );
+            }
+          }
+          for (const filePath of knownInvalid) {
+            if (!nextInvalid.has(filePath)) {
+              server.config.logger.info(
+                `[skybridge] view file "${relative(projectRoot, filePath)}" resolved.`,
+              );
+            }
+          }
+          knownInvalid = nextInvalid;
+
           const views = discoverViewsSync(resolvedViewsDir);
           viewMap = new Map(views.map((v) => [v.name, v]));
           writeViewsDts(projectRoot, views);
@@ -153,7 +179,10 @@ export function skybridge(options?: SkybridgePluginOptions): Plugin {
         }
       };
 
+      // Initial scan emits warnings for broken files that exist at startup.
+      rescan();
       server.watcher.on("add", rescan);
+      server.watcher.on("change", rescan);
       server.watcher.on("unlink", rescan);
     },
 

--- a/packages/core/src/web/plugin/scan-views.test.ts
+++ b/packages/core/src/web/plugin/scan-views.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   discoverViewsSync,
   scanAndWriteViewsDts,
+  scanViewsSync,
   writeViewsDts,
 } from "./scan-views.js";
 
@@ -51,6 +52,69 @@ describe("discoverViewsSync", () => {
     expect(() => discoverViewsSync(viewsDir)).toThrow(
       /duplicate view name "dup"/,
     );
+  });
+});
+
+describe("scanViewsSync", () => {
+  let root: string;
+  let viewsDir: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "skybridge-scan-views-"));
+    viewsDir = join(root, "views");
+    mkdirSync(viewsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("returns valid and invalid views from a flat layout", () => {
+    writeFileSync(join(viewsDir, "ok.tsx"), DEFAULT_EXPORT);
+    writeFileSync(
+      join(viewsDir, "broken.tsx"),
+      "export const Foo = () => null;",
+    );
+
+    const { valid, invalid } = scanViewsSync(viewsDir);
+
+    expect(valid.map((v) => v.name).sort()).toEqual(["ok"]);
+    expect(invalid).toEqual([
+      {
+        filePath: join(viewsDir, "broken.tsx"),
+        reason: "missing-default-export",
+      },
+    ]);
+  });
+
+  it("flags an index file in a view dir that lacks a default export", () => {
+    mkdirSync(join(viewsDir, "broken"));
+    writeFileSync(
+      join(viewsDir, "broken/index.tsx"),
+      "export const Foo = () => null;",
+    );
+
+    const { valid, invalid } = scanViewsSync(viewsDir);
+
+    expect(valid).toEqual([]);
+    expect(invalid).toEqual([
+      {
+        filePath: join(viewsDir, "broken/index.tsx"),
+        reason: "missing-default-export",
+      },
+    ]);
+  });
+
+  it("ignores top-level index.tsx (treated as a barrel, not a view)", () => {
+    writeFileSync(
+      join(viewsDir, "index.tsx"),
+      "export const Foo = () => null;",
+    );
+
+    const { valid, invalid } = scanViewsSync(viewsDir);
+
+    expect(valid).toEqual([]);
+    expect(invalid).toEqual([]);
   });
 });
 

--- a/packages/core/src/web/plugin/scan-views.test.ts
+++ b/packages/core/src/web/plugin/scan-views.test.ts
@@ -79,12 +79,7 @@ describe("scanViewsSync", () => {
     const { valid, invalid } = scanViewsSync(viewsDir);
 
     expect(valid.map((v) => v.name).sort()).toEqual(["ok"]);
-    expect(invalid).toEqual([
-      {
-        filePath: join(viewsDir, "broken.tsx"),
-        reason: "missing-default-export",
-      },
-    ]);
+    expect(invalid).toEqual([{ filePath: join(viewsDir, "broken.tsx") }]);
   });
 
   it("flags an index file in a view dir that lacks a default export", () => {
@@ -97,12 +92,7 @@ describe("scanViewsSync", () => {
     const { valid, invalid } = scanViewsSync(viewsDir);
 
     expect(valid).toEqual([]);
-    expect(invalid).toEqual([
-      {
-        filePath: join(viewsDir, "broken/index.tsx"),
-        reason: "missing-default-export",
-      },
-    ]);
+    expect(invalid).toEqual([{ filePath: join(viewsDir, "broken/index.tsx") }]);
   });
 
   it("ignores top-level index.tsx (treated as a barrel, not a view)", () => {

--- a/packages/core/src/web/plugin/scan-views.ts
+++ b/packages/core/src/web/plugin/scan-views.ts
@@ -7,7 +7,14 @@ export interface DiscoveredView {
   filePath: string;
 }
 
-export function discoverViewsSync(viewsDir: string): DiscoveredView[] {
+export interface InvalidView {
+  filePath: string;
+}
+
+export function scanViewsSync(viewsDir: string): {
+  valid: DiscoveredView[];
+  invalid: InvalidView[];
+} {
   const flatPattern = resolve(viewsDir, "*.{tsx,jsx}");
   const dirPattern = resolve(viewsDir, "*/index.{tsx,jsx}");
 
@@ -21,17 +28,34 @@ export function discoverViewsSync(viewsDir: string): DiscoveredView[] {
     filePath: file,
   }));
 
-  // Filter first, then check duplicates — so a barrel file like
-  // `views/foo/index.tsx` (no default export) doesn't falsely collide with
-  // a sibling view at `views/foo.tsx`.
-  const views = [...flatFiles, ...dirFiles]
-    .filter((v) => v.name !== "index")
-    .filter((v) =>
-      hasDefaultExport(readFileSync(v.filePath, "utf-8"), v.filePath),
-    );
+  // A barrel file like `views/foo/index.tsx` (no default export) must not
+  // falsely collide with a sibling `views/foo.tsx`. Drop top-level `index`
+  // before splitting valid vs invalid.
+  const candidates = [...flatFiles, ...dirFiles].filter(
+    (v) => v.name !== "index",
+  );
+
+  const valid: DiscoveredView[] = [];
+  const invalid: InvalidView[] = [];
+  for (const candidate of candidates) {
+    const code = readFileSync(candidate.filePath, "utf-8");
+    if (hasDefaultExport(code, candidate.filePath)) {
+      valid.push(candidate);
+    } else {
+      invalid.push({
+        filePath: candidate.filePath,
+      });
+    }
+  }
+
+  return { valid, invalid };
+}
+
+export function discoverViewsSync(viewsDir: string): DiscoveredView[] {
+  const { valid } = scanViewsSync(viewsDir);
 
   const nameMap = new Map<string, string[]>();
-  for (const view of views) {
+  for (const view of valid) {
     const paths = nameMap.get(view.name) ?? [];
     paths.push(view.filePath);
     nameMap.set(view.name, paths);
@@ -45,7 +69,7 @@ export function discoverViewsSync(viewsDir: string): DiscoveredView[] {
     }
   }
 
-  return views;
+  return valid;
 }
 
 export function generateViewsDts(views: DiscoveredView[]): string {

--- a/packages/core/src/web/plugin/scan-views.ts
+++ b/packages/core/src/web/plugin/scan-views.ts
@@ -51,11 +51,9 @@ export function scanViewsSync(viewsDir: string): {
   return { valid, invalid };
 }
 
-export function discoverViewsSync(viewsDir: string): DiscoveredView[] {
-  const { valid } = scanViewsSync(viewsDir);
-
+export function assertUniqueViewNames(views: DiscoveredView[]): void {
   const nameMap = new Map<string, string[]>();
-  for (const view of valid) {
+  for (const view of views) {
     const paths = nameMap.get(view.name) ?? [];
     paths.push(view.filePath);
     nameMap.set(view.name, paths);
@@ -68,7 +66,11 @@ export function discoverViewsSync(viewsDir: string): DiscoveredView[] {
       );
     }
   }
+}
 
+export function discoverViewsSync(viewsDir: string): DiscoveredView[] {
+  const { valid } = scanViewsSync(viewsDir);
+  assertUniqueViewNames(valid);
   return valid;
 }
 


### PR DESCRIPTION
if a view file under src/views is missing `export default`, skybridge dev silently drops it — your widget never mounts and no log tells you why. the existing this.warn() in the vite plugin lives in the transform hook, which never fires for these files because they're filtered out of the entry list before transform runs.

fix: emit a logger.warn from the plugin's rescan path. dedupe so a rescan triggered by an unrelated edit doesn't re-spam, and log a "resolved" line when the file comes back. covers initial scan + add/change/unlink.

considered a fancier route (react hook + ink panel + chokidar in the parent cli) but it's a lot of plumbing for one log line.

Closes https://github.com/alpic-ai/skybridge/issues/534

<img width="932" height="235" alt="Screenshot 2026-04-29 at 10 23 08" src="https://github.com/user-attachments/assets/5d821d94-6632-4b16-8e84-442713978812" />