### PR TITLE
feat: Adapt skill to new api

### DIFF
--- a/skills/chatgpt-app-builder/evals/fetch-and-render-data.json
+++ b/skills/chatgpt-app-builder/evals/fetch-and-render-data.json
@@ -1,18 +1,18 @@
 [
   {
     "query": "I'm building a restaurant finder. Users search by cuisine and location, browse restaurants with photos, and reserve a table. Show me the code.",
-    "expected_behavior": "Server: registerView('search-restaurants') with inputSchema {cuisine, location}, returns structuredContent {restaurants[]}, _meta {images[]} for photos. registerTool('make-reservation') with inputSchema {restaurantId, partySize, date}. UI: useToolInfo<'search-restaurants'>() for input/output/responseMetadata, useCallTool('make-reservation') for Reserve button."
+    "expected_behavior": "Server: registerTool('search-restaurants') with view, inputSchema {cuisine, location}, returns structuredContent {restaurants[]}, _meta {images[]} for photos. registerTool('make-reservation') with inputSchema {restaurantId, partySize, date}. UI: useToolInfo<'search-restaurants'>() for input/output/responseMetadata, useCallTool('make-reservation') for Reserve button."
   },
   {
     "query": "I want a product catalog where users browse by category and see product cards with thumbnails. They can add items to cart and then generate a checkout session.",
-    "expected_behavior": "Server: registerView returns structuredContent {products[]} with id/name/price, _meta {thumbnails[]} to hide images from LLM. registerTool('create-checkout'). UI: useToolInfo with responseMetadata.thumbnails for images, useCallTool for Checkout button."
+    "expected_behavior": "Server: registerTool with view returns structuredContent {products[]} with id/name/price, _meta {thumbnails[]} to hide images from LLM. registerTool('create-checkout'). UI: useToolInfo with responseMetadata.thumbnails for images, useCallTool for Checkout button."
   },
   {
     "query": "I need weather functionality. Users ask about weather in any city and can set temperature alerts. No visual UI needed.",
-    "expected_behavior": "Server: Two registerTool calls only (get-weather, set-alert). No registerView since output is conversational text. Returns content array for LLM. No UI components needed."
+    "expected_behavior": "Server: Two registerTool calls only (get-weather, set-alert). No view since output is conversational text. Returns content array for LLM. No UI components needed."
   },
   {
     "query": "Building a job board. Users search jobs by keywords and location, see listings with salary info, and apply with one click. Show loading state while searching.",
-    "expected_behavior": "Server: registerView('search-jobs') with inputSchema {keywords, location}, registerTool('apply-job'). UI: useToolInfo<'search-jobs'>() with isPending for loading state, useCallTool('apply-job') with jobId on Apply button."
+    "expected_behavior": "Server: registerTool('search-jobs') with view, inputSchema {keywords, location}, registerTool('apply-job'). UI: useToolInfo<'search-jobs'>() with isPending for loading state, useCallTool('apply-job') with jobId on Apply button."
   }
 ]

--- a/skills/chatgpt-app-builder/evals/open-external-links.json
+++ b/skills/chatgpt-app-builder/evals/open-external-links.json
@@ -9,6 +9,6 @@
   },
   {
     "query": "When users click 'Book Now' it should redirect to our booking site without any confirmation popup.",
-    "expected_behavior": "Uses useOpenExternal for the redirect. Whitelist domain in server view definition using _meta.ui.csp.redirectDomains array to skip confirmation."
+    "expected_behavior": "Uses useOpenExternal for the redirect. Whitelist domain in server view definition using view.csp.redirectDomains array to skip confirmation."
   }
 ]

--- a/skills/chatgpt-app-builder/references/csp.md
+++ b/skills/chatgpt-app-builder/references/csp.md
@@ -1,6 +1,6 @@
 # Content Security Policy
 
-Views run in sandboxed iframes with strict CSP. Whitelist external domains in view definition `_meta.ui.csp`:
+Views run in sandboxed iframes with strict CSP. Whitelist external domains on the tool's `view.csp`:
 
 | Property | Purpose |
 |----------|---------|
@@ -10,23 +10,22 @@ Views run in sandboxed iframes with strict CSP. Whitelist external domains in vi
 | `frameDomains` | (optional) Iframe embeds — triggers stricter review |
 
 ```typescript
-server.registerView(
-  "search-flights",
+server.registerTool(
   {
+    name: "search-flights",
     description: "Search flights",
-    _meta: {
-      ui: {
-        csp: {
-          connectDomains: ["https://api.example.com"],
-          resourceDomains: ["https://cdn.example.com"],
-          frameDomains: ["https://maps.example.com"],
-          redirectDomains: ["https://checkout.example.com"],
-        },
+    inputSchema: { ... },
+    view: {
+      component: "search-flights",
+      csp: {
+        connectDomains: ["https://api.example.com"],
+        resourceDomains: ["https://cdn.example.com"],
+        frameDomains: ["https://maps.example.com"],
+        redirectDomains: ["https://checkout.example.com"],
       },
     },
   },
-  { inputSchema: { ... } },
-  async (input) => ({ ... })
+  async (input) => ({ ... }),
 );
 ```
 

--- a/skills/chatgpt-app-builder/references/fetch-and-render-data.md
+++ b/skills/chatgpt-app-builder/references/fetch-and-render-data.md
@@ -45,12 +45,13 @@ const server = new McpServer(
   { name: "my-app", version: "0.0.1" },
   { capabilities: {} },
 )
-  .registerView(
-    "search-flights",
-    { description: "Search for flights" },
+  .registerTool(
     {
+      name: "search-flights",
+      description: "Search for flights",
       inputSchema: { destination: z.string(), dates: z.string() },
       annotations: { readOnlyHint: true, openWorldHint: false, destructiveHint: false },
+      view: { component: "search-flights" },
     },
     async ({ destination, dates }) => {
       const flights = await fetchFlights(destination, dates);
@@ -65,11 +66,11 @@ const server = new McpServer(
         content: [{ type: "text", text: `Found ${flights.length} flights.` }],
         _meta // mind the underscore prefix
       };
-    }
+    },
   )
   .registerTool(
-    "book-flight",
     {
+      name: "book-flight",
       description: "Book a flight",
       inputSchema: { flightId: z.string() },
       annotations: { readOnlyHint: false, openWorldHint: false, destructiveHint: false },
@@ -80,12 +81,14 @@ const server = new McpServer(
         structuredContent: { confirmationId },
         content: [{ type: "text", text: `Flight booked. Confirmation: ${confirmationId}` }],
       };
-    }
+    },
   );
 
 export default server;
 export type AppType = typeof server;
 ```
+
+A tool becomes a view by adding the `view` field to its config (with `component` matching the registered name). Without `view`, it's a plain tool with no UI.
 
 ## UI Components
 

--- a/skills/chatgpt-app-builder/references/oauth.md
+++ b/skills/chatgpt-app-builder/references/oauth.md
@@ -103,8 +103,11 @@ export async function getAuth(extra: Extra): Promise<{ userId: string } | null> 
 
 ```typescript
 server.registerTool(
-  "get-orders",
-  { description: "Get user orders", inputSchema: {} },
+  {
+    name: "get-orders",
+    description: "Get user orders",
+    inputSchema: {},
+  },
   async (input, extra) => {
     const auth = await getAuth(extra);
 

--- a/skills/chatgpt-app-builder/references/open-external-links.md
+++ b/skills/chatgpt-app-builder/references/open-external-links.md
@@ -53,19 +53,18 @@ Shows confirmation dialog unless domain is whitelisted:
 
 ```typescript
 // server/src/index.ts
-server.registerView(
-  "search-flights",
+server.registerTool(
   {
+    name: "search-flights",
     description: "Search for flights",
-    _meta: {
-      ui: {
-        csp: {
-          redirectDomains: ["https://airline.example.com"],
-        },
+    inputSchema: { destination: z.string(), dates: z.string() },
+    view: {
+      component: "search-flights",
+      csp: {
+        redirectDomains: ["https://airline.example.com"],
       },
     },
   },
-  { inputSchema: { destination: z.string(), dates: z.string() } },
-  async ({ destination, dates }) => { /* ... */ }
+  async ({ destination, dates }) => { /* ... */ },
 );
 ```

--- a/skills/chatgpt-app-builder/references/state-and-context.md
+++ b/skills/chatgpt-app-builder/references/state-and-context.md
@@ -93,6 +93,10 @@ const [selected, setSelected] = useState(null);
 const [{ selected }, setState] = useViewState({ selected: null });
 ```
 
+Rule of thumb:
+- `useViewState` for data that needs to persist
+- `useState` for data that is ephemeral (e.g. ui state, animation)
+
 ```tsx
 // DON'T: Complex object in data-llm
 <div data-llm={JSON.stringify(cart)}>


### PR DESCRIPTION
- Update skill to match new registerTool api
- Add a "Rule of thumb" to give better guidance to llm about when using setViewState

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the `chatgpt-app-builder` skill references and evals to reflect a new unified `registerTool` API, replacing the previous separate `registerView`/`registerTool` pattern. It also adds a "Rule of thumb" section to `state-and-context.md` to help LLMs decide between `useViewState` and `useState`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are documentation updates with no runtime code affected.

Changes are limited to reference markdown files and eval JSON. All examples are updated consistently: registerView → registerTool with view field, _meta.ui.csp → view.csp, and tool config objects updated to include name as a field. No logic or runtime code is touched.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["Fix discrepency"](https://github.com/alpic-ai/skybridge/commit/c689d72ba48cb545a8009ad55531afef03935a41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30169450)</sub>

<!-- /greptile_comment -->