### PR TITLE
fix(core): dedupe react to prevent invalid hook call

### DIFF
--- a/packages/core/src/web/plugin/plugin.ts
+++ b/packages/core/src/web/plugin/plugin.ts
@@ -65,6 +65,13 @@ export function skybridge(options?: SkybridgePluginOptions): Plugin {
 
       return {
         base: "/assets",
+        // Fixes "Invalid hook call" on createStore by forcing a single
+        // copy of React. Under pnpm's isolated node_modules, zustand
+        // inside `skybridge` resolves React from skybridge's own
+        // dependencies while the host app loads its own copy
+        resolve: {
+          dedupe: ["react", "react-dom"],
+        },
         build: {
           outDir: "dist/assets",
           emptyOutDir: true,


### PR DESCRIPTION
createStore components crashed with "Invalid hook call" because zustand resolved a second react copy from packages/core/node_modules. Deduping react and react-dom in the vite plugin pins everything to one instance.