### PR TITLE
fix: drop template border radius

### DIFF
--- a/packages/create-skybridge/template/src/views/onboarding.tsx
+++ b/packages/create-skybridge/template/src/views/onboarding.tsx
@@ -26,7 +26,7 @@ export default function Onboarding() {
 
   return (
     <div
-      className={`${theme === "dark" ? "dark" : ""} mx-auto w-full max-w-4xl rounded-xl border border-border overflow-hidden bg-background text-foreground`}
+      className={`${theme === "dark" ? "dark" : ""} mx-auto w-full max-w-4xl border border-border overflow-hidden bg-background text-foreground`}
     >
       <div className="min-h-136 md:min-h-95 flex flex-col items-center gap-6 p-6 bg-linear-to-br from-purple-50 via-white to-cyan-50 dark:from-purple-950/30 dark:via-zinc-950 dark:to-cyan-900/30 bg-size-[200%_200%] animate-aurora md:flex-row md:items-stretch">
         <div className="shrink-0 self-center animate-float">


### PR DESCRIPTION
because it does not render well in claude for some reason.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the `rounded-xl` Tailwind class from the outermost wrapper `div` in the onboarding template view, dropping the border radius that reportedly did not render well in Claude's UI.

- The only change is removing `rounded-xl` from the `className` string on line 29 of `onboarding.tsx`; no logic, behavior, or other styles are affected.

<h3>Confidence Score: 5/5</h3>

Safe to merge — removes a single Tailwind utility class with no impact on logic or layout beyond the visual border radius.

The change is a one-line cosmetic tweak: dropping `rounded-xl` from the wrapper div. No functional code, state, or conditional logic is touched.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix: drop template border radius"](https://github.com/alpic-ai/skybridge/commit/be4ac5e453a6f584d185037184ceb62e07815ad3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32761477)</sub>

<!-- /greptile_comment -->