### PR TITLE
fix: docker doc

### DIFF
--- a/docs/quickstart/deploy.mdx
+++ b/docs/quickstart/deploy.mdx
@@ -125,23 +125,29 @@ Skybridge's local dev server (`skybridge dev`) and the Cloudflare path are indep
 
 ## Docker
 
-The `create-skybridge` template ships with a multi-stage `Dockerfile` so you can self-host on any container platform (Cloud Run, Fly.io, ECS, Kubernetes, etc.).
+Projects created with the [Skybridge scaffolder](/quickstart/create-new-app#scaffold-your-project) include a multi-stage `Dockerfile` so you can self-host on any container platform:
 
-```bash
-# Generate a lockfile first — the Dockerfile uses `npm ci`
+<CodeGroup>
+```bash npm
 npm install
-
 docker build -t my-app .
 docker run -p 3000:3000 my-app
 ```
-
-The container always listens on port 3000 internally — map it to whichever host port you want:
-
-```bash
-docker run -p 8080:3000 my-app
+```bash pnpm
+pnpm install
+docker build -t my-app .
+docker run -p 3000:3000 my-app
 ```
+```bash yarn
+yarn install
+docker build -t my-app .
+docker run -p 3000:3000 my-app
+```
+</CodeGroup>
 
-The Dockerfile defaults to `npm`. If you scaffolded with `pnpm`, `yarn`, or `bun`, swap the install / build / prune commands and the lockfile in the `COPY` line.
+<Note>
+The package manager is detected from the lockfile (`package-lock.json`, `yarn.lock`, or `pnpm-lock.yaml`). Bun and Deno are not supported yet: you'll need to adapt the build stage inside the Dockerfile.
+</Note>
 
 ## What's Next?
 


### PR DESCRIPTION
current version is wrong: the dockerfile supports npm, pnpm and yarn.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects the Docker section of the quickstart docs, replacing the misleading npm-only example with a `CodeGroup` covering npm, pnpm, and yarn, and adding a `Note` about lockfile-based package manager detection. The claims are accurate and match the actual `Dockerfile` in `packages/create-skybridge/template/Dockerfile`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation-only change with accurate content verified against the actual Dockerfile.

Single documentation file changed, no code logic affected. All updated claims (lockfile detection, supported package managers, bun/Deno limitation) match the template Dockerfile exactly.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix: docker doc"](https://github.com/alpic-ai/skybridge/commit/a830bd9e6571bd3fbff0bc0160855557a7ecf11a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30867259)</sub>

<!-- /greptile_comment -->