### PR TITLE
Fix strict component name type safety

### DIFF
--- a/packages/core/src/cli/use-typescript-check.ts
+++ b/packages/core/src/cli/use-typescript-check.ts
@@ -6,8 +6,27 @@ type TsError = {
   file: string;
   line: number;
   col: number;
+  code: string;
   message: string;
 };
+
+// TypeScript nests from general to specific — the deepest line is the root cause.
+function extractBestMessage(
+  message: string,
+  continuationLines: Array<string>,
+): string {
+  if (!continuationLines.length) return message;
+  let maxIndent = 0;
+  for (const line of continuationLines) {
+    const indent = line.length - line.trimStart().length;
+    if (indent > maxIndent) maxIndent = indent;
+  }
+  const deepest = continuationLines
+    .filter((l) => l.length - l.trimStart().length === maxIndent)
+    .map((l) => l.trim())
+    .filter(Boolean)[0];
+  return deepest ?? message;
+}
 
 export function useTypeScriptCheck(): Array<TsError> {
   const tsProcessRef = useRef<ReturnType<typeof spawn> | null>(null);
@@ -27,37 +46,57 @@ export function useTypeScriptCheck(): Array<TsError> {
 
     let outputBuffer = "";
     let currentErrors: Array<TsError> = [];
+    let pendingError: TsError | null = null;
+    let continuationLines: Array<string> = [];
+
+    const flushPending = () => {
+      if (!pendingError) return;
+      pendingError.message = extractBestMessage(
+        pendingError.message,
+        continuationLines,
+      );
+      currentErrors.push(pendingError);
+      pendingError = null;
+      continuationLines = [];
+    };
 
     const processOutput = (data: Buffer) => {
       outputBuffer += data.toString();
       const lines = outputBuffer.split("\n");
-      outputBuffer = lines.pop() || ""; // Keep incomplete line in buffer
+      outputBuffer = lines.pop() || "";
 
       for (const line of lines) {
         const trimmed = line.trim();
 
-        // Parse TypeScript error format: file.ts(10,5): error TS2322: message
-        // Match pattern: filename(line,col): error code: message
         const errorMatch = trimmed.match(
           /^(.+?)\((\d+),(\d+)\):\s+error\s+(TS\d+)?\s*:?\s*(.+)$/,
         );
         if (errorMatch) {
-          const [, file, lineStr, colStr, , message] = errorMatch;
+          flushPending();
+          const [, file, lineStr, colStr, code, message] = errorMatch;
           if (file && lineStr && colStr && message) {
             let cleanFile = file.trim();
             if (isAbsolute(cleanFile)) {
               cleanFile = relative(process.cwd(), cleanFile);
             }
-            currentErrors.push({
+            pendingError = {
               file: cleanFile,
               line: Number.parseInt(lineStr, 10),
               col: Number.parseInt(colStr, 10),
+              code: code ?? "",
               message: message.trim(),
-            });
+            };
           }
+          continue;
+        }
+
+        if (pendingError && line.startsWith(" ")) {
+          continuationLines.push(line);
+          continue;
         }
 
         if (trimmed.includes("Found") && trimmed.includes("error")) {
+          flushPending();
           setTsErrors(trimmed.match(/Found 0 error/) ? [] : [...currentErrors]);
           currentErrors = [];
         }

--- a/packages/core/src/cli/use-typescript-check.ts
+++ b/packages/core/src/cli/use-typescript-check.ts
@@ -15,11 +15,15 @@ function extractBestMessage(
   message: string,
   continuationLines: Array<string>,
 ): string {
-  if (!continuationLines.length) return message;
+  if (!continuationLines.length) {
+    return message;
+  }
   let maxIndent = 0;
   for (const line of continuationLines) {
     const indent = line.length - line.trimStart().length;
-    if (indent > maxIndent) maxIndent = indent;
+    if (indent > maxIndent) {
+      maxIndent = indent;
+    }
   }
   const deepest = continuationLines
     .filter((l) => l.length - l.trimStart().length === maxIndent)
@@ -50,7 +54,9 @@ export function useTypeScriptCheck(): Array<TsError> {
     let continuationLines: Array<string> = [];
 
     const flushPending = () => {
-      if (!pendingError) return;
+      if (!pendingError) {
+        return;
+      }
       pendingError.message = extractBestMessage(
         pendingError.message,
         continuationLines,

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -85,9 +85,7 @@ export interface ViewCsp {
 // biome-ignore lint/suspicious/noEmptyInterface: register pattern — augmented by `.skybridge/views.d.ts` to narrow ViewName
 export interface ViewNameRegistry {}
 
-export type ViewName = keyof ViewNameRegistry extends never
-  ? string
-  : keyof ViewNameRegistry & string;
+export type ViewName = keyof ViewNameRegistry & string;
 
 export interface ViewConfig {
   component: ViewName;

--- a/packages/core/src/test/utils.ts
+++ b/packages/core/src/test/utils.ts
@@ -1,7 +1,7 @@
 import { McpServer as McpServerBase } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { type MockInstance, vi } from "vitest";
 import * as z from "zod";
-import { McpServer } from "../server/server.js";
+import { McpServer, type ViewName } from "../server/server.js";
 
 export function createMockMcpServer(): {
   server: McpServer;
@@ -47,7 +47,7 @@ export function createTestServer() {
           ),
           totalCount: z.number(),
         },
-        view: { component: "search-trip" },
+        view: { component: "search-trip" as ViewName },
       },
       async ({ destination }) => {
         return {
@@ -71,7 +71,7 @@ export function createTestServer() {
           description: z.string(),
           images: z.array(z.string()),
         },
-        view: { component: "get-trip-details" },
+        view: { component: "get-trip-details" as ViewName },
       },
       async ({ tripId }) => {
         return {
@@ -90,7 +90,7 @@ export function createTestServer() {
         description: "View with no input",
         inputSchema: {},
         outputSchema: {},
-        view: { component: "no-input-view" },
+        view: { component: "no-input-view" as ViewName },
       },
       async () => {
         return {
@@ -106,7 +106,7 @@ export function createTestServer() {
         inputSchema: {
           query: z.string(),
         },
-        view: { component: "inferred-output-view" },
+        view: { component: "inferred-output-view" as ViewName },
       },
       async ({ query }) => {
         return {
@@ -166,7 +166,7 @@ export function createTestServer() {
         inputSchema: {
           resourceId: z.string(),
         },
-        view: { component: "view-with-metadata" },
+        view: { component: "view-with-metadata" as ViewName },
       },
       async ({ resourceId }) => {
         return {
@@ -211,7 +211,7 @@ export function createTestServer() {
         inputSchema: {
           shouldSucceed: z.boolean(),
         },
-        view: { component: "view-with-mixed-returns" },
+        view: { component: "view-with-mixed-returns" as ViewName },
       },
       async ({ shouldSucceed }) => {
         if (!shouldSucceed) {
@@ -243,7 +243,7 @@ export function createMinimalTestServer() {
       outputSchema: {
         results: z.array(z.object({ id: z.string() })),
       },
-      view: { component: "search-trip" },
+      view: { component: "search-trip" as ViewName },
     },
     async ({ destination }) => {
       return {
@@ -281,7 +281,7 @@ export function createInterfaceTestServer() {
       inputSchema: {
         id: z.string(),
       },
-      view: { component: "interface-view" },
+      view: { component: "interface-view" as ViewName },
     },
     async ({ id }): Promise<InterfaceReturnType> => {
       return {

--- a/packages/core/src/test/view.test.ts
+++ b/packages/core/src/test/view.test.ts
@@ -13,7 +13,7 @@ import {
   type MockInstance,
   vi,
 } from "vitest";
-import type { McpServer } from "../server/server.js";
+import type { McpServer, ViewName } from "../server/server.js";
 import {
   createMockExtra,
   createMockMcpServer,
@@ -95,7 +95,7 @@ describe("McpServer.registerTool (unified API)", () => {
         name: "my-widget",
         description: "Test tool",
         view: {
-          component: "my-widget",
+          component: "my-widget" as ViewName,
           description: "Test view",
         },
       },
@@ -159,7 +159,7 @@ describe("McpServer.registerTool (unified API)", () => {
         name: "my-widget",
         description: "Test tool",
         view: {
-          component: "my-widget",
+          component: "my-widget" as ViewName,
           description: "Test view",
         },
       },
@@ -222,7 +222,7 @@ describe("McpServer.registerTool (unified API)", () => {
       {
         name: "my-widget",
         description: "Test tool",
-        view: { component: "my-widget", description: "Test view" },
+        view: { component: "my-widget" as ViewName, description: "Test view" },
       },
       vi.fn(),
     );
@@ -281,7 +281,7 @@ describe("McpServer.registerTool (unified API)", () => {
         name: "my-widget",
         description: "Test tool",
         view: {
-          component: "my-widget",
+          component: "my-widget" as ViewName,
           description: "Test view",
           prefersBorder: true,
         },
@@ -385,7 +385,7 @@ describe("McpServer.registerTool (unified API)", () => {
       {
         name: "my-widget",
         description: "Test tool",
-        view: { component: "my-widget", description: "Test view" },
+        view: { component: "my-widget" as ViewName, description: "Test view" },
       },
       vi.fn(),
     );
@@ -407,7 +407,7 @@ describe("McpServer.registerTool (unified API)", () => {
         name: "my-widget",
         description: "Test tool",
         view: {
-          component: "my-widget",
+          component: "my-widget" as ViewName,
           description: "Test view",
           hosts: ["apps-sdk"],
         },
@@ -431,7 +431,7 @@ describe("McpServer.registerTool (unified API)", () => {
       {
         name: "my-widget",
         description: "Test tool",
-        view: { component: "my-widget", description: "Test view" },
+        view: { component: "my-widget" as ViewName, description: "Test view" },
       },
       vi.fn(),
     );
@@ -463,7 +463,7 @@ describe("McpServer.registerTool (unified API)", () => {
       {
         name: "my-widget",
         description: "Test tool",
-        view: { component: "my-widget", description: "Test view" },
+        view: { component: "my-widget" as ViewName, description: "Test view" },
       },
       vi.fn(),
     );
@@ -497,7 +497,7 @@ describe("McpServer.registerTool (unified API)", () => {
       {
         name: "my-widget",
         description: "First tool",
-        view: { component: "my-widget" },
+        view: { component: "my-widget" as ViewName },
       },
       vi.fn(),
     );
@@ -505,7 +505,7 @@ describe("McpServer.registerTool (unified API)", () => {
       {
         name: "folder-widget",
         description: "Second tool",
-        view: { component: "folder-widget" },
+        view: { component: "folder-widget" as ViewName },
       },
       vi.fn(),
     );
@@ -529,7 +529,7 @@ describe("McpServer.registerTool (unified API)", () => {
       {
         name: "unknown-widget",
         description: "Test tool",
-        view: { component: "unknown-widget" },
+        view: { component: "unknown-widget" as ViewName },
       },
       vi.fn(),
     );
@@ -548,7 +548,7 @@ describe("McpServer.registerTool (unified API)", () => {
         name: "my-widget",
         description: "Test tool",
         view: {
-          component: "my-widget",
+          component: "my-widget" as ViewName,
           description: "Test view",
           hosts: ["mcp-app"],
         },
@@ -578,7 +578,7 @@ describe("McpServer.registerTool (unified API)", () => {
       {
         name: "my-widget",
         description: "Test tool",
-        view: { component: "my-widget", description: "Test view" },
+        view: { component: "my-widget" as ViewName, description: "Test view" },
       },
       mockToolCallback,
     );
@@ -609,7 +609,7 @@ describe("McpServer.registerTool (unified API)", () => {
       {
         name: "my-widget",
         description: "Test tool",
-        view: { component: "my-widget", description: "Test view" },
+        view: { component: "my-widget" as ViewName, description: "Test view" },
       },
       mockToolCallback,
     );
@@ -634,7 +634,7 @@ describe("McpServer.registerTool (unified API)", () => {
       {
         name: "my-widget",
         description: "Test tool",
-        view: { component: "my-widget", description: "Test view" },
+        view: { component: "my-widget" as ViewName, description: "Test view" },
       },
       mockToolCallback,
     );
@@ -653,7 +653,7 @@ describe("McpServer.registerTool (unified API)", () => {
       {
         name: "shake",
         description: "First tool",
-        view: { component: "magic-8-ball" },
+        view: { component: "magic-8-ball" as ViewName },
       },
       vi.fn(),
     );
@@ -663,7 +663,7 @@ describe("McpServer.registerTool (unified API)", () => {
         {
           name: "shake-v2",
           description: "Second tool",
-          view: { component: "magic-8-ball" },
+          view: { component: "magic-8-ball" as ViewName },
         },
         vi.fn(),
       );
@@ -682,7 +682,7 @@ describe("McpServer.registerTool (unified API)", () => {
       {
         name: "string-content",
         description: "Test tool",
-        view: { component: "string-content" },
+        view: { component: "string-content" as ViewName },
       },
       mockToolCallback,
     );
@@ -705,7 +705,7 @@ describe("McpServer.registerTool (unified API)", () => {
       {
         name: "single-block",
         description: "Test tool",
-        view: { component: "single-block" },
+        view: { component: "single-block" as ViewName },
       },
       mockToolCallback,
     );
@@ -732,7 +732,7 @@ describe("McpServer.registerTool (unified API)", () => {
       {
         name: "array-content",
         description: "Test tool",
-        view: { component: "array-content" },
+        view: { component: "array-content" as ViewName },
       },
       mockToolCallback,
     );
@@ -764,7 +764,7 @@ describe("McpServer.registerTool (unified API)", () => {
         name: "csp-tool",
         description: "Test tool",
         view: {
-          component: "csp-tool",
+          component: "csp-tool" as ViewName,
           description: "Test view",
           csp: {
             connectDomains: ["https://api.example.com"],
@@ -811,7 +811,7 @@ describe("McpServer.registerTool (unified API)", () => {
         name: "override-tool",
         description: "Test tool",
         view: {
-          component: "override-tool",
+          component: "override-tool" as ViewName,
           description: "Test view",
           csp: { connectDomains: ["https://api.x.com"] },
           _meta: {


### PR DESCRIPTION
- Fixes the type safety provided by the new skybridge API
- We use type assertion in tests as the generated type ViewRegistry that we would expect normally is not available in tests
- Displays deepest typescript error instead of shallowest one


<img width="808" height="279" alt="image" src="https://github.com/user-attachments/assets/d2cf2377-59bd-4440-8fc4-d02254506b51" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two improvements: it tightens `ViewName` to `keyof ViewNameRegistry & string` (removing the `never`-fallback conditional type) for strict component-name type safety, and it overhauls `use-typescript-check.ts` to buffer multi-line TypeScript error output and surface the deepest (most specific) nested error message instead of the shallowest one. Test files are updated with `as ViewName` casts to satisfy the stricter type.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge; all deliberate trade-offs (never in tests, strict ViewName) are acknowledged by the team.

No P0 or P1 issues found. The buffering logic in use-typescript-check.ts is correct: flushPending is called at both error-header boundaries and the 'Found N errors' sentinel, continuation lines are properly scoped to the pending error, and extractBestMessage handles all edge cases. The as ViewName / as never cast in tests is intentional and confirmed by the team.

No files require special attention.

<sub>Reviews (3): Last reviewed commit: ["Fix lint"](https://github.com/alpic-ai/skybridge/commit/f3919827231504ad128daddafa109319993c4f55) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30179352)</sub>

<!-- /greptile_comment -->