### PR TITLE
feat: expose underlying express app as McpServer.express

### DIFF
--- a/docs/api-reference/mcp-server.mdx
+++ b/docs/api-reference/mcp-server.mdx
@@ -37,6 +37,30 @@ type McpServerOptions = {
 };
 ```
 
+## Properties
+
+### express
+
+The underlying [Express](https://expressjs.com/) app. Use this to register custom routes, middleware, or settings on the HTTP server backing your MCP server.
+
+```typescript
+import { McpServer } from "skybridge/server";
+
+const server = new McpServer({ name: "my-app", version: "1.0" });
+
+server.express.get("/health", (_req, res) => {
+  res.json({ status: "ok" });
+});
+
+server.express.set("trust proxy", 1);
+```
+
+`express.json()` is pre-applied. Register your handlers before `run()`; after `run()`, Skybridge appends dev-mode middleware (in development), the `/mcp` route, and the default error handler in that order.
+
+<Note>
+Alpic Cloud only routes traffic to `/mcp` on hosted workloads — custom routes work locally and on self-hosted deployments.
+</Note>
+
 ## Methods
 
 ### registerTool

--- a/packages/core/src/server/express.test.ts
+++ b/packages/core/src/server/express.test.ts
@@ -15,8 +15,6 @@ vi.mock("./viewsDevServer.js", () => ({
       next()) as RequestHandler,
 }));
 
-const fakeServer = {} as McpServer;
-
 async function listen(app: Parameters<typeof http.createServer>[1]) {
   const server = http.createServer(app);
   await new Promise<void>((resolve) => server.listen(0, resolve));
@@ -39,6 +37,111 @@ async function postApi(port: number) {
   return fetch(`http://localhost:${port}/api/test`, { method: "POST" });
 }
 
+describe("McpServer.express", () => {
+  it("exposes a ready Express app immediately after construction", () => {
+    const server = new McpServer({ name: "t", version: "0.0.0" });
+    expect(server.express).toBeDefined();
+    expect(typeof server.express.use).toBe("function");
+    expect(typeof server.express.get).toBe("function");
+  });
+
+  it("server.express.get registers a route reachable alongside /mcp", async () => {
+    const { createApp } = await import("./express.js");
+    const server = new McpServer({ name: "t", version: "0.0.0" });
+    server.express.get("/health", (_req, res) => {
+      res.json({ status: "ok" });
+    });
+
+    const httpServer = http.createServer();
+    await createApp({ mcpServer: server, httpServer });
+    const { port, server: listening } = await listen(server.express);
+    openServer = listening;
+
+    const health = await fetch(`http://localhost:${port}/health`);
+    expect(health.status).toBe(200);
+    expect(await health.json()).toEqual({ status: "ok" });
+
+    // /mcp still works (POST returns 200/4xx, not 404)
+    const mcp = await postMcp(port);
+    expect(mcp.status).not.toBe(404);
+  });
+
+  it("server.use and server.express.use produce the same registration order", async () => {
+    const { createApp } = await import("./express.js");
+    const callsA: string[] = [];
+    const callsB: string[] = [];
+
+    const buildServer = () => new McpServer({ name: "t", version: "0.0.0" });
+
+    const sA = buildServer();
+    sA.use((_req, _res, next) => {
+      callsA.push("first");
+      next();
+    });
+    sA.express.use((_req, _res, next) => {
+      callsA.push("second");
+      next();
+    });
+
+    const sB = buildServer();
+    sB.express.use((_req, _res, next) => {
+      callsB.push("first");
+      next();
+    });
+    sB.use((_req, _res, next) => {
+      callsB.push("second");
+      next();
+    });
+
+    for (const s of [sA, sB]) {
+      s.express.get("/probe", (_req, res) => res.json({ ok: true }));
+      const httpServer = http.createServer();
+      await createApp({ mcpServer: s, httpServer });
+      const { port, server: listening } = await listen(s.express);
+      openServer = listening;
+      await fetch(`http://localhost:${port}/probe`);
+      listening.close();
+    }
+
+    expect(callsA).toEqual(["first", "second"]);
+    expect(callsB).toEqual(["first", "second"]);
+  });
+
+  it("useOnError still wraps thrown /mcp errors after the route is mounted", async () => {
+    const { createApp } = await import("./express.js");
+    const server = new McpServer({ name: "t", version: "0.0.0" });
+    // Register the error handler BEFORE createApp — useOnError should still
+    // apply it after /mcp, so /mcp errors hit it.
+    const seen: string[] = [];
+    server.useOnError((_err, _req, res, _next) => {
+      seen.push("useOnError");
+      res.status(503).json({ from: "useOnError" });
+    });
+
+    // Force the /mcp handler to throw so the error pipeline runs.
+    vi.spyOn(server, "connectStatelessTransport").mockRejectedValue(
+      new Error("boom"),
+    );
+
+    const httpServer = http.createServer();
+    await createApp({
+      mcpServer: server,
+      httpServer,
+      // Mirror what run() does: forward the McpServer's useOnError handlers
+      // to createApp so they get applied after /mcp.
+      // biome-ignore lint/complexity/useLiteralKeys: test mirrors run() internals to verify useOnError ordering
+      errorMiddleware: server["customErrorMiddleware"],
+    });
+    const { port, server: listening } = await listen(server.express);
+    openServer = listening;
+
+    const res = await postMcp(port);
+    expect(seen).toEqual(["useOnError"]);
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ from: "useOnError" });
+  });
+});
+
 describe("createApp", () => {
   it("runs global custom middleware before the /mcp handler", async () => {
     const { createApp } = await import("./express.js");
@@ -49,15 +152,14 @@ describe("createApp", () => {
       next();
     };
 
-    const httpServer = http.createServer();
-    const app = await createApp({
-      mcpServer: fakeServer,
-      httpServer,
-      customMiddleware: [{ handlers: [mw] }],
-    });
+    const server = new McpServer({ name: "t", version: "0.0.0" });
+    server.use(mw);
 
-    const { port, server } = await listen(app);
-    openServer = server;
+    const httpServer = http.createServer();
+    const app = await createApp({ mcpServer: server, httpServer });
+
+    const { port, server: httpListening } = await listen(app);
+    openServer = httpListening;
 
     await postMcp(port);
     expect(calls).toEqual(["custom"]);
@@ -72,15 +174,14 @@ describe("createApp", () => {
       next();
     };
 
-    const httpServer = http.createServer();
-    const app = await createApp({
-      mcpServer: fakeServer,
-      httpServer,
-      customMiddleware: [{ path: "/mcp", handlers: [mw] }],
-    });
+    const server = new McpServer({ name: "t", version: "0.0.0" });
+    server.use("/mcp", mw);
 
-    const { port, server } = await listen(app);
-    openServer = server;
+    const httpServer = http.createServer();
+    const app = await createApp({ mcpServer: server, httpServer });
+
+    const { port, server: httpListening } = await listen(app);
+    openServer = httpListening;
 
     await postMcp(port);
     expect(calls).toEqual(["auth"]);
@@ -95,15 +196,14 @@ describe("createApp", () => {
       res.status(401).json({ error: "Unauthorized" });
     };
 
-    const httpServer = http.createServer();
-    const app = await createApp({
-      mcpServer: fakeServer,
-      httpServer,
-      customMiddleware: [{ path: "/mcp", handlers: [reject] }],
-    });
+    const server = new McpServer({ name: "t", version: "0.0.0" });
+    server.use("/mcp", reject);
 
-    const { port, server } = await listen(app);
-    openServer = server;
+    const httpServer = http.createServer();
+    const app = await createApp({ mcpServer: server, httpServer });
+
+    const { port, server: httpListening } = await listen(app);
+    openServer = httpListening;
 
     const res = await postMcp(port);
     expect(calls).toEqual(["reject"]);
@@ -124,15 +224,15 @@ describe("createApp", () => {
       next();
     };
 
-    const httpServer = http.createServer();
-    const app = await createApp({
-      mcpServer: fakeServer,
-      httpServer,
-      customMiddleware: [{ handlers: [mwA] }, { handlers: [mwB] }],
-    });
+    const server = new McpServer({ name: "t", version: "0.0.0" });
+    server.use(mwA);
+    server.use(mwB);
 
-    const { port, server } = await listen(app);
-    openServer = server;
+    const httpServer = http.createServer();
+    const app = await createApp({ mcpServer: server, httpServer });
+
+    const { port, server: httpListening } = await listen(app);
+    openServer = httpListening;
 
     await postMcp(port);
     expect(calls).toEqual(["A", "B"]);
@@ -147,15 +247,14 @@ describe("createApp", () => {
       next();
     };
 
-    const httpServer = http.createServer();
-    const app = await createApp({
-      mcpServer: fakeServer,
-      httpServer,
-      customMiddleware: [{ path: "/api", handlers: [apiMw] }],
-    });
+    const server = new McpServer({ name: "t", version: "0.0.0" });
+    server.use("/api", apiMw);
 
-    const { port, server } = await listen(app);
-    openServer = server;
+    const httpServer = http.createServer();
+    const app = await createApp({ mcpServer: server, httpServer });
+
+    const { port, server: httpListening } = await listen(app);
+    openServer = httpListening;
 
     // Hit /mcp — the /api middleware should NOT fire
     await postMcp(port);
@@ -171,15 +270,14 @@ describe("createApp", () => {
       res.json({ status: "ok" });
     });
 
-    const httpServer = http.createServer();
-    const app = await createApp({
-      mcpServer: fakeServer,
-      httpServer,
-      customMiddleware: [{ handlers: [router as RequestHandler] }],
-    });
+    const server = new McpServer({ name: "t", version: "0.0.0" });
+    server.use(router as RequestHandler);
 
-    const { port, server } = await listen(app);
-    openServer = server;
+    const httpServer = http.createServer();
+    const app = await createApp({ mcpServer: server, httpServer });
+
+    const { port, server: httpListening } = await listen(app);
+    openServer = httpListening;
 
     const res = await fetch(`http://localhost:${port}/health`);
     expect(res.status).toBe(200);
@@ -195,17 +293,14 @@ describe("createApp", () => {
       res.json({ value: 42 });
     });
 
-    const httpServer = http.createServer();
-    const app = await createApp({
-      mcpServer: fakeServer,
-      httpServer,
-      customMiddleware: [
-        { path: "/api", handlers: [router as RequestHandler] },
-      ],
-    });
+    const server = new McpServer({ name: "t", version: "0.0.0" });
+    server.use("/api", router as RequestHandler);
 
-    const { port, server } = await listen(app);
-    openServer = server;
+    const httpServer = http.createServer();
+    const app = await createApp({ mcpServer: server, httpServer });
+
+    const { port, server: httpListening } = await listen(app);
+    openServer = httpListening;
 
     const res = await fetch(`http://localhost:${port}/api/data`);
     expect(res.status).toBe(200);
@@ -219,15 +314,14 @@ describe("createApp", () => {
       throw new Error("boom");
     };
 
-    const httpServer = http.createServer();
-    const app = await createApp({
-      mcpServer: fakeServer,
-      httpServer,
-      customMiddleware: [{ path: "/explode", handlers: [throwing] }],
-    });
+    const server = new McpServer({ name: "t", version: "0.0.0" });
+    server.use("/explode", throwing);
 
-    const { port, server } = await listen(app);
-    openServer = server;
+    const httpServer = http.createServer();
+    const app = await createApp({ mcpServer: server, httpServer });
+
+    const { port, server: httpListening } = await listen(app);
+    openServer = httpListening;
 
     const res = await fetch(`http://localhost:${port}/explode`);
     expect(res.status).toBe(500);
@@ -241,10 +335,18 @@ describe("createApp", () => {
     const { createApp } = await import("./express.js");
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
+    const mcpServer = new McpServer({ name: "t", version: "0.0.0" });
+    // Force the express-level error path: make connectStatelessTransport
+    // reject so the request handler hits its try/catch and calls next(error),
+    // which lands in the default /mcp error handler.
+    vi.spyOn(mcpServer, "connectStatelessTransport").mockRejectedValue(
+      new Error("boom"),
+    );
+
     const httpServer = http.createServer();
-    const app = await createApp({ mcpServer: fakeServer, httpServer });
-    const { port, server } = await listen(app);
-    openServer = server;
+    const app = await createApp({ mcpServer, httpServer });
+    const { port, server: httpListening } = await listen(app);
+    openServer = httpListening;
 
     const res = await postMcp(port);
     expect(res.status).toBe(500);
@@ -269,14 +371,19 @@ describe("createApp", () => {
       res.status(503).json({ custom: true });
     };
 
+    const mcpServer = new McpServer({ name: "t", version: "0.0.0" });
+    vi.spyOn(mcpServer, "connectStatelessTransport").mockRejectedValue(
+      new Error("boom"),
+    );
+
     const httpServer = http.createServer();
     const app = await createApp({
-      mcpServer: fakeServer,
+      mcpServer,
       httpServer,
       errorMiddleware: [{ handlers: [errorHandler] }],
     });
-    const { port, server } = await listen(app);
-    openServer = server;
+    const { port, server: httpListening } = await listen(app);
+    openServer = httpListening;
 
     const res = await postMcp(port);
     expect(calls).toEqual(["error-handler"]);
@@ -297,15 +404,20 @@ describe("createApp", () => {
       next(new Error("api error"));
     };
 
+    const mcpServer = new McpServer({ name: "t", version: "0.0.0" });
+    vi.spyOn(mcpServer, "connectStatelessTransport").mockRejectedValue(
+      new Error("boom"),
+    );
+    mcpServer.use("/api/test", throwingApiRoute);
+
     const httpServer = http.createServer();
     const app = await createApp({
-      mcpServer: fakeServer,
+      mcpServer,
       httpServer,
-      customMiddleware: [{ path: "/api/test", handlers: [throwingApiRoute] }],
       errorMiddleware: [{ path: "/mcp", handlers: [mcpErrorHandler] }],
     });
-    const { port, server } = await listen(app);
-    openServer = server;
+    const { port, server: httpListening } = await listen(app);
+    openServer = httpListening;
 
     const mcpRes = await postMcp(port);
     expect(calls).toEqual(["mcp-error-handler"]);
@@ -392,8 +504,9 @@ describe("createApp tunnel routes", () => {
     process.env.__TUNNEL_CONTROL_PORT = String(controlPort);
     try {
       const { createApp } = await import("./express.js");
+      const mcpServer = new McpServer({ name: "t", version: "0.0.0" });
       const httpServer = http.createServer();
-      const app = await createApp({ mcpServer: fakeServer, httpServer });
+      const app = await createApp({ mcpServer, httpServer });
       const { port, server } = await listen(app);
       openServer = server;
 
@@ -418,8 +531,10 @@ describe("createApp tunnel routes", () => {
     try {
       vi.resetModules();
       const { createApp } = await import("./express.js");
+      const { McpServer: ReloadedMcpServer } = await import("./server.js");
+      const mcpServer = new ReloadedMcpServer({ name: "t", version: "0.0.0" });
       const httpServer = http.createServer();
-      const app = await createApp({ mcpServer: fakeServer, httpServer });
+      const app = await createApp({ mcpServer, httpServer });
       const { port, server } = await listen(app);
       openServer = server;
 

--- a/packages/core/src/server/express.ts
+++ b/packages/core/src/server/express.ts
@@ -20,7 +20,7 @@ function applyMiddlewares(
   app: express.Express,
   middlewares: Array<{
     path?: string;
-    handlers: Array<express.RequestHandler | express.ErrorRequestHandler>;
+    handlers: express.ErrorRequestHandler[];
   }>,
 ): void {
   for (const middleware of middlewares) {
@@ -51,21 +51,16 @@ function defaultErrorHandler(
 export async function createApp({
   mcpServer,
   httpServer,
-  customMiddleware = [],
   errorMiddleware = [],
 }: {
   mcpServer: McpServer;
   httpServer: http.Server;
-  customMiddleware?: { path?: string; handlers: express.RequestHandler[] }[];
   errorMiddleware?: {
     path?: string;
     handlers: express.ErrorRequestHandler[];
   }[];
 }): Promise<express.Express> {
-  const app = express();
-  app.use(express.json());
-
-  applyMiddlewares(app, customMiddleware);
+  const app = mcpServer.express;
 
   // Read `process.env.NODE_ENV` inline: wrangler/esbuild only substitute the literal expression,
   // so a local const would defeat dead-code elimination of the dev-only imports below.

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -26,7 +26,11 @@ import type {
   ToolAnnotations,
 } from "@modelcontextprotocol/sdk/types.js";
 import { mergeWith, union } from "es-toolkit";
-import type { ErrorRequestHandler, Express, RequestHandler } from "express";
+import express, {
+  type ErrorRequestHandler,
+  type Express,
+  type RequestHandler,
+} from "express";
 import { createApp } from "./express.js";
 import { createMiddlewareEntry } from "./metric.js";
 import type {
@@ -256,11 +260,6 @@ type ToolHandler<
   extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
 ) => TReturn | Promise<TReturn>;
 
-type MiddlewareConfig = {
-  path?: string;
-  handlers: RequestHandler[];
-};
-
 type ErrorMiddlewareConfig = {
   path?: string;
   handlers: ErrorRequestHandler[];
@@ -294,8 +293,19 @@ export class McpServer<
   TTools extends Record<string, ToolDef> = Record<never, ToolDef>,
 > extends McpServerBaseOmitted {
   declare readonly $types: McpServerTypes<TTools>;
-  private express?: Express;
-  private customMiddleware: MiddlewareConfig[] = [];
+  /**
+   * The underlying Express app. Use this to extend the HTTP server with
+   * custom routes, middleware, or settings — e.g.
+   * `server.app.get("/health", ...)`.
+   *
+   * `express.json()` is pre-applied. Register your handlers before `run()`;
+   * after `run()`, dev-mode middleware, the `/mcp` route, and the default
+   * error handler are appended in that order.
+   *
+   * Note: Alpic Cloud only routes traffic to `/mcp` — custom routes work
+   * locally and on self-hosted deployments.
+   */
+  readonly express: Express;
   private customErrorMiddleware: ErrorMiddlewareConfig[] = [];
   private mcpMiddlewareEntries: McpMiddlewareEntry[] = [];
   private mcpMiddlewareApplied = false;
@@ -308,6 +318,8 @@ export class McpServer<
     super(serverInfo, options);
     this.serverInfo = serverInfo;
     this.serverOptions = options;
+    this.express = express();
+    this.express.use(express.json());
   }
 
   use(...handlers: RequestHandler[]): this;
@@ -316,17 +328,13 @@ export class McpServer<
     pathOrHandler: string | RequestHandler,
     ...handlers: RequestHandler[]
   ): this {
+    // Branching is load-bearing: Express's `app.use` overloads can't be
+    // resolved against a `string | RequestHandler` union, so we narrow.
     if (typeof pathOrHandler === "string") {
-      this.customMiddleware.push({
-        path: pathOrHandler,
-        handlers,
-      });
+      this.express.use(pathOrHandler, ...handlers);
     } else {
-      this.customMiddleware.push({
-        handlers: [pathOrHandler, ...handlers],
-      });
+      this.express.use(pathOrHandler, ...handlers);
     }
-
     return this;
   }
 
@@ -508,14 +516,11 @@ export class McpServer<
     this.applyMcpMiddleware();
     const httpServer = http.createServer();
 
-    if (!this.express) {
-      this.express = await createApp({
-        mcpServer: this,
-        httpServer,
-        customMiddleware: this.customMiddleware,
-        errorMiddleware: this.customErrorMiddleware,
-      });
-    }
+    await createApp({
+      mcpServer: this,
+      httpServer,
+      errorMiddleware: this.customErrorMiddleware,
+    });
 
     httpServer.on("request", this.express);
     const port = parseInt(process.env.__PORT ?? "3000", 10);

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -296,7 +296,7 @@ export class McpServer<
   /**
    * The underlying Express app. Use this to extend the HTTP server with
    * custom routes, middleware, or settings — e.g.
-   * `server.app.get("/health", ...)`.
+   * `server.express.get("/health", ...)`.
    *
    * `express.json()` is pre-applied. Register your handlers before `run()`;
    * after `run()`, dev-mode middleware, the `/mcp` route, and the default


### PR DESCRIPTION
before this, McpServer exposed `.use()` and `.useOnError()` for express middleware, but anything beyond

McpServer now has a public `readonly express: Express`, eager-init in the constructor with `express.json()` pre-applied. createApp no longer creates its own express instance — it mounts dev middleware → /mcp → user error handlers → default error handler onto `mcpServer.app`. `.use()` becomes a thin passthrough; `.useOnError()` keeps deferred semantics so it still wraps /mcp errors regardless of when you register it.

runtime order is unchanged: express.json → user routes/middleware (registered before run) → dev middleware → /assets static (prod only) → /mcp → user error handlers → default /mcp error handler.

backwards compat: `.use()` and `.useOnError()` keep their existing shape. Only behavioral change: `.use()` now applies immediately rather than deferring until run() — matches how it was already documented.

how to test: add `server.express.get("/health", (_req, res) => res.json({ status: "ok" }))` then curl localhost:3000/health

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Exposes `McpServer.express` as a public `readonly Express` instance, eagerly initialized in the constructor with `express.json()` pre-applied. `use()` becomes an immediate passthrough while `useOnError()` retains deferred semantics so error handlers are always placed after `/mcp` regardless of call order.
- `createApp` now consumes `mcpServer.express` directly instead of creating its own app, removing the `customMiddleware` parameter and eliminating a potential source of divergence between the two app instances.
- Tests are updated to use real `McpServer` instances and a new suite directly exercises the `express` property's availability, routing, middleware ordering, and `useOnError` deferral.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — no bugs or regressions found.

All four changed files are coherent: the public `express` property is initialized correctly, middleware ordering invariants are preserved, tests cover the critical `useOnError` deferral path, and backward-compatible `use()`/`useOnError()` signatures remain unchanged. No P0 or P1 findings.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["fix: doc"](https://github.com/alpic-ai/skybridge/commit/93ec5bafecbf44943670647bd958d3254f246a6b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30851366)</sub>

<!-- /greptile_comment -->