### PR TITLE
feat: add useRequestSize

### DIFF
--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -48,6 +48,9 @@ Skybridge exports hooks and utilities from `skybridge/web` that work across mult
   <Card title="useRequestModal" icon="window-maximize" href="/api-reference/use-request-modal">
     Open a modal portaled outside of the view iframe
   </Card>
+  <Card title="useRequestSize" icon="up-right-and-down-left-from-center" href="/api-reference/use-request-size">
+    Resize the view to an arbitrary size
+  </Card>
 </CardGroup>
 
 ## Actions
@@ -97,6 +100,7 @@ import {
   useMcpAppContext,
   useOpenExternal,
   useRequestModal,
+  useRequestSize,
   useSendFollowUpMessage,
   useToolInfo,
   useUser,
@@ -122,6 +126,7 @@ Skybridge supports two runtime environments: **Apps SDK** (ChatGPT) and **MCP Ap
 | [useFiles](/api-reference/use-files) | ✅ | ❌ | Apps SDK only |
 | [useSetOpenInAppUrl](/api-reference/use-set-open-in-app-url) | ✅ | ❌ | Apps SDK only |
 | [useRequestModal](/api-reference/use-request-modal) | ✅ | ⚠️ | MCP Apps: polyfilled; renders in iframe instead of host modal |
+| [useRequestSize](/api-reference/use-request-size) | ❌ | ✅ | MCP Apps only |
 | [useAppsSdkContext](/api-reference/use-apps-sdk-context) | ✅ | ❌ | Apps SDK only |
 | [useMcpAppContext](/api-reference/use-mcp-app-context) | ❌ | ✅ | MCP Apps only |
 

--- a/docs/api-reference/use-request-size.mdx
+++ b/docs/api-reference/use-request-size.mdx
@@ -1,0 +1,49 @@
+---
+title: useRequestSize
+description: "Resize the view to arbitrary dimensions."
+---
+
+The `useRequestSize` hook returns a function that asks the host to update the iframe height and/or width. Use it to deliberately pin a size.
+
+```tsx
+import { useEffect, useState } from "react";
+import { useRequestSize } from "skybridge/web";
+
+function Expandable() {
+  const requestSize = useRequestSize();
+  const [expanded, setExpanded] = useState(false);
+
+  useEffect(() => {
+    requestSize({ height: expanded ? 500 : undefined });
+  }, [expanded, requestSize]);
+
+  return (
+    <div>
+      <button onClick={() => setExpanded((v) => !v)}>
+        {expanded ? "Collapse" : "Expand"}
+      </button>
+      {expanded && <p>Lots of additional content...</p>}
+    </div>
+  );
+}
+```
+
+## Returns
+
+```ts
+requestSize: (size: { width?: number; height?: number }) => Promise<void>
+```
+
+An async function that asks the host to size your view's container to the given dimensions. Both `width` and `height` are optional; pass only what you want to update.
+
+## Runtime behavior
+
+| Runtime | Behavior |
+|---------|----------|
+| Apps SDK (ChatGPT) | Not supported |
+| MCP Apps | Sends `ui/notifications/size-changed` with both `width` and `height` to the host. |
+
+<Tip>
+The host may clamp the requested size or ignore it entirely in display modes that own the viewport.
+</Tip>
+

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -123,6 +123,7 @@
               "api-reference/use-view-state",
               "api-reference/use-request-modal",
               "api-reference/use-request-close",
+              "api-reference/use-request-size",
               "api-reference/use-files"
             ]
           },

--- a/docs/fundamentals/apps-sdk.mdx
+++ b/docs/fundamentals/apps-sdk.mdx
@@ -60,16 +60,6 @@ Skybridge wraps the raw `window.openai` API with React hooks:
 | `window.openai.setOpenInAppUrl()` | [`useSetOpenInAppUrl()`](/api-reference/use-set-open-in-app-url) | "Open in App" button URL in fullscreen |
 | `window.openai.requestClose()` | [`useRequestClose()`](/api-reference/use-request-close) | Close the view from the UI (e.g. user dismisses) |
 
-## Apps SDK APIs not yet supported in Skybridge
-
-The following [Apps SDK view APIs](https://developers.openai.com/apps-sdk/reference) are not yet wrapped by Skybridge hooks:
-
-| Raw API | Purpose |
-|---------|---------|
-| `window.openai.requestCheckout(...)` | Open ChatGPT Instant Checkout UI (monetization) |
-
-You can call these directly on `window.openai` when running in ChatGPT, if needed. Support may be added in a future release.
-
 ## Skybridge Apps SDK Exclusive Features
 
 These features are **only available in ChatGPT** and not supported in MCP Apps:

--- a/docs/fundamentals/apps-sdk.mdx
+++ b/docs/fundamentals/apps-sdk.mdx
@@ -66,7 +66,6 @@ The following [Apps SDK view APIs](https://developers.openai.com/apps-sdk/refere
 
 | Raw API | Purpose |
 |---------|---------|
-| `window.openai.notifyIntrinsicHeight(...)` | Report dynamic view heights to the host to avoid scroll clipping |
 | `window.openai.requestCheckout(...)` | Open ChatGPT Instant Checkout UI (monetization) |
 
 You can call these directly on `window.openai` when running in ChatGPT, if needed. Support may be added in a future release.

--- a/docs/fundamentals/mcp-apps.mdx
+++ b/docs/fundamentals/mcp-apps.mdx
@@ -64,6 +64,7 @@ Skybridge wraps the MCP ext-apps protocol with the **same React hooks** as the A
 | `ui/notifications/host-context-changed` (theme, maxHeight, safeArea) | [`useLayout()`](/api-reference/use-layout) | Theme, max height, safe area insets |
 | `ui/notifications/host-context-changed` (locale, userAgent) | [`useUser()`](/api-reference/use-user) | Locale and device/capabilities |
 | Modal (polyfilled) | [`useRequestModal()`](/api-reference/use-request-modal) | Request modal display (renders in-iframe) |
+| `ui/notifications/size-changed` | [`useRequestSize()`](/api-reference/use-request-size) | Manually report view size (ext-apps `autoResize` handles this by default) |
 
 ## MCP Apps methods not yet supported in Skybridge
 

--- a/examples/everything/src/views/tabs/image-tab/index.tsx
+++ b/examples/everything/src/views/tabs/image-tab/index.tsx
@@ -1,21 +1,6 @@
-import { useState } from "react";
-import { useRequestSize } from "skybridge/web";
 import skybridge from "./skybridge.jpg";
 
 export function ImageTab() {
-  const requestSize = useRequestSize();
-  const [width, setWidth] = useState("");
-  const [height, setHeight] = useState("");
-
-  const parsed = {
-    width: width.trim() === "" ? undefined : Number(width),
-    height: height.trim() === "" ? undefined : Number(height),
-  };
-  const isValid =
-    (parsed.width !== undefined || parsed.height !== undefined) &&
-    (parsed.width === undefined || Number.isFinite(parsed.width)) &&
-    (parsed.height === undefined || Number.isFinite(parsed.height));
-
   return (
     <div className="tab-content">
       <p className="description">
@@ -33,42 +18,6 @@ export function ImageTab() {
             style={{ maxWidth: "100%", height: "auto" }}
           />
         </div>
-      </div>
-
-      <div className="field">
-        <span className="field-label">Request view size</span>
-        <p className="description">
-          Ask the host to resize the view. On Apps SDK, only height is honored.
-        </p>
-        <form
-          className="button-row"
-          onSubmit={(e) => {
-            e.preventDefault();
-            if (isValid) {
-              requestSize(parsed);
-            }
-          }}
-        >
-          <input
-            type="number"
-            className="input"
-            value={width}
-            placeholder="width (px)"
-            onChange={(e) => setWidth(e.target.value)}
-            style={{ maxWidth: "8rem" }}
-          />
-          <input
-            type="number"
-            className="input"
-            value={height}
-            placeholder="height (px)"
-            onChange={(e) => setHeight(e.target.value)}
-            style={{ maxWidth: "8rem" }}
-          />
-          <button type="submit" className="btn" disabled={!isValid}>
-            Request resize
-          </button>
-        </form>
       </div>
     </div>
   );

--- a/examples/everything/src/views/tabs/image-tab/index.tsx
+++ b/examples/everything/src/views/tabs/image-tab/index.tsx
@@ -1,6 +1,21 @@
+import { useState } from "react";
+import { useRequestSize } from "skybridge/web";
 import skybridge from "./skybridge.jpg";
 
 export function ImageTab() {
+  const requestSize = useRequestSize();
+  const [width, setWidth] = useState("");
+  const [height, setHeight] = useState("");
+
+  const parsed = {
+    width: width.trim() === "" ? undefined : Number(width),
+    height: height.trim() === "" ? undefined : Number(height),
+  };
+  const isValid =
+    (parsed.width !== undefined || parsed.height !== undefined) &&
+    (parsed.width === undefined || Number.isFinite(parsed.width)) &&
+    (parsed.height === undefined || Number.isFinite(parsed.height));
+
   return (
     <div className="tab-content">
       <p className="description">
@@ -18,6 +33,42 @@ export function ImageTab() {
             style={{ maxWidth: "100%", height: "auto" }}
           />
         </div>
+      </div>
+
+      <div className="field">
+        <span className="field-label">Request view size</span>
+        <p className="description">
+          Ask the host to resize the view. On Apps SDK, only height is honored.
+        </p>
+        <form
+          className="button-row"
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (isValid) {
+              requestSize(parsed);
+            }
+          }}
+        >
+          <input
+            type="number"
+            className="input"
+            value={width}
+            placeholder="width (px)"
+            onChange={(e) => setWidth(e.target.value)}
+            style={{ maxWidth: "8rem" }}
+          />
+          <input
+            type="number"
+            className="input"
+            value={height}
+            placeholder="height (px)"
+            onChange={(e) => setHeight(e.target.value)}
+            style={{ maxWidth: "8rem" }}
+          />
+          <button type="submit" className="btn" disabled={!isValid}>
+            Request resize
+          </button>
+        </form>
       </div>
     </div>
   );

--- a/packages/core/src/web/bridges/apps-sdk/adaptor.ts
+++ b/packages/core/src/web/bridges/apps-sdk/adaptor.ts
@@ -7,6 +7,7 @@ import type {
   OpenExternalOptions,
   RequestDisplayMode,
   RequestModalOptions,
+  RequestSizeOptions,
   SendFollowUpMessageOptions,
   SetViewStateAction,
   UploadFileOptions,
@@ -72,6 +73,10 @@ export class AppsSdkAdaptor implements Adaptor {
 
   public requestClose = (): Promise<void> => {
     return window.openai.requestClose();
+  };
+
+  public requestSize = async (_size: RequestSizeOptions): Promise<void> => {
+    console.warn("[skybridge] requestSize: not supported on Apps SDK");
   };
 
   public sendFollowUpMessage = (

--- a/packages/core/src/web/bridges/mcp-app/adaptor.ts
+++ b/packages/core/src/web/bridges/mcp-app/adaptor.ts
@@ -7,6 +7,7 @@ import type {
   OpenExternalOptions,
   RequestDisplayMode,
   RequestModalOptions,
+  RequestSizeOptions,
   SendFollowUpMessageOptions,
   SetViewStateAction,
 } from "../types.js";
@@ -96,6 +97,11 @@ export class McpAppAdaptor implements Adaptor {
   public requestClose = async (): Promise<void> => {
     const app = await McpAppBridge.getInstance().getApp();
     await app.requestTeardown();
+  };
+
+  public requestSize = async (size: RequestSizeOptions): Promise<void> => {
+    const app = await McpAppBridge.getInstance().getApp();
+    await app.sendSizeChanged(size);
   };
 
   public sendFollowUpMessage = async (

--- a/packages/core/src/web/bridges/types.ts
+++ b/packages/core/src/web/bridges/types.ts
@@ -107,6 +107,11 @@ export type OpenExternalOptions = {
 
 export type SendFollowUpMessageOptions = { scrollToBottom?: boolean };
 
+export type RequestSizeOptions = {
+  width?: number;
+  height?: number;
+};
+
 export interface Adaptor {
   getHostContextStore<K extends keyof HostContext>(key: K): HostContextStore<K>;
   callTool<
@@ -117,6 +122,7 @@ export interface Adaptor {
     mode: RequestDisplayMode;
   }>;
   requestClose(): Promise<void>;
+  requestSize(size: RequestSizeOptions): Promise<void>;
   sendFollowUpMessage(
     prompt: string,
     options?: SendFollowUpMessageOptions,

--- a/packages/core/src/web/hooks/index.ts
+++ b/packages/core/src/web/hooks/index.ts
@@ -11,6 +11,7 @@ export { type LayoutState, useLayout } from "./use-layout.js";
 export { type OpenExternalFn, useOpenExternal } from "./use-open-external.js";
 export { type RequestCloseFn, useRequestClose } from "./use-request-close.js";
 export { useRequestModal } from "./use-request-modal.js";
+export { type RequestSizeFn, useRequestSize } from "./use-request-size.js";
 export { useSendFollowUpMessage } from "./use-send-follow-up-message.js";
 export { useSetOpenInAppUrl } from "./use-set-open-in-app-url.js";
 export { useToolInfo } from "./use-tool-info.js";

--- a/packages/core/src/web/hooks/use-request-size.test.ts
+++ b/packages/core/src/web/hooks/use-request-size.test.ts
@@ -1,0 +1,88 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppsSdkAdaptor } from "../bridges/apps-sdk/adaptor.js";
+import { McpAppBridge } from "../bridges/mcp-app/bridge.js";
+import {
+  getMcpAppHostPostMessageMock,
+  MockResizeObserver,
+} from "./test/utils.js";
+import { useRequestSize } from "./use-request-size.js";
+
+describe("useRequestSize", () => {
+  describe("apps-sdk host", () => {
+    let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      AppsSdkAdaptor.resetInstance();
+      vi.stubGlobal("openai", {});
+      vi.stubGlobal("skybridge", { hostType: "apps-sdk" });
+      consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      AppsSdkAdaptor.resetInstance();
+      vi.unstubAllGlobals();
+      vi.resetAllMocks();
+    });
+
+    it("warns that requestSize is not supported on Apps SDK", async () => {
+      const { result } = renderHook(() => useRequestSize());
+
+      await result.current({ height: 400 });
+
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+      expect(consoleWarnSpy.mock.calls[0]?.[0]).toContain("not supported");
+    });
+  });
+
+  describe("mcp-app host", () => {
+    let postMessageMock: ReturnType<typeof getMcpAppHostPostMessageMock>;
+
+    beforeEach(() => {
+      vi.stubGlobal("skybridge", { hostType: "mcp-app" });
+      vi.stubGlobal("ResizeObserver", MockResizeObserver);
+      postMessageMock = getMcpAppHostPostMessageMock();
+      vi.stubGlobal("parent", { postMessage: postMessageMock });
+    });
+
+    afterEach(async () => {
+      vi.unstubAllGlobals();
+      vi.resetAllMocks();
+      McpAppBridge.resetInstance();
+    });
+
+    it("sends a ui/notifications/size-changed notification with width and height", async () => {
+      const { result } = renderHook(() => useRequestSize());
+
+      await result.current({ width: 800, height: 400 });
+
+      await waitFor(() => {
+        expect(postMessageMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            jsonrpc: "2.0",
+            method: "ui/notifications/size-changed",
+            params: { width: 800, height: 400 },
+          }),
+          "*",
+        );
+      });
+    });
+
+    it("forwards height-only payloads as-is", async () => {
+      const { result } = renderHook(() => useRequestSize());
+
+      await result.current({ height: 400 });
+
+      await waitFor(() => {
+        expect(postMessageMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            jsonrpc: "2.0",
+            method: "ui/notifications/size-changed",
+            params: { height: 400 },
+          }),
+          "*",
+        );
+      });
+    });
+  });
+});

--- a/packages/core/src/web/hooks/use-request-size.ts
+++ b/packages/core/src/web/hooks/use-request-size.ts
@@ -1,0 +1,15 @@
+import { useCallback } from "react";
+import { getAdaptor } from "../bridges/index.js";
+import type { RequestSizeOptions } from "../bridges/types.js";
+
+export type RequestSizeFn = (size: RequestSizeOptions) => Promise<void>;
+
+export function useRequestSize(): RequestSizeFn {
+  const adaptor = getAdaptor();
+  const requestSize = useCallback(
+    (size: RequestSizeOptions) => adaptor.requestSize(size),
+    [adaptor],
+  );
+
+  return requestSize;
+}


### PR DESCRIPTION
ask host to resize the widget to arbitrary dimensions. can be tested in claude (at least the height). despite what the [apps sdk reference doc says](https://developers.openai.com/apps-sdk/reference), it's not supported by chatgpt (notifyIntrinsicHeight is a dead api)