### PR TITLE
Add viewless tool

### DIFF
--- a/packages/devtools/src/components/layout/tool-panel/index.tsx
+++ b/packages/devtools/src/components/layout/tool-panel/index.tsx
@@ -11,7 +11,8 @@ import {
 import { useInspectorPreferencesStore } from "@/lib/inspector-preferences-store.js";
 import { useSelectedToolOrNull } from "@/lib/mcp/index.js";
 import { useCallToolResult } from "@/lib/store.js";
-import { cn } from "@/lib/utils.js";
+import { cn, formatBytes } from "@/lib/utils.js";
+import { JsonSyntaxBlock } from "./json-syntax-block.js";
 import { LogsDrawer } from "./logs-drawer.js";
 import { ToolPanelHeader } from "./tool-panel-header.js";
 import { ToolPanelToolbar } from "./tool-panel-toolbar.js";
@@ -27,6 +28,9 @@ const VIEW_LOGS_GROUP_ID = "devtools-tool-panel-view-logs";
 const VIEW_PANEL_ID = "view";
 const LOGS_PANEL_ID = "logs";
 
+const OUTPUT_LOGS_GROUP_ID = "devtools-tool-panel-output-logs";
+const OUTPUT_PANEL_ID = "output";
+
 export const ToolPanel = () => {
   const tool = useSelectedToolOrNull();
   const data = useCallToolResult(tool?.name ?? "");
@@ -37,6 +41,14 @@ export const ToolPanel = () => {
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({
     id: VIEW_LOGS_GROUP_ID,
     panelIds: [VIEW_PANEL_ID, LOGS_PANEL_ID],
+    storage: localStorage,
+  });
+  const {
+    defaultLayout: outputLogsDefaultLayout,
+    onLayoutChanged: outputLogsOnLayoutChanged,
+  } = useDefaultLayout({
+    id: OUTPUT_LOGS_GROUP_ID,
+    panelIds: [OUTPUT_PANEL_ID, LOGS_PANEL_ID],
     storage: localStorage,
   });
   const displayMode = useInspectorPreferencesStore((s) => s.displayMode);
@@ -57,90 +69,149 @@ export const ToolPanel = () => {
   const hasResult = Boolean(tool && data?.response);
   const hasView = Boolean(templateUri);
 
+  if (!tool) {
+    return (
+      <div
+        className="flex h-full min-h-0 w-full flex-col overflow-hidden preview-region transition-colors duration-150 ease-out"
+        data-theme={theme}
+      >
+        <Placeholder text="Choose a tool from the sidebar to begin" />
+      </div>
+    );
+  }
+
+  if (!hasResult) {
+    return (
+      <div
+        className="flex h-full min-h-0 w-full flex-col overflow-hidden preview-region transition-colors duration-150 ease-out"
+        data-theme={theme}
+      />
+    );
+  }
+
+  if (!hasView) {
+    const response = data?.response;
+    const responseJson = JSON.stringify(response ?? null, null, 2);
+    const sizeBytes = new TextEncoder().encode(responseJson).length;
+    const isError = response?.isError === true;
+    const durationMs = data?.durationMs;
+    return (
+      <div
+        className="flex h-full min-h-0 w-full flex-col overflow-hidden preview-region transition-colors duration-150 ease-out"
+        data-theme={theme}
+      >
+        <Group
+          orientation="horizontal"
+          id={OUTPUT_LOGS_GROUP_ID}
+          className="flex min-h-0 min-w-0 flex-1 overflow-hidden"
+          defaultLayout={outputLogsDefaultLayout}
+          onLayoutChanged={outputLogsOnLayoutChanged}
+        >
+          <Panel id={OUTPUT_PANEL_ID} minSize={320} className="min-h-0 min-w-0">
+            <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
+              <div className="flex h-9 w-full shrink-0 items-center border-b-2 border-border bg-white px-3 text-sm text-muted-foreground">
+                <div className="font-medium">Tool output</div>
+                <div className="ml-auto flex items-center gap-2 font-mono text-xs text-light-gray-foreground">
+                  <span
+                    className={isError ? "text-destructive" : "text-success"}
+                  >
+                    {isError ? "Error" : "OK"}
+                  </span>
+                  {durationMs != null ? (
+                    <>
+                      <span>·</span>
+                      <span>{durationMs}ms</span>
+                    </>
+                  ) : null}
+                  <span>·</span>
+                  <span>{formatBytes(sizeBytes)}</span>
+                </div>
+              </div>
+              <section className="min-h-0 min-w-0 flex-1 overflow-auto bg-background p-3">
+                <JsonSyntaxBlock code={responseJson} />
+              </section>
+            </div>
+          </Panel>
+          <Separator className="w-px shrink-0 bg-border transition-colors hover:bg-ring data-separator-active:bg-ring" />
+          <Panel
+            id={LOGS_PANEL_ID}
+            defaultSize={360}
+            minSize={240}
+            maxSize={640}
+            className="min-h-0"
+          >
+            <LogsDrawer key={tool.name} />
+          </Panel>
+        </Group>
+      </div>
+    );
+  }
+
   return (
     <div
       className="flex h-full min-h-0 w-full flex-col overflow-hidden preview-region transition-colors duration-150 ease-out"
       data-theme={theme}
     >
-      {tool ? (
-        hasResult ? (
-          hasView ? (
-            <>
-              <ToolPanelHeader />
-              <Group
-                orientation="horizontal"
-                id={VIEW_LOGS_GROUP_ID}
-                className="flex min-h-0 min-w-0 flex-1 overflow-hidden"
-                defaultLayout={defaultLayout}
-                onLayoutChanged={onLayoutChanged}
+      <ToolPanelHeader />
+      <Group
+        orientation="horizontal"
+        id={VIEW_LOGS_GROUP_ID}
+        className="flex min-h-0 min-w-0 flex-1 overflow-hidden"
+        defaultLayout={defaultLayout}
+        onLayoutChanged={onLayoutChanged}
+      >
+        <Panel id={VIEW_PANEL_ID} minSize={320} className="min-h-0 min-w-0">
+          <div
+            className={cn(
+              "flex flex-col overflow-hidden",
+              isFullscreen
+                ? "absolute inset-0 z-50 bg-background"
+                : "relative h-full min-h-0",
+            )}
+          >
+            <ToolPanelToolbar
+              logsOpen={logsOpen ?? false}
+              onOpenLogs={() => setLogsOpen(true)}
+            />
+            <div
+              className={cn(
+                "flex min-h-0 flex-1 items-center justify-center",
+                isFullscreen
+                  ? "overflow-hidden pt-3"
+                  : "mx-3 overflow-y-auto py-3",
+              )}
+            >
+              <Suspense fallback={<Placeholder text="Loading view…" />}>
+                <View />
+              </Suspense>
+            </div>
+            {isFullscreen && (
+              <button
+                type="button"
+                aria-label="Exit fullscreen"
+                onClick={() => setPreference("displayMode", "inline")}
+                className="absolute right-4 top-4 inline-flex size-8 cursor-pointer items-center justify-center rounded-full border border-border bg-background text-light-gray-foreground shadow-md transition-colors hover:bg-light-gray hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
               >
-                <Panel
-                  id={VIEW_PANEL_ID}
-                  minSize={320}
-                  className="min-h-0 min-w-0"
-                >
-                  <div
-                    className={cn(
-                      "flex flex-col overflow-hidden",
-                      isFullscreen
-                        ? "absolute inset-0 z-50 bg-background"
-                        : "relative h-full min-h-0",
-                    )}
-                  >
-                    <ToolPanelToolbar
-                      logsOpen={logsOpen ?? false}
-                      onOpenLogs={() => setLogsOpen(true)}
-                    />
-                    <div
-                      className={cn(
-                        "flex min-h-0 flex-1 items-center justify-center",
-                        isFullscreen
-                          ? "overflow-hidden pt-3"
-                          : "mx-3 overflow-y-auto py-3",
-                      )}
-                    >
-                      <Suspense fallback={<Placeholder text="Loading view…" />}>
-                        <View />
-                      </Suspense>
-                    </div>
-                    {isFullscreen && (
-                      <button
-                        type="button"
-                        aria-label="Exit fullscreen"
-                        onClick={() => setPreference("displayMode", "inline")}
-                        className="absolute right-4 top-4 inline-flex size-8 cursor-pointer items-center justify-center rounded-full border border-border bg-background text-light-gray-foreground shadow-md transition-colors hover:bg-light-gray hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                      >
-                        <X className="size-4" />
-                      </button>
-                    )}
-                  </div>
-                </Panel>
-                {logsOpen && !isFullscreen && (
-                  <>
-                    <Separator className="w-px shrink-0 bg-border transition-colors hover:bg-ring data-separator-active:bg-ring" />
-                    <Panel
-                      id={LOGS_PANEL_ID}
-                      defaultSize={360}
-                      minSize={240}
-                      maxSize={640}
-                      className="min-h-0"
-                    >
-                      <LogsDrawer
-                        key={tool?.name ?? "none"}
-                        onClose={() => setLogsOpen(false)}
-                      />
-                    </Panel>
-                  </>
-                )}
-              </Group>
-            </>
-          ) : (
-            <Placeholder text="No view template" />
-          )
-        ) : null
-      ) : (
-        <Placeholder text="Choose a tool from the sidebar to begin" />
-      )}
+                <X className="size-4" />
+              </button>
+            )}
+          </div>
+        </Panel>
+        {logsOpen && !isFullscreen && (
+          <>
+            <Separator className="w-px shrink-0 bg-border transition-colors hover:bg-ring data-separator-active:bg-ring" />
+            <Panel
+              id={LOGS_PANEL_ID}
+              defaultSize={360}
+              minSize={240}
+              maxSize={640}
+              className="min-h-0"
+            >
+              <LogsDrawer key={tool.name} onClose={() => setLogsOpen(false)} />
+            </Panel>
+          </>
+        )}
+      </Group>
     </div>
   );
 };

--- a/packages/devtools/src/components/layout/tool-panel/logs-drawer.tsx
+++ b/packages/devtools/src/components/layout/tool-panel/logs-drawer.tsx
@@ -120,7 +120,7 @@ const LogEntry = ({
   );
 };
 
-export const LogsDrawer = ({ onClose }: { onClose: () => void }) => {
+export const LogsDrawer = ({ onClose }: { onClose?: () => void }) => {
   const tool = useSelectedToolOrNull();
   const data = useCallToolResult(tool?.name ?? "");
   const logs = data?.openaiLogs ?? [];
@@ -142,14 +142,16 @@ export const LogsDrawer = ({ onClose }: { onClose: () => void }) => {
             <Trash2 className="size-3.5" />
           </button>
         </div>
-        <button
-          type="button"
-          aria-label="Close logs"
-          onClick={onClose}
-          className="inline-flex size-6 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-light-gray hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-        >
-          <X className="size-3.5" />
-        </button>
+        {onClose ? (
+          <button
+            type="button"
+            aria-label="Close logs"
+            onClick={onClose}
+            className="inline-flex size-6 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-light-gray hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            <X className="size-3.5" />
+          </button>
+        ) : null}
       </div>
       <div className="min-h-0 flex-1 overflow-auto bg-light-gray">
         {logs.map((log) => (

--- a/packages/devtools/src/components/layout/toolbar-actions.tsx
+++ b/packages/devtools/src/components/layout/toolbar-actions.tsx
@@ -9,7 +9,6 @@ import {
   Check,
   ClipboardCheck,
   Copy,
-  ExternalLinkIcon,
   Loader2Icon,
   MessagesSquareIcon,
   RocketIcon,
@@ -155,13 +154,11 @@ function TunnelLinkButton({
   icon,
   buildUrl,
   description,
-  ctaLabel,
 }: {
   label: string;
   icon: ReactNode;
   buildUrl: (tunnelUrl: string) => string;
   description: string;
-  ctaLabel: string;
 }) {
   const state = useTunnelStore((s) => s.state);
   const start = useTunnelStore((s) => s.start);
@@ -214,24 +211,14 @@ function TunnelLinkButton({
       }
     >
       {url ? (
-        <div className="space-y-3 text-center">
-          <p
-            className={cn(
-              "text-sm text-muted-foreground py-2 mx-auto",
-              DESCRIPTION_MAX_W,
-            )}
-          >
-            {description}
-          </p>
-          <Button
-            variant="secondary"
-            className="w-full"
-            onClick={onClick}
-            iconTrailing={<ExternalLinkIcon className="size-3.5" />}
-          >
-            {ctaLabel}
-          </Button>
-        </div>
+        <p
+          className={cn(
+            "text-sm text-muted-foreground text-center mx-auto",
+            DESCRIPTION_MAX_W,
+          )}
+        >
+          {description}
+        </p>
       ) : (
         <p className="text-sm text-muted-foreground text-center">
           {isLaunching
@@ -250,7 +237,6 @@ export function PlaygroundButton() {
       icon={<MessagesSquareIcon className="size-3.5" />}
       buildUrl={(tunnelUrl) => `${tunnelUrl}/try`}
       description="Chat with your MCP server with a real LLM and share it"
-      ctaLabel="Go to Playground"
     />
   );
 }
@@ -264,7 +250,6 @@ export function AuditButton() {
         `https://app.alpic.ai/beacon?url=${encodeURIComponent(tunnelUrl)}`
       }
       description="Audit your MCP server's tools, prompts, and resources"
-      ctaLabel="Audit my server"
     />
   );
 }

--- a/packages/devtools/src/components/layout/toolbar-actions.tsx
+++ b/packages/devtools/src/components/layout/toolbar-actions.tsx
@@ -247,7 +247,7 @@ export function AuditButton() {
       label="Audit"
       icon={<ClipboardCheck className="size-3.5" />}
       buildUrl={(tunnelUrl) =>
-        `https://app.alpic.ai/beacon?url=${encodeURIComponent(tunnelUrl)}`
+        `https://app.alpic.ai/beacon?url=${encodeURIComponent(tunnelUrl)}/mcp`
       }
       description="Audit your MCP server's tools, prompts, and resources"
     />

--- a/packages/devtools/src/components/layout/toolbar-actions.tsx
+++ b/packages/devtools/src/components/layout/toolbar-actions.tsx
@@ -261,7 +261,11 @@ export function DeployButton() {
     <HoverPopover
       className="w-60"
       trigger={
-        <Button variant="cta" icon={<RocketIcon className="size-3.5" />}>
+        <Button
+          variant="cta"
+          className="h-8 px-2"
+          icon={<RocketIcon className="size-3.5" />}
+        >
           Deploy
         </Button>
       }

--- a/packages/devtools/src/components/layout/tools-list/tool-item.tsx
+++ b/packages/devtools/src/components/layout/tools-list/tool-item.tsx
@@ -144,7 +144,9 @@ function ToolBody({
   return (
     <div className="space-y-3">
       {tool.description && (
-        <p className="text-xs text-muted-foreground">{tool.description}</p>
+        <div className="rounded-md border border-border bg-muted/40 px-2.5 py-2 text-xs text-muted-foreground">
+          {tool.description}
+        </div>
       )}
       {hasInput && (
         <Tabs value={tab} onValueChange={(v) => setTab(v as TabValue)}>

--- a/packages/devtools/src/components/layout/tools-list/tool-item.tsx
+++ b/packages/devtools/src/components/layout/tools-list/tool-item.tsx
@@ -143,6 +143,9 @@ function ToolBody({
 
   return (
     <div className="space-y-3">
+      {tool.description && (
+        <p className="text-xs text-muted-foreground">{tool.description}</p>
+      )}
       {hasInput && (
         <Tabs value={tab} onValueChange={(v) => setTab(v as TabValue)}>
           <div className="flex items-center justify-between gap-2">

--- a/packages/devtools/src/components/layout/tools-list/tool-item.tsx
+++ b/packages/devtools/src/components/layout/tools-list/tool-item.tsx
@@ -144,7 +144,7 @@ function ToolBody({
   return (
     <div className="space-y-3">
       {tool.description && (
-        <div className="rounded-md border border-border bg-muted/40 px-2.5 py-2 text-xs text-muted-foreground">
+        <div className="rounded-md border border-border bg-muted/40 px-2.5 py-2 text-xs text-muted-foreground/70">
           {tool.description}
         </div>
       )}

--- a/packages/devtools/src/components/layout/tools-list/tool-item.tsx
+++ b/packages/devtools/src/components/layout/tools-list/tool-item.tsx
@@ -79,7 +79,7 @@ export function ToolItem({ tool, open }: { tool: Tool; open: boolean }) {
       <AccordionTrigger
         className={cn(
           "font-mono text-xs font-normal text-foreground",
-          "no-underline hover:bg-muted/40",
+          "no-underline data-[state=closed]:hover:bg-muted/40",
         )}
         action={
           open ? (


### PR DESCRIPTION
<img width="3456" height="1822" alt="image" src="https://github.com/user-attachments/assets/8b5ab9c4-77c9-4624-94c1-6a6874092bca" />

## Unrelated changes bundled in this PR

- Show tool description inside the opened accordion item, wrapped in a subtle card with faded text
- Suppress hover state on the accordion trigger when the tool item is open
- Append `/mcp` suffix to the tunnel URL
- Normalize Deploy button height to match its toolbar siblings
- Remove the redundant in-popover CTA from the Playground / Audit toolbar buttons

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a "viewless" tool panel — when a tool has no `openai/outputTemplate` view configured, users now see a formatted JSON output panel with status metadata (OK/Error, duration, size) alongside a permanently-visible logs drawer, instead of the previous "No view template" placeholder. The component logic is also refactored from deeply-nested ternaries into cleaner early-return guards.

- **Viewless output panel** (`tool-panel/index.tsx`): new early-return branch renders `JsonSyntaxBlock` with a status bar and always-on `LogsDrawer`; `LogsDrawer.onClose` is now optional to support this always-visible usage.
- **Toolbar cleanup** (`toolbar-actions.tsx`): removes the CTA button from the tunnel popover when a URL is active, changes Audit to point to the `/mcp` endpoint, and adds `h-8 px-2` sizing to the Deploy button.
- **Tool item polish** (`tool-item.tsx`): hover highlight is now suppressed when the accordion is open, and the tool description is shown inline in a muted box.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are well-scoped UI additions with no impact on data flow or state management.

The refactoring is straightforward: nested ternaries become early returns, and the new viewless branch follows the same patterns as the existing view branch. The two nits (hardcoded bg-white and unencoded /mcp in the query string) are cosmetic and do not affect runtime correctness.

The bg-white in tool-panel/index.tsx is worth a quick visual check in dark mode before shipping.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/devtools/src/components/layout/toolbar-actions.tsx:249-251
The `/mcp` path segment is appended after `encodeURIComponent(tunnelUrl)`, so it lands unencoded in the query string. While `/` is technically valid in a query parameter value and most URL parsers will handle it correctly, it's more correct and consistent to encode the full value, including the appended path, as a single unit.

```suggestion
      buildUrl={(tunnelUrl) =>
        `https://app.alpic.ai/beacon?url=${encodeURIComponent(`${tunnelUrl}/mcp`)}`
      }
```

### Issue 2 of 2
packages/devtools/src/components/layout/tool-panel/index.tsx:112
The header bar uses a hardcoded `bg-white` class which won't adapt to dark themes. The surrounding elements all use semantic color tokens (`bg-background`, `border-border`, etc.) — this one outlier will appear visually broken in dark mode.

```suggestion
              <div className="flex h-9 w-full shrink-0 items-center border-b-2 border-border bg-background px-3 text-sm text-muted-foreground">
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["style(devtools): fade tool description t..."](https://github.com/alpic-ai/skybridge/commit/e131f3d66b9ebb516c39ef2768573f141554a24c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31589607)</sub>

<!-- /greptile_comment -->