### PR TITLE
Implement auto-open of devtools after skybridge dev

### DIFF
--- a/docs/api-reference/cli.mdx
+++ b/docs/api-reference/cli.mdx
@@ -39,10 +39,14 @@ You can also set the port via the `PORT` environment variable:
 PORT=8080 skybridge dev
 ```
 
-Set `SKYBRIDGE_OPEN=false` to disable auto-opening DevTools by default (equivalent to passing `--no-open` on every run):
+If you'd rather never have DevTools opened automatically, export `SKYBRIDGE_OPEN=false` at the shell level (e.g. in your `~/.zshrc`, `~/.bashrc`, or shell profile). It's equivalent to passing `--no-open` on every run, but lets you opt out once globally instead of per-invocation:
 
 ```bash
+# one-off
 SKYBRIDGE_OPEN=false skybridge dev
+
+# persistent (add to your shell profile)
+export SKYBRIDGE_OPEN=false
 ```
 
 ---

--- a/docs/api-reference/cli.mdx
+++ b/docs/api-reference/cli.mdx
@@ -29,11 +29,20 @@ skybridge dev
 | Flag | Description |
 |------|-------------|
 | `-p, --port <number>` | Port to run the server on. Defaults to `3000`, or the next available port if `3000` is in use. |
+| `--tunnel` | Open an Alpic tunnel for remote testing. |
+| `--no-open` | Don't open DevTools in the browser when the server is ready. |
+| `-v, --verbose` | Show tunnel logs. |
 
 You can also set the port via the `PORT` environment variable:
 
 ```bash
 PORT=8080 skybridge dev
+```
+
+Set `SKYBRIDGE_OPEN=false` to disable auto-opening DevTools by default (equivalent to passing `--no-open` on every run):
+
+```bash
+SKYBRIDGE_OPEN=false skybridge dev
 ```
 
 ---

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,6 +67,7 @@
     "express": "^5.2.1",
     "handlebars": "^4.7.9",
     "ink": "^7.0.0",
+    "open": "^11.0.0",
     "posthog-node": "^5.28.9",
     "superjson": "^2.2.6",
     "zustand": "^5.0.12"

--- a/packages/core/src/cli/use-open-browser.ts
+++ b/packages/core/src/cli/use-open-browser.ts
@@ -1,0 +1,52 @@
+import net from "node:net";
+import open from "open";
+import { useEffect, useRef } from "react";
+
+const POLL_INTERVAL_MS = 200;
+const POLL_TIMEOUT_MS = 5_000;
+
+const isPortListening = (port: number): Promise<boolean> =>
+  new Promise((resolve) => {
+    const socket = net.createConnection({ port, host: "127.0.0.1" });
+    socket.once("connect", () => {
+      socket.end();
+      resolve(true);
+    });
+    socket.once("error", () => {
+      socket.destroy();
+      resolve(false);
+    });
+  });
+
+export function useOpenBrowser(port: number, enabled: boolean): void {
+  const opened = useRef(false);
+
+  useEffect(() => {
+    if (!enabled || opened.current) {
+      return;
+    }
+
+    let cancelled = false;
+    const deadline = Date.now() + POLL_TIMEOUT_MS;
+
+    const tick = async () => {
+      while (!cancelled && Date.now() < deadline) {
+        if (await isPortListening(port)) {
+          if (cancelled || opened.current) {
+            return;
+          }
+          opened.current = true;
+          await open(`http://localhost:${port}/`).catch(() => {});
+          return;
+        }
+        await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+      }
+    };
+
+    void tick();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [port, enabled]);
+}

--- a/packages/core/src/commands/dev.tsx
+++ b/packages/core/src/commands/dev.tsx
@@ -5,6 +5,7 @@ import { Header } from "../cli/header.js";
 import { startTunnelControlServer } from "../cli/tunnel-control-server.js";
 import { useMessages } from "../cli/use-messages.js";
 import { useNodemon } from "../cli/use-nodemon.js";
+import { useOpenBrowser } from "../cli/use-open-browser.js";
 import { useTunnel } from "../cli/use-tunnel.js";
 import { useTypeScriptCheck } from "../cli/use-typescript-check.js";
 
@@ -20,6 +21,11 @@ export default class Dev extends Command {
     tunnel: Flags.boolean({
       description: "Open an Alpic tunnel for remote testing",
       default: false,
+    }),
+    open: Flags.boolean({
+      description: "Open DevTools in the browser when the server is ready",
+      default: true,
+      allowNo: true,
     }),
     verbose: Flags.boolean({
       char: "v",
@@ -52,6 +58,7 @@ export default class Dev extends Command {
       const tsErrors = useTypeScriptCheck();
       const [messages, pushMessage] = useMessages();
       useNodemon(env, pushMessage);
+      useOpenBrowser(port, flags.open);
       const tunnelState = useTunnel(
         port,
         pushMessage,

--- a/packages/core/src/commands/dev.tsx
+++ b/packages/core/src/commands/dev.tsx
@@ -24,7 +24,7 @@ export default class Dev extends Command {
     }),
     open: Flags.boolean({
       description: "Open DevTools in the browser when the server is ready",
-      default: true,
+      default: process.env.SKYBRIDGE_OPEN !== "false",
       allowNo: true,
     }),
     verbose: Flags.boolean({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -895,6 +895,9 @@ importers:
       nodemon:
         specifier: '>=3.0.0'
         version: 3.1.11
+      open:
+        specifier: ^11.0.0
+        version: 11.0.0
       posthog-node:
         specifier: ^5.28.9
         version: 5.28.9(rxjs@7.8.2)


### PR DESCRIPTION
Just launches devtools on `skybridge dev`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds automatic browser launch on `skybridge dev` via a new `useOpenBrowser` hook that TCP-polls the dev-server port and calls `open()` once it is reachable. Users can opt out with `--no-open` or the `SKYBRIDGE_OPEN=false` env var, and the docs are updated to cover the new flag plus two previously undocumented flags.

- **`use-open-browser.ts`**: polls `127.0.0.1:{port}` every 200 ms up to a 5 s deadline, then calls `open()`. The `useRef` guard and `cancelled` flag correctly prevent double-opens across re-renders.
- **`dev.tsx`**: adds the `open` boolean flag with `allowNo: true`; the env-var default (`process.env.SKYBRIDGE_OPEN !== "false"`) is evaluated at module load time, which is the correct point in the lifecycle.
- **`docs/api-reference/cli.mdx`**: documents `--no-open`, the `SKYBRIDGE_OPEN` env var, and the pre-existing `--tunnel` / `-v` flags.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is self-contained and adds opt-in/opt-out controls at both the CLI and environment-variable level.

The new hook is well-guarded against double-opens and re-render races. The only unreported finding is a minor socket-resource nit (using socket.end() instead of socket.destroy() for the port probe), which does not affect correctness. The two more substantive concerns (short timeout, silent open() error) were already captured in prior review threads.

No files require special attention beyond the previously noted timeout and error-handling improvements in use-open-browser.ts.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/core/src/cli/use-open-browser.ts:11-14
Using `socket.end()` initiates a graceful half-close and leaves the socket in a half-open state until the remote side responds — during polling this means up to ~25 lingering sockets, and the HTTP dev-server will receive and log empty/malformed request attempts for each probe. `socket.destroy()` immediately releases the OS resource and avoids this noise.

```suggestion
    socket.once("connect", () => {
      socket.destroy();
      resolve(true);
    });
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Add precision to the docs"](https://github.com/alpic-ai/skybridge/commit/4fe19bc9e833413473a0f28a7eef7bbf655c5a03) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30851808)</sub>

<!-- /greptile_comment -->