### PR TITLE
fix: template infinite loop

### DIFF
--- a/packages/create-skybridge/template/src/views/components/nav.tsx
+++ b/packages/create-skybridge/template/src/views/components/nav.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@alpic-ai/ui/components/button";
-import { CheckCheck } from "lucide-react";
+import { Check } from "lucide-react";
 
 export default function Nav({
   current,
@@ -23,7 +23,7 @@ export default function Nav({
         disabled={current === total - 1}
         onClick={() => onChange(Math.min(current + 1, total - 1))}
       >
-        <CheckCheck />
+        <Check />
         Next
       </Button>
     </div>

--- a/packages/create-skybridge/template/src/views/components/steps/tool-output.tsx
+++ b/packages/create-skybridge/template/src/views/components/steps/tool-output.tsx
@@ -33,7 +33,7 @@ export default function ToolOutput() {
         <DocLink href="https://docs.skybridge.tech/api-reference/use-tool-info">
           useToolInfo
         </DocLink>{" "}
-        to hydrates the view with tool input, output and metadata.
+        to hydrate the view with tool input, output and metadata.
       </Doc>
     </>
   );

--- a/packages/create-skybridge/template/src/views/onboarding.tsx
+++ b/packages/create-skybridge/template/src/views/onboarding.tsx
@@ -28,7 +28,7 @@ export default function Onboarding() {
     <div
       className={`${theme === "dark" ? "dark" : ""} mx-auto w-full max-w-4xl rounded-xl border border-border overflow-hidden bg-background text-foreground`}
     >
-      <div className="min-h-[34rem] md:min-h-95 flex flex-col items-center gap-6 p-6 bg-gradient-to-br from-purple-50 via-white to-cyan-50 dark:from-purple-950/30 dark:via-zinc-950 dark:to-cyan-900/30 bg-[length:200%_200%] animate-aurora md:flex-row md:items-stretch">
+      <div className="min-h-136 md:min-h-95 flex flex-col items-center gap-6 p-6 bg-linear-to-br from-purple-50 via-white to-cyan-50 dark:from-purple-950/30 dark:via-zinc-950 dark:to-cyan-900/30 bg-size-[200%_200%] animate-aurora md:flex-row md:items-stretch">
         <div className="shrink-0 self-center animate-float">
           <img
             src={img}

--- a/packages/create-skybridge/template/src/views/use-mascot.ts
+++ b/packages/create-skybridge/template/src/views/use-mascot.ts
@@ -51,8 +51,8 @@ export function useMascot() {
     hat,
     changeHat: () => {
       setState((prev) => {
-        const others = LABELS.filter((l) => l !== prev.hat);
-        const next = others[Math.floor(Math.random() * others.length)];
+        const currentIndex = prev.hat ? LABELS.indexOf(prev.hat) : -1;
+        const next = LABELS[(currentIndex + 1) % LABELS.length];
         return { ...prev, hat: next };
       });
     },


### PR DESCRIPTION
clicking "Change my hat" looped setWidgetState forever (host requests cycling through random hats). Math.random in the reducer makes it impure, and react re-invokes reducers when a higher-priority store update interrupts the render — each replay rolled a new hat and pushed it, triggering another interruption.

swapped for a deterministic cycle (LABELS[(currentIndex + 1) % LABELS.length]), so the reducer is pure.

additional commits are unrelated fixes.