### PR TITLE
Add toolbar actions

### DIFF
--- a/packages/devtools/src/App.tsx
+++ b/packages/devtools/src/App.tsx
@@ -2,8 +2,11 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { NuqsAdapter } from "nuqs/adapters/react";
 import AppLayout from "./components/layout/app-layout.js";
 import { queryClient } from "./lib/query-client.js";
+import { useConnectTunnel } from "./lib/tunnel-store.js";
 
 function App() {
+  useConnectTunnel();
+
   return (
     <QueryClientProvider client={queryClient}>
       <NuqsAdapter>

--- a/packages/devtools/src/components/layout/header.tsx
+++ b/packages/devtools/src/components/layout/header.tsx
@@ -4,6 +4,12 @@ import { LogOut } from "lucide-react";
 import { useAuthStore } from "@/lib/auth-store.js";
 import { logout, useServerInfo } from "@/lib/mcp/index.js";
 import { StatusBadge } from "./status-badge.js";
+import {
+  AuditButton,
+  DeployButton,
+  PlaygroundButton,
+  TunnelButton,
+} from "./toolbar-actions.js";
 
 const EXTERNAL_LINKS: ReadonlyArray<{ label: string; href: string }> = [
   { label: "discord", href: "https://discord.gg/awV4gu74wK" },
@@ -42,16 +48,22 @@ export const Header = () => {
 
   return (
     <header className="flex h-13 items-center justify-between gap-3 border-b border-border px-4">
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-12">
         <BrandChip />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <TunnelButton />
+        <PlaygroundButton />
+        <AuditButton />
+        <DeployButton />
+      </div>
+      <div className="flex items-center gap-3">
         {error && (
-          <span className="ml-2 max-w-48 truncate text-xs text-destructive">
+          <span className="max-w-48 truncate text-xs text-destructive">
             {error}
           </span>
         )}
-      </div>
-
-      <div className="flex items-center gap-3">
         {requiresAuth && <StatusBadge status={status} />}
         {requiresAuth && status === "authenticated" && (
           <Button variant="tertiary" onClick={() => logout()}>

--- a/packages/devtools/src/components/layout/header.tsx
+++ b/packages/devtools/src/components/layout/header.tsx
@@ -19,7 +19,7 @@ const EXTERNAL_LINKS: ReadonlyArray<{ label: string; href: string }> = [
 
 function Chip({ children }: { children: React.ReactNode }) {
   return (
-    <div className="inline-flex h-8 cursor-pointer items-center gap-2 rounded-md px-2.5 text-sm  bg-light-gray border">
+    <div className="inline-flex h-8 items-center gap-2 rounded-md px-2.5 text-sm  bg-light-gray border">
       {children}
     </div>
   );

--- a/packages/devtools/src/components/layout/toolbar-actions.tsx
+++ b/packages/devtools/src/components/layout/toolbar-actions.tsx
@@ -4,6 +4,7 @@ import {
   PopoverAnchor,
   PopoverContent,
 } from "@alpic-ai/ui/components/popover";
+import { Separator } from "@alpic-ai/ui/components/separator";
 import {
   Check,
   Copy,
@@ -72,12 +73,25 @@ function useHoverOpen() {
 
 function useCopyToClipboard() {
   const [copied, setCopied] = useState(false);
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (resetTimer.current) {
+        clearTimeout(resetTimer.current);
+      }
+    },
+    [],
+  );
 
   const copy = useCallback(async (text: string) => {
     try {
       await navigator.clipboard.writeText(text);
       setCopied(true);
-      setTimeout(() => setCopied(false), COPIED_RESET_MS);
+      if (resetTimer.current) {
+        clearTimeout(resetTimer.current);
+      }
+      resetTimer.current = setTimeout(() => setCopied(false), COPIED_RESET_MS);
     } catch (err) {
       console.error("Clipboard write failed", err);
     }
@@ -260,58 +274,63 @@ export function DeployButton() {
 
 export function TunnelButton() {
   const { state, start, stop } = useTunnelStore();
+  const { copied, copy } = useCopyToClipboard();
+
+  const isConnected = state.status === "connected";
+  const onClick = isConnected ? () => copy(state.url) : start;
 
   return (
     <HoverPopover
       className={cn(
-        "w-80 text-center",
+        "w-60 text-center",
         state.status === "starting" && "animate-pulse w-60",
       )}
       trigger={
-        <Button variant="secondary" onClick={start}>
-          {state.status !== "starting" && (
-            <span
-              className={`h-2 w-2 rounded-full ${DOT_BY_STATUS[state.status]}`}
-              aria-hidden
-            />
+        <Button variant="secondary" onClick={onClick}>
+          <span
+            className={`h-2 w-2 rounded-full ${DOT_BY_STATUS[state.status]}`}
+            aria-hidden
+          />
+          {isConnected ? (
+            <>
+              <span className="mx-2 font-mono text-xs">
+                {state.url.replace(/^https?:\/\//, "")}
+              </span>
+              {copied ? (
+                <Check className="size-3.5" />
+              ) : (
+                <Copy className="size-3.5" />
+              )}
+            </>
+          ) : (
+            "Tunnel"
           )}
-          Tunnel
         </Button>
       }
     >
-      {state.status === "idle" && <IdleContent onStart={start} />}
+      {state.status === "idle" && <IdleContent />}
       {state.status === "error" && (
         <ErrorContent message={state.message} onRetry={start} />
       )}
       {state.status === "starting" && (
         <StartingContent message={state.message} />
       )}
-      {state.status === "connected" && (
-        <ConnectedContent url={state.url} onStop={stop} />
-      )}
+      {state.status === "connected" && <ConnectedContent onStop={stop} />}
     </HoverPopover>
   );
 }
 
-function IdleContent({ onStart }: { onStart: () => void }) {
+function IdleContent() {
   return (
     <div className="space-y-3">
       <p
         className={cn(
-          "text-sm text-muted-foreground py-4 mx-auto",
+          "text-sm text-muted-foreground mx-auto",
           DESCRIPTION_MAX_W,
         )}
       >
         Get a public URL that you can use in Claude or ChatGPT.
       </p>
-      <Button
-        variant="cta"
-        className="w-full"
-        onClick={onStart}
-        icon={<PlugIcon className="size-3.5" />}
-      >
-        Start tunnel
-      </Button>
     </div>
   );
 }
@@ -350,20 +369,15 @@ function StartingContent({ message }: { message: string }) {
   );
 }
 
-function ConnectedContent({
-  url,
-  onStop,
-}: {
-  url: string;
-  onStop: () => void;
-}) {
+function ConnectedContent({ onStop }: { onStop: () => void }) {
   return (
     <div className="space-y-3 text-left">
-      <p className="text-xs font-medium text-muted-foreground">Tunnel URL</p>
-      <div className="flex items-center gap-2 rounded-md border bg-light-gray px-2 py-1.5">
-        <span className="flex-1 truncate font-mono text-xs">{url}</span>
-        <CopyButton value={url} label="Copy URL" />
+      <div className="flex items-center gap-2">
+        <p className="text-sm text-muted-foreground">
+          Click to copy the tunnel URL to use in Claude or ChatGPT
+        </p>
       </div>
+      <Separator />
       <Button
         variant="tertiary"
         className="w-full"

--- a/packages/devtools/src/components/layout/toolbar-actions.tsx
+++ b/packages/devtools/src/components/layout/toolbar-actions.tsx
@@ -7,12 +7,11 @@ import {
 import { Separator } from "@alpic-ai/ui/components/separator";
 import {
   Check,
+  ClipboardCheck,
   Copy,
   ExternalLinkIcon,
   Loader2Icon,
   MessagesSquareIcon,
-  PlugIcon,
-  RadarIcon,
   RocketIcon,
   UnplugIcon,
 } from "lucide-react";
@@ -165,13 +164,33 @@ function TunnelLinkButton({
   ctaLabel: string;
 }) {
   const state = useTunnelStore((s) => s.state);
+  const start = useTunnelStore((s) => s.start);
+  const [pendingOpen, setPendingOpen] = useState(false);
   const url = state.status === "connected" ? buildUrl(state.url) : null;
 
-  const go = () => {
+  useEffect(() => {
+    if (pendingOpen && state.status === "connected") {
+      window.open(buildUrl(state.url), "_blank", "noreferrer,noopener");
+      setPendingOpen(false);
+    } else if (
+      pendingOpen &&
+      (state.status === "error" || state.status === "idle")
+    ) {
+      setPendingOpen(false);
+    }
+  }, [pendingOpen, state, buildUrl]);
+
+  const onClick = () => {
     if (url) {
       window.open(url, "_blank", "noreferrer,noopener");
+      return;
     }
+    setPendingOpen(true);
+    start();
   };
+
+  const isLaunching = pendingOpen;
+  const isDisabled = !url && state.status === "starting";
 
   return (
     <HoverPopover
@@ -179,10 +198,16 @@ function TunnelLinkButton({
       trigger={
         <Button
           variant="secondary"
-          aria-disabled={!url}
-          className={cn(!url && "opacity-50 cursor-not-allowed")}
-          icon={icon}
-          onClick={url ? go : undefined}
+          aria-disabled={isDisabled}
+          className={cn(isDisabled && "opacity-50 cursor-not-allowed")}
+          icon={
+            isLaunching ? (
+              <Loader2Icon className="size-3.5 animate-spin" />
+            ) : (
+              icon
+            )
+          }
+          onClick={isDisabled ? undefined : onClick}
         >
           {label}
         </Button>
@@ -201,7 +226,7 @@ function TunnelLinkButton({
           <Button
             variant="secondary"
             className="w-full"
-            onClick={go}
+            onClick={onClick}
             iconTrailing={<ExternalLinkIcon className="size-3.5" />}
           >
             {ctaLabel}
@@ -209,7 +234,9 @@ function TunnelLinkButton({
         </div>
       ) : (
         <p className="text-sm text-muted-foreground text-center">
-          Start the tunnel first to use {label}.
+          {isLaunching
+            ? `Starting the tunnel, ${label} will open shortly…`
+            : `Click to start the tunnel and open ${label}.`}
         </p>
       )}
     </HoverPopover>
@@ -232,7 +259,7 @@ export function AuditButton() {
   return (
     <TunnelLinkButton
       label="Audit"
-      icon={<RadarIcon className="size-3.5" />}
+      icon={<ClipboardCheck className="size-3.5" />}
       buildUrl={(tunnelUrl) =>
         `https://app.alpic.ai/beacon?url=${encodeURIComponent(tunnelUrl)}`
       }
@@ -277,7 +304,11 @@ export function TunnelButton() {
   const { copied, copy } = useCopyToClipboard();
 
   const isConnected = state.status === "connected";
-  const onClick = isConnected ? () => copy(state.url) : start;
+  const onClick = isConnected
+    ? () => copy(state.url)
+    : state.status === "starting"
+      ? stop
+      : start;
 
   return (
     <HoverPopover

--- a/packages/devtools/src/components/layout/toolbar-actions.tsx
+++ b/packages/devtools/src/components/layout/toolbar-actions.tsx
@@ -1,0 +1,377 @@
+import { Button } from "@alpic-ai/ui/components/button";
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from "@alpic-ai/ui/components/popover";
+import {
+  Check,
+  Copy,
+  ExternalLinkIcon,
+  Loader2Icon,
+  MessagesSquareIcon,
+  PlugIcon,
+  RadarIcon,
+  RocketIcon,
+  UnplugIcon,
+} from "lucide-react";
+import {
+  cloneElement,
+  type MouseEventHandler,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { useTunnelStore } from "@/lib/tunnel-store.js";
+import { cn } from "@/lib/utils.js";
+
+const DOT_BY_STATUS = {
+  idle: "bg-red-500",
+  starting: "bg-orange-500 animate-pulse",
+  connected: "bg-green-500",
+  error: "bg-red-500",
+} as const;
+
+const HOVER_CLOSE_DELAY_MS = 120;
+const COPIED_RESET_MS = 1500;
+const DESCRIPTION_MAX_W = "max-w-[200px]";
+
+function useHoverOpen() {
+  const [open, setOpen] = useState(false);
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (closeTimer.current) {
+        clearTimeout(closeTimer.current);
+      }
+    },
+    [],
+  );
+
+  const onEnter = useCallback(() => {
+    if (closeTimer.current) {
+      clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+    setOpen(true);
+  }, []);
+
+  const onLeave = useCallback(() => {
+    if (closeTimer.current) {
+      clearTimeout(closeTimer.current);
+    }
+    closeTimer.current = setTimeout(() => setOpen(false), HOVER_CLOSE_DELAY_MS);
+  }, []);
+
+  return { open, setOpen, onEnter, onLeave };
+}
+
+function useCopyToClipboard() {
+  const [copied, setCopied] = useState(false);
+
+  const copy = useCallback(async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), COPIED_RESET_MS);
+    } catch (err) {
+      console.error("Clipboard write failed", err);
+    }
+  }, []);
+
+  return { copied, copy };
+}
+
+type HoverHandlers = {
+  onMouseEnter: MouseEventHandler;
+  onMouseLeave: MouseEventHandler;
+};
+
+function HoverPopover({
+  trigger,
+  className,
+  children,
+}: {
+  trigger: ReactElement<HoverHandlers>;
+  className?: string;
+  children: ReactNode;
+}) {
+  const { open, setOpen, onEnter, onLeave } = useHoverOpen();
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverAnchor asChild>
+        {cloneElement(trigger, {
+          onMouseEnter: onEnter,
+          onMouseLeave: onLeave,
+        })}
+      </PopoverAnchor>
+      <PopoverContent
+        align="end"
+        sideOffset={0}
+        className={cn("p-4", className)}
+        onMouseEnter={onEnter}
+        onMouseLeave={onLeave}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        {children}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function CopyButton({ value, label }: { value: string; label: string }) {
+  const { copied, copy } = useCopyToClipboard();
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      onClick={() => copy(value)}
+      className="text-quaternary-foreground hover:text-foreground"
+    >
+      {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+    </button>
+  );
+}
+
+function TunnelLinkButton({
+  label,
+  icon,
+  buildUrl,
+  description,
+  ctaLabel,
+}: {
+  label: string;
+  icon: ReactNode;
+  buildUrl: (tunnelUrl: string) => string;
+  description: string;
+  ctaLabel: string;
+}) {
+  const state = useTunnelStore((s) => s.state);
+  const url = state.status === "connected" ? buildUrl(state.url) : null;
+
+  const go = () => {
+    if (url) {
+      window.open(url, "_blank", "noreferrer,noopener");
+    }
+  };
+
+  return (
+    <HoverPopover
+      className="w-72"
+      trigger={
+        <Button
+          variant="secondary"
+          aria-disabled={!url}
+          className={cn(!url && "opacity-50 cursor-not-allowed")}
+          icon={icon}
+          onClick={url ? go : undefined}
+        >
+          {label}
+        </Button>
+      }
+    >
+      {url ? (
+        <div className="space-y-3 text-center">
+          <p
+            className={cn(
+              "text-sm text-muted-foreground py-2 mx-auto",
+              DESCRIPTION_MAX_W,
+            )}
+          >
+            {description}
+          </p>
+          <Button
+            variant="secondary"
+            className="w-full"
+            onClick={go}
+            iconTrailing={<ExternalLinkIcon className="size-3.5" />}
+          >
+            {ctaLabel}
+          </Button>
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground text-center">
+          Start the tunnel first to use {label}.
+        </p>
+      )}
+    </HoverPopover>
+  );
+}
+
+export function PlaygroundButton() {
+  return (
+    <TunnelLinkButton
+      label="Playground"
+      icon={<MessagesSquareIcon className="size-3.5" />}
+      buildUrl={(tunnelUrl) => `${tunnelUrl}/try`}
+      description="Chat with your MCP server with a real LLM and share it"
+      ctaLabel="Go to Playground"
+    />
+  );
+}
+
+export function AuditButton() {
+  return (
+    <TunnelLinkButton
+      label="Audit"
+      icon={<RadarIcon className="size-3.5" />}
+      buildUrl={(tunnelUrl) =>
+        `https://app.alpic.ai/beacon?url=${encodeURIComponent(tunnelUrl)}`
+      }
+      description="Audit your MCP server's tools, prompts, and resources"
+      ctaLabel="Audit my server"
+    />
+  );
+}
+
+export function DeployButton() {
+  const command = "pnpm deploy";
+
+  return (
+    <HoverPopover
+      className="w-60"
+      trigger={
+        <Button variant="cta" icon={<RocketIcon className="size-3.5" />}>
+          Deploy
+        </Button>
+      }
+    >
+      <div className="space-y-3">
+        <p
+          className={cn(
+            "text-sm text-muted-foreground py-2 mx-auto text-center",
+            DESCRIPTION_MAX_W,
+          )}
+        >
+          Run this command to deploy your project to the Alpic platform
+        </p>
+        <div className="flex items-center gap-2 rounded-md border bg-light-gray px-2 py-1.5">
+          <span className="flex-1 truncate font-mono text-xs">{command}</span>
+          <CopyButton value={command} label="Copy command" />
+        </div>
+      </div>
+    </HoverPopover>
+  );
+}
+
+export function TunnelButton() {
+  const { state, start, stop } = useTunnelStore();
+
+  return (
+    <HoverPopover
+      className={cn(
+        "w-80 text-center",
+        state.status === "starting" && "animate-pulse w-60",
+      )}
+      trigger={
+        <Button variant="secondary" onClick={start}>
+          {state.status !== "starting" && (
+            <span
+              className={`h-2 w-2 rounded-full ${DOT_BY_STATUS[state.status]}`}
+              aria-hidden
+            />
+          )}
+          Tunnel
+        </Button>
+      }
+    >
+      {state.status === "idle" && <IdleContent onStart={start} />}
+      {state.status === "error" && (
+        <ErrorContent message={state.message} onRetry={start} />
+      )}
+      {state.status === "starting" && (
+        <StartingContent message={state.message} />
+      )}
+      {state.status === "connected" && (
+        <ConnectedContent url={state.url} onStop={stop} />
+      )}
+    </HoverPopover>
+  );
+}
+
+function IdleContent({ onStart }: { onStart: () => void }) {
+  return (
+    <div className="space-y-3">
+      <p
+        className={cn(
+          "text-sm text-muted-foreground py-4 mx-auto",
+          DESCRIPTION_MAX_W,
+        )}
+      >
+        Get a public URL that you can use in Claude or ChatGPT.
+      </p>
+      <Button
+        variant="cta"
+        className="w-full"
+        onClick={onStart}
+        icon={<PlugIcon className="size-3.5" />}
+      >
+        Start tunnel
+      </Button>
+    </div>
+  );
+}
+
+function ErrorContent({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="space-y-3 text-left">
+      <p className="text-sm text-destructive">{message}</p>
+      <Button variant="primary" className="w-full" onClick={onRetry}>
+        Retry
+      </Button>
+    </div>
+  );
+}
+
+function StartingContent({ message }: { message: string }) {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-center gap-2">
+        <span
+          className="h-2 w-2 rounded-full bg-orange-500 animate-pulse"
+          aria-hidden
+        />
+        <p className={cn("text-sm text-muted-foreground", DESCRIPTION_MAX_W)}>
+          {message}
+        </p>
+        <Loader2Icon className="size-3.5 animate-spin" />
+      </div>
+    </div>
+  );
+}
+
+function ConnectedContent({
+  url,
+  onStop,
+}: {
+  url: string;
+  onStop: () => void;
+}) {
+  return (
+    <div className="space-y-3 text-left">
+      <p className="text-xs font-medium text-muted-foreground">Tunnel URL</p>
+      <div className="flex items-center gap-2 rounded-md border bg-light-gray px-2 py-1.5">
+        <span className="flex-1 truncate font-mono text-xs">{url}</span>
+        <CopyButton value={url} label="Copy URL" />
+      </div>
+      <Button
+        variant="tertiary"
+        className="w-full"
+        onClick={onStop}
+        icon={<UnplugIcon />}
+      >
+        Stop tunnel
+      </Button>
+    </div>
+  );
+}

--- a/packages/devtools/src/index.css
+++ b/packages/devtools/src/index.css
@@ -13,6 +13,7 @@
   --color-primary-foreground: var(--color-foreground);
   --color-primary-hover: #6be4e1;
   --color-ring: #6be4e1;
+  --color-cta-accent: #e90060;
 }
 
 .dark {

--- a/packages/devtools/src/lib/tunnel-store.ts
+++ b/packages/devtools/src/lib/tunnel-store.ts
@@ -1,11 +1,15 @@
 import { useEffect } from "react";
+import { z } from "zod";
 import { create } from "zustand";
 
-export type TunnelState =
-  | { status: "idle" }
-  | { status: "starting"; message: string }
-  | { status: "connected"; url: string }
-  | { status: "error"; message: string };
+const tunnelStateSchema = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("idle") }),
+  z.object({ status: z.literal("starting"), message: z.string() }),
+  z.object({ status: z.literal("connected"), url: z.string() }),
+  z.object({ status: z.literal("error"), message: z.string() }),
+]);
+
+export type TunnelState = z.infer<typeof tunnelStateSchema>;
 
 type TunnelStore = {
   state: TunnelState;
@@ -61,7 +65,10 @@ export const useTunnelStore = create<TunnelStore>()((set, get) => ({
         return;
       }
       try {
-        set({ state: JSON.parse(event.data) });
+        const parsed = tunnelStateSchema.safeParse(JSON.parse(event.data));
+        if (parsed.success) {
+          set({ state: parsed.data });
+        }
       } catch {
         // ignore malformed frame
       }

--- a/packages/devtools/src/lib/tunnel-store.ts
+++ b/packages/devtools/src/lib/tunnel-store.ts
@@ -1,0 +1,90 @@
+import { useEffect } from "react";
+import { create } from "zustand";
+
+export type TunnelState =
+  | { status: "idle" }
+  | { status: "starting"; message: string }
+  | { status: "connected"; url: string }
+  | { status: "error"; message: string };
+
+type TunnelStore = {
+  state: TunnelState;
+  start: () => Promise<void>;
+  stop: () => Promise<void>;
+  connect: () => () => void;
+};
+
+const TUNNEL_PATH = "/__skybridge/tunnel";
+
+export const useTunnelStore = create<TunnelStore>()((set, get) => ({
+  state: { status: "idle" },
+
+  async start() {
+    if (
+      get().state.status === "starting" ||
+      get().state.status === "connected"
+    ) {
+      return;
+    }
+    set({ state: { status: "starting", message: "Starting tunnel…" } });
+    try {
+      const res = await fetch(TUNNEL_PATH, { method: "POST" });
+      if (!res.ok) {
+        throw new Error(`Tunnel start failed (${res.status})`);
+      }
+    } catch (err) {
+      if (get().state.status !== "connected") {
+        set({
+          state: {
+            status: "error",
+            message:
+              err instanceof Error ? err.message : "Failed to start tunnel",
+          },
+        });
+      }
+    }
+  },
+
+  async stop() {
+    try {
+      await fetch(TUNNEL_PATH, { method: "DELETE" });
+    } catch {
+      // ignore — SSE will reconcile state
+    }
+  },
+
+  connect() {
+    const source = new EventSource(`${TUNNEL_PATH}/events`);
+
+    source.addEventListener("state", (event) => {
+      if (!(event instanceof MessageEvent)) {
+        return;
+      }
+      try {
+        set({ state: JSON.parse(event.data) });
+      } catch {
+        // ignore malformed frame
+      }
+    });
+
+    source.addEventListener("error", () => {
+      if (source.readyState === EventSource.CLOSED) {
+        set({
+          state: {
+            status: "error",
+            message: "Lost tunnel connection",
+          },
+        });
+      }
+    });
+
+    return () => {
+      source.close();
+    };
+  },
+}));
+
+export function useConnectTunnel() {
+  const connect = useTunnelStore((s) => s.connect);
+  useEffect(() => connect(), [connect]);
+}

--- a/packages/devtools/vite.config.ts
+++ b/packages/devtools/vite.config.ts
@@ -11,4 +11,14 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  server: {
+    proxy: {
+      "/__skybridge": {
+        target: new URL(
+          process.env.VITE_MCP_SERVER_URL || "http://localhost:3000",
+        ).origin,
+        changeOrigin: true,
+      },
+    },
+  },
 });


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces four toolbar action buttons (Tunnel, Playground, Audit, Deploy) into the devtools header, backed by a new Zustand store that manages tunnel lifecycle state via SSE. The concerns raised in previous review rounds have been addressed: SSE payloads are now validated with a Zod discriminated union before touching the store, and timer handles for both the copy-to-clipboard and hover-close timers are properly stored in `useRef` and cleared in `useEffect` cleanup callbacks.

- **`tunnel-store.ts`**: New Zustand store with `start`/`stop`/`connect` actions; SSE connection established once at the App root via `useConnectTunnel`, cleaned up on unmount.
- **`toolbar-actions.tsx`**: Four new toolbar components using a shared `HoverPopover` pattern; `TunnelButton` handles all four tunnel states in its popover body; `TunnelLinkButton` defers `window.open` until tunnel reaches "connected" via a `pendingOpen` effect.
- **`vite.config.ts`**: Dev-server proxy added for `/__skybridge` path, forwarding to the configured MCP server origin.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes add self-contained UI components and a Zustand store with no impact on existing data paths.

The two previously flagged runtime defects (unvalidated SSE payloads and leaked setTimeout handles) have both been correctly fixed. SSE frames are now filtered through a Zod discriminated union, and timer handles for hover-close and copy-reset are stored in refs with effect cleanup. No new correctness issues were found in the component logic, store lifecycle, or Vite proxy config.

No files require special attention.

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into julien/sky-338-..."](https://github.com/alpic-ai/skybridge/commit/606dbc290239e4242036a6b22844ea9e64a149a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31577450)</sub>

<!-- /greptile_comment -->