### PR TITLE
Fix: Expose typegen command for prepare hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Run ${{ matrix.name }}
         run: ${{ matrix.command }}
@@ -91,7 +91,7 @@ jobs:
           cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Build
         run: pnpm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,12 +59,18 @@ jobs:
           cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Build core and devtools
         run: |
           pnpm --filter skybridge build
           pnpm --filter @skybridge/devtools build
+
+      - name: Generate template view types
+        run: pnpm --filter apps-sdk-template exec skybridge typegen
+
+      - name: Type check template
+        run: pnpm --filter apps-sdk-template exec tsc -b
 
       - name: Build template
         run: pnpm --filter apps-sdk-template run build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: pnpm/action-setup@v5
 
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile --ignore-scripts
 
       - run: pnpm build
 

--- a/packages/core/src/cli/resolve-views-dir.ts
+++ b/packages/core/src/cli/resolve-views-dir.ts
@@ -1,4 +1,6 @@
-export async function resolveViewsDir(root: string): Promise<string | undefined> {
+export async function resolveViewsDir(
+  root: string,
+): Promise<string | undefined> {
   const { loadConfigFromFile } = await import("vite");
   const loaded = await loadConfigFromFile(
     { command: "build", mode: "production" },

--- a/packages/core/src/cli/resolve-views-dir.ts
+++ b/packages/core/src/cli/resolve-views-dir.ts
@@ -1,0 +1,24 @@
+export async function resolveViewsDir(root: string): Promise<string | undefined> {
+  const { loadConfigFromFile } = await import("vite");
+  const loaded = await loadConfigFromFile(
+    { command: "build", mode: "production" },
+    undefined,
+    root,
+  );
+
+  const isPluginCandidate = (
+    value: unknown,
+  ): value is { name?: string; api?: { viewsDir?: string } } =>
+    typeof value === "object" && value !== null;
+
+  const plugins: Array<{ name?: string; api?: { viewsDir?: string } }> = [];
+  const walk = (value: unknown) => {
+    if (Array.isArray(value)) {
+      value.forEach(walk);
+    } else if (isPluginCandidate(value)) {
+      plugins.push(value);
+    }
+  };
+  walk(loaded?.config.plugins ?? []);
+  return plugins.find((p) => p.name === "skybridge")?.api?.viewsDir;
+}

--- a/packages/core/src/commands/build.tsx
+++ b/packages/core/src/commands/build.tsx
@@ -3,33 +3,9 @@ import { Command } from "@oclif/core";
 import { Box, render, Text } from "ink";
 import { useEffect } from "react";
 import { Header } from "../cli/header.js";
+import { resolveViewsDir } from "../cli/resolve-views-dir.js";
 import { type CommandStep, useExecuteSteps } from "../cli/use-execute-steps.js";
 import { scanAndWriteViewsDts } from "../web/plugin/scan-views.js";
-
-async function resolveViewsDir(root: string): Promise<string | undefined> {
-  const { loadConfigFromFile } = await import("vite");
-  const loaded = await loadConfigFromFile(
-    { command: "build", mode: "production" },
-    undefined,
-    root,
-  );
-
-  const isPluginCandidate = (
-    value: unknown,
-  ): value is { name?: string; api?: { viewsDir?: string } } =>
-    typeof value === "object" && value !== null;
-
-  const plugins: Array<{ name?: string; api?: { viewsDir?: string } }> = [];
-  const walk = (value: unknown) => {
-    if (Array.isArray(value)) {
-      value.forEach(walk);
-    } else if (isPluginCandidate(value)) {
-      plugins.push(value);
-    }
-  };
-  walk(loaded?.config.plugins ?? []);
-  return plugins.find((p) => p.name === "skybridge")?.api?.viewsDir;
-}
 
 export const commandSteps: CommandStep[] = [
   {

--- a/packages/core/src/commands/typegen.ts
+++ b/packages/core/src/commands/typegen.ts
@@ -1,0 +1,16 @@
+import { Command } from "@oclif/core";
+import { resolveViewsDir } from "../cli/resolve-views-dir.js";
+import { scanAndWriteViewsDts } from "../web/plugin/scan-views.js";
+
+export default class Typegen extends Command {
+  static override description =
+    "Generate .skybridge/views.d.ts from src/views without running a full build";
+  static override examples = ["skybridge typegen"];
+  static override flags = {};
+
+  public async run(): Promise<void> {
+    const root = process.cwd();
+    const viewsDir = await resolveViewsDir(root);
+    scanAndWriteViewsDts(root, viewsDir);
+  }
+}

--- a/packages/create-skybridge/template/package.json
+++ b/packages/create-skybridge/template/package.json
@@ -9,7 +9,8 @@
     "dev:tunnel": "skybridge dev --tunnel",
     "build": "skybridge build",
     "start": "skybridge start",
-    "deploy": "alpic deploy"
+    "deploy": "alpic deploy",
+    "postinstall": "skybridge typegen"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
Running `pnpm test:type` fails in the examples and the template because the generated typed from the scanned views are only created during `skybridge build` or `skybridge dev`

This PR introduces a dedicated skybridge command `skybridge typegen` to only generate those types. It also adds a prepare hook to generate the types on dev install.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts `resolveViewsDir` into a shared module and adds a new `skybridge typegen` command that generates `.skybridge/views.d.ts` without running a full build. A `postinstall` hook is added to the template `package.json` so types are generated on install, and CI is updated with `--ignore-scripts` plus an explicit `typegen` step to control ordering correctly.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are additive, well-scoped, and the CI ordering is handled correctly.

No P0 or P1 issues found. The refactored resolveViewsDir is identical to the inlined version in build.tsx, scanAndWriteViewsDts is synchronous so the call in typegen.ts is correct, and the CI --ignore-scripts + explicit typegen step properly sequences the monorepo build before type generation.

No files require special attention.

<sub>Reviews (4): Last reviewed commit: ["format: wrap long resolveViewsDir signat..."](https://github.com/alpic-ai/skybridge/commit/68d10d01be4fbdf074e980d4c2c6330bc78890e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30319507)</sub>

<!-- /greptile_comment -->