### PR TITLE
WIP: Improve docs metadata and SEO

### DIFF
--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: API Reference
-description: "Reference for Skybridge server APIs, React hooks, utilities, and runtime helpers."
+description: "Explore Skybridge API reference docs for server APIs, React hooks, CLI commands, type helpers, and utilities for building MCP Apps."
 ---
 
 Skybridge exports hooks and utilities from `skybridge/web` that work across multiple runtimes. See the [compatibility matrix](#runtime-compatibility) below for platform-specific availability.

--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: API Reference
-description: Detailed documentation for all hooks and utilities provided by Skybridge.
+description: "Reference for Skybridge server APIs, React hooks, utilities, and runtime helpers."
 ---
 
 Skybridge exports hooks and utilities from `skybridge/web` that work across multiple runtimes. See the [compatibility matrix](#runtime-compatibility) below for platform-specific availability.
@@ -133,4 +133,3 @@ Skybridge supports two runtime environments: **Apps SDK** (ChatGPT) and **MCP Ap
 <Tip>
 Learn more about runtime differences in [Write Once, Run Everywhere](/concepts/write-once-run-everywhere).
 </Tip>
-

--- a/docs/api-reference/cli.mdx
+++ b/docs/api-reference/cli.mdx
@@ -1,6 +1,6 @@
 ---
 title: "CLI Reference"
-description: "Reference every Skybridge CLI command for creating, developing, building, and running MCP Apps from your terminal workflow and CI setup."
+description: "Reference every Skybridge CLI command for creating, developing, building, and running MCP Apps from your terminal."
 ---
 
 Skybridge provides two CLI tools: the main `skybridge` CLI for development and production workflows, and `create-skybridge` for bootstrapping new projects.

--- a/docs/api-reference/cli.mdx
+++ b/docs/api-reference/cli.mdx
@@ -1,6 +1,6 @@
 ---
 title: "CLI Reference"
-description: "Complete reference for Skybridge CLI commands"
+description: "Reference every Skybridge CLI command for creating, developing, building, and running MCP Apps from your terminal workflow and CI setup."
 ---
 
 Skybridge provides two CLI tools: the main `skybridge` CLI for development and production workflows, and `create-skybridge` for bootstrapping new projects.

--- a/docs/api-reference/create-store.mdx
+++ b/docs/api-reference/create-store.mdx
@@ -1,6 +1,6 @@
 ---
 title: createStore
-description: "Create Zustand stores with automatic view state persistence, actions, and middleware support."
+description: "Create Zustand-powered stores for Skybridge views with persistent view state, typed actions, derived values, and middleware support."
 ---
 
 

--- a/docs/api-reference/create-store.mdx
+++ b/docs/api-reference/create-store.mdx
@@ -1,6 +1,6 @@
 ---
 title: createStore
-description: "Create Zustand-powered stores for Skybridge views with persistent view state, typed actions, derived values, and middleware support."
+description: "Create Zustand-powered stores for MCP Apps views with persistent view state, typed actions, derived values, and middleware support."
 ---
 
 

--- a/docs/api-reference/data-llm.mdx
+++ b/docs/api-reference/data-llm.mdx
@@ -1,6 +1,6 @@
 ---
 title: data-llm Attribute
-description: "Create a feedback loop between your view UI state and the model for contextual responses."
+description: "Expose important view UI state to the model with data-llm so MCP Apps can keep ChatGPT and other hosts context-aware during interactions."
 ---
 
 The `data-llm` attribute allows your view to communicate its current UI state back to the model. This creates a feedback loop where the model can understand what the user is seeing and respond contextually to their questions.

--- a/docs/api-reference/generate-helpers.mdx
+++ b/docs/api-reference/generate-helpers.mdx
@@ -1,6 +1,6 @@
 ---
 title: generateHelpers
-description: "Create fully typed hooks with end-to-end inference from your MCP server, like tRPC for views."
+description: "Generate fully typed React hooks from your MCP server definition with end-to-end inference for tool calls, tool inputs, and results."
 ---
 
 

--- a/docs/api-reference/infer-utility-types.mdx
+++ b/docs/api-reference/infer-utility-types.mdx
@@ -1,6 +1,6 @@
 ---
 title: Type Utilities
-description: "Extract input, output, and structured content types from your MCP server definition."
+description: "Extract input, output, and structured content types from your Skybridge MCP server for safer React views and shared TypeScript helpers."
 ---
 
 

--- a/docs/api-reference/infer-utility-types.mdx
+++ b/docs/api-reference/infer-utility-types.mdx
@@ -1,6 +1,6 @@
 ---
 title: Type Utilities
-description: "Extract input, output, and structured content types from your Skybridge MCP server for safer React views and shared TypeScript helpers."
+description: "Extract input, output, and structured content types from your Skybridge MCP server for tool-to-view type safety."
 ---
 
 

--- a/docs/api-reference/mcp-server.mdx
+++ b/docs/api-reference/mcp-server.mdx
@@ -1,6 +1,6 @@
 ---
 title: McpServer
-description: "The main class for building MCP servers with Skybridge, supporting tools, views, and type inference."
+description: "Use the McpServer class to build Skybridge MCP servers with registered tools, React views, resources, and server-to-view type inference."
 ---
 
 

--- a/docs/api-reference/register-tool.mdx
+++ b/docs/api-reference/register-tool.mdx
@@ -1,6 +1,6 @@
 ---
 title: registerTool
-description: "Register an MCP tool — with or without a React view"
+description: "Register MCP tools in Skybridge, bind them to React views, configure tool metadata, and return structured content for AI hosts and MCP clients."
 ---
 
 

--- a/docs/api-reference/use-apps-sdk-context.mdx
+++ b/docs/api-reference/use-apps-sdk-context.mdx
@@ -1,6 +1,6 @@
 ---
 title: useAppsSdkContext
-description: "Read low-level OpenAI Apps SDK host state from Skybridge views when you need direct access to ChatGPT runtime context and global values."
+description: "Read low-level OpenAI Apps SDK host state from MCP Apps views when you need direct access to ChatGPT runtime context and global values."
 tag: "ChatGPT"
 ---
 

--- a/docs/api-reference/use-apps-sdk-context.mdx
+++ b/docs/api-reference/use-apps-sdk-context.mdx
@@ -1,6 +1,6 @@
 ---
 title: useAppsSdkContext
-description: "Read low-level OpenAI Apps SDK host state from MCP Apps views when you need direct access to ChatGPT runtime context and global values."
+description: "Read low-level OpenAI Apps SDK host state from MCP Apps views when you need direct access to ChatGPT runtime context."
 tag: "ChatGPT"
 ---
 

--- a/docs/api-reference/use-apps-sdk-context.mdx
+++ b/docs/api-reference/use-apps-sdk-context.mdx
@@ -1,6 +1,6 @@
 ---
 title: useAppsSdkContext
-description: "Low-level hook for subscribing to OpenAI host global state values directly."
+description: "Read low-level OpenAI Apps SDK host state from Skybridge views when you need direct access to ChatGPT runtime context and global values."
 tag: "ChatGPT"
 ---
 

--- a/docs/api-reference/use-call-tool.mdx
+++ b/docs/api-reference/use-call-tool.mdx
@@ -1,6 +1,6 @@
 ---
 title: useCallTool
-description: "React hook for calling MCP tools from views with typed API and state management."
+description: "Call MCP tools from React views with useCallTool, including typed inputs, async state, user-triggered fetching, and tool results in Skybridge."
 ---
 
 The `useCallTool` function allows you to call additional MCP tools from your view. It wraps the [`window.openai.callTool`](https://developers.openai.com/apps-sdk/build/chatgpt-ui#trigger-server-actions) function while providing a more convenient state management and typed API.

--- a/docs/api-reference/use-call-tool.mdx
+++ b/docs/api-reference/use-call-tool.mdx
@@ -3,7 +3,7 @@ title: useCallTool
 description: "Call MCP tools from React views with useCallTool, including typed inputs, async state, user-triggered fetching, and tool results in Skybridge."
 ---
 
-The `useCallTool` function allows you to call additional MCP tools from your view. It wraps the [`window.openai.callTool`](https://developers.openai.com/apps-sdk/build/chatgpt-ui#trigger-server-actions) function while providing a more convenient state management and typed API.
+The `useCallTool` function allows you to call additional MCP tools from your view. It wraps the [`window.openai.callTool`](https://developers.openai.com/apps-sdk/build/chatgpt-ui#trigger-server-actions) function while providing a more convenient typed API with state management.
 
 Make sure your tool `_meta["openai/widgetAccessible"]` property is set to `true` to make it accessible from views - more info on [component-initiated tool calls](https://developers.openai.com/apps-sdk/build/mcp-server#component-initiated-tool-calls).
 
@@ -122,7 +122,7 @@ The mutation function you can call to trigger the tool. Optionally pass side-eff
 callToolAsync: (toolArgs?: ToolArgs) => Promise<ToolResponse>;
 ```
 
-Similar to `callTool` but returns a promise which can be awaited.
+Similar to `callTool`, but returns a promise that can be awaited.
 
 ### `status`
 

--- a/docs/api-reference/use-display-mode.mdx
+++ b/docs/api-reference/use-display-mode.mdx
@@ -1,6 +1,6 @@
 ---
 title: useDisplayMode
-description: "Read and control view display modes: inline, fullscreen, or picture-in-picture."
+description: "Read and control Skybridge view display modes such as inline, fullscreen, and picture-in-picture across supported MCP clients and AI hosts."
 ---
 
 <Info>

--- a/docs/api-reference/use-display-mode.mdx
+++ b/docs/api-reference/use-display-mode.mdx
@@ -1,6 +1,6 @@
 ---
 title: useDisplayMode
-description: "Read and control Skybridge view display modes such as inline, fullscreen, and picture-in-picture across supported MCP clients and AI hosts."
+description: "Read and control MCP Apps view display modes such as inline, fullscreen, and picture-in-picture across supported MCP clients and AI hosts."
 ---
 
 <Info>

--- a/docs/api-reference/use-files.mdx
+++ b/docs/api-reference/use-files.mdx
@@ -1,6 +1,6 @@
 ---
 title: useFiles
-description: "Upload, select, and download files within views, with host-managed storage across tool calls."
+description: "Upload, select, and download files from Skybridge views with host-managed file storage across MCP tool calls and view interactions."
 tag: "ChatGPT"
 ---
 

--- a/docs/api-reference/use-files.mdx
+++ b/docs/api-reference/use-files.mdx
@@ -1,6 +1,6 @@
 ---
 title: useFiles
-description: "Upload, select, and download files from Skybridge views with host-managed file storage across MCP tool calls and view interactions."
+description: "Upload, select, and download files from MCP Apps views with host-managed file storage across MCP tool calls and view interactions."
 tag: "ChatGPT"
 ---
 

--- a/docs/api-reference/use-layout.mdx
+++ b/docs/api-reference/use-layout.mdx
@@ -1,6 +1,6 @@
 ---
 title: useLayout
-description: "Access dynamic layout info like viewport dimensions, theme, and visual environment in views."
+description: "Read host layout data in Skybridge views, including viewport size, display mode, theme, and visual environment for responsive React UI."
 ---
 
 The `useLayout` hook returns layout and visual environment information. These values may change dynamically during the session (e.g., on resize or theme toggle).

--- a/docs/api-reference/use-layout.mdx
+++ b/docs/api-reference/use-layout.mdx
@@ -1,6 +1,6 @@
 ---
 title: useLayout
-description: "Read host layout data in Skybridge views, including viewport size, display mode, theme, and visual environment for responsive React UI."
+description: "Read host layout data in MCP Apps views, including viewport size, display mode, theme, and visual environment for responsive React UI."
 ---
 
 The `useLayout` hook returns layout and visual environment information. These values may change dynamically during the session (e.g., on resize or theme toggle).

--- a/docs/api-reference/use-mcp-app-context.mdx
+++ b/docs/api-reference/use-mcp-app-context.mdx
@@ -1,6 +1,6 @@
 ---
 title: useMcpAppContext
-description: "Read low-level MCP App host context from Skybridge views when you need direct access to ext-apps runtime values, updates, and events."
+description: "Read low-level MCP App host context from MCP Apps views when you need direct access to ext-apps runtime values, updates, and events."
 tag: "MCP Apps"
 ---
 

--- a/docs/api-reference/use-mcp-app-context.mdx
+++ b/docs/api-reference/use-mcp-app-context.mdx
@@ -1,6 +1,6 @@
 ---
 title: useMcpAppContext
-description: "Low-level hook for subscribing to MCP App host context values directly."
+description: "Read low-level MCP App host context from Skybridge views when you need direct access to ext-apps runtime values, updates, and events."
 tag: "MCP Apps"
 ---
 

--- a/docs/api-reference/use-open-external.mdx
+++ b/docs/api-reference/use-open-external.mdx
@@ -1,6 +1,6 @@
 ---
 title: useOpenExternal
-description: "Navigate users to external URLs properly from within your app views."
+description: "Open external URLs safely from Skybridge views with host-aware navigation for ChatGPT Apps, MCP Apps, embedded UI, and user workflows."
 ---
 
 The `useOpenExternal` hook returns a function to open external links. This is the proper way to navigate users to external URLs from within a view, as it delegates to the host application to handle the navigation appropriately.

--- a/docs/api-reference/use-open-external.mdx
+++ b/docs/api-reference/use-open-external.mdx
@@ -1,6 +1,6 @@
 ---
 title: useOpenExternal
-description: "Open external URLs safely from Skybridge views with host-aware navigation for ChatGPT Apps, MCP Apps, embedded UI, and user workflows."
+description: "Open external URLs safely from MCP Apps views with host-aware navigation for ChatGPT Apps, MCP Apps, embedded UI, and user workflows."
 ---
 
 The `useOpenExternal` hook returns a function to open external links. This is the proper way to navigate users to external URLs from within a view, as it delegates to the host application to handle the navigation appropriately.

--- a/docs/api-reference/use-request-close.mdx
+++ b/docs/api-reference/use-request-close.mdx
@@ -1,6 +1,6 @@
 ---
 title: useRequestClose
-description: "Request the host to close MCP Apps views from inside your React app when a user finishes a flow and should return to the conversation."
+description: "Request the host to close the MCP Apps view from inside your React app when the user should return to the conversation."
 ---
 
 The `useRequestClose` hook returns a function that asks the host to dismiss the view. Use it when the user has finished a flow and you want to return them to the conversation.

--- a/docs/api-reference/use-request-close.mdx
+++ b/docs/api-reference/use-request-close.mdx
@@ -1,6 +1,6 @@
 ---
 title: useRequestClose
-description: "Request the host to close (dismiss) the view from inside your app."
+description: "Request the host to close MCP Apps views from inside your React app when a user finishes a flow and should return to the conversation."
 ---
 
 The `useRequestClose` hook returns a function that asks the host to dismiss the view. Use it when the user has finished a flow and you want to return them to the conversation.

--- a/docs/api-reference/use-request-modal.mdx
+++ b/docs/api-reference/use-request-modal.mdx
@@ -1,6 +1,6 @@
 ---
 title: useRequestModal
-description: "Request host-rendered modals from Skybridge views so overlays, dialogs, and expanded UI can appear outside iframe bounds in MCP clients."
+description: "Request host-rendered modals from MCP Apps views so overlays, dialogs, and expanded UI can appear outside iframe bounds in MCP clients."
 ---
 
 <Warning>

--- a/docs/api-reference/use-request-modal.mdx
+++ b/docs/api-reference/use-request-modal.mdx
@@ -1,6 +1,6 @@
 ---
 title: useRequestModal
-description: "Trigger modals portaled outside the view iframe for better overlay display."
+description: "Request host-rendered modals from Skybridge views so overlays, dialogs, and expanded UI can appear outside iframe bounds in MCP clients."
 ---
 
 <Warning>

--- a/docs/api-reference/use-request-size.mdx
+++ b/docs/api-reference/use-request-size.mdx
@@ -1,6 +1,6 @@
 ---
 title: useRequestSize
-description: "Resize the view to arbitrary dimensions."
+description: "Resize MCP Apps views with useRequestSize by asking the host to update iframe width, height, responsive UI dimensions, and layout."
 ---
 
 The `useRequestSize` hook returns a function that asks the host to update the iframe height and/or width. Use it to deliberately pin a size.
@@ -46,4 +46,3 @@ An async function that asks the host to size your view's container to the given 
 <Tip>
 The host may clamp the requested size or ignore it entirely in display modes that own the viewport.
 </Tip>
-

--- a/docs/api-reference/use-send-follow-up-message.mdx
+++ b/docs/api-reference/use-send-follow-up-message.mdx
@@ -1,6 +1,6 @@
 ---
 title: useSendFollowUpMessage
-description: "Send follow-up messages from Skybridge views to the conversation when user actions should trigger a new AI response, tool flow, or workflow."
+description: "Send follow-up messages from MCP Apps views to the conversation when user actions should trigger a new AI response, tool flow, or workflow."
 ---
 
 The `useSendFollowUpMessage` hook returns a function to programmatically trigger a follow-up turn in the AI conversation. This allows your view to prompt the model to continue the conversation based on user actions.

--- a/docs/api-reference/use-send-follow-up-message.mdx
+++ b/docs/api-reference/use-send-follow-up-message.mdx
@@ -1,6 +1,6 @@
 ---
 title: useSendFollowUpMessage
-description: "Programmatically trigger AI conversation turns based on user actions in your view."
+description: "Send follow-up messages from Skybridge views to the conversation when user actions should trigger a new AI response, tool flow, or workflow."
 ---
 
 The `useSendFollowUpMessage` hook returns a function to programmatically trigger a follow-up turn in the AI conversation. This allows your view to prompt the model to continue the conversation based on user actions.

--- a/docs/api-reference/use-set-open-in-app-url.mdx
+++ b/docs/api-reference/use-set-open-in-app-url.mdx
@@ -1,6 +1,6 @@
 ---
 title: useSetOpenInAppUrl
-description: "Set the URL that will be opened when users click the 'open in app' button in fullscreen mode."
+description: "Configure the open-in-app URL for fullscreen Skybridge views so users can continue workflows in your product, website, or external app."
 tag: "ChatGPT"
 ---
 

--- a/docs/api-reference/use-set-open-in-app-url.mdx
+++ b/docs/api-reference/use-set-open-in-app-url.mdx
@@ -1,6 +1,6 @@
 ---
 title: useSetOpenInAppUrl
-description: "Configure the open-in-app URL for fullscreen Skybridge views so users can continue workflows in your product, website, or external app."
+description: "Configure the open-in-app URL for fullscreen MCP Apps views so users can continue workflows in your product, website, or external app."
 tag: "ChatGPT"
 ---
 

--- a/docs/api-reference/use-tool-info.mdx
+++ b/docs/api-reference/use-tool-info.mdx
@@ -1,6 +1,6 @@
 ---
 title: useToolInfo
-description: "React hook for accessing tool input, output, metadata, and execution status in Skybridge views."
+description: "Read tool input, output, metadata, and execution status in Skybridge React views with useToolInfo for MCP App rendering and state."
 ---
 
 The `useToolInfo` hook provides access to the tool's input arguments, output, and response metadata. It also tracks whether the tool execution is still pending or has completed successfully.

--- a/docs/api-reference/use-tool-info.mdx
+++ b/docs/api-reference/use-tool-info.mdx
@@ -1,6 +1,6 @@
 ---
 title: useToolInfo
-description: "Read tool input, output, metadata, and execution status in Skybridge React views with useToolInfo for MCP App rendering and state."
+description: "Read tool input, output, metadata, and execution status in MCP Apps React views with useToolInfo for MCP App rendering and UI state."
 ---
 
 The `useToolInfo` hook provides access to the tool's input arguments, output, and response metadata. It also tracks whether the tool execution is still pending or has completed successfully.

--- a/docs/api-reference/use-user.mdx
+++ b/docs/api-reference/use-user.mdx
@@ -1,6 +1,6 @@
 ---
 title: useUser
-description: "Access session-stable user information like locale and timezone in your app views."
+description: "Access session-stable user context in Skybridge views, including locale, timezone, host-provided profile data, and personalization signals."
 ---
 
 The `useUser` hook returns session-stable user information. These values are set once at initialization and do not change during the session.

--- a/docs/api-reference/use-user.mdx
+++ b/docs/api-reference/use-user.mdx
@@ -1,6 +1,6 @@
 ---
 title: useUser
-description: "Access session-stable user context in Skybridge views, including locale, timezone, host-provided profile data, and personalization signals."
+description: "Access session-stable user context in MCP Apps views, including locale, timezone, host-provided profile data, and personalization signals."
 ---
 
 The `useUser` hook returns session-stable user information. These values are set once at initialization and do not change during the session.

--- a/docs/api-reference/use-view-state.mdx
+++ b/docs/api-reference/use-view-state.mdx
@@ -1,6 +1,6 @@
 ---
 title: useViewState
-description: "React hook for persistent view state that survives re-renders and display mode changes."
+description: "Persist Skybridge view state across renders, display mode changes, and host updates with useViewState for interactive MCP App UI state."
 ---
 
 The `useViewState` hook provides persistent state management for your view. Unlike React's `useState`, this state is persisted by the host and survives across view re-renders and display mode changes.

--- a/docs/api-reference/use-view-state.mdx
+++ b/docs/api-reference/use-view-state.mdx
@@ -1,6 +1,6 @@
 ---
 title: useViewState
-description: "Persist Skybridge view state across renders, display mode changes, and host updates with useViewState for interactive MCP App UI state."
+description: "Persist MCP Apps view state across renders, display mode changes, and host updates with useViewState for interactive MCP App UI state."
 ---
 
 The `useViewState` hook provides persistent state management for your view. Unlike React's `useState`, this state is persisted by the host and survives across view re-renders and display mode changes.

--- a/docs/concepts/data-flow.mdx
+++ b/docs/concepts/data-flow.mdx
@@ -29,7 +29,7 @@ flowchart LR
     style Server fill:#dbeafe,stroke:#93c5fd,color:#1e40af
 ```
 
-1. **The MCP Host**: The conversational interface where users type messages and the model responds (ChatGPT, Claude, Goose, VSCode, etc.)
+1. **The MCP Host**: The conversational interface where users type messages and the model responds (ChatGPT, Claude, Goose, VS Code, etc.)
 2. **Your MCP server**: The backend that exposes tools and business logic
 3. **Your View (Guest)**: The React component rendered in an iframe inside the host
 

--- a/docs/concepts/data-flow.mdx
+++ b/docs/concepts/data-flow.mdx
@@ -1,6 +1,6 @@
 ---
 title: Data flow
-description: "Learn how data moves between the host, your MCP server, and views in Skybridge applications."
+description: "Learn how data moves between the AI host, MCP server, tools, resources, and React views in a Skybridge application and MCP App runtime."
 ---
 
 

--- a/docs/concepts/data-flow.mdx
+++ b/docs/concepts/data-flow.mdx
@@ -1,5 +1,5 @@
 ---
-title: Data Flow
+title: Data flow
 description: "Learn how data moves between the host, your MCP server, and views in Skybridge applications."
 ---
 
@@ -8,7 +8,7 @@ description: "Learn how data moves between the host, your MCP server, and views 
 
 **Solution:** Skybridge provides clear abstractions for each communication pattern.
 
-## The Three Actors
+## The three actors
 
 ```mermaid
 %%{init: {'theme': 'base', 'themeVariables': { 'lineColor': '#64748b' }}}%%
@@ -30,10 +30,10 @@ flowchart LR
 ```
 
 1. **The MCP Host**: The conversational interface where users type messages and the model responds (ChatGPT, Claude, Goose, VSCode, etc.)
-2. **Your MCP Server**: The backend that exposes tools and business logic
+2. **Your MCP server**: The backend that exposes tools and business logic
 3. **Your View (Guest)**: The React component rendered in an iframe inside the host
 
-## Key Terms
+## Key terms
 
 Tool responses contain three fields:
 
@@ -77,9 +77,9 @@ server.registerTool(
 );
 ```
 
-## Data Flow Patterns
+## Data flow patterns
 
-### 1. Tool → View (Initial Hydration)
+### 1. Tool → view (initial hydration)
 
 When the host calls a tool returning a view, it returns `structuredContent` to hydrate the React component:
 
@@ -131,7 +131,7 @@ export function FlightView() {
 `useToolInfo` provides the initial hydration data and should not be used as a mutable data store. For persistent view state that survives re-renders, use [`useViewState`](/api-reference/use-view-state).
 </Note>
 
-### 2. View → Server (Tool Calls)
+### 2. View → server (tool calls)
 
 Views can trigger additional tool calls in response to user actions:
 
@@ -163,11 +163,11 @@ Never wrap `callTool` in a `useEffect` to fetch data on mount. Pass initial data
 **Why?** Tool calls add latency and model round-trips. You control what initially comes from `structuredContent`, leverage it.
 </Warning>
 
-### 3. View → Model (Context Sync)
+### 3. View → model (context sync)
 
 Your view needs to communicate its state back to the model. Use the **`data-llm` attribute** to declaratively describe what the user sees. See [LLM Context Sync](/concepts/llm-context-sync).
 
-### 4. View → Chat (Follow-up Messages)
+### 4. View → chat (follow-up messages)
 
 Views can send messages back into the conversation:
 
@@ -198,7 +198,7 @@ This creates a continuous loop: the view can ask the model for help, and the mod
 If the model's response triggers another view, the host renders a new view instance (not nested inside the current one).
 </Tip>
 
-## Response Fields Explained
+## Response fields explained
 
 Tool responses have three fields:
 
@@ -220,7 +220,7 @@ return {
 };
 ```
 
-## When to Use What
+## When to use what
 
 | Need | Use | Why |
 |------|-----|-----|
@@ -247,7 +247,7 @@ Direct API calls don't add to context. Use them only for data the model doesn't 
 If you use `fetch()` directly from views, you need to configure Content Security Policy (CSP) headers. The host blocks requests to domains not explicitly allowed. Add allowed domains to `view.csp.connectDomains` in your `registerTool` call. See [registerTool](/api-reference/register-tool).
 </Warning>
 
-## The Communication Loop
+## The communication loop
 
 1. **Host calls your tool** → Server responds with `structuredContent`
 2. **View hydrates** with [`useToolInfo`](/api-reference/use-tool-info)

--- a/docs/concepts/fast-iteration.mdx
+++ b/docs/concepts/fast-iteration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Fast iteration
-description: "Develop Apps locally with Skybridge's DevTools and Vite HMR for instant feedback without tunneling."
+description: "Use Skybridge DevTools, Vite HMR, local emulation, and tunnels to iterate on MCP Apps quickly before deploying to AI hosts and stores."
 ---
 
 

--- a/docs/concepts/fast-iteration.mdx
+++ b/docs/concepts/fast-iteration.mdx
@@ -1,14 +1,14 @@
 ---
-title: Fast Iteration
+title: Fast iteration
 description: "Develop Apps locally with Skybridge's DevTools and Vite HMR for instant feedback without tunneling."
 ---
 
 
-**Problem:** Testing views in remote MCP Clients (e.g. ChatGPT, Claude, etc.) is slow. It requires HTTP tunneling, manual refreshes, and provides limited debugging feedback.
+**Problem:** Testing views in remote MCP clients (e.g. ChatGPT, Claude, etc.) is slow. It requires HTTP tunneling, manual refreshes, and provides limited debugging feedback.
 
 **Solution:** Skybridge includes DevTools and a Vite HMR plugin that let you develop views entirely on your machine with instant feedback.
 
-## The Challenge
+## The challenge
 
 When building Apps the traditional way, your development loop looks like:
 
@@ -23,7 +23,7 @@ When building Apps the traditional way, your development loop looks like:
 
 This can take 30-60 seconds per iteration. With complex views, that adds up fast.
 
-## The Skybridge Approach
+## The Skybridge approach
 
 With Skybridge, the loop becomes:
 
@@ -57,7 +57,7 @@ For comprehensive documentation on all DevTools features, including view inspect
 
 <img src="/images/devtools-landing.png" alt="Skybridge DevTools" style={{maxWidth: '100%', borderRadius: '8px', border: '1px solid #e0e0e0'}} />
 
-## HMR with Vite Plugin
+## HMR with Vite plugin
 
 Skybridge includes a Vite plugin that enables Hot Module Replacement for views:
 
@@ -86,7 +86,7 @@ These features require the Skybridge starter template structure (`pnpm create sk
 
 When you save a file, only the changed component re-renders. Form inputs, scroll position, and local state are preserved.
 
-## Automatic Environment Detection
+## Automatic environment detection
 
 Your view code works identically in ChatGPT, MCP Apps clients like Claude, and local DevTools. Skybridge detects the environment and uses the appropriate communication layer:
 
@@ -97,7 +97,7 @@ Your view code works identically in ChatGPT, MCP Apps clients like Claude, and l
 | DevTools | Mocked Apps SDK (postMessage) |
 You don't need to know which is active—just use the hooks.
 
-## When to Use What
+## When to use what
 
 **DevTools (90% of development time)**
 - Rapid UI iteration
@@ -119,21 +119,21 @@ Build locally → validate in [ChatGPT](/quickstart/test-your-app#testing-in-cha
 See [Test Your App](/quickstart/test-your-app) for detailed testing setup instructions.
 </Tip>
 
-## DevTools Features
+## DevTools features
 
 The DevTools UI includes:
 
-### Tool Inspector
+### Tool inspector
 See all registered tools and their schemas. Click to fill input forms automatically.
 
-### View Preview
+### View preview
 Renders your view in an iframe with mocked `window.openai`. Supports:
 - Theme switching (light/dark)
 - Display mode switching (pip/inline/fullscreen)
 - Locale changing
 
 
-### Response Inspector
+### Response inspector
 View the full tool response including `content`, `structuredContent`, and `_meta`.
 
 ## Related

--- a/docs/concepts/index.mdx
+++ b/docs/concepts/index.mdx
@@ -4,7 +4,7 @@ description: "Learn the core ideas behind Skybridge: write once run everywhere, 
 ---
 
 <Info>
-We assume that you are already familiar with ChatGPT Apps, MCP Apps, and MCP Servers. If you're not, read [Fundamentals](/fundamentals) first.
+We assume that you are already familiar with ChatGPT Apps, MCP Apps, and MCP servers. If you're not, read [Fundamentals](/fundamentals) first.
 </Info>
 
 Five concepts power Skybridge:

--- a/docs/concepts/index.mdx
+++ b/docs/concepts/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Core concepts
-description: "Learn the core ideas behind Skybridge: write once run everywhere, data flow, context sync, fast iteration, and type safety."
+description: "Learn the core Skybridge concepts behind MCP Apps, including data flow, context sync, fast iteration, type safety, and host runtimes."
 ---
 
 <Info>

--- a/docs/concepts/index.mdx
+++ b/docs/concepts/index.mdx
@@ -11,7 +11,7 @@ Five concepts power Skybridge:
 
 <CardGroup cols={2}>
   <Card title="Write Once, Run Everywhere" icon="shuffle" href="/concepts/write-once-run-everywhere">
-    Write once, run anywhere - ChatGPT, Claude, Goose, VSCode, etc.
+    Write once, run anywhere - ChatGPT, Claude, Goose, VS Code, etc.
   </Card>
   <Card title="Data Flow" icon="arrows-rotate" href="/concepts/data-flow">
     How data moves between server, host, and view

--- a/docs/concepts/index.mdx
+++ b/docs/concepts/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: Core Concepts
-description: "Understand the five key concepts that power Skybridge: write once run everywhere, data flow, LLM context sync, fast iteration, and type safety."
+title: Core concepts
+description: "Learn the core ideas behind Skybridge: write one run everywhere, data flow, context sync, fast iteration, and type safety."
 ---
 
 <Info>

--- a/docs/concepts/index.mdx
+++ b/docs/concepts/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Core concepts
-description: "Learn the core ideas behind Skybridge: write one run everywhere, data flow, context sync, fast iteration, and type safety."
+description: "Learn the core ideas behind Skybridge: write once run everywhere, data flow, context sync, fast iteration, and type safety."
 ---
 
 <Info>

--- a/docs/concepts/llm-context-sync.mdx
+++ b/docs/concepts/llm-context-sync.mdx
@@ -1,6 +1,6 @@
 ---
 title: LLM Context Sync
-description: "Keep the LLM informed about view state with data-llm attributes for better conversational context."
+description: "Keep the model aware of view state and user actions with data-llm attributes, context sync patterns, Skybridge UI updates, and MCP Apps."
 ---
 
 

--- a/docs/concepts/type-safety.mdx
+++ b/docs/concepts/type-safety.mdx
@@ -1,6 +1,6 @@
 ---
 title: Type Safety
-description: "Get end-to-end TypeScript type inference from server to view with generateHelpers."
+description: "Build type-safe MCP Apps with Skybridge by carrying TypeScript inference from server tools to React views, generated helpers, and UI code."
 ---
 
 

--- a/docs/concepts/write-once-run-everywhere.mdx
+++ b/docs/concepts/write-once-run-everywhere.mdx
@@ -1,7 +1,7 @@
 ---
 title: Write Once, Run Everywhere
 sidebarTitle: Write Once, Run Everywhere
-description: "How Skybridge abstracts runtime differences so your apps work across all ChatGPT and MCP Apps hosts."
+description: "Understand how Skybridge lets one React and MCP server codebase run across ChatGPT, Claude, Cursor, MCP App clients, and AI hosts."
 ---
 
 Skybridge is designed to be **runtime-agnostic**. Your view code works the same whether it runs in MCP Apps compatible clients (like Claude, Goose, VSCode) via the MCP ext-apps specification, or in ChatGPT via the Apps SDK.

--- a/docs/concepts/write-once-run-everywhere.mdx
+++ b/docs/concepts/write-once-run-everywhere.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Write Once, Run Everywhere
 description: "Understand how Skybridge lets one React and MCP server codebase run across ChatGPT, Claude, Cursor, MCP App clients, and AI hosts."
 ---
 
-Skybridge is designed to be **runtime-agnostic**. Your view code works the same whether it runs in MCP Apps compatible clients (like Claude, Goose, VS Code) via the MCP ext-apps specification, or in ChatGPT via the Apps SDK.
+Skybridge is designed to be **runtime-agnostic**. Your view code works the same whether it runs in MCP Apps clients (like Claude, Goose, VS Code) via the MCP ext-apps specification, or in ChatGPT via the Apps SDK.
 
 ## The Problem
 

--- a/docs/concepts/write-once-run-everywhere.mdx
+++ b/docs/concepts/write-once-run-everywhere.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Write Once, Run Everywhere
 description: "Understand how Skybridge lets one React and MCP server codebase run across ChatGPT, Claude, Cursor, MCP App clients, and AI hosts."
 ---
 
-Skybridge is designed to be **runtime-agnostic**. Your view code works the same whether it runs in MCP Apps compatible clients (like Claude, Goose, VSCode) via the MCP ext-apps specification, or in ChatGPT via the Apps SDK.
+Skybridge is designed to be **runtime-agnostic**. Your view code works the same whether it runs in MCP Apps compatible clients (like Claude, Goose, VS Code) via the MCP ext-apps specification, or in ChatGPT via the Apps SDK.
 
 ## The Problem
 
@@ -44,7 +44,7 @@ flowchart TB
     end
 
     AppsSdk --> ChatGPT["ChatGPT"]
-    McpApp --> McpClients["Claude, Goose, VSCode..."]
+    McpApp --> McpClients["Claude, Goose, VS Code..."]
 
     style Code fill:#f1f5f9,stroke:#cbd5e1,stroke-width:2px,color:#334155
     style Skybridge fill:#f1f5f9,stroke:#cbd5e1,stroke-width:2px,color:#334155
@@ -67,7 +67,7 @@ These include [useToolInfo](/api-reference/use-tool-info), [useCallTool](/api-re
     As new AI platforms adopt MCP, your views will work without code changes
   </Card>
   <Card title="No Vendor Lock-in" icon="unlock">
-    Build once, deploy to multiple AI clients: ChatGPT, Claude, Goose, VSCode, and more
+    Build once, deploy to multiple AI clients: ChatGPT, Claude, Goose, VS Code, and more
   </Card>
   <Card title="Single Codebase" icon="code">
     One set of hooks, one mental model, multiple platforms

--- a/docs/devtools/devtools.mdx
+++ b/docs/devtools/devtools.mdx
@@ -1,6 +1,6 @@
 ---
 title: DevTools
-description: "Test your app views locally with Skybridge's browser-based DevTools and debugging tools."
+description: "Test your MCP App tools, preview views, inspect state, and debug locally with Skybridge DevTools."
 ---
 
 DevTools is designed to help you test your apps locally in a short feedback loop fashion. It lets you develop and debug views without needing to deploy or use external services.

--- a/docs/devtools/devtools.mdx
+++ b/docs/devtools/devtools.mdx
@@ -1,6 +1,6 @@
 ---
 title: DevTools
-description: "Test your MCP App tools, preview views, inspect state, and debug locally with Skybridge DevTools."
+description: "Use Skybridge DevTools to test MCP tools, preview React views, inspect state, debug locally, and connect apps to AI hosts and clients."
 ---
 
 DevTools is designed to help you test your apps locally in a short feedback loop fashion. It lets you develop and debug views without needing to deploy or use external services.

--- a/docs/devtools/devtools.mdx
+++ b/docs/devtools/devtools.mdx
@@ -9,27 +9,27 @@ DevTools is designed to help you test your apps locally in a short feedback loop
 DevTools currently renders views using the **Apps SDK runtime** (mocked `window.openai`). MCP Apps rendering is not yet supported in DevTools. 
 </Note>
 
-## Quick Start
+## Quick start
 
 When you run `pnpm dev`, DevTools is automatically available at `http://localhost:3000/`.
 
 <img src="/images/devtools-landing.png" alt="Skybridge DevTools Overview" style={{maxWidth: '100%', borderRadius: '8px', border: '1px solid #e0e0e0'}} />
 
-## Automatic Tool Discovery
+## Automatic tool discovery
 
 DevTools automatically discovers all tools registered in your MCP server. Simply start your development server, and all available tools will appear in the sidebar, ready to test.
 
-## Testing Tools
+## Testing tools
 
 DevTools generates a form based on each tool's input schema, making it easy to test your tools with different inputs. Fill in the form and click "Call Tool" to execute the tool and see its output.
 
 <img src="/images/devtools-toolcall.png" alt="DevTools Tool Input Form" style={{maxWidth: '100%', borderRadius: '8px', border: '1px solid #e0e0e0'}} />
 
-## View Inspection
+## View inspection
 
 When a tool renders a view, DevTools provides comprehensive inspection capabilities:
 
-### Apps SDK Environment Inspector
+### Apps SDK environment inspector
 
 Inspect and edit the Apps SDK environment properties in real-time (mocked `window.openai`):
 - **Display Mode**: Switch between inline, fullscreen, and picture-in-picture modes
@@ -42,10 +42,10 @@ Inspect and edit the Apps SDK environment properties in real-time (mocked `windo
 Changes are immediately reflected in the view preview, allowing you to test how your view behaves under different conditions.
 
 <Note>
-This inspector mocks the **Apps SDK runtime** (`window.openai`). For testing MCP Apps-specific behavior, use a MCP Apps Client like Goose or MCPJam.
+This inspector mocks the **Apps SDK runtime** (`window.openai`). For testing MCP Apps-specific behavior, use an MCP Apps client like Goose or MCPJam.
 </Note>
 
-### Inspectable View State
+### Inspectable view state
 
 View and monitor the view's state as it changes. The view state inspector shows the current state object in a JSON tree view, making it easy to debug state management and track state updates.
 
@@ -73,7 +73,7 @@ DevTools uses the **Apps SDK runtime** (mocked `window.openai`) but has some dif
 - **LLM responses**: Follow-up messages don't trigger actual LLM responses—test these in ChatGPT dev mode or MCP Apps clients
 - **MCP Apps runtime**: DevTools does not support MCP Apps view rendering—test MCP Apps views in real clients like Goose or Claude
 
-## Custom Integration
+## Custom integration
 
 If you're not using the Skybridge starter template, add DevTools to your server:
 
@@ -89,4 +89,4 @@ if (process.env.NODE_ENV !== "production") {
 ## Related
 
 - [Fast Iteration](/concepts/fast-iteration) - Development workflow and concepts
-- [Test Your App](/quickstart/test-your-app) - Testing in production settings (ChatGPT, Claude, other MCP Apps Clients)
+- [Test Your App](/quickstart/test-your-app) - Testing in production settings (ChatGPT, Claude, other MCP Apps clients)

--- a/docs/devtools/skills.mdx
+++ b/docs/devtools/skills.mdx
@@ -1,6 +1,6 @@
 ---
 title: Skills
-description: "Use AI coding assistants pre-loaded with Skybridge expertise to build your app."
+description: "Use the Skybridge Skill to build, migrate, and maintain MCP apps and ChatGPT apps with your AI coding assistant."
 ---
 
 <Tip>

--- a/docs/devtools/skills.mdx
+++ b/docs/devtools/skills.mdx
@@ -1,6 +1,6 @@
 ---
 title: Skills
-description: "Use the Skybridge Skill to build, migrate, and maintain MCP Apps and ChatGPT Apps with your AI coding assistant."
+description: "Use the Skybridge Skill with AI coding agents to create, migrate, debug, and maintain MCP Apps and ChatGPT Apps faster in your IDE."
 ---
 
 <Tip>

--- a/docs/devtools/skills.mdx
+++ b/docs/devtools/skills.mdx
@@ -1,6 +1,6 @@
 ---
 title: Skills
-description: "Use the Skybridge Skill to build, migrate, and maintain MCP apps and ChatGPT apps with your AI coding assistant."
+description: "Use the Skybridge Skill to build, migrate, and maintain MCP Apps and ChatGPT Apps with your AI coding assistant."
 ---
 
 <Tip>
@@ -18,7 +18,7 @@ Turn your AI assistant into a Skybridge expert that guides you through the full 
 5. **Run & Test** — Start the dev server and connect to AI assistants
 6. **Deploy & Publish** — Ship to production and submit to app directories
 
-## Installation
+## Install the skill
 
 Add the Skybridge skill by running the following command:
 
@@ -40,7 +40,7 @@ deno run -A npm:skills add alpic-ai/skybridge -s skybridge
 ```
 </CodeGroup>
 
-## Example Prompts
+## Example prompts
 
 After installing, try asking your AI assistant:
 

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -1,6 +1,6 @@
 ---
 title: FAQ
-description: "Common questions and troubleshooting for Skybridge type safety, deployment, and App development."
+description: "Find answers to common Skybridge questions about MCP Apps, ChatGPT Apps, type safety, local development, deployment, and troubleshooting."
 ---
 
 # Frequently Asked Questions

--- a/docs/fundamentals.mdx
+++ b/docs/fundamentals.mdx
@@ -60,7 +60,7 @@ This creates a **dual-surface interaction model**: users interact with both the 
 Read our [in-depth blog article](https://alpic.ai/blog/inside-openai-s-apps-sdk-how-to-build-interactive-chatgpt-apps-with-mcp) for a detailed technical breakdown of how AI Apps work under the hood.
 </Note>
 
-## Runtime Environments
+## Runtime environments
 
 Both ChatGPT Apps and MCP Apps use the same MCP server architecture and the same portable MCP Apps UI contract. The key practical difference is that ChatGPT additionally exposes `window.openai` extensions.
 
@@ -81,7 +81,7 @@ Skybridge supports the two main runtime environments for rendering views:
 Skybridge abstracts away the differences between these runtime environments so you can write your views once and run them anywhere. Learn more in our <a href="/concepts/write-once-run-everywhere">Write Once, Run Everywhere</a> guide.
 
 
-## Runtimes Comparison at a Glance
+## Runtime comparison at a glance
 
 | Feature | Apps SDK (ChatGPT) | MCP Apps |
 |---------|-------------------|----------|

--- a/docs/fundamentals.mdx
+++ b/docs/fundamentals.mdx
@@ -1,6 +1,7 @@
 ---
-title: Fundamentals
-description: "Understanding Model Context Protocol (MCP), the MCP Apps portable baseline, and ChatGPT-specific extensions."
+title: MCP Apps fundamentals
+description: "Understand the protocols and runtimes behind Skybridge, from MCP servers to apps that render inside AI conversations."
+keywords: ["MCP Apps", "Model Context Protocol"]
 ---
 
 Skybridge enables you to build **ChatGPT Apps** and **MCP Apps** - interactive UI views that render inside AI conversations. Before diving into Skybridge's APIs, understand the underlying protocols and runtimes it builds upon.

--- a/docs/fundamentals.mdx
+++ b/docs/fundamentals.mdx
@@ -6,7 +6,7 @@ keywords: ["MCP Apps", "Model Context Protocol"]
 
 Skybridge enables you to build **ChatGPT Apps** and **MCP Apps** - interactive UI views that render inside AI conversations. Before diving into Skybridge's APIs, understand the underlying protocols and runtimes it builds upon.
 
-## How views appear in MCP Apps Clients
+## How views appear in MCP Apps clients
 
 In MCP Apps clients, the model triggers your tool, and the client then renders both the assistant response and your view from the tool result.
 
@@ -20,24 +20,24 @@ In MCP Apps clients, the model triggers your tool, and the client then renders b
 
 [MCP](https://modelcontextprotocol.io) is an open standard that allows AI models to connect with external tools, resources, and services. Think of it as an API layer specifically designed for LLMs.
 
-### What is an MCP Client?
+### What is an MCP client?
 
-An **MCP Client** is a frontend application that implements the MCP protocol, and that can consume MCP Servers. Major MCP Clients include:
+An **MCP client** is a frontend application that implements the MCP protocol and can consume MCP servers. Major MCP clients include:
 - General-purpose AI apps: ChatGPT, Claude, Goose, etc
 - IDEs: Cursor, VSCode, Amp, etc
 - Coding agents: Claude Code, Codex CLI, Gemini CLI, etc
 - Any other software that implements the MCP protocol
 
-### What is an MCP Server?
+### What is an MCP server?
 
-An **MCP server** is a backend service that implements the MCP protocol. It exposes capabilities to MCP Clients through:
+An **MCP server** is a backend service that implements the MCP protocol. It exposes capabilities to MCP clients through:
 
 - **Tools**: Functions the model can call (e.g., `search_flights`, `get_weather`, `book_hotel`)
 - **Resources**: Data the model can access (e.g., files, database records, UI components)
 
 When you ask an AI assistant a question, it can invoke tools on your MCP server to fetch data or perform actions on your behalf. The server handles your business logic, database queries, API calls, and any other backend operations.
 
-### MCP Apps and ChatGPT Apps: The Same Foundation
+### MCP Apps and ChatGPT Apps: The same foundation
 
 **MCP Apps** is the open UI extension for MCP. It defines the portable contract for interactive views in AI clients, including the `ui/*` bridge, `tools/call`, and `_meta.ui.resourceUri`.
 
@@ -47,8 +47,8 @@ To avoid repetition, we will now refer to both ChatGPT Apps and MCP Apps as **AI
 
 An **AI App** consists of two components working together:
 
-1. **MCP Server**: Your backend that handles business logic and exposes tools via the MCP protocol
-2. **UI Views**: HTML components that render in the AI Client's interface as interactive UIs
+1. **MCP server**: Your backend that handles business logic and exposes tools via the MCP protocol
+2. **UI views**: HTML components that render in the AI client's interface as interactive UIs
 
 When a tool is called, it can return both:
 - **Text content**: What the model sees and responds with
@@ -92,7 +92,7 @@ Skybridge abstracts away the differences between these runtime environments so y
 
 
 
-## Next Steps
+## Next steps
 
 <CardGroup cols={2}>
   <Card title="Apps SDK Deep Dive" icon="message" href="/fundamentals/apps-sdk">

--- a/docs/fundamentals.mdx
+++ b/docs/fundamentals.mdx
@@ -24,7 +24,7 @@ In MCP Apps clients, the model triggers your tool, and the client then renders b
 
 An **MCP client** is a frontend application that implements the MCP protocol and can consume MCP servers. Major MCP clients include:
 - General-purpose AI apps: ChatGPT, Claude, Goose, etc
-- IDEs: Cursor, VSCode, Amp, etc
+- IDEs: Cursor, VS Code, Amp, etc
 - Coding agents: Claude Code, Codex CLI, Gemini CLI, etc
 - Any other software that implements the MCP protocol
 
@@ -86,7 +86,7 @@ Skybridge abstracts away the differences between these runtime environments so y
 | Feature | Apps SDK (ChatGPT) | MCP Apps |
 |---------|-------------------|----------|
 | **Protocol** | MCP Apps bridge + optional `window.openai` extensions | Open MCP Apps (`ext-apps`) spec |
-| **Client Support** | ChatGPT only | Goose, VSCode, Postman, ... |
+| **Client Support** | ChatGPT only | Goose, VS Code, Postman, ... |
 | **Documentation** | [Apps SDK Docs](https://developers.openai.com/apps-sdk) and [MCP Apps compatibility in ChatGPT](https://developers.openai.com/apps-sdk/mcp-apps-in-chatgpt/) | [ext-apps specs](https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx) |
 
 

--- a/docs/fundamentals.mdx
+++ b/docs/fundamentals.mdx
@@ -1,6 +1,6 @@
 ---
 title: MCP Apps fundamentals
-description: "Understand the protocols and runtimes behind Skybridge, from MCP servers to apps that render inside AI conversations."
+description: "Understand the protocols and runtimes behind Skybridge, including MCP servers, MCP Apps, ChatGPT Apps, interactive AI views, and hosts."
 keywords: ["MCP Apps", "Model Context Protocol"]
 ---
 

--- a/docs/fundamentals/apps-sdk.mdx
+++ b/docs/fundamentals/apps-sdk.mdx
@@ -1,7 +1,7 @@
 ---
 title: Apps SDK (ChatGPT)
 sidebarTitle: Apps SDK
-description: "Deep dive into ChatGPT's runtime: MCP Apps compatibility, the window.openai API, and ChatGPT-only features."
+description: "Learn how Skybridge maps to the OpenAI Apps SDK, including window.openai, ChatGPT Apps runtime behavior, MCP compatibility, and views."
 ---
 
 The [OpenAI Apps SDK](https://developers.openai.com/apps-sdk/) is the ChatGPT runtime layer for ChatGPT Apps, [announced in October 2025](https://alpic.ai/blog/inside-openai-s-apps-sdk-how-to-build-interactive-chatgpt-apps-with-mcp). ChatGPT supports the MCP Apps UI model, and also provides `window.openai` for compatibility and ChatGPT-specific extensions.

--- a/docs/fundamentals/mcp-apps.mdx
+++ b/docs/fundamentals/mcp-apps.mdx
@@ -6,7 +6,7 @@ description: "Learn how MCP Apps extend MCP servers with interactive views, host
 
 [MCP Apps](https://github.com/modelcontextprotocol/ext-apps) are based on the **MCP ext-apps specification** — an open standard for rendering interactive UI views inside AI conversations. 
 
-MCP Apps are the portable baseline across hosts (e.g. Claude, Goose, VSCode, and ChatGPT compatibility mode). Skybridge implements the protocol via the `McpAppAdaptor` so you use the same hooks regardless of runtime.
+MCP Apps are the portable baseline across hosts (e.g. Claude, Goose, VS Code, and ChatGPT compatibility mode). Skybridge implements the protocol via the `McpAppAdaptor` so you use the same hooks regardless of runtime.
 
 ## View rendering flow
 
@@ -22,7 +22,7 @@ The view–host connection looks like this:
 
 <img src="/images/mcp-apps-explainer.avif" alt="MCP Apps architecture: MCP server, MCP host (ChatGPT, Claude), host UI with sandbox and guest app iframe" style={{ width: "100%", maxWidth: "600px", display: "block", margin: "0 auto" }} />
 
-The host UI in this diagram designates the MCP client (Claude, Goose, VSCode, etc.), and the guest app is your app running in an iframe.
+The host UI in this diagram designates the MCP client (Claude, Goose, VS Code, etc.), and the guest app is your app running in an iframe.
 
 ## The MCP ext-apps protocol
 

--- a/docs/fundamentals/mcp-apps.mdx
+++ b/docs/fundamentals/mcp-apps.mdx
@@ -8,7 +8,7 @@ description: "Deep dive into the MCP ext-apps specification: MCP protocol, Skybr
 
 MCP Apps are the portable baseline across hosts (e.g. Claude, Goose, VSCode, and ChatGPT compatibility mode). Skybridge implements the protocol via the `McpAppAdaptor` so you use the same hooks regardless of runtime.
 
-## View Rendering Flow
+## View rendering flow
 
 Here's what happens when an MCP Apps client renders a view:
 
@@ -20,9 +20,9 @@ Here's what happens when an MCP Apps client renders a view:
 
 The view–host connection looks like this:
 
-<img src="/images/mcp-apps-explainer.avif" alt="MCP Apps architecture: MCP Server, MCP Host (ChatGPT, Claude), Host UI with Sandbox and Guest App iframe" style={{ width: "100%", maxWidth: "600px", display: "block", margin: "0 auto" }} />
+<img src="/images/mcp-apps-explainer.avif" alt="MCP Apps architecture: MCP server, MCP host (ChatGPT, Claude), host UI with sandbox and guest app iframe" style={{ width: "100%", maxWidth: "600px", display: "block", margin: "0 auto" }} />
 
-The Host UI in this diagram designates the MCP Client (Claude, Goose, VSCode, etc.), and the Guest App is your App running in an iframe.
+The host UI in this diagram designates the MCP client (Claude, Goose, VSCode, etc.), and the guest app is your app running in an iframe.
 
 ## The MCP ext-apps protocol
 
@@ -49,7 +49,7 @@ Views run inside an iframe and talk to the host via the **same [MCP protocol](ht
 | `ui/notifications/tool-cancelled` | Tool call was cancelled |
 | `ui/notifications/tool-input-partial` | Streaming partial tool arguments (e.g. while the model is still sending) |
 
-## Skybridge Hook Mapping
+## Skybridge hook mapping
 
 Skybridge wraps the MCP ext-apps protocol with the **same React hooks** as the Apps SDK. The `McpAppAdaptor` translates hook usage into the protocol under the hood:
 

--- a/docs/fundamentals/mcp-apps.mdx
+++ b/docs/fundamentals/mcp-apps.mdx
@@ -1,7 +1,7 @@
 ---
 title: MCP Apps
 sidebarTitle: MCP Apps
-description: "Deep dive into the MCP ext-apps specification: MCP protocol, Skybridge hooks, and how MCP Apps clients render views."
+description: "Learn how MCP Apps extend MCP servers with interactive views, host runtimes, Skybridge hooks, the ext-apps specification, and AI clients."
 ---
 
 [MCP Apps](https://github.com/modelcontextprotocol/ext-apps) are based on the **MCP ext-apps specification** — an open standard for rendering interactive UI views inside AI conversations. 

--- a/docs/guides/communicating-with-model.mdx
+++ b/docs/guides/communicating-with-model.mdx
@@ -1,6 +1,6 @@
 ---
-title: Communicating with the Model
-description: "Use data-llm for passive context sync and useSendFollowUpMessage for active communication with the LLM."
+title: Communicate with the model
+description: "Keep the model aware of what happens in your view with data-llm, and send messages to the model with useSendFollowUpMessage."
 ---
 
 

--- a/docs/guides/communicating-with-model.mdx
+++ b/docs/guides/communicating-with-model.mdx
@@ -1,6 +1,6 @@
 ---
 title: Communicate with the model
-description: "Keep the model aware of what happens in your view with data-llm, and send messages to the model with useSendFollowUpMessage."
+description: "Keep the model informed from your Skybridge view with data-llm, follow-up messages, tool results, and context-aware UI interactions."
 ---
 
 

--- a/docs/guides/fetching-data.mdx
+++ b/docs/guides/fetching-data.mdx
@@ -1,6 +1,6 @@
 ---
-title: Fetching Data
-description: "Learn two patterns for getting data into views: initial hydration with useToolInfo and user-triggered fetching with useCallTool."
+title: Fetching data
+description: "Learn the two main patterns for getting data into views: initial hydration with useToolInfo and user-triggered fetching with useCallTool."
 ---
 
 

--- a/docs/guides/host-environment-context.mdx
+++ b/docs/guides/host-environment-context.mdx
@@ -1,6 +1,6 @@
 ---
 title: Host Environment Context
-description: "Adapt your view to the host's theme, locale, display mode, and device with environment hooks."
+description: "Adapt Skybridge views to host environment context such as theme, locale, user, display mode, viewport, and MCP client capabilities."
 ---
 
 

--- a/docs/guides/managing-state.mdx
+++ b/docs/guides/managing-state.mdx
@@ -1,6 +1,6 @@
 ---
-title: Managing State
-description: "Persist view state across renders with useViewState and createStore for local and global state management."
+title: Managing state
+description: "Persist view state across renders with useViewState, or use createStore for more complex state with actions and derived values."
 ---
 
 

--- a/docs/guides/managing-state.mdx
+++ b/docs/guides/managing-state.mdx
@@ -1,6 +1,6 @@
 ---
 title: Managing state
-description: "Persist view state across renders with useViewState, or use createStore for more complex state with actions and derived values."
+description: "Manage Skybridge view state with useViewState and createStore for persistent UI state, actions, derived values, and tool-driven updates."
 ---
 
 

--- a/docs/home.mdx
+++ b/docs/home.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Build MCP Apps with Skybridge"
-description: "Skybridge lets you build MCP Apps: MCP servers with UI views for ChatGPT, Claude, and other AI hosts."
+description: "Build MCP Apps and ChatGPT Apps with Skybridge, a fullstack TypeScript framework for MCP servers, React views, and AI host runtimes."
 keywords: ["MCP Apps", "ChatGPT Apps"]
 sidebarTitle: "Introduction"
 icon: "house"

--- a/docs/home.mdx
+++ b/docs/home.mdx
@@ -1,6 +1,7 @@
 ---
-title: "Start building with Skybridge"
-description: "Everything you need to create MCP and ChatGPT Apps, from brainstorming to production."
+title: "Build MCP Apps with Skybridge"
+description: "Skybridge lets you build MCP Apps: MCP servers with UI views for ChatGPT, Claude, and other AI hosts."
+keywords: ["MCP Apps", "ChatGPT Apps"]
 sidebarTitle: "Introduction"
 icon: "house"
 ---

--- a/docs/quickstart/add-to-existing-app.mdx
+++ b/docs/quickstart/add-to-existing-app.mdx
@@ -1,7 +1,7 @@
 ---
 title: Add Skybridge to an existing app
 sidebarTitle: "Overview"
-description: "Add Skybridge to an existing MCP server or React app."
+description: "Add Skybridge to an existing MCP server or React app by wiring server tools, views, hooks, build setup, and MCP App runtime support."
 ---
 
 Skybridge contains 2 main packages that can be used together or independently.

--- a/docs/quickstart/add-to-existing-app.mdx
+++ b/docs/quickstart/add-to-existing-app.mdx
@@ -1,7 +1,7 @@
 ---
-title: Add Skybridge to existing app
+title: Add Skybridge to an existing app
 sidebarTitle: "Overview"
-description: "Add Skybridge packages to your existing MCP server or React app for view support and type inference."
+description: "Add Skybridge to an existing MCP server or React app."
 ---
 
 Skybridge contains 2 main packages that can be used together or independently.

--- a/docs/quickstart/add-to-existing-app/server.mdx
+++ b/docs/quickstart/add-to-existing-app/server.mdx
@@ -1,6 +1,6 @@
 ---
 title: Use skybridge/server
-description: "Use skybridge/server to register tools and bind views from an existing MCP server."
+description: "Use skybridge/server to register MCP tools, bind React views, configure metadata, and integrate Skybridge with an existing server."
 ---
 
 # Use skybridge/server

--- a/docs/quickstart/add-to-existing-app/server.mdx
+++ b/docs/quickstart/add-to-existing-app/server.mdx
@@ -1,6 +1,6 @@
 ---
 title: Use skybridge/server
-description: "Add view registration and TypeScript type inference to your existing MCP server with skybridge/server."
+description: "Use skybridge/server to register tools and bind views from an existing MCP server."
 ---
 
 # Use skybridge/server

--- a/docs/quickstart/add-to-existing-app/web.mdx
+++ b/docs/quickstart/add-to-existing-app/web.mdx
@@ -1,6 +1,6 @@
 ---
 title: Use skybridge/web
-description: "Use skybridge/web to add hooks, host context, tool calls, and view state to your React views."
+description: "Use skybridge/web to add React hooks, host context, tool calls, layout data, persistent view state, and MCP App UI to existing views."
 ---
 
 # Use skybridge/web

--- a/docs/quickstart/add-to-existing-app/web.mdx
+++ b/docs/quickstart/add-to-existing-app/web.mdx
@@ -1,6 +1,6 @@
 ---
 title: Use skybridge/web
-description: "Add React hooks and utilities to your App views with skybridge/web standalone package."
+description: "Use skybridge/web to add hooks, host context, tool calls, and view state to your React views."
 ---
 
 # Use skybridge/web

--- a/docs/quickstart/build-for-production.mdx
+++ b/docs/quickstart/build-for-production.mdx
@@ -7,7 +7,7 @@ sidebar_position: 3
 
 When you're ready to deploy your App to production, Skybridge provides two commands: `skybridge build` to compile your app, and `skybridge start` to run it in production mode.
 
-## Build for Production
+## Build for production
 
 Before deploying, you need to build your application. Run the build command from your project root:
 
@@ -31,7 +31,7 @@ deno task build
 
 This runs the `skybridge build` command, which compiles your views and server code for production.
 
-## Start Production Server
+## Start the production server
 
 Once your app is built, start the production server:
 
@@ -60,17 +60,17 @@ This runs the `skybridge start` command, which starts your production server.
 The production server runs your compiled application from the `dist/` directory with `NODE_ENV=production`. Unlike the development server, it:
 
 - **Serves pre-built assets** - Views and styles are served as static files from `/assets` (compiled during `skybridge build`)
-- **MCP endpoint** - Exposes your MCP server at `/mcp` for MCP Clients to connect to
+- **MCP endpoint** - Exposes your MCP server at `/mcp` for MCP clients to connect to
 - **No dev tools** - DevTools and Vite dev server are excluded in production for better performance
 - **Optimized rendering** - Uses production templates that load pre-bundled JavaScript and CSS files
 
 The server listens on port 3000 by default. 
 
-When deployed remotely, the MCP Client (ChatGPT, Claude, etc.) connects to your MCP endpoint (e.g., `https://your-domain.com/mcp`) to access your tools and views.
+When deployed remotely, the MCP client (ChatGPT, Claude, etc.) connects to your MCP endpoint (e.g., `https://your-domain.com/mcp`) to access your tools and views.
 
 To deploy your app to Alpic's infrastructure, see [Deploy](/quickstart/deploy).
 
-## What's Next?
+## What's next?
 
 <CardGroup cols={2}>
   <Card title="Core Concepts" icon="lightbulb" href="/concepts">

--- a/docs/quickstart/build-for-production.mdx
+++ b/docs/quickstart/build-for-production.mdx
@@ -1,6 +1,6 @@
 ---
-title: Build for Production
-description: "Deploy your app to production with optimized builds and production server configuration."
+title: Build for production
+description: "Build your MCP App server and views for production."
 icon: "hammer"
 sidebar_position: 3
 ---

--- a/docs/quickstart/build-for-production.mdx
+++ b/docs/quickstart/build-for-production.mdx
@@ -1,6 +1,6 @@
 ---
 title: Build for production
-description: "Build your MCP App server and views for production."
+description: "Build your Skybridge MCP server and React views for production with optimized assets, server output, and deployment-ready artifacts."
 icon: "hammer"
 sidebar_position: 3
 ---

--- a/docs/quickstart/create-new-app.mdx
+++ b/docs/quickstart/create-new-app.mdx
@@ -93,7 +93,7 @@ When you run `skybridge`:
 2. You can access **DevTools** at `http://localhost:3000/` to test your app locally
 3. The **MCP server** is available at `http://localhost:3000/mcp`
 4. **File watching** is enabled - changes to server code will automatically restart the server
-5. **Hot Module Reload (HMR)** is active for Views components - changes appear instantly in the host without reconnecting
+5. **Hot Module Reload (HMR)** is active for view components - changes appear instantly in the host without reconnecting
 
 ### Exposing a public URL
 
@@ -122,5 +122,5 @@ Skybridge downloads and runs [Alpic tunnel](https://docs.alpic.ai/cli/tunnel) au
 ## Next steps
 
 <Card title="Test Your App" icon="flask-vial" href="/quickstart/test-your-app">
-  Learn how to test your app locally, in ChatGPT and compatible MCP Clients.
+  Learn how to test your app locally, in ChatGPT and compatible MCP clients.
 </Card>

--- a/docs/quickstart/create-new-app.mdx
+++ b/docs/quickstart/create-new-app.mdx
@@ -1,6 +1,6 @@
 ---
 title: Quickstart
-description: "Create your first MCP App with Skybridge in minutes."
+description: "Create your first Skybridge MCP App in minutes with the starter template, local DevTools, React views, TypeScript, and MCP server setup."
 icon: "bolt"
 iconType: "regular"
 ---

--- a/docs/quickstart/create-new-app.mdx
+++ b/docs/quickstart/create-new-app.mdx
@@ -1,6 +1,6 @@
 ---
 title: Quickstart
-description: "Get started with a fully working App in 5 minutes thanks to our starter template."
+description: "Create your first MCP App with Skybridge in minutes."
 icon: "bolt"
 iconType: "regular"
 ---

--- a/docs/quickstart/deploy.mdx
+++ b/docs/quickstart/deploy.mdx
@@ -18,7 +18,7 @@ Below are some easy options closely integrated with Skybridge.
 To deploy your App on Alpic you can:
 1. Create a free account on [app.alpic.ai](https://app.alpic.ai)
 2. Deploy your App either by:
-   - Pushing your App to Github, and connecting it to Alpic for automatic deployment at each commit.
+   - Pushing your App to GitHub, and connecting it to Alpic for automatic deployment at each commit.
    - Using the [Alpic CLI](https://docs.alpic.ai/cli/overview):
 
 <CodeGroup>

--- a/docs/quickstart/deploy.mdx
+++ b/docs/quickstart/deploy.mdx
@@ -1,6 +1,6 @@
 ---
 title: Deploy
-description: "Deploy your Skybridge app to Alpic Cloud, Cloudflare Workers or your own infrastructure with Docker."
+description: "Deploy Skybridge MCP Apps to Alpic Cloud, Cloudflare Workers, Docker, or your own infrastructure for production AI clients and stores."
 icon: "cloud-arrow-up"
 sidebar_position: 4
 ---

--- a/docs/quickstart/deploy.mdx
+++ b/docs/quickstart/deploy.mdx
@@ -15,10 +15,10 @@ Below are some easy options closely integrated with Skybridge.
 
 **[Alpic](https://alpic.ai)** is a developer-friendly cloud platform for deploying and hosting MCP Apps. It is also the company behind Skybridge :) 
 
-To deploy your App on Alpic you can:
+To deploy your App on Alpic, you can:
 1. Create a free account on [app.alpic.ai](https://app.alpic.ai)
 2. Deploy your App either by:
-   - Pushing your App to GitHub, and connecting it to Alpic for automatic deployment at each commit.
+   - Pushing your App to GitHub and connecting it to Alpic for automatic deployment at each commit.
    - Using the [Alpic CLI](https://docs.alpic.ai/cli/overview):
 
 <CodeGroup>
@@ -36,14 +36,14 @@ bun run deploy
 ```
 </CodeGroup>
 
-Once your App is deployed, you will be able to access specific MCP analytics, logs, and test your app remotely in the Alpic Playground.
+Once your App is deployed, you can access MCP-specific analytics and logs, and test your app remotely in the Alpic Playground.
 
 Learn more about deploying to Alpic in the [Alpic documentation](https://docs.alpic.ai/).
 
 
 ### Alpic MCP App
 
-Alpic also provides its own [MCP App](https://docs.alpic.ai/features/mcp-server) that lets you manage your apps directly from your favorite MCP Client. Connect to the Alpic MCP Server using:
+Alpic also provides its own [MCP App](https://docs.alpic.ai/features/mcp-server) that lets you manage your apps directly from your favorite MCP client. Connect to the Alpic MCP server using:
 ```
 https://mcp.alpic.ai/mcp
 ```
@@ -149,7 +149,7 @@ docker run -p 3000:3000 my-app
 The package manager is detected from the lockfile (`package-lock.json`, `yarn.lock`, or `pnpm-lock.yaml`). Bun and Deno are not supported yet: you'll need to adapt the build stage inside the Dockerfile.
 </Note>
 
-## What's Next?
+## What's next?
 
 <CardGroup cols={2}>
   <Card title="Core Concepts" icon="lightbulb" href="/concepts">

--- a/docs/quickstart/deploy.mdx
+++ b/docs/quickstart/deploy.mdx
@@ -1,6 +1,6 @@
 ---
 title: Deploy
-description: "Deploy your App and share it to your users"
+description: "Deploy your Skybridge app to Alpic Cloud, Cloudflare Workers or your own infrastructure with Docker."
 icon: "cloud-arrow-up"
 sidebar_position: 4
 ---

--- a/docs/quickstart/migrate.mdx
+++ b/docs/quickstart/migrate.mdx
@@ -1,6 +1,6 @@
 ---
-title: Migrate
-description: "Migrate ChatGPT App or ext-apps to Skybridge"
+title: Migrate to Skybridge
+description: "Use the Skybridge Skill to migrate an existing app to Skybridge."
 icon: "right-to-bracket"
 ---
 

--- a/docs/quickstart/migrate.mdx
+++ b/docs/quickstart/migrate.mdx
@@ -1,6 +1,6 @@
 ---
 title: Migrate to Skybridge
-description: "Use the Skybridge Skill to migrate an existing app to Skybridge."
+description: "Migrate an existing MCP App or ChatGPT App to Skybridge with the Skybridge Skill, guided code updates, compatibility checks, and docs."
 icon: "right-to-bracket"
 ---
 

--- a/docs/quickstart/test-your-app.mdx
+++ b/docs/quickstart/test-your-app.mdx
@@ -1,6 +1,6 @@
 ---
-title: Test Your App
-description: "Test your app locally with DevTools, or in ChatGPT Developer Mode and compatible MCP Clients for integration testing."
+title: Test your app
+description: "Test your app locally with DevTools, with an LLM in the Alpic Playground, and then try it in ChatGPT, Claude, or another MCP client."
 icon: "flask-vial"
 ---
 

--- a/docs/quickstart/test-your-app.mdx
+++ b/docs/quickstart/test-your-app.mdx
@@ -37,7 +37,7 @@ When you're ready to test your AI App with an LLM, you can connect it to ChatGPT
     Test with Claude using the MCP Apps runtime
   </Card>
   <Card title="Testing in desktop MCP clients" icon="desktop" href="#testing-in-other-mcp-clients">
-    Test locally with VSCode, Goose, and other desktop clients
+    Test locally with VS Code, Goose, and other desktop clients
   </Card>
 </CardGroup>
 
@@ -135,7 +135,7 @@ Skybridge downloads and runs [Alpic tunnel](https://docs.alpic.ai/cli/tunnel) au
 
 ### Testing in other MCP clients
 
-Desktop MCP clients like VSCode, Goose, and others can connect directly to your local server without needing a HTTP tunnel or a public URL.
+Desktop MCP clients like VS Code, Goose, and others can connect directly to your local server without needing an HTTP tunnel or a public URL.
 
 #### 1. Start your server
 
@@ -149,7 +149,7 @@ Your MCP server will be available at `http://localhost:3000/mcp`.
 
 #### 2. Connect to your MCP client
 
-Connect your server to any desktop MCP client that supports the [ext-apps specification](https://github.com/modelcontextprotocol/ext-apps), such as [VSCode](https://code.visualstudio.com/), [Goose](https://block.github.io/goose), [Postman](https://www.postman.com/), or [MCPJam](https://mcpjam.com/).
+Connect your server to any desktop MCP client that supports the [ext-apps specification](https://github.com/modelcontextprotocol/ext-apps), such as [VS Code](https://code.visualstudio.com/), [Goose](https://block.github.io/goose), [Postman](https://www.postman.com/), or [MCPJam](https://mcpjam.com/).
 
 
 #### 3. Test your app

--- a/docs/quickstart/test-your-app.mdx
+++ b/docs/quickstart/test-your-app.mdx
@@ -4,9 +4,9 @@ description: "Test your app locally with DevTools, with an LLM in the Alpic Play
 icon: "flask-vial"
 ---
 
-Skybridge provides two ways to test your app: **local DevTools** for rapid iteration, and production testing in ChatGPT and compatible MCP Apps Clients.
+Skybridge provides two ways to test your app: **local DevTools** for rapid iteration, and production testing in ChatGPT and compatible MCP Apps clients.
 
-## Local Development (Recommended)
+## Local development (recommended)
 
 Open `http://localhost:3000/` in your browser to access DevTools. This is the fastest way to develop:
 
@@ -15,7 +15,7 @@ Open `http://localhost:3000/` in your browser to access DevTools. This is the fa
 - **View preview** - Render views in a mocked Apps SDK environment
 - **Theme/locale switching** - Test different display modes
 
-The DevTools mock the Apps SDK and the MCP apps runtimes, so your view code works identically in both environments.
+DevTools mocks the Apps SDK and MCP Apps runtimes, so your view code works identically in both environments.
 
 <Tip>
 **Fast Iteration**
@@ -25,7 +25,7 @@ For full details on DevTools, HMR, and Vite plugin, see [Fast Iteration](/concep
 
 
 
-## Production Testing
+## Production testing
 
 When you're ready to test your AI App with an LLM, you can connect it to ChatGPT, Claude, or other compatible MCP clients.
 
@@ -36,7 +36,7 @@ When you're ready to test your AI App with an LLM, you can connect it to ChatGPT
   <Card title="Testing in Claude" icon="user" href="#testing-in-claude">
     Test with Claude using the MCP Apps runtime
   </Card>
-  <Card title="Testing in Desktop MCP Clients" icon="desktop" href="#testing-in-other-mcp-clients">
+  <Card title="Testing in desktop MCP clients" icon="desktop" href="#testing-in-other-mcp-clients">
     Test locally with VSCode, Goose, and other desktop clients
   </Card>
 </CardGroup>
@@ -84,7 +84,7 @@ Skybridge downloads and runs [Alpic tunnel](https://docs.alpic.ai/cli/tunnel) au
 2. Select your app using the **+** button
 3. Prompt the model to trigger your tools
 
-#### Hot Module Reload
+#### Hot module reload
 
 View changes in `src/views/` appear instantly without reconnecting.
 
@@ -133,7 +133,7 @@ Skybridge downloads and runs [Alpic tunnel](https://docs.alpic.ai/cli/tunnel) au
 2. Make sure your Connector is selected in the Connectors dropdown
 3. Test view interactions and tool responses
 
-### Testing in other MCP Clients
+### Testing in other MCP clients
 
 Desktop MCP clients like VSCode, Goose, and others can connect directly to your local server without needing a HTTP tunnel or a public URL.
 
@@ -159,7 +159,7 @@ Connect your server to any desktop MCP client that supports the [ext-apps specif
 3. Test your app by invoking tools and interacting with the views
 
 
-## What's Next?
+## What's next?
 
 <CardGroup cols={2}>
   <Card title="Core Concepts" icon="lightbulb" href="/concepts">

--- a/docs/showcase.mdx
+++ b/docs/showcase.mdx
@@ -161,7 +161,7 @@ Open-source apps with source code available on GitHub.
 
 </CardGroup>
 
-## 3rd Party Apps
+## Third-party apps
 
 Apps built by customers and the community using Skybridge.
 

--- a/docs/showcase.mdx
+++ b/docs/showcase.mdx
@@ -1,6 +1,6 @@
 ---
 title: Showcase
-description: "Explore apps built with Skybridge, from simple e-commerce and SaaS examples, to complete oauth providers templates."
+description: "Explore production apps, templates, auth examples, and UI libraries built with Skybridge for MCP Apps, ChatGPT Apps, and AI clients."
 ---
 
 Explore real-world examples built with Skybridge. Each app demonstrates different features and integrations. Click an app to see a full-page walkthrough.

--- a/docs/showcase.mdx
+++ b/docs/showcase.mdx
@@ -1,6 +1,6 @@
 ---
-title: All Apps
-description: Example apps built with Skybridge
+title: Showcase
+description: "Explore apps built with Skybridge, from simple e-commerce and SaaS examples, to complete oauth providers templates."
 ---
 
 Explore real-world examples built with Skybridge. Each app demonstrates different features and integrations. Click an app to see a full-page walkthrough.

--- a/docs/showcase/auth-auth0.mdx
+++ b/docs/showcase/auth-auth0.mdx
@@ -1,6 +1,6 @@
 ---
 title: Auth — Auth0
-description: Full OAuth authentication with Auth0 and personalized coffee shop search.
+description: "See a Skybridge Auth0 OAuth example with personalized coffee shop search, user identity, secure login, and MCP App React views and UI."
 ---
 
 Auth (Auth0) is an example that demonstrates full OAuth authentication using [Auth0](https://auth0.com/), with a personalized coffee shop finder view that displays user-specific favorites.

--- a/docs/showcase/auth-clerk.mdx
+++ b/docs/showcase/auth-clerk.mdx
@@ -1,6 +1,6 @@
 ---
 title: Auth — Clerk
-description: Full OAuth authentication with Clerk and personalized coffee shop search.
+description: "See a Skybridge Clerk OAuth example with personalized coffee shop search, user identity, secure login, and MCP App React views and UI."
 ---
 
 Auth (Clerk) is an example that demonstrates full OAuth authentication using [Clerk](https://clerk.com/), with a personalized coffee shop finder view that displays user-specific favorites.

--- a/docs/showcase/auth-stytch.mdx
+++ b/docs/showcase/auth-stytch.mdx
@@ -1,6 +1,6 @@
 ---
 title: Auth — Stytch
-description: Full OAuth authentication with Stytch and personalized coffee shop search.
+description: "See a Skybridge Stytch OAuth example with personalized coffee shop search, user identity, secure login, and MCP App React views and UI."
 ---
 
 Auth (Stytch) is an example that demonstrates full OAuth authentication using [Stytch](https://stytch.com/), with a personalized coffee shop finder view that displays user-specific favorites.

--- a/docs/showcase/auth-workos.mdx
+++ b/docs/showcase/auth-workos.mdx
@@ -1,6 +1,6 @@
 ---
 title: Auth — WorkOS AuthKit
-description: Full OAuth authentication with WorkOS AuthKit and personalized coffee shop search.
+description: "See a Skybridge WorkOS AuthKit OAuth example with personalized coffee shop search, user identity, secure login, and MCP App views."
 ---
 
 Auth (WorkOS) is an example that demonstrates full OAuth authentication using [WorkOS AuthKit](https://workos.com/docs/user-management/authkit), with a personalized coffee shop finder view that displays user-specific favorites.

--- a/docs/showcase/awaze.mdx
+++ b/docs/showcase/awaze.mdx
@@ -1,6 +1,6 @@
 ---
 title: Awaze — Cottage Search
-description: Holiday cottage search and booking experience powered by MCP.
+description: "Explore a holiday cottage search MCP App built with Skybridge, including destination search, booking links, and rich React views for travel."
 ---
 
 Awaze brings holiday cottage search into the AI conversation — browse properties, filter by location, and explore availability directly in the chat.

--- a/docs/showcase/capitals.mdx
+++ b/docs/showcase/capitals.mdx
@@ -1,6 +1,6 @@
 ---
 title: Capitals Explorer
-description: Interactive world map with geolocation and dynamic capital exploration.
+description: "Explore a Skybridge world capitals MCP App with an interactive map, geolocation, dynamic country data, React rendering, and AI host UI."
 ---
 
 Capitals Explorer uses Skybridge tools to fetch country data and create a rich, fullscreen map experience.

--- a/docs/showcase/ecommerce-carousel.mdx
+++ b/docs/showcase/ecommerce-carousel.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ecommerce Carousel
-description: Product carousel with persistent cart, localization, and modal checkout flow.
+description: "Explore a Skybridge ecommerce MCP App with product carousel browsing, persistent cart state, localization, modal checkout, and React UI."
 ---
 
 Ecommerce Carousel highlights localization, modal dialogs, persistent state, and external checkout flows.

--- a/docs/showcase/evaneos.mdx
+++ b/docs/showcase/evaneos.mdx
@@ -1,6 +1,6 @@
 ---
 title: Evaneos — Travel Destinations
-description: Personalized travel discovery powered by Evaneos experts in ChatGPT.
+description: "Explore an Evaneos travel discovery MCP App built with Skybridge, personalized destinations, expert recommendations, and ChatGPT UI."
 ---
 
 Evaneos helps travelers discover personalized destinations based on their interests, travel dates, and preferences. The app suggests tailored itineraries, highlights activities and best travel periods, and surfaces sustainable alternatives to help avoid overtourism.

--- a/docs/showcase/everything.mdx
+++ b/docs/showcase/everything.mdx
@@ -1,6 +1,6 @@
 ---
 title: Everything
-description: Comprehensive playground showcasing Skybridge hooks and utilities.
+description: "Explore the Everything Skybridge playground for MCP Apps, showcasing hooks, utilities, tool calls, view state, host context, and demos."
 ---
 
 Everything is the reference view that demonstrates every Skybridge hook and utility in one place.

--- a/docs/showcase/flight-booking.mdx
+++ b/docs/showcase/flight-booking.mdx
@@ -1,6 +1,6 @@
 ---
 title: Flight Booking
-description: Flight search carousel with route details, pricing comparison, and external booking links.
+description: "Explore a Skybridge flight booking MCP App with route search, pricing comparison, flight details, external booking links, and React views."
 ---
 
 Flight Booking showcases a Skyscanner-style flight carousel with outbound/inbound legs, price comparison, and external redirect via `useOpenExternal`.

--- a/docs/showcase/generative-ui.mdx
+++ b/docs/showcase/generative-ui.mdx
@@ -1,6 +1,6 @@
 ---
 title: Generative UI
-description: LLM-generated dynamic UIs with json-render and shadcn/ui components.
+description: "Explore a generative UI example for Skybridge that renders dynamic LLM-generated interfaces with json-render and shadcn/ui components."
 ---
 
 Generative UI lets the LLM compose rich interfaces on the fly using [json-render](https://json-render.dev) and 36 pre-built shadcn/ui components. The AI generates a json-render spec, the server validates it against the component catalog, and the view renders it instantly.

--- a/docs/showcase/investigation-game.mdx
+++ b/docs/showcase/investigation-game.mdx
@@ -1,6 +1,6 @@
 ---
 title: Investigation Game
-description: Interactive murder mystery game for MCP Apps
+description: "Explore an interactive investigation game built with Skybridge, combining MCP tools, React views, clues, suspects, and game state."
 ---
 
 An interactive murder mystery game with multi-screen gameplay, fullscreen display mode, and dynamic story progression driven by follow-up messages.

--- a/docs/showcase/lumo.mdx
+++ b/docs/showcase/lumo.mdx
@@ -1,6 +1,6 @@
 ---
 title: Lumo — Interactive AI Tutor
-description: Adaptive educational tutor with diagrams, mind maps, quizzes, and exercises.
+description: "Explore Lumo, an interactive AI tutor built with Skybridge for diagrams, mind maps, quizzes, exercises, adaptive learning, and MCP Apps."
 ---
 
 Lumo is an interactive AI tutor that generates adaptive lessons combining Mermaid.js diagrams, zoomable mind maps, multiple-choice quizzes, and fill-in-the-blank exercises on any topic. Built during the Claude Code London Hack Night.

--- a/docs/showcase/magic-8-ball.mdx
+++ b/docs/showcase/magic-8-ball.mdx
@@ -1,6 +1,6 @@
 ---
 title: Magic 8-Ball
-description: Classic fortune-telling toy that answers yes-or-no questions with mystical responses.
+description: "Explore a Magic 8-Ball MCP App built with Skybridge, including playful yes-or-no answers, React views, simple tool output, and AI UI."
 ---
 
 Magic 8-Ball is the default Skybridge starter app — ask a question, shake the ball, and get a mystical answer. A minimal example that demonstrates the core Skybridge loop: tool input, server logic, and view rendering.

--- a/docs/showcase/manifest-ui.mdx
+++ b/docs/showcase/manifest-ui.mdx
@@ -1,6 +1,6 @@
 ---
 title: Manifest UI
-description: Manifest UI is an agentic component library for building rich, interactive views.
+description: "Explore Manifest UI, an agentic component library for Skybridge views with structured components, rich interactions, and MCP App UI."
 ---
 
 Manifest UI is an agentic component library that provides beautifully designed, ready-to-use views for building rich AI-powered experiences.

--- a/docs/showcase/productivity.mdx
+++ b/docs/showcase/productivity.mdx
@@ -1,6 +1,6 @@
 ---
 title: Productivity
-description: Data visualization dashboard for MCP Apps
+description: "Explore a productivity dashboard MCP App built with Skybridge for data visualization, task workflows, charts, and interactive React views."
 ---
 
 Interactive charts with theme adaptation, multi-language support, fullscreen toggle, and bidirectional tool calls.

--- a/docs/showcase/times-up.mdx
+++ b/docs/showcase/times-up.mdx
@@ -1,6 +1,6 @@
 ---
 title: Time's Up
-description: Word-guessing party game for MCP Apps
+description: "Explore a Time's Up party game built with Skybridge, including word guessing, game state, multiplayer-style flows, and MCP App views."
 ---
 
 A word-guessing party game where the user sees a secret word and gives hints to the AI, which tries to guess it. Features hidden metadata, PiP display mode, multilingual support, and view-to-tool communication.

--- a/docs/telemetry.mdx
+++ b/docs/telemetry.mdx
@@ -1,6 +1,6 @@
 ---
 title: Telemetry
-description: "Learn what Skybridge telemetry collects, why it helps improve MCP App development, how privacy works, and how to opt out in projects."
+description: "Learn what Skybridge telemetry collects, why it helps improve Skybridge development, how privacy works, and how to opt out in projects."
 ---
 
 # Telemetry

--- a/docs/telemetry.mdx
+++ b/docs/telemetry.mdx
@@ -1,6 +1,6 @@
 ---
 title: Telemetry
-description: "Learn what data Skybridge collects, why we collect it, and how to opt out."
+description: "Learn what Skybridge telemetry collects, why it helps improve MCP App development, how privacy works, and how to opt out in projects."
 ---
 
 # Telemetry

--- a/docs/telemetry.mdx
+++ b/docs/telemetry.mdx
@@ -54,7 +54,7 @@ That's the entire payload. There is no machine ID, no session ID, no tool name, 
 - ❌ End-user prompts, conversations, or model output
 - ❌ Environment variables or secrets
 - ❌ IP addresses or location data stored or used as identifiers
-- ❌ Personal identifiable information
+- ❌ Personally identifiable information
 
 ## Why We Collect Telemetry
 
@@ -67,15 +67,15 @@ Telemetry helps us:
 
 ## How to Opt Out
 
-Telemetry preferences are stored per-machine. You can opt-out of telemetry using any of the following methods:
+Telemetry preferences are stored per-machine. You can opt out of telemetry using any of the following methods:
 - updating the `telemetry.enabled` property in `~/.skybridge/config.json` configuration file
-- using CLI `skybridge telemetry disable` command
-- setting environment variables `SKYBRIDGE_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1`
+- running `skybridge telemetry disable`
+- setting the `SKYBRIDGE_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1` environment variable
 
 The right opt-out method depends on **where** the telemetry is being emitted from:
 
-- **Your local development machine**: Prefer the use of `skybridge telemetry disable` that will update your local `~/.skybridge/config.json` config file
-- **CI runners** & **Deployed Skybridge servers**: Prefer the use of `SKYBRIDGE_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1` environment variable. It's much simpler than packaging a local `~/.skybridge/config.json`
+- **Your local development machine**: Prefer `skybridge telemetry disable`, which updates your local `~/.skybridge/config.json` config file
+- **CI runners** & **Deployed Skybridge servers**: Prefer the `SKYBRIDGE_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1` environment variable. It's much simpler than packaging a local `~/.skybridge/config.json`
 
 ### Using the Configuration File
 
@@ -90,7 +90,7 @@ Telemetry settings are stored per-machine in `~/.skybridge/config.json`:
 }
 ``` 
 
-This file is generated on first skybridge CLI command run with `telemetry.enabled` set to `true` by default.
+This file is generated the first time you run a Skybridge CLI command, with `telemetry.enabled` set to `true` by default.
 
 Disable telemetry by setting `telemetry.enabled` to `false`.
 
@@ -118,7 +118,7 @@ Check your current telemetry status:
 skybridge telemetry status
 ```
 
-All the above commands write and read from the `~/.skybridge/config.json` configuration file.
+All the above commands read from and write to the `~/.skybridge/config.json` configuration file.
 
 ### Using Environment Variables
 


### PR DESCRIPTION
## Summary
- Apply documentation manifesto casing and terminology updates across docs pages
- Improve MDX frontmatter so docs pages have unique, specific SEO titles and descriptions
- Prefer MCP Apps views wording in API reference metadata
- Fix typos and grammar issues found during the docs pass, including GitHub, VS Code, HTTP article usage, and telemetry wording

## Validation
- Custom metadata audit: 67 MDX pages checked, 0 issues
- pnpm --dir docs lint
- git diff --check

## Notes
- It looks like a long PR but it's only content!

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a docs-only pass across 67 MDX pages improving SEO metadata and applying consistent terminology and casing rules throughout the Skybridge documentation.

- **Frontmatter metadata**: Every page receives a unique, keyword-rich `description` (and `keywords` on the two top-level pages) replacing generic one-liners, with no changes to routing or navigation structure.
- **Terminology and casing**: "VSCode" → "VS Code", "Github" → "GitHub", "a HTTP" → "an HTTP", "MCP Clients/Servers" → "MCP clients/servers", "Personal identifiable information" → "Personally identifiable information", and sentence-cased headings throughout.
- **Prose polish**: Telemetry opt-out instructions are simplified, one word-order fix in `telemetry.mdx` ("read from and write to"), and a handful of minor grammar improvements across the guides.

<h3>Confidence Score: 5/5</h3>

Pure documentation content changes with no functional code, no broken links, and no navigation structure modifications — safe to merge.

All 67 changed files are MDX documentation pages. Every change is limited to frontmatter metadata (title, description, keywords) and prose copy — casing fixes, grammar corrections, and terminology standardisation. There is no executable code, no schema changes, and no routing or sidebar structure touched.

No files require special attention.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
docs/telemetry.mdx:73
Using the singular "environment variable" when listing two distinct variables is mildly ambiguous — a reader could interpret it as needing to set both rather than choosing one. The previous plural form was clearer.

```suggestion
- setting the `SKYBRIDGE_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1` environment variables
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Apply suggestions from code review"](https://github.com/alpic-ai/skybridge/commit/c461150f63da84c2b9f37d7af7909f009ce6ca3f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32043596)</sub>

<!-- /greptile_comment -->