### PR TITLE
Update telemetry documentation with server runtime telemetry collection

### DIFF
--- a/docs/telemetry.mdx
+++ b/docs/telemetry.mdx
@@ -186,7 +186,7 @@ Debug mode applies to CLI telemetry only. The runtime tool-call counter has no p
 - We retain aggregated data for product analytics purposes
 - Individual events are anonymized and cannot be linked to specific users
 
-### Server tool-call counters
+### Tools/call events
 
 - The Skybridge runtime emits a [DogStatsD](https://docs.datadoghq.com/developers/dogstatsd/) counter over UDP for every `tools/call`
 - Packets are sent fire-and-forget; failures never block or delay tool execution

--- a/docs/telemetry.mdx
+++ b/docs/telemetry.mdx
@@ -53,7 +53,7 @@ That's the entire payload. There is no machine ID, no session ID, no tool name, 
 - ❌ Tool names, tool arguments, or tool results
 - ❌ End-user prompts, conversations, or model output
 - ❌ Environment variables or secrets
-- ❌ IP addresses or location data
+- ❌ IP addresses or location data stored or used as identifiers
 - ❌ Personal identifiable information
 
 ## Why We Collect Telemetry

--- a/docs/telemetry.mdx
+++ b/docs/telemetry.mdx
@@ -67,13 +67,14 @@ Telemetry helps us:
 
 ## How to Opt Out
 
-Telemetry configuration is **machine-wide**, not project-specific. Your preference is stored in `~/.skybridge/config.json` and applies to both the CLI and the Skybridge server runtime on the same machine. The runtime checks the same setting on every tool call, so toggling it takes effect immediately without restarting your server.
+Telemetry preferences are stored per-machine in `~/.skybridge/config.json`. You can also opt-out using environment variables `SKYBRIDGE_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1`. Environment variable overrides local configuration file. That file is only ever read on the machine where it lives, so the right opt-out depends on **where** the telemetry is being emitted from:
 
-You have multiple ways to disable telemetry:
+- **Your local development machine**: Prefer the use of `skybridge telemetry disable` that will update your local `~/.skybridge/config.json` config file
+- **CI runners** & **Deployed Skybridge servers**: Prefer the use of `SKYBRIDGE_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1` environment variable
 
-### Using the CLI
+### On your local machine
 
-The easiest way to disable telemetry:
+The easiest way to disable telemetry for the CLI and any local `skybridge dev` server:
 
 ```bash
 skybridge telemetry disable
@@ -91,9 +92,7 @@ Check your current telemetry status:
 skybridge telemetry status
 ```
 
-### Using Environment Variables
-
-Set `SKYBRIDGE_TELEMETRY_DISABLED=1` to disable telemetry:
+You can also set an environment variable in your shell profile:
 
 ```bash
 # In your shell profile (.bashrc, .zshrc, etc.)
@@ -106,9 +105,48 @@ Or use the standard `DO_NOT_TRACK` environment variable:
 export DO_NOT_TRACK=1
 ```
 
+### On a remote machine (CI and servers)
+
+`skybridge telemetry disable` only writes to the local machine's config file. It has **no effect** on deployed infrastructure — a server running in a container, on a VM, or in a serverless platform has its own filesystem where `~/.skybridge/config.json` does not exist, so the runtime falls back to the default (telemetry enabled).
+
+To opt a deployed server out, set `SKYBRIDGE_TELEMETRY_DISABLED=1` (or `DO_NOT_TRACK=1`) in the server's environment using whatever mechanism your platform provides:
+
+```bash
+# Docker
+docker run -e SKYBRIDGE_TELEMETRY_DISABLED=1 my-skybridge-app
+
+# Docker Compose
+services:
+  app:
+    environment:
+      SKYBRIDGE_TELEMETRY_DISABLED: "1"
+
+# Kubernetes
+env:
+  - name: SKYBRIDGE_TELEMETRY_DISABLED
+    value: "1"
+
+# AWS ECS / Fargate task definition
+"environment": [
+  { "name": "SKYBRIDGE_TELEMETRY_DISABLED", "value": "1" }
+]
+
+# Aplic / Cloudflare / Vercel / Netlify / Render / Fly.io / Railway
+# Set SKYBRIDGE_TELEMETRY_DISABLED=1 in the project's
+# environment variables / secrets dashboard.
+
+# GitHub Actions example
+env:
+  SKYBRIDGE_TELEMETRY_DISABLED: "1"
+
+# systemd unit
+[Service]
+Environment=SKYBRIDGE_TELEMETRY_DISABLED=1
+```
+
 ### Configuration File
 
-Telemetry settings are stored in `~/.skybridge/config.json`:
+On the local machine, telemetry settings are stored in `~/.skybridge/config.json`:
 
 ```json
 {
@@ -120,20 +158,10 @@ Telemetry settings are stored in `~/.skybridge/config.json`:
 ```
 
 <Note>
-Environment variables take precedence over the configuration file. If `SKYBRIDGE_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1` is set, telemetry will be disabled regardless of the config file setting.
+Environment variables always take precedence over the configuration file. If `SKYBRIDGE_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1` is set, telemetry is disabled regardless of any config file setting — and regardless of whether a config file exists at all.
 </Note>
 
-## CI Environments
-
 In CI environments (GitHub Actions, GitLab CI, Jenkins, etc.), telemetry is **enabled by default** and the machine ID is set to the CI provider name (e.g., `GitHub Actions`).
-
-To disable telemetry in CI, set the environment variable in your CI configuration:
-
-```yaml
-# GitHub Actions example
-env:
-  SKYBRIDGE_TELEMETRY_DISABLED: "1"
-```
 
 ## Debug Mode
 

--- a/docs/telemetry.mdx
+++ b/docs/telemetry.mdx
@@ -5,15 +5,22 @@ description: "Learn what data Skybridge collects, why we collect it, and how to 
 
 # Telemetry
 
-Skybridge collects anonymous usage telemetry to help us understand how the CLI is being used and improve the developer experience. **Telemetry is completely optional** and you can opt out at any time.
+Skybridge collects anonymous usage telemetry to help us understand how the framework is being used and improve the developer experience. Telemetry is collected from two places:
+
+1. **CLI commands** — when you run `skybridge dev`, `build`, `start`, etc.
+2. **Skybridge server runtime** — when a Skybridge-powered MCP server handles a `tools/call` request.
+
+**Telemetry is completely optional** and you can opt out at any time. The same opt-out controls apply to both telemetry collectors.
 
 <Info>
 **Your Privacy Matters**
 
-We only collect aggregate usage data. We never collect personal information, project code, file contents, or any sensitive data.
+We only collect aggregate usage data. We never collect personal information, project code, file contents, tool names, tool arguments, tool results, or any sensitive data.
 </Info>
 
 ## What We Collect
+
+### CLI commands
 
 When you run a Skybridge CLI command, we collect the following anonymous information:
 
@@ -29,10 +36,22 @@ When you run a Skybridge CLI command, we collect the following anonymous informa
 | **Node Version** | Your Node.js version | `v24.0.0` |
 | **Is CI** | Whether running in a CI environment | `true` or `false` |
 
+### Skybridge server tool calls
+
+When your deployed Skybridge server handles an MCP `tools/call` request, it emits a single anonymous counter so we can measure aggregate usage of Skybridge in production. We collect **only**:
+
+| Data | Description | Example |
+|------|-------------|---------|
+| **Version** | The Skybridge runtime version (major.minor only) | `1.2` |
+
+That's the entire payload. There is no machine ID, no session ID, no tool name, no arguments, no result, no IP-derived identity, and no user metadata attached to these events.
+
 ### What We Don't Collect
 
 - ❌ Project names or file paths
 - ❌ Source code or file contents
+- ❌ Tool names, tool arguments, or tool results
+- ❌ End-user prompts, conversations, or model output
 - ❌ Environment variables or secrets
 - ❌ IP addresses or location data
 - ❌ Personal identifiable information
@@ -44,11 +63,11 @@ Telemetry helps us:
 - **Understand usage patterns** — Which commands are most used? Where do developers spend time?
 - **Identify common errors** — What problems do developers encounter most frequently?
 - **Prioritize improvements** — Which platforms and Node versions should we support?
-- **Measure adoption** — How is Skybridge being adopted over time?
+- **Measure adoption** — How is Skybridge being adopted in production over time, and which versions are still in active use?
 
 ## How to Opt Out
 
-Telemetry configuration is **machine-wide**, not project-specific. Your preference is stored in `~/.skybridge/config.json` and applies to all Skybridge projects on the same machine.
+Telemetry configuration is **machine-wide**, not project-specific. Your preference is stored in `~/.skybridge/config.json` and applies to both the CLI and the Skybridge server runtime on the same machine. The runtime checks the same setting on every tool call, so toggling it takes effect immediately without restarting your server.
 
 You have multiple ways to disable telemetry:
 
@@ -118,7 +137,7 @@ env:
 
 ## Debug Mode
 
-To see what telemetry data would be sent without actually sending it, enable debug mode:
+To see what CLI telemetry data would be sent without actually sending it, enable debug mode:
 
 ```bash
 SKYBRIDGE_TELEMETRY_DEBUG=1 skybridge dev
@@ -126,9 +145,22 @@ SKYBRIDGE_TELEMETRY_DEBUG=1 skybridge dev
 
 This will print the telemetry event to stderr instead of sending it, useful for understanding exactly what data is collected.
 
+<Note>
+Debug mode applies to CLI telemetry only. The runtime tool-call counter has no payload beyond the version tag, so there is nothing to inspect — disabling telemetry is the only relevant control.
+</Note>
+
 ## Data Handling
 
-- Telemetry data is sent to [PostHog](https://posthog.com/), a privacy-focused analytics platform
+### CLI events
+
+- CLI telemetry is sent to [PostHog](https://posthog.com/), a privacy-focused analytics platform
 - Data is stored on PostHog's US servers
 - We retain aggregated data for product analytics purposes
 - Individual events are anonymized and cannot be linked to specific users
+
+### Server tool-call counters
+
+- The Skybridge runtime emits a [DogStatsD](https://docs.datadoghq.com/developers/dogstatsd/) counter over UDP for every `tools/call`
+- Packets are sent fire-and-forget; failures never block or delay tool execution
+- They are received by a Skybridge-operated [Vector](https://vector.dev/) instance
+- Only aggregate per-version counters are stored — there is no per-event record retained, and individual calls cannot be linked to a server, project, or user

--- a/docs/telemetry.mdx
+++ b/docs/telemetry.mdx
@@ -67,14 +67,40 @@ Telemetry helps us:
 
 ## How to Opt Out
 
-Telemetry preferences are stored per-machine in `~/.skybridge/config.json`. You can also opt-out using environment variables `SKYBRIDGE_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1`. Environment variable overrides local configuration file. That file is only ever read on the machine where it lives, so the right opt-out depends on **where** the telemetry is being emitted from:
+Telemetry preferences are stored per-machine. You can opt-out of telemetry using any of the following methods:
+- updating the `telemetry.enabled` property in `~/.skybridge/config.json` configuration file
+- using CLI `skybridge telemetry disable` command
+- setting environment variables `SKYBRIDGE_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1`
+
+The right opt-out method depends on **where** the telemetry is being emitted from:
 
 - **Your local development machine**: Prefer the use of `skybridge telemetry disable` that will update your local `~/.skybridge/config.json` config file
-- **CI runners** & **Deployed Skybridge servers**: Prefer the use of `SKYBRIDGE_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1` environment variable
+- **CI runners** & **Deployed Skybridge servers**: Prefer the use of `SKYBRIDGE_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1` environment variable. It's much simpler than packaging a local `~/.skybridge/config.json`
 
-### On your local machine
+### Using the Configuration File
 
-The easiest way to disable telemetry for the CLI and any local `skybridge dev` server:
+Telemetry settings are stored per-machine in `~/.skybridge/config.json`:
+
+```json
+{
+  "machineId": "a1b2c3d4-e5f6-...",
+  "telemetry": {
+    "enabled": false
+  }
+}
+``` 
+
+This file is generated on first skybridge CLI command run with `telemetry.enabled` set to `true` by default.
+
+Disable telemetry by setting `telemetry.enabled` to `false`.
+
+<Note>
+In CI environments (GitHub Actions, GitLab CI, Jenkins, etc.), telemetry is **enabled by default** and the machine ID is set to the CI provider name (e.g., `GitHub Actions`).
+</Note>
+
+### Using the CLI
+
+The easiest way to disable telemetry:
 
 ```bash
 skybridge telemetry disable
@@ -92,7 +118,11 @@ Check your current telemetry status:
 skybridge telemetry status
 ```
 
-You can also set an environment variable in your shell profile:
+All the above commands write and read from the `~/.skybridge/config.json` configuration file.
+
+### Using Environment Variables
+
+Set `SKYBRIDGE_TELEMETRY_DISABLED=1` to disable telemetry:
 
 ```bash
 # In your shell profile (.bashrc, .zshrc, etc.)
@@ -105,63 +135,9 @@ Or use the standard `DO_NOT_TRACK` environment variable:
 export DO_NOT_TRACK=1
 ```
 
-### On a remote machine (CI and servers)
-
-`skybridge telemetry disable` only writes to the local machine's config file. It has **no effect** on deployed infrastructure — a server running in a container, on a VM, or in a serverless platform has its own filesystem where `~/.skybridge/config.json` does not exist, so the runtime falls back to the default (telemetry enabled).
-
-To opt a deployed server out, set `SKYBRIDGE_TELEMETRY_DISABLED=1` (or `DO_NOT_TRACK=1`) in the server's environment using whatever mechanism your platform provides:
-
-```bash
-# Docker
-docker run -e SKYBRIDGE_TELEMETRY_DISABLED=1 my-skybridge-app
-
-# Docker Compose
-services:
-  app:
-    environment:
-      SKYBRIDGE_TELEMETRY_DISABLED: "1"
-
-# Kubernetes
-env:
-  - name: SKYBRIDGE_TELEMETRY_DISABLED
-    value: "1"
-
-# AWS ECS / Fargate task definition
-"environment": [
-  { "name": "SKYBRIDGE_TELEMETRY_DISABLED", "value": "1" }
-]
-
-# Aplic / Cloudflare / Vercel / Netlify / Render / Fly.io / Railway
-# Set SKYBRIDGE_TELEMETRY_DISABLED=1 in the project's
-# environment variables / secrets dashboard.
-
-# GitHub Actions example
-env:
-  SKYBRIDGE_TELEMETRY_DISABLED: "1"
-
-# systemd unit
-[Service]
-Environment=SKYBRIDGE_TELEMETRY_DISABLED=1
-```
-
-### Configuration File
-
-On the local machine, telemetry settings are stored in `~/.skybridge/config.json`:
-
-```json
-{
-  "machineId": "a1b2c3d4-e5f6-...",
-  "telemetry": {
-    "enabled": false
-  }
-}
-```
-
 <Note>
-Environment variables always take precedence over the configuration file. If `SKYBRIDGE_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1` is set, telemetry is disabled regardless of any config file setting — and regardless of whether a config file exists at all.
+Environment variables always take precedence over the configuration file. If `SKYBRIDGE_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1` is set, telemetry is disabled regardless of any config file setting, and regardless of whether a config file exists at all.
 </Note>
-
-In CI environments (GitHub Actions, GitLab CI, Jenkins, etc.), telemetry is **enabled by default** and the machine ID is set to the CI provider name (e.g., `GitHub Actions`).
 
 ## Debug Mode
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Adds documentation for a new server runtime telemetry channel that emits a DogStatsD UDP counter (version only) on every `tools/call`, alongside the existing CLI PostHog telemetry. The "What We Don't Collect" list is expanded, the IP-address bullet is narrowed to "stored or used as identifiers", and opt-out guidance is restructured to recommend env vars for CI/deployed servers.
- The previous review feedback on opt-out guidance for production deployments and the IP-address network-level claim have both been addressed in this revision.

<h3>Confidence Score: 5/5</h3>

Documentation-only PR with no logic changes; safe to merge.

Both previously raised issues (opt-out guidance for deployed servers and the network-level IP address claim) have been addressed. No remaining P0 or P1 findings. The restructured opt-out section now clearly directs production operators to env vars, and the IP bullet is correctly scoped to "stored or used as identifiers".

No files require special attention.

<sub>Reviews (6): Last reviewed commit: ["Rework the disable section"](https://github.com/alpic-ai/skybridge/commit/b93d3cf771bf1f69d2c6d77ee628292ec92e2240) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30831757)</sub>

<!-- /greptile_comment -->