### PR TITLE
docs: add client support status page

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -34,7 +34,8 @@
                 "pages": [
                   "fundamentals",
                   "fundamentals/apps-sdk",
-                  "fundamentals/mcp-apps"
+                  "fundamentals/mcp-apps",
+                  "fundamentals/client-support"
                 ]
               },
               "quickstart/create-new-app",

--- a/docs/fundamentals/client-support.mdx
+++ b/docs/fundamentals/client-support.mdx
@@ -1,0 +1,111 @@
+---
+title: Client Support
+sidebarTitle: Client Support
+description: "Support status and feature availability for Skybridge apps across ChatGPT, Claude, Goose, VSCode, and other MCP clients."
+---
+
+Skybridge apps run on two runtimes — **Apps SDK** (ChatGPT) and **MCP Apps** (open spec). This page maps each AI client to its runtime, shows which Skybridge features are available per client, and documents known client-specific behavior.
+
+## Client Overview
+
+| Client | Type | Runtime | Connection |
+|--------|------|---------|------------|
+| **ChatGPT** | General-purpose AI | Apps SDK (`window.openai`) | Public URL required |
+| **Claude** | General-purpose AI | MCP Apps (ext-apps) | Public URL required |
+| **Goose** | Desktop agent | MCP Apps (ext-apps) | Localhost OK |
+| **VSCode** | IDE | MCP Apps (ext-apps) | Localhost OK |
+| **Postman** | API tool | MCP Apps (ext-apps) | Localhost OK |
+| **MCPJam** | MCP inspector | MCP Apps (ext-apps) | Localhost OK |
+
+<Note>
+Coding agents (Claude Code, Codex CLI, Gemini CLI, Cursor, Amp) implement MCP for tool calling but are headless — they do not render iframes and cannot display views.
+</Note>
+
+All MCP Apps clients (Claude, Goose, VSCode, and others) share the same feature set because they all implement the same [ext-apps specification](https://github.com/modelcontextprotocol/ext-apps).
+
+## Feature Availability by Client
+
+| Hook / Feature | ChatGPT | Claude | Goose | VSCode |
+|----------------|:-------:|:------:|:-----:|:------:|
+| [useToolInfo](/api-reference/use-tool-info) | ✅ | ✅ | ✅ | ✅ |
+| [useCallTool](/api-reference/use-call-tool) | ✅ | ✅ | ✅ | ✅ |
+| [useSendFollowUpMessage](/api-reference/use-send-follow-up-message) | ✅ | ✅ | ✅ | ✅ |
+| [useOpenExternal](/api-reference/use-open-external) | ✅ | ✅ | ✅ | ✅ |
+| [useLayout](/api-reference/use-layout) | ✅ | ✅ | ✅ | ✅ |
+| [useUser](/api-reference/use-user) | ✅ | ✅ | ✅ | ✅ |
+| [useDisplayMode](/api-reference/use-display-mode) | ✅ | ✅ | ✅ | ✅ |
+| [useViewState](/api-reference/use-view-state) | ✅ | ⚠️ | ⚠️ | ⚠️ |
+| [data-llm](/api-reference/data-llm) | ✅ | ⚠️ | ⚠️ | ⚠️ |
+| [useRequestModal](/api-reference/use-request-modal) | ✅ | ⚠️ | ⚠️ | ⚠️ |
+| [useFiles](/api-reference/use-files) | ✅ | ❌ | ❌ | ❌ |
+| [useSetOpenInAppUrl](/api-reference/use-set-open-in-app-url) | ✅ | ❌ | ❌ | ❌ |
+| [useAppsSdkContext](/api-reference/use-apps-sdk-context) | ✅ | ❌ | ❌ | ❌ |
+| [useMcpAppContext](/api-reference/use-mcp-app-context) | ❌ | ✅ | ✅ | ✅ |
+
+## Client-Specific Notes
+
+### ChatGPT
+
+- **Runtime**: Apps SDK (`window.openai`) with MCP Apps compatibility layer
+- **Exclusive features**: `useFiles`, `useSetOpenInAppUrl`, and raw `window.openai` APIs not yet wrapped by Skybridge (`requestCheckout`, `requestClose`, `notifyIntrinsicHeight`)
+- **Tool accessibility**: Tools invoked from a view must set `_meta["openai/widgetAccessible"]: true`
+- **Caching**: ChatGPT aggressively caches views — use [DevTools](/devtools) for iteration and test in ChatGPT only for final validation
+- **Connection**: Requires a public URL. Run `npm run dev --tunnel` during development
+
+<Note>
+ChatGPT: tools must declare `_meta["openai/widgetAccessible"]: true`; MCP Apps: all tools accessible by default
+</Note>
+
+### Claude
+
+- **Runtime**: MCP Apps (ext-apps spec)
+- **Connection**: Requires a public URL. Run `npm run dev --tunnel` during development
+- **Setup**: **Settings → Connectors → Add Custom Connector**, then enter your `/mcp` URL
+
+<Note>
+`useViewState` and `data-llm` are polyfilled — state does not persist across view renders. `useRequestModal` is polyfilled — renders in-iframe instead of a host modal. All tools are accessible via `useCallTool` by default.
+</Note>
+
+### Goose
+
+- **Runtime**: MCP Apps (ext-apps spec)
+- **Connection**: Connects directly to `localhost` — no tunnel or public URL needed
+- **Setup**: Point Goose to `http://localhost:3000/mcp`
+- **Note**: Preferred for validating MCP Apps views during development because DevTools only mocks the Apps SDK (ChatGPT) runtime
+
+<Note>
+`useViewState` and `data-llm` are polyfilled — state does not persist across view renders. `useRequestModal` is polyfilled — renders in-iframe instead of a host modal. All tools are accessible via `useCallTool` by default.
+</Note>
+
+### VSCode
+
+- **Runtime**: MCP Apps (ext-apps spec)
+- **Connection**: Connects directly to `localhost` — no tunnel or public URL needed
+- **Setup**: Point your VSCode MCP config to `http://localhost:3000/mcp`
+
+<Note>
+`useViewState` and `data-llm` are polyfilled — state does not persist across view renders. `useRequestModal` is polyfilled — renders in-iframe instead of a host modal. All tools are accessible via `useCallTool` by default.
+</Note>
+
+## DevTools Runtime Coverage
+
+DevTools mocks the **Apps SDK runtime only** (mocked `window.openai`). MCP Apps view rendering is not supported in DevTools.
+
+| Environment | Runtime |
+|-------------|---------|
+| DevTools (localhost) | Apps SDK (ChatGPT) — mocked |
+| ChatGPT | Apps SDK |
+| Claude | MCP Apps |
+| Goose | MCP Apps |
+| VSCode | MCP Apps |
+
+<Warning>
+Always validate MCP Apps-specific behavior in a real client such as Goose or Claude before shipping. See [Fast Iteration](/concepts/fast-iteration) for the recommended development workflow.
+</Warning>
+
+## Related
+
+- [Apps SDK (ChatGPT)](/fundamentals/apps-sdk) — ChatGPT runtime deep dive
+- [MCP Apps](/fundamentals/mcp-apps) — MCP Apps specification, protocol, and limitations
+- [Test Your App](/quickstart/test-your-app) — Step-by-step setup for each client
+- [API Reference](/api-reference#runtime-compatibility) — Complete hook compatibility matrix


### PR DESCRIPTION
Closes #681

## Additions 

- Add `fundamentals/client-support.mdx` with a per-client feature matrix (ChatGPT, Claude, Goose, VSCode), client-specific notes, and DevTools runtime coverage. 
- Register the page in `docs.json` under Fundamentals.

Note: Used Claude to make this docs PR.

## Result 

Link: [live video](https://drive.google.com/file/d/18LEd4s_w03861kpp8yB_BXviORcYDtQT/view?usp=sharing)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new `fundamentals/client-support.mdx` page and registers it in the navigation. The page consolidates per-client feature availability, runtime mapping, connection requirements, and client-specific setup notes in one place.

- New documentation page with a feature matrix (✅/⚠️/❌) covering ChatGPT, Claude, Goose, and VSCode across all Skybridge hooks, plus a DevTools runtime coverage table and client-specific notes sections.
- `docs.json` updated to add `fundamentals/client-support` as the third entry under the Fundamentals nav group.

<h3>Confidence Score: 4/5</h3>

Safe to merge — purely additive documentation with no code changes.

The content is accurate and consistent with the existing mcp-apps.mdx reference page. Two small clarity gaps exist: the ⚠️ symbol in the feature matrix has no inline legend (its meaning is only revealed further down the page), and Postman/MCPJam appear in the Client Overview table but are silently dropped from the feature matrix. Neither affects correctness, but both could confuse readers consulting the table in isolation.

docs/fundamentals/client-support.mdx — feature matrix legend and Postman/MCPJam coverage.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
docs/fundamentals/client-support.mdx:28-29
The feature matrix uses ⚠️ without defining what it means at the point of reference. A reader scanning the table won't know whether ⚠️ means "partial support", "experimental", or "polyfilled" unless they scroll down to the Client-Specific Notes — or happen to have read `mcp-apps.mdx` first. Adding a one-line legend beneath the table header keeps the page self-contained.

```suggestion
✅ Supported · ⚠️ Polyfilled (works with limitations) · ❌ Not supported

| Hook / Feature | ChatGPT | Claude | Goose | VSCode |
|----------------|:-------:|:------:|:-----:|:------:|
```

### Issue 2 of 2
docs/fundamentals/client-support.mdx:28-43
**Postman and MCPJam absent from feature matrix**

The Client Overview table (lines 11–18) lists six clients including Postman and MCPJam, but the Feature Availability matrix only covers four (ChatGPT, Claude, Goose, VSCode). Since both Postman and MCPJam are listed as full MCP Apps clients their feature columns would be identical to Goose/VSCode, but their omission leaves readers uncertain. Either add their columns to the matrix or add a brief note explaining they share the same feature set as other MCP Apps clients.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add client support status page"](https://github.com/alpic-ai/skybridge/commit/2ed1ad5cba22ca5412c6a1793265b969d47cdf56) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31006903)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->