### PR TITLE
feat: add missing tool definition _meta

### DIFF
--- a/docs/api-reference/register-tool.mdx
+++ b/docs/api-reference/register-tool.mdx
@@ -35,9 +35,17 @@ type ToolMeta = {
   // Custom status messages
   "openai/toolInvocation/invoking"?: string; // While running
   "openai/toolInvocation/invoked"?: string;  // After completion
+  "openai/fileParams": string[] // List of top-level input fields that references files.
+  // Controls whether a tool is available to the model, the UI (app), or both.
+  "visibility": Array<"model" | "app">
   [key: string]: unknown;
 };
 ```
+
+<Note>
+Flag input parameters that ChatGPT can use to reference files by adding the keys to `openai/fileParams`.
+Learn more about files lifecycle with tool calling by reading the [`FileRef`](/api-reference/file-ref) doc.
+</Note>
 
 ### `view`
 

--- a/docs/api-reference/register-tool.mdx
+++ b/docs/api-reference/register-tool.mdx
@@ -35,9 +35,9 @@ type ToolMeta = {
   // Custom status messages
   "openai/toolInvocation/invoking"?: string; // While running
   "openai/toolInvocation/invoked"?: string;  // After completion
-  "openai/fileParams": string[] // List of top-level input fields that references files.
+  "openai/fileParams"?: string[]; // List of top-level input fields that references files.
   // Controls whether a tool is available to the model, the UI (app), or both.
-  "visibility": Array<"model" | "app">
+  ui?: { visibility?: Array<"model" | "app"> };
   [key: string]: unknown;
 };
 ```

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -105,6 +105,8 @@ export interface KnownToolMeta {
   "openai/widgetAccessible"?: boolean;
   "openai/toolInvocation/invoking"?: string;
   "openai/toolInvocation/invoked"?: string;
+  "openai/fileParams"?: string[];
+  ui?: Pick<McpUiToolMeta, "visibility">;
 }
 
 export type ToolMeta = KnownToolMeta & Record<string, unknown>;
@@ -129,6 +131,7 @@ type OpenaiToolMeta = {
   "openai/widgetAccessible"?: boolean;
   "openai/toolInvocation/invoking"?: string;
   "openai/toolInvocation/invoked"?: string;
+  "openai/fileParams"?: string[];
 };
 
 /** @see https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/draft/apps.mdx#resource-discovery */
@@ -701,7 +704,10 @@ export class McpServer<
       });
       // @ts-expect-error - For backwards compatibility with Claude current implementation of the specs
       toolMeta["ui/resourceUri"] = viewResource.uri;
-      toolMeta.ui = { resourceUri: viewResource.uri };
+
+      const ui = toolMeta.ui || {};
+      ui.resourceUri = viewResource.uri;
+      toolMeta.ui = ui;
     }
   }
 

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -705,9 +705,7 @@ export class McpServer<
       // @ts-expect-error - For backwards compatibility with Claude current implementation of the specs
       toolMeta["ui/resourceUri"] = viewResource.uri;
 
-      const ui = toolMeta.ui || {};
-      ui.resourceUri = viewResource.uri;
-      toolMeta.ui = ui;
+      toolMeta.ui = { ...toolMeta.ui, resourceUri: viewResource.uri };
     }
   }
 


### PR DESCRIPTION
Namely: OpenAI's fileParams and visibility.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two previously missing `_meta` fields to the `KnownToolMeta` interface and the public documentation: `"openai/fileParams"` (to declare which input parameters reference file objects) and `ui.visibility` (to control tool accessibility for the model and/or app). It also fixes a pre-existing regression where registering a `view` on a tool silently overwrote any user-supplied `ui` object (e.g., a caller-provided `visibility`), replacing it entirely with `{ resourceUri }`.

- `"openai/fileParams": string[]` is added to both `KnownToolMeta` and the internal `OpenaiToolMeta`, and the docs now surface it with a usage note pointing to the `FileRef` reference.
- `ui?: Pick<McpUiToolMeta, "visibility">` is added to `KnownToolMeta`, and the docs correctly nest it under `ui` (matching the actual TypeScript shape), addressing the mismatch noted in prior review threads.
- Line 708 changes from a full overwrite `toolMeta.ui = { resourceUri }` to a spread `toolMeta.ui = { ...toolMeta.ui, resourceUri }`, so a caller-supplied `visibility` is preserved when a view resource URI is attached.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are purely additive type/doc additions plus a targeted spread fix that preserves existing caller state.

The two new KnownToolMeta fields are backward-compatible additions. The toolMeta.ui spread on line 708 correctly preserves any caller-supplied visibility while still setting resourceUri, and spreading undefined in TypeScript/ES2018 is safe. The docs now match the actual TypeScript shape. No existing behavior is broken.

No files require special attention.

<sub>Reviews (3): Last reviewed commit: ["Update packages/core/src/server/server.t..."](https://github.com/alpic-ai/skybridge/commit/494f4638ae5530c3aca79ff59e011e3dd486f0c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32175433)</sub>

<!-- /greptile_comment -->