### PR TITLE
fix(skill): view and oauth

### DIFF
--- a/skills/chatgpt-app-builder/evals/fetch-and-render-data.json
+++ b/skills/chatgpt-app-builder/evals/fetch-and-render-data.json
@@ -1,18 +1,18 @@
 [
   {
     "query": "I'm building a restaurant finder. Users search by cuisine and location, browse restaurants with photos, and reserve a table. Show me the code.",
-    "expected_behavior": "Server: registerView('search-restaurants') with inputSchema {cuisine, location}, returns structuredContent {restaurants[]}, _meta {images[]} for photos. registerTool('make-reservation') with inputSchema {restaurantId, partySize, date}. UI: useToolInfo<'search-restaurants'>() for input/output/responseMetadata, useCallTool('make-reservation') for Reserve button."
+    "expected_behavior": "Server: registerTool('search-restaurants') with inputSchema {cuisine, location} and view.component 'search-restaurants', returns structuredContent {restaurants[]}, _meta {images[]} for photos. registerTool('make-reservation') with inputSchema {restaurantId, partySize, date}. UI: useToolInfo<'search-restaurants'>() for input/output/responseMetadata, useCallTool('make-reservation') for Reserve button."
   },
   {
     "query": "I want a product catalog where users browse by category and see product cards with thumbnails. They can add items to cart and then generate a checkout session.",
-    "expected_behavior": "Server: registerView returns structuredContent {products[]} with id/name/price, _meta {thumbnails[]} to hide images from LLM. registerTool('create-checkout'). UI: useToolInfo with responseMetadata.thumbnails for images, useCallTool for Checkout button."
+    "expected_behavior": "Server: registerTool with view.component returns structuredContent {products[]} with id/name/price, _meta {thumbnails[]} to hide images from LLM. registerTool('create-checkout'). UI: useToolInfo with responseMetadata.thumbnails for images, useCallTool for Checkout button."
   },
   {
     "query": "I need weather functionality. Users ask about weather in any city and can set temperature alerts. No visual UI needed.",
-    "expected_behavior": "Server: Two registerTool calls only (get-weather, set-alert). No registerView since output is conversational text. Returns content array for LLM. No UI components needed."
+    "expected_behavior": "Server: Two registerTool calls only (get-weather, set-alert), no view property since output is conversational text. Returns content array for LLM. No UI components needed."
   },
   {
     "query": "Building a job board. Users search jobs by keywords and location, see listings with salary info, and apply with one click. Show loading state while searching.",
-    "expected_behavior": "Server: registerView('search-jobs') with inputSchema {keywords, location}, registerTool('apply-job'). UI: useToolInfo<'search-jobs'>() with isPending for loading state, useCallTool('apply-job') with jobId on Apply button."
+    "expected_behavior": "Server: registerTool('search-jobs') with view.component 'search-jobs' and inputSchema {keywords, location}, registerTool('apply-job'). UI: useToolInfo<'search-jobs'>() with isPending for loading state, useCallTool('apply-job') with jobId on Apply button."
   }
 ]

--- a/skills/chatgpt-app-builder/evals/open-external-links.json
+++ b/skills/chatgpt-app-builder/evals/open-external-links.json
@@ -9,6 +9,6 @@
   },
   {
     "query": "When users click 'Book Now' it should redirect to our booking site without any confirmation popup.",
-    "expected_behavior": "Uses useOpenExternal for the redirect. Whitelist domain in server view definition using _meta.ui.csp.redirectDomains array to skip confirmation."
+    "expected_behavior": "Uses useOpenExternal for the redirect. Whitelist domain in the tool's view.csp.redirectDomains array to skip confirmation."
   }
 ]

--- a/skills/chatgpt-app-builder/references/csp.md
+++ b/skills/chatgpt-app-builder/references/csp.md
@@ -1,6 +1,6 @@
 # Content Security Policy
 
-Views run in sandboxed iframes with strict CSP. Whitelist external domains in view definition `_meta.ui.csp`:
+Views run in sandboxed iframes with strict CSP. Whitelist external domains under the tool's `view.csp`:
 
 | Property | Purpose |
 |----------|---------|
@@ -10,22 +10,22 @@ Views run in sandboxed iframes with strict CSP. Whitelist external domains in vi
 | `frameDomains` | (optional) Iframe embeds — triggers stricter review |
 
 ```typescript
-server.registerView(
-  "search-flights",
+server.registerTool(
   {
+    name: "search-flights",
     description: "Search flights",
-    _meta: {
-      ui: {
-        csp: {
-          connectDomains: ["https://api.example.com"],
-          resourceDomains: ["https://cdn.example.com"],
-          frameDomains: ["https://maps.example.com"],
-          redirectDomains: ["https://checkout.example.com"],
-        },
+    inputSchema: { ... },
+    view: {
+      component: "search-flights",
+      description: "Flight results",
+      csp: {
+        connectDomains: ["https://api.example.com"],
+        resourceDomains: ["https://cdn.example.com"],
+        frameDomains: ["https://maps.example.com"],
+        redirectDomains: ["https://checkout.example.com"],
       },
     },
   },
-  { inputSchema: { ... } },
   async (input) => ({ ... })
 );
 ```

--- a/skills/chatgpt-app-builder/references/fetch-and-render-data.md
+++ b/skills/chatgpt-app-builder/references/fetch-and-render-data.md
@@ -8,19 +8,17 @@
 
 ```
 my-app/
-├── server/src/
-│   ├── index.ts          # HTTP server with middlewares
-│   └── server.ts         # McpServer with tool and view registration
-├── web/src/
-│   ├── views/          # React components (filename = view name)
-│   │   └── search-flights.tsx
+├── src/
+│   ├── server.ts         # McpServer with tool + view registration
+│   ├── helpers.ts        # Type-safe hooks via generateHelpers
 │   ├── index.css         # Global CSS, must be imported in every view
-│   └── helpers.ts        # Type-safe hooks via generateHelpers
+│   └── views/            # React components (filename = view component name)
+│       └── search-flights.tsx
 └── package.json
 ```
 
-**Naming convention**: View filename must match registered name using kebab-case.
-`search_flights` → register as `search-flights` → file `search-flights.tsx`
+**Naming convention**: View filename must match the `view.component` name using kebab-case.
+`search_flights` → register with `view.component: "search-flights"` → file `views/search-flights.tsx`
 
 ## Server Handlers
 
@@ -36,7 +34,7 @@ Annotations (set `true` when):
 
 **Example**:
 
-- server/src/index.ts
+- src/server.ts
 ```typescript
 import { McpServer } from "skybridge/server";
 import { z } from "zod";
@@ -45,12 +43,16 @@ const server = new McpServer(
   { name: "my-app", version: "0.0.1" },
   { capabilities: {} },
 )
-  .registerView(
-    "search-flights",
-    { description: "Search for flights" },
+  .registerTool(
     {
+      name: "search-flights",
+      description: "Search for flights",
       inputSchema: { destination: z.string(), dates: z.string() },
       annotations: { readOnlyHint: true, openWorldHint: false, destructiveHint: false },
+      view: {
+        component: "search-flights",
+        description: "Flight results",
+      },
     },
     async ({ destination, dates }) => {
       const flights = await fetchFlights(destination, dates);
@@ -68,8 +70,8 @@ const server = new McpServer(
     }
   )
   .registerTool(
-    "book-flight",
     {
+      name: "book-flight",
       description: "Book a flight",
       inputSchema: { flightId: z.string() },
       annotations: { readOnlyHint: false, openWorldHint: false, destructiveHint: false },
@@ -83,7 +85,8 @@ const server = new McpServer(
     }
   );
 
-export default server;
+server.run();
+
 export type AppType = typeof server;
 ```
 
@@ -95,21 +98,20 @@ export type AppType = typeof server;
 
 **Example**:
 
-- web/src/helpers.ts
+- src/helpers.ts
 ```typescript
 import { generateHelpers } from "skybridge/web";
-import type { AppType } from "../../server/src/server";
+import type { AppType } from "./server.js";
 
 export const { useToolInfo, useCallTool } = generateHelpers<AppType>();
 ```
 
-- web/src/views/search-flights.tsx
+- src/views/search-flights.tsx
 ```tsx
 import "@/index.css";
-import { mountView } from "skybridge/web";
-import { useToolInfo, useCallTool } from "../helpers";
+import { useToolInfo, useCallTool } from "../helpers.js";
 
-function SearchFlights() {
+export default function SearchFlights() {
   const { input, output, isPending, responseMetadata } = useToolInfo<"search-flights">();
   const {
     callTool, // returns void, use `data` to get the actual output
@@ -146,8 +148,4 @@ function SearchFlights() {
     </div>
   );
 }
-
-export default SearchFlights;
-
-mountView(<SearchFlights />);
 ```

--- a/skills/chatgpt-app-builder/references/oauth.md
+++ b/skills/chatgpt-app-builder/references/oauth.md
@@ -5,19 +5,24 @@ Enable user authentication so tools can access user-specific data.
 ## How it works
 
 1. MCP server exposes OAuth discovery endpoints
-2. Host reads them, handles OAuth flow with user and token refresh
-3. Host sends access token in `Authorization: Bearer <token>` header
-4. Tool handlers validate token and get user info
+2. Host reads them, walks the user through OAuth, refreshes tokens
+3. Host calls `/mcp` with `Authorization: Bearer <token>`
+4. `requireBearerAuth` middleware verifies the token and rejects with HTTP 401 if invalid — tool handlers never run unauthenticated
+5. Tool handlers read user identity from `extra.authInfo`
 
-## 1. Discovery Endpoints
+## 1. Discovery endpoints
 
-Serve two JSON endpoints so the LLM host knows where to authenticate users:
+Mount OAuth metadata so MCP clients can discover the authorization server:
 
 ```typescript
-// index.ts
+// src/server.ts
 import { mcpAuthMetadataRouter } from "@modelcontextprotocol/sdk/server/auth/router.js";
+import { McpServer } from "skybridge/server";
 
-app.use(
+const server = new McpServer(
+  { name: "my-app", version: "0.0.1" },
+  { capabilities: {} },
+).use(
   mcpAuthMetadataRouter({
     oauthMetadata: {
       issuer: "https://your-oauth-provider.com",
@@ -27,104 +32,110 @@ app.use(
       grant_types_supported: ["authorization_code", "refresh_token"],
       code_challenge_methods_supported: ["S256"],
     },
-    // MCP_SERVER_URL: the server's public URL (localhost:3000, Alpic tunnel, or prod)
-    resourceServerUrl: new URL(process.env.MCP_SERVER_URL),
+    // SERVER_URL: this server's public URL (localhost:3000, Alpic tunnel, or prod)
+    resourceServerUrl: new URL(process.env.SERVER_URL),
   }),
 );
 ```
 
-This creates:
-- `/.well-known/oauth-authorization-server` — where to send users to login
-- `/.well-known/oauth-protected-resource` — declares this server requires auth
+This serves `/.well-known/oauth-authorization-server` and `/.well-known/oauth-protected-resource`.
 
-## 2. Validate Token in Handlers
+## 2. Write a token verifier
 
-Access token via `extra.requestInfo.headers.authorization`. Most providers use one of these patterns.
+`requireBearerAuth` takes a `verifier` with `verifyAccessToken(token): Promise<AuthInfo>`. Pick the strategy that matches your provider — both produce the same `AuthInfo` shape.
 
-⚠️ **Fetch provider's docs for exact URLs — JWKS paths and issuer formats vary**.
+⚠️ Fetch your provider's docs for exact URLs — JWKS paths and issuer formats vary.
 
-**Pattern A: JWT + JWKS**
+**JWT + JWKS** (provider issues signed JWTs):
+
 ```typescript
-// auth.ts
+// src/auth.ts
+import { InvalidTokenError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import * as jose from "jose";
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-
-type Extra = RequestHandlerExtra<any, any>;
 
 const jwks = jose.createRemoteJWKSet(
-  new URL("https://your-oauth-provider.com/oauth2/jwks")
+  new URL("https://your-oauth-provider.com/oauth2/jwks"),
 );
 
-export async function getAuth(extra: Extra): Promise<{ userId: string } | null> {
-  const authHeader = extra.requestInfo?.headers?.authorization;
-  if (!authHeader?.toLowerCase().startsWith("bearer ")) {
-    return null;
+export async function verifyAccessToken(token: string): Promise<AuthInfo> {
+  const { payload } = await jose.jwtVerify(token, jwks, {
+    issuer: "https://your-oauth-provider.com",
+  });
+
+  if (!payload.sub || typeof payload.sub !== "string") {
+    throw new InvalidTokenError("missing sub claim");
   }
 
-  const token = authHeader.slice(7).trim();
-
-  try {
-    const { payload } = await jose.jwtVerify(token, jwks, {
-      issuer: "https://your-oauth-provider.com",
-    });
-    return { userId: payload.sub as string };
-  } catch {
-    return null;
-  }
+  return {
+    token,
+    clientId: (payload.client_id ?? payload.azp) as string,
+    scopes: typeof payload.scope === "string" ? payload.scope.split(" ") : [],
+    expiresAt: payload.exp,
+    extra: { sub: payload.sub },
+  };
 }
 ```
 
-**Pattern B: Userinfo endpoint (opaque tokens)**
+**Userinfo endpoint** (provider issues opaque tokens):
+
 ```typescript
-// auth.ts
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
+// src/auth.ts
+import { InvalidTokenError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 
-type Extra = RequestHandlerExtra<any, any>;
-
-export async function getAuth(extra: Extra): Promise<{ userId: string } | null> {
-  const authHeader = extra.requestInfo?.headers?.authorization;
-  if (!authHeader?.toLowerCase().startsWith("bearer ")) {
-    return null;
-  }
-
-  const token = authHeader.slice(7).trim();
-
+export async function verifyAccessToken(token: string): Promise<AuthInfo> {
   const res = await fetch("https://your-oauth-provider.com/oauth2/userinfo", {
     headers: { Authorization: `Bearer ${token}` },
   });
-  if (!res.ok) return null;
-
-  const user = await res.json();
-  return { userId: user.sub };
+  if (!res.ok) {
+    throw new InvalidTokenError(`userinfo failed: ${res.status}`);
+  }
+  const user = (await res.json()) as { sub: string };
+  return {
+    token,
+    clientId: user.sub,
+    scopes: [],
+    extra: { sub: user.sub },
+  };
 }
 ```
 
-## 3. Use in Tool Handlers
+## 3. Enforce auth on /mcp
 
 ```typescript
+// src/server.ts (continued)
+import { requireBearerAuth } from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js";
+import { verifyAccessToken } from "./auth.js";
+
+server.use(
+  "/mcp",
+  requireBearerAuth({
+    verifier: { verifyAccessToken },
+    requiredScopes: ["openid", "email", "profile"], // optional
+  }),
+);
+```
+
+Unauthenticated requests get HTTP 401 before any tool handler runs.
+
+## 4. Read auth in handlers
+
+```typescript
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+
 server.registerTool(
-  "get-orders",
-  { description: "Get user orders", inputSchema: {} },
-  async (input, extra) => {
-    const auth = await getAuth(extra);
-
-    if (!auth) {
-      return {
-        content: [{ type: "text", text: "Please sign in to view orders." }],
-        isError: true,
-        _meta: {
-          "mcp/www_authenticate": [
-            `Bearer resource_metadata="${process.env.MCP_SERVER_URL}/.well-known/oauth-protected-resource"`,
-          ],
-        },
-      };
-    }
-
-    const orders = await fetchOrders(auth.userId);
+  {
+    name: "get-orders",
+    description: "Get user orders",
+  },
+  async (_input, extra) => {
+    const auth = extra.authInfo as AuthInfo;
+    const orders = await fetchOrders(auth.extra?.sub as string);
     return {
       structuredContent: { orders },
       content: [{ type: "text", text: `Found ${orders.length} orders` }],
     };
-  }
+  },
 );
 ```

--- a/skills/chatgpt-app-builder/references/oauth.md
+++ b/skills/chatgpt-app-builder/references/oauth.md
@@ -42,11 +42,9 @@ This serves `/.well-known/oauth-authorization-server` and `/.well-known/oauth-pr
 
 ## 2. Write a token verifier
 
-`requireBearerAuth` takes a `verifier` with `verifyAccessToken(token): Promise<AuthInfo>`. Pick the strategy that matches your provider — both produce the same `AuthInfo` shape.
+x`requireBearerAuth` takes a `verifier` with `verifyAccessToken(token): Promise<AuthInfo>`. Verify the provider's JWT against its JWKS:
 
-⚠️ Fetch your provider's docs for exact URLs — JWKS paths and issuer formats vary.
-
-**JWT + JWKS** (provider issues signed JWTs):
+⚠️ Fetch your provider's docs for the exact JWKS URL and issuer.
 
 ```typescript
 // src/auth.ts
@@ -69,34 +67,10 @@ export async function verifyAccessToken(token: string): Promise<AuthInfo> {
 
   return {
     token,
-    clientId: (payload.client_id ?? payload.azp) as string,
+    clientId: (payload.client_id ?? payload.azp ?? "") as string,
     scopes: typeof payload.scope === "string" ? payload.scope.split(" ") : [],
     expiresAt: payload.exp,
     extra: { sub: payload.sub },
-  };
-}
-```
-
-**Userinfo endpoint** (provider issues opaque tokens):
-
-```typescript
-// src/auth.ts
-import { InvalidTokenError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
-import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
-
-export async function verifyAccessToken(token: string): Promise<AuthInfo> {
-  const res = await fetch("https://your-oauth-provider.com/oauth2/userinfo", {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  if (!res.ok) {
-    throw new InvalidTokenError(`userinfo failed: ${res.status}`);
-  }
-  const user = (await res.json()) as { sub: string };
-  return {
-    token,
-    clientId: user.sub,
-    scopes: [],
-    extra: { sub: user.sub },
   };
 }
 ```

--- a/skills/chatgpt-app-builder/references/oauth.md
+++ b/skills/chatgpt-app-builder/references/oauth.md
@@ -42,7 +42,7 @@ This serves `/.well-known/oauth-authorization-server` and `/.well-known/oauth-pr
 
 ## 2. Write a token verifier
 
-x`requireBearerAuth` takes a `verifier` with `verifyAccessToken(token): Promise<AuthInfo>`. Verify the provider's JWT against its JWKS:
+`requireBearerAuth` takes a `verifier` with `verifyAccessToken(token): Promise<AuthInfo>`. Verify the provider's JWT against its JWKS:
 
 ⚠️ Fetch your provider's docs for the exact JWKS URL and issuer.
 

--- a/skills/chatgpt-app-builder/references/open-external-links.md
+++ b/skills/chatgpt-app-builder/references/open-external-links.md
@@ -52,20 +52,20 @@ Use `redirectUrl: false` to skip automatic `?redirectUrl=...` appending.
 Shows confirmation dialog unless domain is whitelisted:
 
 ```typescript
-// server/src/index.ts
-server.registerView(
-  "search-flights",
+// src/server.ts
+server.registerTool(
   {
+    name: "search-flights",
     description: "Search for flights",
-    _meta: {
-      ui: {
-        csp: {
-          redirectDomains: ["https://airline.example.com"],
-        },
+    inputSchema: { destination: z.string(), dates: z.string() },
+    view: {
+      component: "search-flights",
+      description: "Flight results",
+      csp: {
+        redirectDomains: ["https://airline.example.com"],
       },
     },
   },
-  { inputSchema: { destination: z.string(), dates: z.string() } },
   async ({ destination, dates }) => { /* ... */ }
 );
 ```

--- a/skills/chatgpt-app-builder/references/publish.md
+++ b/skills/chatgpt-app-builder/references/publish.md
@@ -6,7 +6,7 @@
 
 ## 2. Audit CSP
 
-Ensure all external domains are declared in views `_meta.ui.csp`. See [csp.md](csp.md).
+Ensure all external domains are declared in the tool's `view.csp`. See [csp.md](csp.md).
 
 ## 3. Submit
 


### PR DESCRIPTION
some of it was stale, and some parts were straight-up hallucinated

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the `chatgpt-app-builder` skill documentation and evals to reflect the current API, replacing the old `registerView` + `_meta.ui.csp` pattern with `registerTool` + `view.csp`, and rewriting the OAuth guide to use the `requireBearerAuth` middleware and `extra.authInfo` instead of manual header parsing.

- All references to `registerView`, `_meta.ui.csp`, and `mountView` are replaced with the new `registerTool({ view: { ... } })` shape, consistently across eval fixtures, reference docs, and the publish checklist.
- The OAuth guide is simplified to a single JWT/JWKS verifier pattern using `requireBearerAuth`; the opaque-token userinfo pattern (which had scoping bugs noted in prior review) is removed entirely.
- The file-structure diagram and import paths are updated to reflect a flat `src/` layout with `server.run()` instead of a separate HTTP server file.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are documentation and eval fixtures only, with no runtime logic affected.

All changed files are Markdown reference docs and JSON eval fixtures. The API patterns are internally consistent across every updated file, the JWT verifier template correctly populates clientId, scopes, and expiresAt, and the previously flagged userinfo-pattern scoping issues are resolved by removing that pattern entirely.

No files require special attention.

<sub>Reviews (3): Last reviewed commit: ["fix: typo"](https://github.com/alpic-ai/skybridge/commit/22daa1c3a3b49e40c52e1b3b0c65d21264c47c23) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31637082)</sub>

<!-- /greptile_comment -->