### PR TITLE
feat: add useRequestClose

### DIFF
--- a/docs/api-reference/use-request-close.mdx
+++ b/docs/api-reference/use-request-close.mdx
@@ -1,0 +1,20 @@
+---
+title: useRequestClose
+description: "Request the host to close (dismiss) the view from inside your app."
+---
+
+The `useRequestClose` hook returns a function that asks the host to dismiss the view. Use it when the user has finished a flow and you want to return them to the conversation.
+
+```tsx
+import { useRequestClose } from "skybridge/web";
+
+function DoneButton() {
+  const requestClose = useRequestClose();
+
+  return (
+    <button onClick={() => requestClose()}>
+      Done
+    </button>
+  );
+}
+```

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -122,6 +122,7 @@
               "api-reference/use-send-follow-up-message",
               "api-reference/use-view-state",
               "api-reference/use-request-modal",
+              "api-reference/use-request-close",
               "api-reference/use-files"
             ]
           },

--- a/docs/fundamentals/apps-sdk.mdx
+++ b/docs/fundamentals/apps-sdk.mdx
@@ -58,6 +58,7 @@ Skybridge wraps the raw `window.openai` API with React hooks:
 | `window.openai.displayMode` and `window.openai.requestDisplayMode` | [`useDisplayMode()`](/api-reference/use-display-mode) | Access/change display mode |
 | `window.openai.uploadFile()`, `getFileDownloadUrl()` | [`useFiles()`](/api-reference/use-files) | Upload and download files |
 | `window.openai.setOpenInAppUrl()` | [`useSetOpenInAppUrl()`](/api-reference/use-set-open-in-app-url) | "Open in App" button URL in fullscreen |
+| `window.openai.requestClose()` | [`useRequestClose()`](/api-reference/use-request-close) | Close the view from the UI (e.g. user dismisses) |
 
 ## Apps SDK APIs not yet supported in Skybridge
 
@@ -66,7 +67,6 @@ The following [Apps SDK view APIs](https://developers.openai.com/apps-sdk/refere
 | Raw API | Purpose |
 |---------|---------|
 | `window.openai.notifyIntrinsicHeight(...)` | Report dynamic view heights to the host to avoid scroll clipping |
-| `window.openai.requestClose()` | Close the view from the UI (e.g. user dismisses) |
 | `window.openai.requestCheckout(...)` | Open ChatGPT Instant Checkout UI (monetization) |
 
 You can call these directly on `window.openai` when running in ChatGPT, if needed. Support may be added in a future release.

--- a/packages/core/src/web/bridges/apps-sdk/adaptor.ts
+++ b/packages/core/src/web/bridges/apps-sdk/adaptor.ts
@@ -70,6 +70,10 @@ export class AppsSdkAdaptor implements Adaptor {
     return window.openai.requestDisplayMode({ mode });
   };
 
+  public requestClose = (): Promise<void> => {
+    return window.openai.requestClose();
+  };
+
   public sendFollowUpMessage = (
     prompt: string,
     options?: SendFollowUpMessageOptions,

--- a/packages/core/src/web/bridges/apps-sdk/types.ts
+++ b/packages/core/src/web/bridges/apps-sdk/types.ts
@@ -89,6 +89,9 @@ export type AppsSdkMethods<WS extends AppsSdkWidgetState = AppsSdkWidgetState> =
       mode: RequestDisplayMode;
     }>;
 
+    /** Requests the host to close (dismiss) the widget. */
+    requestClose: () => Promise<void>;
+
     /**
      * Sets the widget state.
      * This state is persisted across widget renders.

--- a/packages/core/src/web/bridges/mcp-app/adaptor.ts
+++ b/packages/core/src/web/bridges/mcp-app/adaptor.ts
@@ -93,6 +93,11 @@ export class McpAppAdaptor implements Adaptor {
     return app.requestDisplayMode({ mode });
   };
 
+  public requestClose = async (): Promise<void> => {
+    const app = await McpAppBridge.getInstance().getApp();
+    await app.requestTeardown();
+  };
+
   public sendFollowUpMessage = async (
     prompt: string,
     _options?: SendFollowUpMessageOptions,

--- a/packages/core/src/web/bridges/types.ts
+++ b/packages/core/src/web/bridges/types.ts
@@ -116,6 +116,7 @@ export interface Adaptor {
   requestDisplayMode(mode: RequestDisplayMode): Promise<{
     mode: RequestDisplayMode;
   }>;
+  requestClose(): Promise<void>;
   sendFollowUpMessage(
     prompt: string,
     options?: SendFollowUpMessageOptions,

--- a/packages/core/src/web/hooks/index.ts
+++ b/packages/core/src/web/hooks/index.ts
@@ -9,6 +9,7 @@ export { useDisplayMode } from "./use-display-mode.js";
 export { useFiles } from "./use-files.js";
 export { type LayoutState, useLayout } from "./use-layout.js";
 export { type OpenExternalFn, useOpenExternal } from "./use-open-external.js";
+export { type RequestCloseFn, useRequestClose } from "./use-request-close.js";
 export { useRequestModal } from "./use-request-modal.js";
 export { useSendFollowUpMessage } from "./use-send-follow-up-message.js";
 export { useSetOpenInAppUrl } from "./use-set-open-in-app-url.js";

--- a/packages/core/src/web/hooks/use-request-close.test.ts
+++ b/packages/core/src/web/hooks/use-request-close.test.ts
@@ -1,0 +1,69 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { McpAppBridge } from "../bridges/mcp-app/bridge.js";
+import {
+  getMcpAppHostPostMessageMock,
+  MockResizeObserver,
+} from "./test/utils.js";
+import { useRequestClose } from "./use-request-close.js";
+
+describe("useRequestClose", () => {
+  describe("apps-sdk host", () => {
+    let requestCloseMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      requestCloseMock = vi.fn().mockResolvedValue(undefined);
+      vi.stubGlobal("openai", {
+        requestClose: requestCloseMock,
+      });
+      vi.stubGlobal("skybridge", { hostType: "apps-sdk" });
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      vi.resetAllMocks();
+    });
+
+    it("should return a function that calls window.openai.requestClose", async () => {
+      const { result } = renderHook(() => useRequestClose());
+
+      await result.current();
+
+      expect(requestCloseMock).toHaveBeenCalledTimes(1);
+      expect(requestCloseMock).toHaveBeenCalledWith();
+    });
+  });
+
+  describe("mcp-app host", () => {
+    let postMessageMock: ReturnType<typeof getMcpAppHostPostMessageMock>;
+
+    beforeEach(() => {
+      vi.stubGlobal("skybridge", { hostType: "mcp-app" });
+      vi.stubGlobal("ResizeObserver", MockResizeObserver);
+      postMessageMock = getMcpAppHostPostMessageMock();
+      vi.stubGlobal("parent", { postMessage: postMessageMock });
+    });
+
+    afterEach(async () => {
+      vi.unstubAllGlobals();
+      vi.resetAllMocks();
+      McpAppBridge.resetInstance();
+    });
+
+    it("should send a ui/notifications/request-teardown notification to the MCP host", async () => {
+      const { result } = renderHook(() => useRequestClose());
+
+      await result.current();
+
+      await waitFor(() => {
+        expect(postMessageMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            jsonrpc: "2.0",
+            method: "ui/notifications/request-teardown",
+          }),
+          "*",
+        );
+      });
+    });
+  });
+});

--- a/packages/core/src/web/hooks/use-request-close.ts
+++ b/packages/core/src/web/hooks/use-request-close.ts
@@ -1,0 +1,11 @@
+import { useCallback } from "react";
+import { getAdaptor } from "../bridges/index.js";
+
+export type RequestCloseFn = () => Promise<void>;
+
+export function useRequestClose(): RequestCloseFn {
+  const adaptor = getAdaptor();
+  const requestClose = useCallback(() => adaptor.requestClose(), [adaptor]);
+
+  return requestClose;
+}

--- a/packages/devtools/src/components/layout/tool-panel/view/create-openai-mock.ts
+++ b/packages/devtools/src/components/layout/tool-panel/view/create-openai-mock.ts
@@ -41,6 +41,9 @@ function createOpenaiMethods(
     sendFollowUpMessage: async (args: { prompt: string }) => {
       log("sendFollowUpMessage", args);
     },
+    requestClose: async () => {
+      log("requestClose", {});
+    },
     openExternal: (args: { href: string; redirectUrl?: false }) => {
       window.open(args.href, "_blank", "noopener,noreferrer");
       log("openExternal", args);


### PR DESCRIPTION
for host to teardown the widget. i added the mcp app variant even tho it's not supported by claude atm.

test: the usual skybridge: workspace dance on some example app, then connect to chatgpt via tunnel

