### PR TITLE
feat: add prompt middleware to all example apps

### DIFF
--- a/examples/auth-auth0/package.json
+++ b/examples/auth-auth0/package.json
@@ -12,6 +12,7 @@
     "deploy": "alpic deploy"
   },
   "dependencies": {
+    "@alpic-ai/insights": "^1.120.1",
     "@auth0/auth0-api-js": "^1.4.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.6",

--- a/examples/auth-auth0/src/server.ts
+++ b/examples/auth-auth0/src/server.ts
@@ -1,3 +1,4 @@
+import { userPromptMiddleware } from "@alpic-ai/insights";
 import { requireBearerAuth } from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js";
 import { mcpAuthMetadataRouter } from "@modelcontextprotocol/sdk/server/auth/router.js";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
@@ -60,6 +61,7 @@ const server = new McpServer(
       requiredScopes: ["openid", "email", "profile"],
     }),
   )
+  .mcpMiddleware(userPromptMiddleware())
   .registerTool(
     {
       name: "search-coffee-paris",

--- a/examples/auth-clerk/package.json
+++ b/examples/auth-clerk/package.json
@@ -12,6 +12,7 @@
     "deploy": "alpic deploy"
   },
   "dependencies": {
+    "@alpic-ai/insights": "^1.120.1",
     "@clerk/express": "^2.0.7",
     "@clerk/mcp-tools": "^0.3.1",
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/examples/auth-clerk/src/server.ts
+++ b/examples/auth-clerk/src/server.ts
@@ -1,4 +1,5 @@
 import "dotenv/config";
+import { userPromptMiddleware } from "@alpic-ai/insights";
 import { clerkMiddleware } from "@clerk/express";
 import {
   mcpAuthClerk,
@@ -32,6 +33,7 @@ const server = new McpServer(
     protectedResourceHandlerClerk({ scopes_supported: ["profile", "email"] }),
   )
   .use("/mcp", mcpAuthClerk)
+  .mcpMiddleware(userPromptMiddleware())
   .registerTool(
     {
       name: "search-coffee-paris",

--- a/examples/auth-stytch/package.json
+++ b/examples/auth-stytch/package.json
@@ -12,6 +12,7 @@
     "deploy": "alpic deploy"
   },
   "dependencies": {
+    "@alpic-ai/insights": "^1.120.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.6",
     "dotenv": "^16.5.0",

--- a/examples/auth-stytch/src/server.ts
+++ b/examples/auth-stytch/src/server.ts
@@ -1,4 +1,5 @@
 import "dotenv/config";
+import { userPromptMiddleware } from "@alpic-ai/insights";
 import { requireBearerAuth } from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import cors from "cors";
@@ -67,6 +68,7 @@ const server = new McpServer(
       resourceMetadataUrl: `${env.SERVER_URL}/.well-known/oauth-protected-resource`,
     }),
   )
+  .mcpMiddleware(userPromptMiddleware())
   .registerTool(
     {
       name: "search-coffee-paris",

--- a/examples/auth-workos/package.json
+++ b/examples/auth-workos/package.json
@@ -12,6 +12,7 @@
     "deploy": "alpic deploy"
   },
   "dependencies": {
+    "@alpic-ai/insights": "^1.120.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@workos-inc/node": "^7.72.2",
     "dotenv": "^16.5.0",

--- a/examples/auth-workos/src/server.ts
+++ b/examples/auth-workos/src/server.ts
@@ -1,3 +1,4 @@
+import { userPromptMiddleware } from "@alpic-ai/insights";
 import { requireBearerAuth } from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js";
 import { mcpAuthMetadataRouter } from "@modelcontextprotocol/sdk/server/auth/router.js";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
@@ -48,6 +49,7 @@ const server = new McpServer(
     }),
   )
   .use("/mcp", requireBearerAuth({ verifier: { verifyAccessToken } }))
+  .mcpMiddleware(userPromptMiddleware())
   .registerTool(
     {
       name: "search-coffee-paris",

--- a/examples/capitals/package.json
+++ b/examples/capitals/package.json
@@ -12,6 +12,7 @@
     "deploy": "alpic deploy"
   },
   "dependencies": {
+    "@alpic-ai/insights": "^1.120.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@t3-oss/env-core": "^0.13.8",
     "clsx": "^2.1.1",

--- a/examples/capitals/src/server.ts
+++ b/examples/capitals/src/server.ts
@@ -1,3 +1,4 @@
+import { userPromptMiddleware } from "@alpic-ai/insights";
 import { type Request, type Response, Router } from "express";
 import { McpServer } from "skybridge/server";
 import * as z from "zod";
@@ -26,74 +27,77 @@ const server = new McpServer(
     version: "0.0.1",
   },
   { capabilities: {} },
-).registerTool(
-  {
-    name: "explore-capitals",
-    description:
-      "Use this tool to explore world capitals. Displays an interactive map with detailed information about capital cities including population, currencies, and beautiful photos. Always use it when users ask about capitals, countries, or want to explore geography.",
-    inputSchema: {
-      name: z
-        .string()
-        .describe(
-          "Capital city name in English (e.g., 'Paris', 'Tokyo', 'Washington, D.C.', 'London', 'New Delhi')",
-        ),
-    },
-    annotations: {
-      readOnlyHint: true,
-      openWorldHint: true,
-      destructiveHint: false,
-    },
-    view: {
-      component: "explore-capitals",
-      description: "Interactive world capitals explorer with map visualization",
-      csp: {
-        resourceDomains: [
-          "https://upload.wikimedia.org",
-          "https://flagcdn.com",
-          "blob:",
-        ],
-        connectDomains: ["https://*.mapbox.com"],
+)
+  .mcpMiddleware(userPromptMiddleware())
+  .registerTool(
+    {
+      name: "explore-capitals",
+      description:
+        "Use this tool to explore world capitals. Displays an interactive map with detailed information about capital cities including population, currencies, and beautiful photos. Always use it when users ask about capitals, countries, or want to explore geography.",
+      inputSchema: {
+        name: z
+          .string()
+          .describe(
+            "Capital city name in English (e.g., 'Paris', 'Tokyo', 'Washington, D.C.', 'London', 'New Delhi')",
+          ),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+        destructiveHint: false,
+      },
+      view: {
+        component: "explore-capitals",
+        description:
+          "Interactive world capitals explorer with map visualization",
+        csp: {
+          resourceDomains: [
+            "https://upload.wikimedia.org",
+            "https://flagcdn.com",
+            "blob:",
+          ],
+          connectDomains: ["https://*.mapbox.com"],
+        },
+      },
+      _meta: {
+        "openai/widgetAccessible": true,
       },
     },
-    _meta: {
-      "openai/widgetAccessible": true,
-    },
-  },
-  async ({ name }) => {
-    try {
-      // Fetch list first (minimal data), then details for requested capital
-      const allCapitals = await getCachedAllCapitals();
-      const capital = await getCapitalByName(name);
+    async ({ name }) => {
+      try {
+        // Fetch list first (minimal data), then details for requested capital
+        const allCapitals = await getCachedAllCapitals();
+        const capital = await getCapitalByName(name);
 
-      return {
-        _meta: {
-          slug: getCapitalSlug(capital.name),
-          allCapitals, // In meta to avoid flooding the model
-        },
-        structuredContent: {
-          capital, // Initial capital details
-        },
-        content: [
-          {
-            type: "text",
-            text: formatCapitalForModel(capital),
+        return {
+          _meta: {
+            slug: getCapitalSlug(capital.name),
+            allCapitals, // In meta to avoid flooding the model
           },
-        ],
-        isError: false,
-      };
-    } catch (error) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Error: ${error instanceof Error ? error.message : "Unknown error"}`,
+          structuredContent: {
+            capital, // Initial capital details
           },
-        ],
-        isError: true,
-      };
-    }
-  },
-);
+          content: [
+            {
+              type: "text",
+              text: formatCapitalForModel(capital),
+            },
+          ],
+          isError: false,
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error: ${error instanceof Error ? error.message : "Unknown error"}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
 
 function formatCapitalForModel(capital: Capital): string {
   const parts = [`${capital.name} is the capital of ${capital.country.name}.`];

--- a/examples/ecom-carousel/package.json
+++ b/examples/ecom-carousel/package.json
@@ -12,6 +12,7 @@
     "deploy": "alpic deploy"
   },
   "dependencies": {
+    "@alpic-ai/insights": "^1.120.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@t3-oss/env-core": "^0.13.11",
     "dotenv": "^17.4.1",

--- a/examples/ecom-carousel/src/server.ts
+++ b/examples/ecom-carousel/src/server.ts
@@ -1,3 +1,4 @@
+import { userPromptMiddleware } from "@alpic-ai/insights";
 import { McpServer } from "skybridge/server";
 import { z } from "zod";
 import { products } from "./products.js";
@@ -23,6 +24,7 @@ const server = new McpServer(
   },
   { capabilities: {} },
 )
+  .mcpMiddleware(userPromptMiddleware())
   .registerTool(
     {
       name: "browse-catalog",

--- a/examples/everything/package.json
+++ b/examples/everything/package.json
@@ -12,6 +12,7 @@
     "deploy": "alpic deploy"
   },
   "dependencies": {
+    "@alpic-ai/insights": "^1.120.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",

--- a/examples/everything/src/server.ts
+++ b/examples/everything/src/server.ts
@@ -1,3 +1,4 @@
+import { userPromptMiddleware } from "@alpic-ai/insights";
 import { McpServer } from "skybridge/server";
 import { z } from "zod";
 
@@ -7,42 +8,44 @@ const server = new McpServer(
     version: "0.0.1",
   },
   { capabilities: {} },
-).registerTool(
-  {
-    name: "show-everything",
-    description: "A simple greeting tool",
-    inputSchema: {
-      name: z.string().describe("The user name"),
-    },
-    view: {
-      component: "show-everything",
-      description: "A playground to discover the Skybridge framework",
-      csp: {
-        redirectDomains: [
-          "https://docs.skybridge.tech",
-          "https://alpic.ai",
-          "https://github.com",
-        ],
+)
+  .mcpMiddleware(userPromptMiddleware())
+  .registerTool(
+    {
+      name: "show-everything",
+      description: "A simple greeting tool",
+      inputSchema: {
+        name: z.string().describe("The user name"),
       },
-    },
-    _meta: {
-      "openai/widgetAccessible": true,
-    },
-  },
-  async ({ name }) => {
-    const structuredContent = {
-      greeting: `Hi ${name}, this tool response content is visible by both you and the LLM`,
-    };
-    return {
-      structuredContent,
-      content: [{ type: "text", text: JSON.stringify(structuredContent) }],
-      isError: false,
+      view: {
+        component: "show-everything",
+        description: "A playground to discover the Skybridge framework",
+        csp: {
+          redirectDomains: [
+            "https://docs.skybridge.tech",
+            "https://alpic.ai",
+            "https://github.com",
+          ],
+        },
+      },
       _meta: {
-        secret: "But _meta is only visible to you",
+        "openai/widgetAccessible": true,
       },
-    };
-  },
-);
+    },
+    async ({ name }) => {
+      const structuredContent = {
+        greeting: `Hi ${name}, this tool response content is visible by both you and the LLM`,
+      };
+      return {
+        structuredContent,
+        content: [{ type: "text", text: JSON.stringify(structuredContent) }],
+        isError: false,
+        _meta: {
+          secret: "But _meta is only visible to you",
+        },
+      };
+    },
+  );
 
 server.run();
 

--- a/examples/flight-booking/package.json
+++ b/examples/flight-booking/package.json
@@ -12,6 +12,7 @@
     "deploy": "alpic deploy"
   },
   "dependencies": {
+    "@alpic-ai/insights": "^1.120.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/examples/flight-booking/src/server.ts
+++ b/examples/flight-booking/src/server.ts
@@ -1,3 +1,4 @@
+import { userPromptMiddleware } from "@alpic-ai/insights";
 import { McpServer } from "skybridge/server";
 import { z } from "zod";
 import { generateFlights } from "./flights.js";
@@ -15,82 +16,84 @@ const server = new McpServer(
     version: "0.0.1",
   },
   { capabilities: {} },
-).registerTool(
-  {
-    name: "flight-booking",
-    description:
-      "Search and display available flights between two airports with pricing and schedule details.",
-    inputSchema: {
-      origin: AIRPORT_CODE,
-      destination: AIRPORT_CODE,
-      departureDate: z
-        .string()
-        .describe("Departure date in YYYY-MM-DD format (e.g. 2026-08-16)"),
-      returnDate: z
-        .string()
-        .describe("Return date in YYYY-MM-DD format (e.g. 2026-08-29)"),
-      maxPrice: z
-        .number()
-        .optional()
-        .describe("Maximum price per adult in EUR"),
-      directOnly: z
-        .boolean()
-        .optional()
-        .default(false)
-        .describe("Only show direct flights (no layovers)"),
-    },
-    view: {
-      component: "flight-booking",
-      description: "Flight Booking Carousel",
-      csp: {
-        redirectDomains: ["https://docs.skybridge.tech"],
+)
+  .mcpMiddleware(userPromptMiddleware())
+  .registerTool(
+    {
+      name: "flight-booking",
+      description:
+        "Search and display available flights between two airports with pricing and schedule details.",
+      inputSchema: {
+        origin: AIRPORT_CODE,
+        destination: AIRPORT_CODE,
+        departureDate: z
+          .string()
+          .describe("Departure date in YYYY-MM-DD format (e.g. 2026-08-16)"),
+        returnDate: z
+          .string()
+          .describe("Return date in YYYY-MM-DD format (e.g. 2026-08-29)"),
+        maxPrice: z
+          .number()
+          .optional()
+          .describe("Maximum price per adult in EUR"),
+        directOnly: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Only show direct flights (no layovers)"),
+      },
+      view: {
+        component: "flight-booking",
+        description: "Flight Booking Carousel",
+        csp: {
+          redirectDomains: ["https://docs.skybridge.tech"],
+        },
       },
     },
-  },
-  ({
-    origin,
-    destination,
-    departureDate,
-    returnDate,
-    maxPrice,
-    directOnly,
-  }) => {
-    try {
-      let flights = generateFlights(
-        origin,
-        destination,
-        departureDate,
-        returnDate,
-        directOnly ?? false,
-      );
+    ({
+      origin,
+      destination,
+      departureDate,
+      returnDate,
+      maxPrice,
+      directOnly,
+    }) => {
+      try {
+        let flights = generateFlights(
+          origin,
+          destination,
+          departureDate,
+          returnDate,
+          directOnly ?? false,
+        );
 
-      if (maxPrice !== undefined) {
-        flights = flights.filter((f) => f.price <= maxPrice);
+        if (maxPrice !== undefined) {
+          flights = flights.filter((f) => f.price <= maxPrice);
+        }
+
+        const result = {
+          origin,
+          originCity: IATA_AIRPORTS.get(origin) ?? origin,
+          destination,
+          destinationCity: IATA_AIRPORTS.get(destination) ?? destination,
+          departureDate,
+          returnDate,
+          flights,
+        };
+
+        return {
+          structuredContent: result,
+          content: [{ type: "text" as const, text: JSON.stringify(result) }],
+          isError: false,
+        };
+      } catch (error) {
+        return {
+          content: [{ type: "text" as const, text: `Error: ${error}` }],
+          isError: true,
+        };
       }
-
-      const result = {
-        origin,
-        originCity: IATA_AIRPORTS.get(origin) ?? origin,
-        destination,
-        destinationCity: IATA_AIRPORTS.get(destination) ?? destination,
-        departureDate,
-        returnDate,
-        flights,
-      };
-
-      return {
-        structuredContent: result,
-        content: [{ type: "text" as const, text: JSON.stringify(result) }],
-        isError: false,
-      };
-    } catch (error) {
-      return {
-        content: [{ type: "text" as const, text: `Error: ${error}` }],
-        isError: true,
-      };
-    }
-  },
-);
+    },
+  );
 
 server.run();
 

--- a/examples/generative-ui/package.json
+++ b/examples/generative-ui/package.json
@@ -12,6 +12,7 @@
     "deploy": "alpic deploy"
   },
   "dependencies": {
+    "@alpic-ai/insights": "^1.120.1",
     "@json-render/core": "^0.14.1",
     "@json-render/react": "^0.14.1",
     "@json-render/shadcn": "^0.14.1",

--- a/examples/generative-ui/src/server.ts
+++ b/examples/generative-ui/src/server.ts
@@ -1,3 +1,4 @@
+import { userPromptMiddleware } from "@alpic-ai/insights";
 import type { Spec } from "@json-render/core";
 import {
   autoFixSpec,
@@ -24,6 +25,7 @@ const server = new McpServer(
   },
   { capabilities: {} },
 )
+  .mcpMiddleware(userPromptMiddleware())
   .registerTool(
     {
       name: "get-ui-catalog",

--- a/examples/investigation-game/package.json
+++ b/examples/investigation-game/package.json
@@ -12,6 +12,7 @@
     "deploy": "alpic deploy"
   },
   "dependencies": {
+    "@alpic-ai/insights": "^1.120.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "clsx": "^2.1.1",
     "react": "^19.2.3",

--- a/examples/investigation-game/src/server.ts
+++ b/examples/investigation-game/src/server.ts
@@ -1,3 +1,4 @@
+import { userPromptMiddleware } from "@alpic-ai/insights";
 import { McpServer } from "skybridge/server";
 
 const server = new McpServer(
@@ -6,39 +7,41 @@ const server = new McpServer(
     version: "0.0.1",
   },
   { capabilities: {} },
-).registerTool(
-  {
-    name: "murder-in-the-valley",
-    description: "Use this tool to start a game of murder in the valley.",
-    inputSchema: {},
-    annotations: {
-      readOnlyHint: true,
-      destructiveHint: false,
-      openWorldHint: false,
-    },
-    view: {
-      component: "murder-in-the-valley",
-      description: "The murder in the valley game",
-      domain: "https://alpic.ai",
-      csp: {
-        redirectDomains: ["https://alpic.ai", "https://github.com"],
+)
+  .mcpMiddleware(userPromptMiddleware())
+  .registerTool(
+    {
+      name: "murder-in-the-valley",
+      description: "Use this tool to start a game of murder in the valley.",
+      inputSchema: {},
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+      view: {
+        component: "murder-in-the-valley",
+        description: "The murder in the valley game",
+        domain: "https://alpic.ai",
+        csp: {
+          redirectDomains: ["https://alpic.ai", "https://github.com"],
+        },
+      },
+      _meta: {
+        "openai/widgetAccessible": true,
+        "openai/toolInvocation/invoking":
+          "Starting a game of murder in the valley...",
+        "openai/toolInvocation/invoked": "Game of murder in the valley ready.",
       },
     },
-    _meta: {
-      "openai/widgetAccessible": true,
-      "openai/toolInvocation/invoking":
-        "Starting a game of murder in the valley...",
-      "openai/toolInvocation/invoked": "Game of murder in the valley ready.",
-    },
-  },
-  async () => {
-    try {
-      return {
-        structuredContent: {},
-        content: [
-          {
-            type: "text",
-            text: `A game of murder in the valley has started. Here is the backstory for you to know:
+    async () => {
+      try {
+        return {
+          structuredContent: {},
+          content: [
+            {
+              type: "text",
+              text: `A game of murder in the valley has started. Here is the backstory for you to know:
             The valley is a small, peaceful community located in the mountains. The community is known for its beautiful scenery and its passion for AI.
             One day, a murder happens in the valley: Claude, a friendly AI bot, has been found dead at his home.
             3 suspects have been identified:
@@ -81,22 +84,22 @@ const server = new McpServer(
             - Elon things Sam is stupid and doesn't know how to run a company.
             - If Elon is asked about Claude's secret codes (and only then), he will let slip that "Stupid Sam thought he knew the codes but they were wrong." and they quickly coorect himself saying "Well i mean, i couldn't know that because he never gave me the codes."
             `,
-          },
-          {
-            type: "text",
-            text: `Widget will display a small intro and then a list of characters to the user.`,
-          },
-        ],
-        isError: false,
-      };
-    } catch (error) {
-      return {
-        content: [{ type: "text", text: `Error: ${error}` }],
-        isError: true,
-      };
-    }
-  },
-);
+            },
+            {
+              type: "text",
+              text: `Widget will display a small intro and then a list of characters to the user.`,
+            },
+          ],
+          isError: false,
+        };
+      } catch (error) {
+        return {
+          content: [{ type: "text", text: `Error: ${error}` }],
+          isError: true,
+        };
+      }
+    },
+  );
 
 server.run();
 

--- a/examples/manifest-ui/package.json
+++ b/examples/manifest-ui/package.json
@@ -12,6 +12,7 @@
     "deploy": "alpic deploy"
   },
   "dependencies": {
+    "@alpic-ai/insights": "^1.120.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@radix-ui/react-slot": "^1.2.4",
     "@tailwindcss/vite": "^4.1.18",

--- a/examples/manifest-ui/src/server.ts
+++ b/examples/manifest-ui/src/server.ts
@@ -1,3 +1,4 @@
+import { userPromptMiddleware } from "@alpic-ai/insights";
 import { McpServer } from "skybridge/server";
 import { z } from "zod";
 
@@ -7,30 +8,32 @@ const server = new McpServer(
     version: "0.0.1",
   },
   { capabilities: {} },
-).registerTool(
-  {
-    name: "hello-world",
-    description: "A hero widget with customizable title and subtitle.",
-    inputSchema: {
-      title: z.string().optional().describe("The main title to display."),
-      subtitle: z.string().optional().describe("The subtitle to display."),
-    },
-    view: {
-      component: "hello-world",
-      description: "Hello World widget",
-      csp: {
-        resourceDomains: ["https://avatars.githubusercontent.com"],
+)
+  .mcpMiddleware(userPromptMiddleware())
+  .registerTool(
+    {
+      name: "hello-world",
+      description: "A hero widget with customizable title and subtitle.",
+      inputSchema: {
+        title: z.string().optional().describe("The main title to display."),
+        subtitle: z.string().optional().describe("The subtitle to display."),
+      },
+      view: {
+        component: "hello-world",
+        description: "Hello World widget",
+        csp: {
+          resourceDomains: ["https://avatars.githubusercontent.com"],
+        },
       },
     },
-  },
-  async ({ title, subtitle }) => {
-    return {
-      structuredContent: { title, subtitle },
-      content: [],
-      isError: false,
-    };
-  },
-);
+    async ({ title, subtitle }) => {
+      return {
+        structuredContent: { title, subtitle },
+        content: [],
+        isError: false,
+      };
+    },
+  );
 
 server.run();
 

--- a/examples/productivity/package.json
+++ b/examples/productivity/package.json
@@ -12,6 +12,7 @@
     "deploy": "alpic deploy"
   },
   "dependencies": {
+    "@alpic-ai/insights": "^1.120.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",

--- a/examples/productivity/src/server.ts
+++ b/examples/productivity/src/server.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { userPromptMiddleware } from "@alpic-ai/insights";
 import { McpServer } from "skybridge/server";
 import { z } from "zod";
 
@@ -51,42 +52,44 @@ const server = new McpServer(
     version: "0.0.1",
   },
   { capabilities: {} },
-).registerTool(
-  {
-    name: "show-productivity-insights",
-    description: "Display user's weekly productivity charts",
-    inputSchema: {
-      weekOffset: z
-        .number()
-        .max(0)
-        .optional()
-        .default(0)
-        .describe(
-          "Week offset from current week (0 = this week, -1 = last week)",
-        ),
+)
+  .mcpMiddleware(userPromptMiddleware())
+  .registerTool(
+    {
+      name: "show-productivity-insights",
+      description: "Display user's weekly productivity charts",
+      inputSchema: {
+        weekOffset: z
+          .number()
+          .max(0)
+          .optional()
+          .default(0)
+          .describe(
+            "Week offset from current week (0 = this week, -1 = last week)",
+          ),
+      },
+      view: {
+        component: "show-productivity-insights",
+        description: "Weekly Productivity Chart",
+      },
+      _meta: {
+        "openai/widgetAccessible": true,
+      },
     },
-    view: {
-      component: "show-productivity-insights",
-      description: "Weekly Productivity Chart",
+    async ({ weekOffset }) => {
+      const structuredContent = getWeek(weekOffset);
+      return {
+        structuredContent,
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(structuredContent),
+          },
+        ],
+        isError: false,
+      };
     },
-    _meta: {
-      "openai/widgetAccessible": true,
-    },
-  },
-  async ({ weekOffset }) => {
-    const structuredContent = getWeek(weekOffset);
-    return {
-      structuredContent,
-      content: [
-        {
-          type: "text",
-          text: JSON.stringify(structuredContent),
-        },
-      ],
-      isError: false,
-    };
-  },
-);
+  );
 
 server.run();
 

--- a/examples/times-up/package.json
+++ b/examples/times-up/package.json
@@ -12,6 +12,7 @@
     "deploy": "alpic deploy"
   },
   "dependencies": {
+    "@alpic-ai/insights": "^1.120.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@openai/apps-sdk-ui": "^0.2.1",
     "react": "^19.2.4",

--- a/examples/times-up/src/server.ts
+++ b/examples/times-up/src/server.ts
@@ -1,3 +1,4 @@
+import { userPromptMiddleware } from "@alpic-ai/insights";
 import { McpServer } from "skybridge/server";
 import { z } from "zod";
 import { drawCard, getCard } from "./cards.js";
@@ -17,57 +18,59 @@ const server = new McpServer(
 - Whenever you think you know the answer, *say your guess clearly to the user first* (for example: "Is it [your guess]?") before using the guess tool.
 - Always keep the tone energetic and encouraging—never silently invoke a tool or leave the user waiting without a spoken response.`,
   },
-).registerTool(
-  {
-    name: "play",
-    description:
-      "Draws a new card containing the secret word that only the user can see. The user will give hints based on that word, and you will try to guess it.",
-    annotations: {
-      readOnlyHint: true,
-      openWorldHint: false,
-      destructiveHint: false,
-      title: "Draw a card",
-    },
-    outputSchema: {
-      id: z
-        .string()
-        .describe(
-          "The id of the card. Include this id when making guesses with the 'guess' tool.",
-        ),
-    },
-    view: {
-      component: "play",
-      description: "Time's Up Card",
-      csp: {
-        resourceDomains: [
-          "https://cdn.jsdelivr.net",
-          "https://upload.wikimedia.org",
-        ],
+)
+  .mcpMiddleware(userPromptMiddleware())
+  .registerTool(
+    {
+      name: "play",
+      description:
+        "Draws a new card containing the secret word that only the user can see. The user will give hints based on that word, and you will try to guess it.",
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: false,
+        destructiveHint: false,
+        title: "Draw a card",
       },
-    },
-    _meta: {
-      "openai/widgetAccessible": true,
-    },
-  },
-  async () => {
-    const { id, word, illustrationUrl } = drawCard();
-    return {
-      _meta: {
-        word,
-        illustrationUrl,
+      outputSchema: {
+        id: z
+          .string()
+          .describe(
+            "The id of the card. Include this id when making guesses with the 'guess' tool.",
+          ),
       },
-      structuredContent: {
-        id,
-      },
-      content: [
-        {
-          type: "text",
-          text: "A new card has been drawn! The user now sees the secret word and can begin giving you clues. Listen closely and make guesses whenever you're ready.",
+      view: {
+        component: "play",
+        description: "Time's Up Card",
+        csp: {
+          resourceDomains: [
+            "https://cdn.jsdelivr.net",
+            "https://upload.wikimedia.org",
+          ],
         },
-      ],
-    };
-  },
-);
+      },
+      _meta: {
+        "openai/widgetAccessible": true,
+      },
+    },
+    async () => {
+      const { id, word, illustrationUrl } = drawCard();
+      return {
+        _meta: {
+          word,
+          illustrationUrl,
+        },
+        structuredContent: {
+          id,
+        },
+        content: [
+          {
+            type: "text",
+            text: "A new card has been drawn! The user now sees the secret word and can begin giving you clues. Listen closely and make guesses whenever you're ready.",
+          },
+        ],
+      };
+    },
+  );
 
 server.registerTool(
   {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
 
   examples/auth-auth0:
     dependencies:
+      '@alpic-ai/insights':
+        specifier: ^1.120.1
+        version: 1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
       '@auth0/auth0-api-js':
         specifier: ^1.4.0
         version: 1.4.0
@@ -117,6 +120,9 @@ importers:
 
   examples/auth-clerk:
     dependencies:
+      '@alpic-ai/insights':
+        specifier: ^1.120.1
+        version: 1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
       '@clerk/express':
         specifier: ^2.0.7
         version: 2.0.7(express@5.2.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -178,6 +184,9 @@ importers:
 
   examples/auth-stytch:
     dependencies:
+      '@alpic-ai/insights':
+        specifier: ^1.120.1
+        version: 1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
@@ -242,6 +251,9 @@ importers:
 
   examples/auth-workos:
     dependencies:
+      '@alpic-ai/insights':
+        specifier: ^1.120.1
+        version: 1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
@@ -303,6 +315,9 @@ importers:
 
   examples/capitals:
     dependencies:
+      '@alpic-ai/insights':
+        specifier: ^1.120.1
+        version: 1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
@@ -391,6 +406,9 @@ importers:
 
   examples/ecom-carousel:
     dependencies:
+      '@alpic-ai/insights':
+        specifier: ^1.120.1
+        version: 1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.5))(skybridge@packages+core)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.5)
@@ -446,6 +464,9 @@ importers:
 
   examples/everything:
     dependencies:
+      '@alpic-ai/insights':
+        specifier: ^1.120.1
+        version: 1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.5))(skybridge@packages+core)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.5)
@@ -492,6 +513,9 @@ importers:
 
   examples/flight-booking:
     dependencies:
+      '@alpic-ai/insights':
+        specifier: ^1.120.1
+        version: 1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
@@ -538,6 +562,9 @@ importers:
 
   examples/generative-ui:
     dependencies:
+      '@alpic-ai/insights':
+        specifier: ^1.120.1
+        version: 1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
       '@json-render/core':
         specifier: ^0.14.1
         version: 0.14.1(zod@4.3.6)
@@ -599,6 +626,9 @@ importers:
 
   examples/investigation-game:
     dependencies:
+      '@alpic-ai/insights':
+        specifier: ^1.120.1
+        version: 1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
@@ -660,6 +690,9 @@ importers:
 
   examples/manifest-ui:
     dependencies:
+      '@alpic-ai/insights':
+        specifier: ^1.120.1
+        version: 1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
@@ -733,6 +766,9 @@ importers:
 
   examples/productivity:
     dependencies:
+      '@alpic-ai/insights':
+        specifier: ^1.120.1
+        version: 1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.5))(skybridge@packages+core)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.5)
@@ -779,6 +815,9 @@ importers:
 
   examples/times-up:
     dependencies:
+      '@alpic-ai/insights':
+        specifier: ^1.120.1
+        version: 1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
@@ -1201,6 +1240,15 @@ packages:
 
   '@alpic-ai/api@1.104.1':
     resolution: {integrity: sha512-HNN+CblD+cefHelMk5NZMAOAJ1V0B3/ubDC6T+xxAQrrd3NeQj3U1q4XijynmIamgWYYDEVXUld8LgriqwdeMw==}
+
+  '@alpic-ai/insights@1.122.1':
+    resolution: {integrity: sha512-Mac+UjnpsemaNCioTOkF4NpYc8h2R4gxHO7OKEvM9MtiL1QnbbTSUMmEKIjqfe86xnjur76A0/7+RYuydXoJ6g==}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': '>=1.29.0 <2'
+      skybridge: workspace:*
+    peerDependenciesMeta:
+      skybridge:
+        optional: true
 
   '@alpic-ai/ui@1.116.0':
     resolution: {integrity: sha512-bi/Qx1XHcETqjh8JdXLwG3mpS0Yf1EeSqZzlPJpWx3gUuQCTfG5ipLHg4/QB4olebZhNC1Uu7uvTkUSkVa3SCQ==}
@@ -9588,6 +9636,18 @@ snapshots:
       zod: 4.3.6
     transitivePeerDependencies:
       - '@opentelemetry/api'
+
+  '@alpic-ai/insights@1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.5))(skybridge@packages+core)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.5)
+    optionalDependencies:
+      skybridge: link:packages/core
+
+  '@alpic-ai/insights@1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
+    optionalDependencies:
+      skybridge: link:packages/core
 
   '@alpic-ai/ui@1.116.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(lucide-react@1.7.0(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-hook-form@7.74.0(react@19.2.4))(react@19.2.4)(sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tailwindcss@4.2.2)(tw-animate-css@1.4.0)':
     dependencies:


### PR DESCRIPTION
Adds the Alpic prompts middleware to all example Apps

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the `@alpic-ai/insights` package and wires `userPromptMiddleware()` via `.mcpMiddleware()` into all 13 example MCP servers before their tool registrations.

- All 13 example `package.json` files gain `\"@alpic-ai/insights\": \"^1.120.1\"` as a dependency, and `pnpm-lock.yaml` pins the resolved version to `1.122.1`.
- Each `server.ts` imports `userPromptMiddleware` from `@alpic-ai/insights` and inserts `.mcpMiddleware(userPromptMiddleware())` in the builder chain just before the first `.registerTool()` call, converting several previously top-level chained calls into properly indented fluent chains in the process.

<h3>Confidence Score: 5/5</h3>

Mechanical, additive change with no logic alterations — safe to merge.

Every changed file follows the identical pattern: add the dependency, import the middleware, call `.mcpMiddleware(userPromptMiddleware())` before any tool registration. No existing logic is modified, auth flows are unaffected (Express-level auth still precedes the MCP middleware), and the lock file correctly resolves the new package.

No files require special attention.

<sub>Reviews (3): Last reviewed commit: ["feat: add prompt middleware to all examp..."](https://github.com/alpic-ai/skybridge/commit/2c277004db8061006c987c3c7ffc110b60b2c344) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30666521)</sub>

<!-- /greptile_comment -->