### PR TITLE
feat: add token limit warning for setWidgetState

### DIFF
--- a/packages/core/src/web/bridges/apps-sdk/adaptor.ts
+++ b/packages/core/src/web/bridges/apps-sdk/adaptor.ts
@@ -15,6 +15,35 @@ import type {
 import { AppsSdkBridge } from "./bridge.js";
 import type { AppsSdkWidgetState } from "./types.js";
 
+/**
+ * Estimates the token count for a given state object.
+ * Uses a rough approximation: 1 token ≈ 4 characters.
+ * @param state - The widget state to estimate tokens for
+ * @returns Estimated token count
+ */
+function estimateTokenCount(state: unknown): number {
+  const jsonString = JSON.stringify(state);
+  return Math.ceil(jsonString.length / 4);
+}
+
+/**
+ * Warns if the widget state exceeds the 4K token limit.
+ * Per OpenAI Apps SDK documentation, widget state should not exceed 4K tokens.
+ * @param state - The widget state to check
+ */
+function warnIfExceedsTokenLimit(state: AppsSdkWidgetState): void {
+  const TOKEN_LIMIT = 4000;
+  const estimatedTokens = estimateTokenCount(state);
+
+  if (estimatedTokens > TOKEN_LIMIT) {
+    console.warn(
+      `[skybridge] Widget state exceeds ${TOKEN_LIMIT} token limit (estimated: ${estimatedTokens} tokens). ` +
+        `This may cause issues with ChatGPT context. Consider reducing the state size. ` +
+        `See: https://developers.openai.com/apps-sdk/build/chatgpt-ui#persist-component-state-expose-context-to-chatgpt`,
+    );
+  }
+}
+
 export class AppsSdkAdaptor implements Adaptor {
   private static instance: AppsSdkAdaptor | null = null;
 
@@ -99,11 +128,15 @@ export class AppsSdkAdaptor implements Adaptor {
         ? stateOrUpdater(window.openai.widgetState?.modelContent ?? null)
         : stateOrUpdater;
 
-    return window.openai.setWidgetState({
+    const newState: AppsSdkWidgetState = {
       privateContent: {},
       ...window.openai.widgetState,
       modelContent,
-    });
+    };
+
+    warnIfExceedsTokenLimit(newState);
+
+    return window.openai.setWidgetState(newState);
   };
 
   public uploadFile = async (file: File, options?: UploadFileOptions) => {
@@ -137,6 +170,9 @@ export class AppsSdkAdaptor implements Adaptor {
       state.imageIds = [];
     }
     state.imageIds.push(...fileIds);
+
+    warnIfExceedsTokenLimit(state);
+
     await window.openai.setWidgetState(state);
   }
 


### PR DESCRIPTION
## Summary

Adds console warnings when widget state exceeds the 4K token limit, as requested in #356.

Per the [OpenAI Apps SDK documentation](https://developers.openai.com/apps-sdk/build/chatgpt-ui#persist-component-state-expose-context-to-chatgpt), widget state should not exceed 4K tokens to avoid issues with ChatGPT context.

## Changes

### Added token estimation and warning functions

**`estimateTokenCount(state: unknown): number`**
- Estimates token count using a rough approximation: 1 token ≈ 4 characters
- Serializes state to JSON and divides character count by 4

**`warnIfExceedsTokenLimit(state: AppsSdkWidgetState): void`**
- Checks if estimated tokens exceed 4,000
- Logs a console warning with:
  - Current estimated token count
  - Guidance to reduce state size
  - Link to OpenAI documentation

### Integrated warnings into state updates

**`setViewState()`** (line 125-140)
- Now constructs the new state first
- Calls `warnIfExceedsTokenLimit()` before calling `window.openai.setWidgetState()`

**`trackFileIds()`** (line 165-177)
- Calls `warnIfExceedsTokenLimit()` after adding file IDs to state
- Warns before calling `window.openai.setWidgetState()`

## Example Warning

```
[skybridge] Widget state exceeds 4000 token limit (estimated: 5234 tokens). This may cause issues with ChatGPT context. Consider reducing the state size. See: https://developers.openai.com/apps-sdk/build/chatgpt-ui#persist-component-state-expose-context-to-chatgpt
```

## Testing

The warning will trigger automatically when:
1. `setViewState()` is called with large state (e.g., via `data-llm` attribute)
2. `trackFileIds()` is called and the resulting state exceeds 4K tokens

Developers can monitor the browser console during development to catch oversized state early.

## Notes

- The 4-character-per-token approximation is a common heuristic for English text
- Actual token count may vary depending on the tokenizer, but this provides a reasonable warning threshold
- The warning is non-blocking and only appears in the console

Fixes #356

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds console warnings to `setViewState` and `trackFileIds` when the serialized widget state is estimated to exceed 4,000 tokens, using a `JSON.stringify` length ÷ 4 heuristic as requested in #356.

- `estimateTokenCount` calls `JSON.stringify` without a try-catch; a non-serializable value in `modelContent` (e.g. `BigInt`, circular reference) will throw before `setWidgetState` is ever reached, silently dropping the state update.
- There is no deduplication on the warning; in a reactive app that calls `setViewState` on every render the console will be flooded with identical messages once the limit is exceeded.

<h3>Confidence Score: 3/5</h3>

The change is additive and low-risk in the happy path, but the unguarded `JSON.stringify` inside the new warning function can throw and block a state update that previously would have succeeded.

The `estimateTokenCount` helper calls `JSON.stringify` without any error handling. Because it runs synchronously before `setWidgetState`, any non-serializable value in the widget state (such as a `BigInt` or a circular reference in `modelContent`) would cause the exception to bubble up and prevent the state from being written — a regression compared to pre-PR behavior where `setWidgetState` was called unconditionally.

packages/core/src/web/bridges/apps-sdk/adaptor.ts — specifically the `estimateTokenCount` function and the two call sites inside `setViewState` and `trackFileIds`.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/core/src/web/bridges/apps-sdk/adaptor.ts:24-27
`JSON.stringify` throws for non-serializable values — `BigInt`, functions embedded in `modelContent`, or circular object graphs. When that happens the exception bubbles out of `warnIfExceedsTokenLimit`, skips the `return window.openai.setWidgetState(newState)` call entirely, and silently breaks the state update. Before this PR, non-serializable state would still reach `setWidgetState` (which may handle it differently). Wrapping the call in a try-catch keeps the warning best-effort and non-blocking.

```suggestion
function estimateTokenCount(state: unknown): number {
  try {
    const jsonString = JSON.stringify(state);
    return Math.ceil(jsonString.length / 4);
  } catch {
    return 0;
  }
}
```

### Issue 2 of 2
packages/core/src/web/bridges/apps-sdk/adaptor.ts:34-45
The warning fires on every `setViewState` / `trackFileIds` call while the state remains oversized. In practice, React components often call `setViewState` on each render cycle, so once the limit is exceeded the console gets flooded with identical messages. A module-level `warned` flag (reset whenever the state drops back under the limit) keeps the signal useful without the noise.

```suggestion
let _tokenLimitWarned = false;

function warnIfExceedsTokenLimit(state: AppsSdkWidgetState): void {
  const TOKEN_LIMIT = 4000;
  const estimatedTokens = estimateTokenCount(state);

  if (estimatedTokens > TOKEN_LIMIT) {
    if (!_tokenLimitWarned) {
      _tokenLimitWarned = true;
      console.warn(
        `[skybridge] Widget state exceeds ${TOKEN_LIMIT} token limit (estimated: ${estimatedTokens} tokens). ` +
          `This may cause issues with ChatGPT context. Consider reducing the state size. ` +
          `See: https://developers.openai.com/apps-sdk/build/chatgpt-ui#persist-component-state-expose-context-to-chatgpt`,
      );
    }
  } else {
    _tokenLimitWarned = false;
  }
}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add token limit warning for setWid..."](https://github.com/alpic-ai/skybridge/commit/806788f80f7d8633836139fbaafc3037904e98c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32289541)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->