### PR TITLE
Feat/root domain dns

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -66,4 +66,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/infrastructure/lib/constructs/SkybridgeRecords.ts
+++ b/infrastructure/lib/constructs/SkybridgeRecords.ts
@@ -1,6 +1,9 @@
 import {
+  AaaaRecord,
+  ARecord,
   CnameRecord,
   PublicHostedZone,
+  RecordTarget,
   TxtRecord,
 } from "aws-cdk-lib/aws-route53";
 import { Construct } from "constructs";
@@ -8,6 +11,20 @@ import { Construct } from "constructs";
 type SkybridgeRecordsProps = {
   domain: string;
 };
+
+// GitHub Pages anycast IPs — https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site
+const GITHUB_PAGES_IPV4 = [
+  "185.199.108.153",
+  "185.199.109.153",
+  "185.199.110.153",
+  "185.199.111.153",
+];
+const GITHUB_PAGES_IPV6 = [
+  "2606:50c0:8000::153",
+  "2606:50c0:8001::153",
+  "2606:50c0:8002::153",
+  "2606:50c0:8003::153",
+];
 
 export class SkybridgeRecords extends Construct {
   constructor(scope: Construct, id: string, { domain }: SkybridgeRecordsProps) {
@@ -17,11 +34,19 @@ export class SkybridgeRecords extends Construct {
       zoneName: domain,
     });
 
-    // Apex + www: intentionally empty during the GitHub Pages migration.
-    // CloudFormation creates before deleting, so coexisting old (HttpsRedirect)
-    // and new (GitHub Pages) records on the same name would conflict at Route 53.
-    // Step 1 (this commit): remove the HttpsRedirect.
-    // Step 2 (follow-up commit): add the GitHub Pages A/AAAA + www CNAME.
+    new ARecord(this, "ApexGitHubPagesA", {
+      zone: hostedZone,
+      target: RecordTarget.fromIpAddresses(...GITHUB_PAGES_IPV4),
+    });
+    new AaaaRecord(this, "ApexGitHubPagesAAAA", {
+      zone: hostedZone,
+      target: RecordTarget.fromIpAddresses(...GITHUB_PAGES_IPV6),
+    });
+    new CnameRecord(this, "WwwGitHubPages", {
+      zone: hostedZone,
+      recordName: "www",
+      domainName: "alpic-ai.github.io",
+    });
 
     // Showcase apps pointing to alpic.ai
     for (const subdomain of [


### PR DESCRIPTION
These records are already deployed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the two-step GitHub Pages migration for the root domain by adding the missing A, AAAA, and CNAME DNS records in CDK, and bumps `actions/deploy-pages` from v4 to v5 in the deployment workflow.

- Adds apex A and AAAA records targeting GitHub Pages' documented anycast IPs, and a `www` CNAME pointing to `alpic-ai.github.io`, correctly avoiding a CNAME at the zone apex.
- Bumps `actions/deploy-pages` to v5 in `.github/workflows/deploy-landing.yml`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the DNS changes are straightforward and the IP addresses match GitHub Pages' published anycast addresses.

The changes are minimal and well-scoped: apex A/AAAA records use the correct RecordTarget.fromIpAddresses CDK API, the www CNAME correctly avoids a CNAME-at-apex conflict, and the IPs match GitHub's documented values. The workflow action bump is a single-line version pin with no logic change.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["Add records to point github"](https://github.com/alpic-ai/skybridge/commit/b8ccfb800bda00036cbfa9113090f165580ba24f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31926183)</sub>

<!-- /greptile_comment -->