### PR TITLE
fix(landing): mobile responsive fixes

### DIFF
--- a/landing/app/components/hero.tsx
+++ b/landing/app/components/hero.tsx
@@ -101,7 +101,7 @@ export function Hero() {
 
         <div className="sb-cta-stack">
           <div className="sb-cta-row sb-cta-row-split">
-            <div className="sb-cta-installs" style={{ width: 720 }}>
+            <div className="sb-cta-installs">
               <div className="sb-cta-installs-head">
                 Get started in 5 seconds
               </div>

--- a/landing/app/components/social.tsx
+++ b/landing/app/components/social.tsx
@@ -87,7 +87,7 @@ export function SocialProofSection() {
     <section className="sb-section" id="customers" style={{ paddingTop: 72 }}>
       <div className="sb-wrap">
         <div className="sb-stat-row">
-          <div className="sb-stat-lead" style={{ width: "700px" }}>
+          <div className="sb-stat-lead">
             <div
               className="sb-big"
               style={{ fontSize: "52px", fontWeight: "400" }}

--- a/landing/app/sb-showcase.css
+++ b/landing/app/sb-showcase.css
@@ -1045,6 +1045,12 @@
   .sx-submit-split .sx-submit-col.sx-submit-secondary {
     padding: 32px 24px;
   }
+  .sx-submit-title {
+    font-size: 32px;
+  }
+  .sx-submit-lede {
+    font-size: 15px;
+  }
   .sx-page {
     padding: 80px 16px 64px;
   }

--- a/landing/app/skybridge.css
+++ b/landing/app/skybridge.css
@@ -1804,13 +1804,16 @@ body {
     padding: 80px 0;
   }
   .sb-values {
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr;
   }
-  .sb-value:nth-child(3n) {
-    border-right: 1px solid var(--sb-border);
-  }
+  .sb-value,
+  .sb-value:nth-child(3n),
   .sb-value:nth-child(2n) {
     border-right: none;
+    border-bottom: 1px solid var(--sb-border);
+  }
+  .sb-value:last-child {
+    border-bottom: none;
   }
   .sb-footer-inner {
     grid-template-columns: 1fr 1fr;
@@ -1818,6 +1821,17 @@ body {
   .sb-final h2 {
     font-size: 42px;
     letter-spacing: 0;
+  }
+  .sb-nav-stars {
+    display: none;
+  }
+  .sb-brand-ver {
+    display: none;
+  }
+  .sb-nav-inner {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
   }
   .sb-nav-links {
     display: none;
@@ -3112,7 +3126,7 @@ body {
 
 @media (max-width: 900px) {
   .sb-devtools-shot {
-    min-height: 0;
+    display: none;
   }
   .sb-devpanel {
     display: none;
@@ -3247,5 +3261,46 @@ body {
   }
   .sb-community-seg:last-child {
     border-bottom: none;
+  }
+}
+
+@media (max-width: 500px) {
+  .sb-wrap {
+    padding: 0 20px;
+  }
+  .sb-hero {
+    padding: 90px 0 64px;
+    min-height: 0;
+  }
+  .sb-h1 {
+    font-size: 40px;
+    line-height: 1.05;
+  }
+  .sb-section {
+    padding: 64px 0;
+  }
+  .sb-section-title {
+    font-size: 30px;
+  }
+  .sb-featured {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .sb-value {
+    padding: 36px 28px;
+  }
+  .sb-stat-lead .sb-big {
+    font-size: 34px;
+    line-height: 1.1;
+  }
+  .sb-final h2 {
+    font-size: 34px;
+  }
+  .sb-footer-inner {
+    grid-template-columns: 1fr;
+  }
+  .sb-footer {
+    padding: 60px 0 52px;
   }
 }

--- a/landing/app/skybridge.css
+++ b/landing/app/skybridge.css
@@ -1808,7 +1808,8 @@ body {
   }
   .sb-value,
   .sb-value:nth-child(3n),
-  .sb-value:nth-child(2n) {
+  .sb-value:nth-child(2n),
+  .sb-value:nth-last-child(-n + 3) {
     border-right: none;
     border-bottom: 1px solid var(--sb-border);
   }


### PR DESCRIPTION
## Summary

- Remove hardcoded inline widths on the hero install block and social stat lead that were blowing past the viewport edge on mobile
- Add `≤500px` breakpoint: reduced wrap padding, h1/section title font sizes, hero padding, footer collapses to single column
- Values grid: single-column at `≤900px` (previously 2-wide on tablet)
- Devtools illustration (`sb-devtools-shot`) hidden on mobile — text list only
- Nav on mobile (`≤900px`): hides GitHub stars and version badge; switches to flex `space-between` so logo pins left and "Get started" pins right
- Showcase submit section: title and lede shrink at `≤820px` to stop overflow

## Test plan

- [ ] Check homepage on 375px (iPhone SE) — hero, values, devtools, footer
- [ ] Check nav at mobile width — logo left, Get started right, no stars/version
- [ ] Check `/showcase` on mobile — submit CTA text no longer overflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes hardcoded inline widths from two React components that were preventing fluid shrinkage on mobile, and adds a new `≤500 px` breakpoint to `skybridge.css` along with targeted overrides to the `≤900 px` and `≤820 px` breakpoints in both stylesheets.

- **Inline style removal** (`hero.tsx`, `social.tsx`): both `width: 720` and `width: "700px"` are already expressed as `max-width` + `width: 100%` in the base CSS, so removing the inline overrides lets media queries take effect correctly.
- **Values grid** (`skybridge.css` `≤900 px`): the single-column refactor resolves a specificity cascade issue by including `.sb-value:nth-last-child(-n+3)` in the combined reset selector, restoring correct dividers for all six items.
- **New 500 px breakpoint**: shrinks hero padding, heading sizes, section titles, and collapses the footer to a single column; the `.sb-featured` badge switches to `display: flex` with `flex-wrap: wrap`, which changes it from an auto-sized inline pill to a full-container-width element — see the inline comment for a suggested adjustment.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are scoped entirely to CSS responsive overrides and inline-style cleanup with no impact on logic or data.

All four files contain purely presentational changes: removal of inline widths that were already expressed in the stylesheet, correct specificity-aware cascade resets for the values grid, and straightforward breakpoint additions. The one note worth reviewing is the `display: flex` on `.sb-featured` at 500 px, but it does not break functionality.

The ≤500 px block in `skybridge.css` — specifically the `.sb-featured` display change — is worth a visual spot-check on a 375 px device to confirm the badge width looks intentional.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
landing/app/skybridge.css:3286-3290
Changing `.sb-featured` from `display: inline-flex` to `display: flex` turns the element from an inline/auto-width pill into a block-level element that fills the full container width (viewport minus 40 px wrap padding). On a 375 px screen the announcement badge becomes a ~335 px-wide pill, which is a significant visual departure from the compact inline badge at wider sizes. If the goal is to let the inner content wrap (badge chip + text), `flex-wrap: wrap` works on `inline-flex` too — there's no need to change the outer formatting context.

```suggestion
  .sb-featured {
    flex-wrap: wrap;
    gap: 8px;
  }
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into erica/landing-u..."](https://github.com/alpic-ai/skybridge/commit/c3c09e996cf8edc3e61770f188c76826f51aaeb6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32629004)</sub>

<!-- /greptile_comment -->