### PR TITLE
Add header actions (tunnel/playground/audit/deploy)

### DIFF
--- a/packages/devtools/src/App.tsx
+++ b/packages/devtools/src/App.tsx
@@ -2,8 +2,11 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { NuqsAdapter } from "nuqs/adapters/react";
 import AppLayout from "./components/layout/app-layout.js";
 import { queryClient } from "./lib/query-client.js";
+import { useConnectTunnel } from "./lib/tunnel-store.js";
 
 function App() {
+  useConnectTunnel();
+
   return (
     <QueryClientProvider client={queryClient}>
       <NuqsAdapter>

--- a/packages/devtools/src/components/layout/header.tsx
+++ b/packages/devtools/src/components/layout/header.tsx
@@ -4,6 +4,12 @@ import { LogOut } from "lucide-react";
 import { useAuthStore } from "@/lib/auth-store.js";
 import { logout, useServerInfo } from "@/lib/mcp/index.js";
 import { StatusBadge } from "./status-badge.js";
+import {
+  AuditButton,
+  DeployButton,
+  PlaygroundButton,
+  TunnelButton,
+} from "./toolbar-actions.js";
 
 const EXTERNAL_LINKS: ReadonlyArray<{ label: string; href: string }> = [
   { label: "discord", href: "https://discord.gg/awV4gu74wK" },
@@ -42,16 +48,22 @@ export const Header = () => {
 
   return (
     <header className="flex h-13 items-center justify-between gap-3 border-b border-border px-4">
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-12">
         <BrandChip />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <TunnelButton />
+        <PlaygroundButton />
+        <AuditButton />
+        <DeployButton />
+      </div>
+      <div className="flex items-center gap-3">
         {error && (
-          <span className="ml-2 max-w-48 truncate text-xs text-destructive">
+          <span className="max-w-48 truncate text-xs text-destructive">
             {error}
           </span>
         )}
-      </div>
-
-      <div className="flex items-center gap-3">
         {requiresAuth && <StatusBadge status={status} />}
         {requiresAuth && status === "authenticated" && (
           <Button variant="tertiary" onClick={() => logout()}>

--- a/packages/devtools/src/components/layout/toolbar-actions.tsx
+++ b/packages/devtools/src/components/layout/toolbar-actions.tsx
@@ -1,0 +1,377 @@
+import { Button } from "@alpic-ai/ui/components/button";
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from "@alpic-ai/ui/components/popover";
+import {
+  Check,
+  Copy,
+  ExternalLinkIcon,
+  Loader2Icon,
+  MessagesSquareIcon,
+  PlugIcon,
+  RadarIcon,
+  RocketIcon,
+  UnplugIcon,
+} from "lucide-react";
+import {
+  cloneElement,
+  type MouseEventHandler,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { useTunnelStore } from "@/lib/tunnel-store.js";
+import { cn } from "@/lib/utils.js";
+
+const DOT_BY_STATUS = {
+  idle: "bg-red-500",
+  starting: "bg-orange-500 animate-pulse",
+  connected: "bg-green-500",
+  error: "bg-red-500",
+} as const;
+
+const HOVER_CLOSE_DELAY_MS = 120;
+const COPIED_RESET_MS = 1500;
+const DESCRIPTION_MAX_W = "max-w-[200px]";
+
+function useHoverOpen() {
+  const [open, setOpen] = useState(false);
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (closeTimer.current) {
+        clearTimeout(closeTimer.current);
+      }
+    },
+    [],
+  );
+
+  const onEnter = useCallback(() => {
+    if (closeTimer.current) {
+      clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+    setOpen(true);
+  }, []);
+
+  const onLeave = useCallback(() => {
+    if (closeTimer.current) {
+      clearTimeout(closeTimer.current);
+    }
+    closeTimer.current = setTimeout(() => setOpen(false), HOVER_CLOSE_DELAY_MS);
+  }, []);
+
+  return { open, setOpen, onEnter, onLeave };
+}
+
+function useCopyToClipboard() {
+  const [copied, setCopied] = useState(false);
+
+  const copy = useCallback(async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), COPIED_RESET_MS);
+    } catch (err) {
+      console.error("Clipboard write failed", err);
+    }
+  }, []);
+
+  return { copied, copy };
+}
+
+type HoverHandlers = {
+  onMouseEnter: MouseEventHandler;
+  onMouseLeave: MouseEventHandler;
+};
+
+function HoverPopover({
+  trigger,
+  className,
+  children,
+}: {
+  trigger: ReactElement<HoverHandlers>;
+  className?: string;
+  children: ReactNode;
+}) {
+  const { open, setOpen, onEnter, onLeave } = useHoverOpen();
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverAnchor asChild>
+        {cloneElement(trigger, {
+          onMouseEnter: onEnter,
+          onMouseLeave: onLeave,
+        })}
+      </PopoverAnchor>
+      <PopoverContent
+        align="end"
+        sideOffset={0}
+        className={cn("p-4", className)}
+        onMouseEnter={onEnter}
+        onMouseLeave={onLeave}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        {children}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function CopyButton({ value, label }: { value: string; label: string }) {
+  const { copied, copy } = useCopyToClipboard();
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      onClick={() => copy(value)}
+      className="text-quaternary-foreground hover:text-foreground"
+    >
+      {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+    </button>
+  );
+}
+
+function TunnelLinkButton({
+  label,
+  icon,
+  buildUrl,
+  description,
+  ctaLabel,
+}: {
+  label: string;
+  icon: ReactNode;
+  buildUrl: (tunnelUrl: string) => string;
+  description: string;
+  ctaLabel: string;
+}) {
+  const state = useTunnelStore((s) => s.state);
+  const url = state.status === "connected" ? buildUrl(state.url) : null;
+
+  const go = () => {
+    if (url) {
+      window.open(url, "_blank", "noreferrer,noopener");
+    }
+  };
+
+  return (
+    <HoverPopover
+      className="w-72"
+      trigger={
+        <Button
+          variant="secondary"
+          aria-disabled={!url}
+          className={cn(!url && "opacity-50 cursor-not-allowed")}
+          icon={icon}
+          onClick={url ? go : undefined}
+        >
+          {label}
+        </Button>
+      }
+    >
+      {url ? (
+        <div className="space-y-3 text-center">
+          <p
+            className={cn(
+              "text-sm text-muted-foreground py-2 mx-auto",
+              DESCRIPTION_MAX_W,
+            )}
+          >
+            {description}
+          </p>
+          <Button
+            variant="secondary"
+            className="w-full"
+            onClick={go}
+            iconTrailing={<ExternalLinkIcon className="size-3.5" />}
+          >
+            {ctaLabel}
+          </Button>
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground text-center">
+          Start the tunnel first to use {label}.
+        </p>
+      )}
+    </HoverPopover>
+  );
+}
+
+export function PlaygroundButton() {
+  return (
+    <TunnelLinkButton
+      label="Playground"
+      icon={<MessagesSquareIcon className="size-3.5" />}
+      buildUrl={(tunnelUrl) => `${tunnelUrl}/try`}
+      description="Chat with your MCP server with a real LLM and share it"
+      ctaLabel="Go to Playground"
+    />
+  );
+}
+
+export function AuditButton() {
+  return (
+    <TunnelLinkButton
+      label="Audit"
+      icon={<RadarIcon className="size-3.5" />}
+      buildUrl={(tunnelUrl) =>
+        `https://app.alpic.ai/beacon?url=${encodeURIComponent(tunnelUrl)}`
+      }
+      description="Audit your MCP server's tools, prompts, and resources"
+      ctaLabel="Audit my server"
+    />
+  );
+}
+
+export function DeployButton() {
+  const command = "pnpm deploy";
+
+  return (
+    <HoverPopover
+      className="w-60"
+      trigger={
+        <Button variant="cta" icon={<RocketIcon className="size-3.5" />}>
+          Deploy
+        </Button>
+      }
+    >
+      <div className="space-y-3">
+        <p
+          className={cn(
+            "text-sm text-muted-foreground py-2 mx-auto text-center",
+            DESCRIPTION_MAX_W,
+          )}
+        >
+          Run this command to deploy your project to the Alpic platform
+        </p>
+        <div className="flex items-center gap-2 rounded-md border bg-light-gray px-2 py-1.5">
+          <span className="flex-1 truncate font-mono text-xs">{command}</span>
+          <CopyButton value={command} label="Copy command" />
+        </div>
+      </div>
+    </HoverPopover>
+  );
+}
+
+export function TunnelButton() {
+  const { state, start, stop } = useTunnelStore();
+
+  return (
+    <HoverPopover
+      className={cn(
+        "w-80 text-center",
+        state.status === "starting" && "animate-pulse w-60",
+      )}
+      trigger={
+        <Button variant="secondary" onClick={start}>
+          {state.status !== "starting" && (
+            <span
+              className={`h-2 w-2 rounded-full ${DOT_BY_STATUS[state.status]}`}
+              aria-hidden
+            />
+          )}
+          Tunnel
+        </Button>
+      }
+    >
+      {state.status === "idle" && <IdleContent onStart={start} />}
+      {state.status === "error" && (
+        <ErrorContent message={state.message} onRetry={start} />
+      )}
+      {state.status === "starting" && (
+        <StartingContent message={state.message} />
+      )}
+      {state.status === "connected" && (
+        <ConnectedContent url={state.url} onStop={stop} />
+      )}
+    </HoverPopover>
+  );
+}
+
+function IdleContent({ onStart }: { onStart: () => void }) {
+  return (
+    <div className="space-y-3">
+      <p
+        className={cn(
+          "text-sm text-muted-foreground py-4 mx-auto",
+          DESCRIPTION_MAX_W,
+        )}
+      >
+        Get a public URL that you can use in Claude or ChatGPT.
+      </p>
+      <Button
+        variant="cta"
+        className="w-full"
+        onClick={onStart}
+        icon={<PlugIcon className="size-3.5" />}
+      >
+        Start tunnel
+      </Button>
+    </div>
+  );
+}
+
+function ErrorContent({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="space-y-3 text-left">
+      <p className="text-sm text-destructive">{message}</p>
+      <Button variant="primary" className="w-full" onClick={onRetry}>
+        Retry
+      </Button>
+    </div>
+  );
+}
+
+function StartingContent({ message }: { message: string }) {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-center gap-2">
+        <span
+          className="h-2 w-2 rounded-full bg-orange-500 animate-pulse"
+          aria-hidden
+        />
+        <p className={cn("text-sm text-muted-foreground", DESCRIPTION_MAX_W)}>
+          {message}
+        </p>
+        <Loader2Icon className="size-3.5 animate-spin" />
+      </div>
+    </div>
+  );
+}
+
+function ConnectedContent({
+  url,
+  onStop,
+}: {
+  url: string;
+  onStop: () => void;
+}) {
+  return (
+    <div className="space-y-3 text-left">
+      <p className="text-xs font-medium text-muted-foreground">Tunnel URL</p>
+      <div className="flex items-center gap-2 rounded-md border bg-light-gray px-2 py-1.5">
+        <span className="flex-1 truncate font-mono text-xs">{url}</span>
+        <CopyButton value={url} label="Copy URL" />
+      </div>
+      <Button
+        variant="tertiary"
+        className="w-full"
+        onClick={onStop}
+        icon={<UnplugIcon />}
+      >
+        Stop tunnel
+      </Button>
+    </div>
+  );
+}

--- a/packages/devtools/src/index.css
+++ b/packages/devtools/src/index.css
@@ -13,6 +13,7 @@
   --color-primary-foreground: var(--color-foreground);
   --color-primary-hover: #6be4e1;
   --color-ring: #6be4e1;
+  --color-cta-accent: #e90060;
 }
 
 .dark {

--- a/packages/devtools/src/lib/tunnel-store.ts
+++ b/packages/devtools/src/lib/tunnel-store.ts
@@ -1,0 +1,90 @@
+import { useEffect } from "react";
+import { create } from "zustand";
+
+export type TunnelState =
+  | { status: "idle" }
+  | { status: "starting"; message: string }
+  | { status: "connected"; url: string }
+  | { status: "error"; message: string };
+
+type TunnelStore = {
+  state: TunnelState;
+  start: () => Promise<void>;
+  stop: () => Promise<void>;
+  connect: () => () => void;
+};
+
+const TUNNEL_PATH = "/__skybridge/tunnel";
+
+export const useTunnelStore = create<TunnelStore>()((set, get) => ({
+  state: { status: "idle" },
+
+  async start() {
+    if (
+      get().state.status === "starting" ||
+      get().state.status === "connected"
+    ) {
+      return;
+    }
+    set({ state: { status: "starting", message: "Starting tunnel…" } });
+    try {
+      const res = await fetch(TUNNEL_PATH, { method: "POST" });
+      if (!res.ok) {
+        throw new Error(`Tunnel start failed (${res.status})`);
+      }
+    } catch (err) {
+      if (get().state.status !== "connected") {
+        set({
+          state: {
+            status: "error",
+            message:
+              err instanceof Error ? err.message : "Failed to start tunnel",
+          },
+        });
+      }
+    }
+  },
+
+  async stop() {
+    try {
+      await fetch(TUNNEL_PATH, { method: "DELETE" });
+    } catch {
+      // ignore — SSE will reconcile state
+    }
+  },
+
+  connect() {
+    const source = new EventSource(`${TUNNEL_PATH}/events`);
+
+    source.addEventListener("state", (event) => {
+      if (!(event instanceof MessageEvent)) {
+        return;
+      }
+      try {
+        set({ state: JSON.parse(event.data) });
+      } catch {
+        // ignore malformed frame
+      }
+    });
+
+    source.addEventListener("error", () => {
+      if (source.readyState === EventSource.CLOSED) {
+        set({
+          state: {
+            status: "error",
+            message: "Lost tunnel connection",
+          },
+        });
+      }
+    });
+
+    return () => {
+      source.close();
+    };
+  },
+}));
+
+export function useConnectTunnel() {
+  const connect = useTunnelStore((s) => s.connect);
+  useEffect(() => connect(), [connect]);
+}

--- a/packages/devtools/vite.config.ts
+++ b/packages/devtools/vite.config.ts
@@ -11,4 +11,14 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  server: {
+    proxy: {
+      "/__skybridge": {
+        target: new URL(
+          process.env.VITE_MCP_SERVER_URL || "http://localhost:3000",
+        ).origin,
+        changeOrigin: true,
+      },
+    },
+  },
 });


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces four header action buttons — **Tunnel**, **Playground**, **Audit**, and **Deploy** — backed by a new Zustand-based SSE tunnel store, and wires the tunnel connection into the app root. The dev-server proxy config is updated so `/__skybridge` requests are forwarded to the MCP server during local development.

- `toolbar-actions.tsx` (new, 377 lines) implements hover-popover action buttons with proper timer cleanup, copy-to-clipboard, and state-driven popover content; the `TunnelLinkButton` pattern correctly disables navigation and shows contextual guidance when the tunnel is not active.
- `tunnel-store.ts` (new) manages tunnel lifecycle via SSE; `start()` guards against double-invocation and avoids clobbering a connected state in the error path; `useConnectTunnel` returns the `EventSource` teardown as the `useEffect` cleanup, so the subscription is correctly closed on unmount.
- `header.tsx` restructures into three flex sections (brand / action toolbar / auth controls) while keeping the auth `error` display in the right-side section.

<h3>Confidence Score: 5/5</h3>

The changes are self-contained additions with no modifications to shared business logic; safe to merge.

The tunnel store correctly handles the start-race condition with a connected-state guard, and the SSE teardown is properly wired through useEffect's cleanup return value. The hover-popover, copy, and link-button helpers are all straightforward and defensively written. No regressions were found in the header layout or CSS variable additions.

No files require special attention.

<sub>Reviews (9): Last reviewed commit: ["Add toolbar actions"](https://github.com/alpic-ai/skybridge/commit/9a94ad2a8ae402112d15ba8f337a7bf684438787) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31161375)</sub>

<!-- /greptile_comment -->