### PR TITLE
fix: normalize _meta to meta in ChatGPT Apps SDK adaptor

### DIFF
--- a/packages/core/src/web/bridges/apps-sdk/adaptor.ts
+++ b/packages/core/src/web/bridges/apps-sdk/adaptor.ts
@@ -61,7 +61,17 @@ export class AppsSdkAdaptor implements Adaptor {
     name: string,
     args: ToolArgs,
   ): Promise<ToolResponse> => {
-    return window.openai.callTool<ToolArgs, ToolResponse>(name, args);
+    const response = await (
+      window.openai.callTool(name, args) as Promise<
+        CallToolResponse & { _meta?: CallToolResponse["meta"] }
+      >
+    );
+    return {
+      content: response.content,
+      structuredContent: response.structuredContent ?? {},
+      isError: response.isError ?? false,
+      meta: response._meta ?? response.meta ?? {},
+    } as ToolResponse;
   };
 
   public requestDisplayMode = (

--- a/packages/core/src/web/bridges/apps-sdk/adaptor.ts
+++ b/packages/core/src/web/bridges/apps-sdk/adaptor.ts
@@ -61,11 +61,9 @@ export class AppsSdkAdaptor implements Adaptor {
     name: string,
     args: ToolArgs,
   ): Promise<ToolResponse> => {
-    const response = await (
-      window.openai.callTool(name, args) as Promise<
-        CallToolResponse & { _meta?: CallToolResponse["meta"] }
-      >
-    );
+    const response = await (window.openai.callTool(name, args) as Promise<
+      CallToolResponse & { _meta?: CallToolResponse["meta"] }
+    >);
     return {
       content: response.content,
       structuredContent: response.structuredContent ?? {},

--- a/packages/core/src/web/hooks/use-call-tool.test.ts
+++ b/packages/core/src/web/hooks/use-call-tool.test.ts
@@ -167,8 +167,14 @@ describe("useCallTool - onSuccess callback", () => {
       useCallTool<typeof args, typeof data>(toolName),
     );
 
-    const firstCallData = { ...data, structuredContent: { result: "first call result" } };
-    const secondCallData = { ...data, structuredContent: { result: "second call result" } };
+    const firstCallData = {
+      ...data,
+      structuredContent: { result: "first call result" },
+    };
+    const secondCallData = {
+      ...data,
+      structuredContent: { result: "second call result" },
+    };
     const { promise: firstCallToolPromise, resolve: resolveFirstCallTool } =
       Promise.withResolvers();
     const { promise: secondCallToolPromise, resolve: resolveSecondCallTool } =

--- a/packages/core/src/web/hooks/use-call-tool.test.ts
+++ b/packages/core/src/web/hooks/use-call-tool.test.ts
@@ -35,8 +35,30 @@ describe("useCallTool - onSuccess callback", () => {
     content: [{ type: "text" as const, text: "test result" }],
     structuredContent: { result: "test" },
     isError: false,
+    meta: {},
   };
   const error = new Error("test error");
+
+  it("should normalize _meta to meta when SDK returns _meta instead of meta", async () => {
+    const rawSdkResponse = {
+      content: [{ type: "text" as const, text: "result" }],
+      structuredContent: { value: 1 },
+      isError: false,
+      _meta: { secret: "only visible to widget" },
+    };
+    OpenaiMock.callTool.mockResolvedValueOnce(rawSdkResponse);
+    const { result } = renderHook(() => useCallTool(toolName));
+
+    await act(async () => {
+      result.current.callTool(args);
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toMatchObject({
+        meta: { secret: "only visible to widget" },
+      });
+    });
+  });
 
   it("should call window.openai.callTool with correct arguments", async () => {
     const { result } = renderHook(() =>
@@ -143,8 +165,8 @@ describe("useCallTool - onSuccess callback", () => {
       useCallTool<typeof args, typeof data>(toolName),
     );
 
-    const firstCallData = { ...data, result: "first call result" };
-    const secondCallData = { ...data, result: "second call result" };
+    const firstCallData = { ...data, structuredContent: { result: "first call result" } };
+    const secondCallData = { ...data, structuredContent: { result: "second call result" } };
     const { promise: firstCallToolPromise, resolve: resolveFirstCallTool } =
       Promise.withResolvers();
     const { promise: secondCallToolPromise, resolve: resolveSecondCallTool } =

--- a/packages/core/src/web/hooks/use-call-tool.test.ts
+++ b/packages/core/src/web/hooks/use-call-tool.test.ts
@@ -47,7 +47,9 @@ describe("useCallTool - onSuccess callback", () => {
       _meta: { secret: "only visible to widget" },
     };
     OpenaiMock.callTool.mockResolvedValueOnce(rawSdkResponse);
-    const { result } = renderHook(() => useCallTool(toolName));
+    const { result } = renderHook(() =>
+      useCallTool<typeof args, typeof data>(toolName),
+    );
 
     await act(async () => {
       result.current.callTool(args);


### PR DESCRIPTION
Fixes #709 

 Before the fix:
  - MCP-apps runtime → adaptor mapped _meta → meta → app saw data.meta ✅
  - ChatGPT runtime → adaptor did no mapping → OpenAI's raw _meta leaked through → app saw data._meta, and
  data.meta was undefined ❌

  After your fix:
  - ChatGPT runtime → adaptor now also maps _meta → meta → app sees data.meta ✅

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where the ChatGPT Apps SDK adaptor was not normalizing OpenAI's raw `_meta` field to `meta`, causing app consumers to receive `data._meta` with `data.meta` being `undefined` at runtime.

- `adaptor.ts` now awaits and re-shapes the raw SDK response, mapping `_meta` → `meta` (with `meta` as a fallback) — bringing it into parity with the MCP-app adaptor which already performed this mapping.
- `use-call-tool.test.ts` adds a targeted normalization test and corrects an existing "last call wins" test that was diffing on a stale `result` spread instead of `structuredContent`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is a targeted normalization that matches the existing MCP-app adaptor pattern, and the updated tests correctly cover the new behavior.

The change is a minimal, well-understood field remapping that closes a clear behavioral gap between two adaptor implementations. The existing MCP-app adaptor already uses the same pattern successfully, the new test directly exercises the _meta → meta mapping, and the corrected last-call-wins test removes a latent mismatch where result was being spread onto the wrong level of the response object.

No files require special attention.

<sub>Reviews (3): Last reviewed commit: ["Fix Lint Errors"](https://github.com/alpic-ai/skybridge/commit/8e1ce6bc4bd6bc8dcc48cd57639c99e2ccead3d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31970037)</sub>

<!-- /greptile_comment -->