### PR TITLE
fix(landing): widen showcase sidebar from 280px to 300px

### DIFF
--- a/landing/app/sb-showcase.css
+++ b/landing/app/sb-showcase.css
@@ -649,7 +649,7 @@
 
 .sxD-body {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 280px;
+  grid-template-columns: minmax(0, 1fr) 300px;
   gap: 56px;
   padding: 48px 48px 56px;
 }


### PR DESCRIPTION
<img width="315" height="247" alt="Screenshot 2026-05-18 at 12 11 10" src="https://github.com/user-attachments/assets/e5bfef56-9c7d-4c9c-8cb3-adad51af1743" />

The "npx create skybridge" command in the detail page sidebar card was being truncated to "skybr..." due to insufficient column width. Increased .sxD-body grid sidebar column from 280px to 300px.

<img width="340" height="237" alt="image" src="https://github.com/user-attachments/assets/f8f8c050-fa36-4da8-a4df-2757d1c57f83" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Increases the fixed-width sidebar column in the `.sxD-body` grid from `280px` to `300px` to prevent the `npx create skybridge` command string from being truncated in the showcase detail page sidebar card.

- The change is scoped to a single CSS property in `sb-showcase.css`; the existing responsive breakpoint already collapses the layout to a single column on mobile, so the wider value only applies at desktop widths.

<h3>Confidence Score: 5/5</h3>

A one-line CSS tweak that widens a fixed sidebar column by 20px; the mobile breakpoint already overrides it with a single-column layout, so there is no risk of layout breakage on smaller screens.

The change touches exactly one value in one file, the before/after screenshots confirm the intent, and the responsive fallback is already in place, making this straightforward and low-risk.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix(landing): widen showcase sidebar fro..."](https://github.com/alpic-ai/skybridge/commit/e5930c1aedefdb1bd3df3ded0c6882554f397b84) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32592698)</sub>

<!-- /greptile_comment -->