### PR TITLE
Fix/devtools v2 fixes batch

### DIFF
--- a/packages/core/src/cli/use-nodemon.ts
+++ b/packages/core/src/cli/use-nodemon.ts
@@ -37,7 +37,9 @@ export function useNodemon(
 
     const handleStderrData = (chunk: Buffer) => {
       const message = chunk.toString().trim();
-      if (!message) return;
+      if (!message) {
+        return;
+      }
       // Node's source-map warnings for third-party deps (superjson, @mcp/sdk, …) — not actionable.
       const filtered = message
         .split("\n")

--- a/packages/core/src/cli/use-nodemon.ts
+++ b/packages/core/src/cli/use-nodemon.ts
@@ -7,6 +7,8 @@ import type { PushMessage } from "./use-messages.js";
 
 const nodemon = nodemonOriginal as ExtendedNodemon;
 
+const SOURCEMAP_WARNING = /^Sourcemap for ".*" points to missing source files$/;
+
 export function useNodemon(
   env: NodeJS.ProcessEnv,
   pushMessage: PushMessage,
@@ -35,8 +37,14 @@ export function useNodemon(
 
     const handleStderrData = (chunk: Buffer) => {
       const message = chunk.toString().trim();
-      if (message) {
-        pushMessage(message, "error");
+      if (!message) return;
+      // Node's source-map warnings for third-party deps (superjson, @mcp/sdk, …) — not actionable.
+      const filtered = message
+        .split("\n")
+        .filter((line) => !SOURCEMAP_WARNING.test(line))
+        .join("\n");
+      if (filtered) {
+        pushMessage(filtered, "error");
       }
     };
 

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -6,7 +6,8 @@
     "jsx": "react-jsx",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": ["ESNext", "DOM", "DOM.Iterable"]
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "inlineSources": true
   },
   "include": ["src/**/*"]
 }

--- a/packages/devtools/src/components/layout/tool-panel/tool-panel-toolbar.tsx
+++ b/packages/devtools/src/components/layout/tool-panel/tool-panel-toolbar.tsx
@@ -93,6 +93,8 @@ export const ToolPanelToolbar = ({
 
   const isDark = theme === "dark";
   const isMobile = (userAgent?.device?.type ?? "desktop") === "mobile";
+  const localeLabel =
+    locales.find((l) => l.code === locale)?.englishName ?? locale;
 
   return (
     <div className="mt-3 flex w-full shrink-0 items-center gap-1.5 px-3">
@@ -136,7 +138,7 @@ export const ToolPanelToolbar = ({
             )}
           >
             <Languages className="size-3.5" />
-            <span>{locale}</span>
+            <span>{localeLabel}</span>
           </button>
         </PopoverTrigger>
         <PopoverContent className="w-[260px] p-0" align="start">

--- a/packages/devtools/src/components/layout/tool-panel/view/create-openai-mock.ts
+++ b/packages/devtools/src/components/layout/tool-panel/view/create-openai-mock.ts
@@ -11,6 +11,7 @@ import type {
 } from "skybridge/web";
 
 import { SET_GLOBALS_EVENT_TYPE, SetGlobalsEvent } from "skybridge/web";
+import { useInspectorPreferencesStore } from "@/lib/inspector-preferences-store.js";
 
 function createOpenaiMethods(
   openai: AppsSdkContext & AppsSdkMethods,
@@ -48,6 +49,9 @@ function createOpenaiMethods(
       log("requestDisplayMode", args);
       openai.displayMode = args.mode;
       setValue("displayMode", args.mode);
+      useInspectorPreferencesStore
+        .getState()
+        .setPreference("displayMode", args.mode);
       return {
         mode: args.mode,
       };

--- a/packages/devtools/src/components/layout/tool-panel/view/index.tsx
+++ b/packages/devtools/src/components/layout/tool-panel/view/index.tsx
@@ -136,10 +136,8 @@ export const View = () => {
     <div
       ref={containerRef}
       className={cn(
-        "relative overflow-hidden bg-background transition-[width] duration-150 ease-out",
-        isFullscreen
-          ? "h-full w-full"
-          : "mx-auto border border-border shadow-md",
+        "relative transition-[width] duration-150 ease-out",
+        isFullscreen ? "h-full w-full bg-background" : "mx-auto",
       )}
       style={{
         width: isFullscreen ? undefined : width,

--- a/packages/devtools/src/components/layout/tool-panel/view/index.tsx
+++ b/packages/devtools/src/components/layout/tool-panel/view/index.tsx
@@ -139,7 +139,7 @@ export const View = () => {
         "relative overflow-hidden bg-background transition-[width] duration-150 ease-out",
         isFullscreen
           ? "h-full w-full"
-          : "mx-auto rounded-2xl border border-border shadow-md",
+          : "mx-auto border border-border shadow-md",
       )}
       style={{
         width: isFullscreen ? undefined : width,

--- a/packages/devtools/src/components/layout/tool-panel/view/index.tsx
+++ b/packages/devtools/src/components/layout/tool-panel/view/index.tsx
@@ -9,6 +9,7 @@ import mcpClient, {
 import { useCallToolResult, useStore } from "@/lib/store.js";
 import { asString, cn, injectWaitForOpenai } from "@/lib/utils.js";
 import { createAndInjectOpenAi } from "./create-openai-mock.js";
+import { useSyncOpenaiLocale } from "./use-sync-openai-locale.js";
 import { useSyncOpenaiTheme } from "./use-sync-openai-theme.js";
 
 const MOBILE_WIDTH_PX = 345;
@@ -50,6 +51,7 @@ export const View = () => {
       ? "100%"
       : `${isMobile ? MOBILE_WIDTH_PX : DESKTOP_WIDTH_PX}px`;
   const theme = useInspectorPreferencesStore((s) => s.theme);
+  const locale = useInspectorPreferencesStore((s) => s.locale);
 
   const resourceEntry = resource.contents[0] as {
     text: string;
@@ -120,6 +122,13 @@ export const View = () => {
     iframeRef,
     toolName: tool.name,
     theme,
+    updateOpenaiObject,
+  });
+
+  useSyncOpenaiLocale({
+    iframeRef,
+    toolName: tool.name,
+    locale,
     updateOpenaiObject,
   });
 

--- a/packages/devtools/src/components/layout/tool-panel/view/use-sync-openai-locale.ts
+++ b/packages/devtools/src/components/layout/tool-panel/view/use-sync-openai-locale.ts
@@ -1,0 +1,32 @@
+import { type RefObject, useEffect } from "react";
+import type { AppsSdkContext } from "skybridge/web";
+
+type UseSyncOpenaiLocaleParams = {
+  iframeRef: RefObject<HTMLIFrameElement | null>;
+  toolName: string;
+  locale: string;
+  updateOpenaiObject: (
+    toolName: string,
+    key: keyof AppsSdkContext,
+    value: unknown,
+  ) => void;
+};
+
+export const useSyncOpenaiLocale = ({
+  iframeRef,
+  toolName,
+  locale,
+  updateOpenaiObject,
+}: UseSyncOpenaiLocaleParams) => {
+  useEffect(() => {
+    const window = iframeRef.current?.contentWindow as
+      | (Window & { openai?: AppsSdkContext })
+      | null;
+    if (!window?.openai) {
+      return;
+    }
+
+    window.openai.locale = locale;
+    updateOpenaiObject(toolName, "locale", locale);
+  }, [iframeRef, locale, toolName, updateOpenaiObject]);
+};

--- a/packages/devtools/src/hooks/use-iframe-auto-height.ts
+++ b/packages/devtools/src/hooks/use-iframe-auto-height.ts
@@ -32,6 +32,10 @@ export const useIframeAutoHeight = ({
     };
 
     const observer = new ResizeObserver(measure);
+    const root = iframe.contentDocument.getElementById("root");
+    if (root) {
+      observer.observe(root);
+    }
     observer.observe(iframe.contentDocument.body);
     observer.observe(iframe.contentDocument.documentElement);
     const parentEl = containerRef.current?.parentElement;

--- a/packages/devtools/src/index.css
+++ b/packages/devtools/src/index.css
@@ -60,4 +60,3 @@
     16px 16px;
   background-position: 0 0;
 }
-

--- a/packages/devtools/src/index.css
+++ b/packages/devtools/src/index.css
@@ -61,7 +61,3 @@
   background-position: 0 0;
 }
 
-.preview-region[data-theme="dark"] {
-  --preview-region-bg: #071718;
-  --preview-region-grid: color-mix(in oklab, #ffffff 14%, transparent);
-}

--- a/packages/devtools/src/lib/utils.ts
+++ b/packages/devtools/src/lib/utils.ts
@@ -59,10 +59,12 @@ export const measureIframeHeight = (
   const parentH = parentEl?.clientHeight ?? 0;
   // Before layout, the scroll parent can report 0 — do not clamp to 0 or we never commit height.
   const maxH = parentH > 0 ? parentH : Number.POSITIVE_INFINITY;
-  const innerScroll = Math.max(
-    doc.body.scrollHeight,
-    doc.documentElement.scrollHeight,
-  );
+
+  // Prefer the mount node so body/html stretching (e.g. min-h-screen) doesn't pin us tall.
+  const root = doc.getElementById("root");
+  const innerScroll = root
+    ? root.getBoundingClientRect().height
+    : Math.max(doc.body.scrollHeight, doc.documentElement.scrollHeight);
 
   return Math.min(innerScroll, maxH);
 };


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses a batch of bug fixes for the devtools v2, covering iframe height measurement, locale display and sync, sourcemap warning noise, and a CSS cleanup.

- **Iframe height measurement**: `measureIframeHeight` now prefers `#root`'s `getBoundingClientRect().height` over `scrollHeight` to avoid `min-h-screen` inflating the measured height, and `useIframeAutoHeight` adds `#root` as an additional `ResizeObserver` target for consistency.
- **Locale sync**: A new `useSyncOpenaiLocale` hook (mirroring the existing `useSyncOpenaiTheme`) pushes locale changes into the iframe's `openai` object, and the toolbar now displays the locale's English name instead of its BCP-47 code.
- **`requestDisplayMode` persistence**: Calling `requestDisplayMode` from the SDK now also persists the chosen mode to `useInspectorPreferencesStore` so the preference survives tool re-renders.
- **Sourcemap noise**: Nodemon stderr output filters lines matching the \"points to missing source files\" pattern; `inlineSources: true` is added to `packages/core/tsconfig.json` to reduce those warnings at their source.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — all changes are self-contained bug fixes with no cross-cutting logic regressions.

The changes are straightforward: a new locale-sync hook that mirrors an already-working theme-sync hook, a height-measurement improvement with a zero-guard on all call sites, a store-persistence addition using idiomatic Zustand, and noise filtering in the CLI layer. No altered control paths that could introduce silent regressions.

No files require special attention.

<sub>Reviews (6): Last reviewed commit: ["Fix trailing whitespace in devtools CSS"](https://github.com/alpic-ai/skybridge/commit/da22f74d6a6734d02c2d38d35cdeddd01cf9c6ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31564012)</sub>

<!-- /greptile_comment -->