### PR TITLE
Change owner + remove unecessary recordname property

### DIFF
--- a/infrastructure/lib/constructs/SkybridgeRecords.ts
+++ b/infrastructure/lib/constructs/SkybridgeRecords.ts
@@ -63,9 +63,8 @@ export class SkybridgeRecords extends Construct {
 
     new TxtRecord(this, "GoogleSiteVerification", {
       zone: hostedZone,
-      recordName: `${domain}.`,
       values: [
-        "google-site-verification=myFnQc1sSrPYoaWsq6XYxYKJlklRVgs93j3EejPDfe8",
+        "google-site-verification=0w7sA9_Qh5zLQ6XmUYMGaxiyBoZRXs_pRir0Hm5va1I",
       ],
     });
   }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Google Site Verification TXT record in two ways: it changes the verification token (transferring Google Search Console ownership) and removes the explicit `recordName: \`${domain}.\`` property, which was redundant since omitting `recordName` in CDK's `TxtRecord` defaults to placing the record at the zone apex — the same result as the explicit FQDN with a trailing dot.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the recordName omission is functionally equivalent and the token change is intentional.

Only two changes: removing a redundant recordName that resolves to the same zone apex as the CDK default, and updating the Google site-verification token. No logic errors, security issues, or behavioral differences introduced.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["Change owner + remove unecessary recordn..."](https://github.com/alpic-ai/skybridge/commit/66d58d8ff1026e032f38e2af7209189416eba78c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30346276)</sub>

<!-- /greptile_comment -->