### PR TITLE
Landing/better animations

### DIFF
--- a/landing/app/components/devtools.tsx
+++ b/landing/app/components/devtools.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import Image from "next-image-export-optimizer";
 import { useState } from "react";
 import { Icon } from "./icons";
-import { ClaudeStarSVG } from "./showcase/chatgpt-frame";
 
 type AuditRow = {
   icon: string;
@@ -250,101 +250,84 @@ function DevPanel({
       <div
         className={`sb-devpanel-card sb-dp-tun ${hover === "tunnel" ? "is-on" : ""}`}
       >
-        <div className="sb-dp-term">
-          <div className="sb-dp-term-h">$ skybridge tunnel</div>
-          <div>
-            <span className="sb-c-com">→ Stable URL provisioned</span>
+        <div className="sb-dp-tun-source">
+          <div className="sb-dp-tun-laptop-frame">
+            <div className="sb-dp-tun-laptop">
+              <div className="sb-dp-tun-laptop-chrome">
+                <span />
+                <span />
+                <span />
+              </div>
+              <div className="sb-dp-tun-widget">
+                <div className="sb-dp-tun-widget-row">
+                  <span>Paris → Tokyo</span>
+                  <strong>$891</strong>
+                </div>
+                <div className="sb-dp-tun-widget-row sub">
+                  <span>AF 276 · Nonstop</span>
+                  <span>11h 15m</span>
+                </div>
+              </div>
+            </div>
+            <div className="sb-dp-tun-laptop-base" aria-hidden />
           </div>
-          <div className="sb-dp-url">
-            https://cool-marmot-fondue-420.alpic.dev/mcp
-          </div>
-          <div>
-            <span className="sb-c-com">→ Ready on Claude, ChatGPT, mobile</span>
+          <div className="sb-dp-tun-url">
+            <Icon name="globe" size={10} />
+            <span>cool-marmot.alpic.dev/mcp</span>
           </div>
         </div>
-        <div className="sb-dp-tun-diagram">
-          <div className="sb-dp-tun-btn">
-            <span className="sb-dp-tun-btn-dot" />
-            Tunnel
-          </div>
+
+        <div className="sb-dp-tun-link">
           <svg
-            className="sb-dp-tun-arrows"
-            width="180"
-            height="36"
-            viewBox="0 0 180 36"
-            fill="none"
+            className="sb-dp-tun-svg"
+            viewBox="0 0 130 220"
             aria-hidden="true"
           >
-            <defs>
-              <marker
-                id="arr-l"
-                markerWidth="6"
-                markerHeight="6"
-                refX="3"
-                refY="3"
-                orient="auto"
-              >
-                <path d="M0,0 L6,3 L0,6 Z" fill="rgba(137,240,236,0.4)" />
-              </marker>
-              <marker
-                id="arr-r"
-                markerWidth="6"
-                markerHeight="6"
-                refX="3"
-                refY="3"
-                orient="auto"
-              >
-                <path d="M0,0 L6,3 L0,6 Z" fill="rgba(137,240,236,0.4)" />
-              </marker>
-            </defs>
-            <line
-              x1="90"
-              y1="2"
-              x2="22"
-              y2="30"
-              stroke="rgba(137,240,236,0.35)"
-              strokeWidth="1"
-              strokeDasharray="3 2"
-              markerEnd="url(#arr-l)"
+            <path
+              className="sb-dp-tun-path"
+              d="M 0 110 L 40 110 C 70 110 70 30 130 30"
             />
-            <line
-              x1="90"
-              y1="2"
-              x2="158"
-              y2="30"
-              stroke="rgba(137,240,236,0.35)"
-              strokeWidth="1"
-              strokeDasharray="3 2"
-              markerEnd="url(#arr-r)"
+            <path
+              className="sb-dp-tun-path"
+              d="M 0 110 L 40 110 C 70 110 70 190 130 190"
+            />
+            <path
+              className="sb-dp-tun-flow"
+              d="M 0 110 L 40 110 C 70 110 70 30 130 30"
+            />
+            <path
+              className="sb-dp-tun-flow"
+              d="M 0 110 L 40 110 C 70 110 70 190 130 190"
             />
           </svg>
-          <div className="sb-dp-tun-clients">
-            <div className="sb-dp-tun-client sb-dp-tun-client--chatgpt">
-              <div className="sb-dp-tun-client-chrome">
-                <svg
-                  width="10"
-                  height="10"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                  aria-hidden="true"
-                >
-                  <path d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.985 5.985 0 0 0-3.998 2.9 6.046 6.046 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.795.795 0 0 0 .392-.681v-6.737l2.02 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.771.771 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.677l5.815 3.354-2.02 1.168a.076.076 0 0 1-.071.005L2.34 13.01A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855l-5.833-3.387L15.124 7.2a.076.076 0 0 1 .071-.005l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.407-.664zm2.01-3.023l-.141-.085-4.774-2.782a.776.776 0 0 0-.785 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.681 4.66zm-12.64 4.135l-2.02-1.164a.08.08 0 0 1-.038-.057V6.074a4.5 4.5 0 0 1 7.375-3.453l-.142.08-4.778 2.758a.795.795 0 0 0-.393.681zm1.097-2.361l2.602-1.502 2.603 1.502v3.003l-2.603 1.502-2.602-1.502z" />
-                </svg>
-                <span>ChatGPT</span>
-              </div>
-              <div className="sb-dp-tun-client-body">
-                <span className="sb-dp-tun-used">Used app</span>
-              </div>
-            </div>
-            <div className="sb-dp-tun-client sb-dp-tun-client--claude">
-              <div className="sb-dp-tun-client-chrome">
-                <ClaudeStarSVG size={10} />
-                <span>Claude</span>
-              </div>
-              <div className="sb-dp-tun-client-body">
-                <span className="sb-dp-tun-used">Used app</span>
-              </div>
-            </div>
+          <div className="sb-dp-tun-packet sb-dp-tun-packet-top sb-dp-tun-packet-1" />
+          <div className="sb-dp-tun-packet sb-dp-tun-packet-top sb-dp-tun-packet-2" />
+          <div className="sb-dp-tun-packet sb-dp-tun-packet-top sb-dp-tun-packet-3" />
+          <div className="sb-dp-tun-packet sb-dp-tun-packet-bot sb-dp-tun-packet-1" />
+          <div className="sb-dp-tun-packet sb-dp-tun-packet-bot sb-dp-tun-packet-2" />
+          <div className="sb-dp-tun-packet sb-dp-tun-packet-bot sb-dp-tun-packet-3" />
+        </div>
+
+        <div className="sb-dp-tun-clients">
+          <div className="sb-dp-tun-tile sb-dp-tun-tile-chatgpt">
+            <Image
+              src="/assets/clients/chatgpt.webp"
+              alt="ChatGPT"
+              width={32}
+              height={32}
+            />
+            <span className="sb-dp-tun-tile-name">ChatGPT</span>
+            <span className="sb-dp-tun-tile-dot" aria-hidden />
+          </div>
+          <div className="sb-dp-tun-tile sb-dp-tun-tile-claude">
+            <Image
+              src="/assets/clients/claude.webp"
+              alt="Claude"
+              width={32}
+              height={32}
+            />
+            <span className="sb-dp-tun-tile-name">Claude</span>
+            <span className="sb-dp-tun-tile-dot" aria-hidden />
           </div>
         </div>
       </div>

--- a/landing/app/components/devtools.tsx
+++ b/landing/app/components/devtools.tsx
@@ -88,48 +88,61 @@ function DevPanel({
           <div className="sb-dp-diff-body">
             <div className="sb-dp-diff-line sb-dp-diff-ctx">
               <span className="sb-dp-diff-sign"> </span>
-              <span className="sb-c-kw">const</span>{" "}
-              <span className="sb-c-punc">{"{"}</span>{" "}
-              <span className="sb-c-var">output</span>{" "}
-              <span className="sb-c-punc">{"}"}</span>{" "}
-              <span className="sb-c-punc">=</span>{" "}
-              <span className="sb-c-fn">useToolInfo</span>
-              <span className="sb-c-punc">&lt;</span>
-              <span className="sb-c-str">"searchFlights"</span>
-              <span className="sb-c-punc">&gt;()</span>
+              <span className="sb-dp-diff-line-content">
+                <span className="sb-c-kw">const</span>{" "}
+                <span className="sb-c-punc">{"{"}</span>{" "}
+                <span className="sb-c-var">output</span>{" "}
+                <span className="sb-c-punc">{"}"}</span>{" "}
+                <span className="sb-c-punc">=</span>{" "}
+                <span className="sb-c-fn">useToolInfo</span>
+                <span className="sb-c-punc">&lt;</span>
+                <span className="sb-c-str">"searchFlights"</span>
+                <span className="sb-c-punc">&gt;()</span>
+              </span>
             </div>
             <div className="sb-dp-diff-line sb-dp-diff-del">
               <span className="sb-dp-diff-sign">−</span>
-              <span className="sb-c-tag">&lt;FlightCard</span>{" "}
-              <span className="sb-c-var">flight</span>
-              <span className="sb-c-punc">
-                ={"{"}output{"}"}
-              </span>{" "}
-              <span className="sb-c-tag">/&gt;</span>
+              <span className="sb-dp-diff-line-content">
+                <span className="sb-c-tag">&lt;FlightCard</span>{" "}
+                <span className="sb-c-var">flight</span>
+                <span className="sb-c-punc">
+                  ={"{"}output{"}"}
+                </span>{" "}
+                <span className="sb-c-tag">/&gt;</span>
+              </span>
             </div>
             <div className="sb-dp-diff-line sb-dp-diff-add">
               <span className="sb-dp-diff-sign">+</span>
-              <span className="sb-c-tag">&lt;FlightCard</span>{" "}
-              <span className="sb-c-var">flight</span>
-              <span className="sb-c-punc">
-                ={"{"}output{"}"}
-              </span>{" "}
-              <span className="sb-c-var">highlight</span>{" "}
-              <span className="sb-c-tag">/&gt;</span>
+              <span className="sb-dp-diff-line-content">
+                <span className="sb-c-tag">&lt;FlightCard</span>{" "}
+                <span className="sb-c-var">flight</span>
+                <span className="sb-c-punc">
+                  ={"{"}output{"}"}
+                </span>{" "}
+                <span className="sb-c-var">highlight</span>{" "}
+                <span className="sb-c-tag">/&gt;</span>
+                <span className="sb-dp-diff-caret" aria-hidden />
+              </span>
             </div>
             <div className="sb-dp-diff-line sb-dp-diff-ctx">
               <span className="sb-dp-diff-sign"> </span>
-              <span className="sb-c-tag">&lt;BookButton</span>{" "}
-              <span className="sb-c-var">flight</span>
-              <span className="sb-c-punc">
-                ={"{"}output{"}"}
-              </span>{" "}
-              <span className="sb-c-tag">/&gt;</span>
+              <span className="sb-dp-diff-line-content">
+                <span className="sb-c-tag">&lt;BookButton</span>{" "}
+                <span className="sb-c-var">flight</span>
+                <span className="sb-c-punc">
+                  ={"{"}output{"}"}
+                </span>{" "}
+                <span className="sb-c-tag">/&gt;</span>
+              </span>
             </div>
           </div>
         </div>
-        <div className="sb-dp-diff-arrow">↓</div>
+        <div className="sb-dp-diff-arrow">
+          <span className="sb-dp-diff-arrow-glyph">↓</span>
+          <span className="sb-dp-diff-arrow-beam" aria-hidden />
+        </div>
         <div className="sb-dp-widget">
+          <div className="sb-dp-widget-flash" aria-hidden />
           <div className="sb-dp-widget-highlight-row">
             <span className="sb-dp-widget-pill">✦ Best fare</span>
             <strong className="sb-dp-widget-price">$891</strong>

--- a/landing/app/skybridge.css
+++ b/landing/app/skybridge.css
@@ -2905,129 +2905,301 @@ body {
 /* --- Tunnel --- */
 .sb-dp-tun {
   display: grid;
-  grid-template-rows: auto 1fr;
-  gap: 16px;
+  grid-template-columns: minmax(0, 1.2fr) 130px minmax(0, 0.95fr);
+  gap: 14px;
+  align-items: center;
 }
-.sb-dp-term {
-  font: 500 12.5px / 1.8 var(--font-mono);
-  color: var(--sb-ink-soft);
-  background: rgba(0, 0, 0, 0.25);
-  border: 1px solid var(--sb-border);
-  border-radius: 10px;
-  padding: 14px 16px;
-}
-.sb-dp-term-h {
-  color: var(--sb-ink);
-  margin-bottom: 4px;
-}
-.sb-dp-term .sb-c-com {
-  color: var(--sb-c-com);
-}
-.sb-dp-url {
-  color: var(--sb-accent);
-  font-weight: 600;
-  margin: 4px 0;
-}
-.sb-dp-tun-diagram {
+
+/* Left: laptop + URL strip */
+.sb-dp-tun-source {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  flex: 1;
-  gap: 0;
+  gap: 12px;
+  min-width: 0;
 }
-.sb-dp-tun-btn {
+.sb-dp-tun-laptop-frame {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+.sb-dp-tun-laptop {
+  border: 1px solid var(--sb-border);
+  border-radius: 10px 10px 2px 2px;
+  background: #0e1c1c;
+  padding: 10px 12px 12px;
+  box-shadow: 0 8px 20px -10px rgba(0, 0, 0, 0.4);
+  position: relative;
+  z-index: 1;
+}
+.sb-dp-tun-laptop-base {
+  margin: 0 -14%;
+  height: 14px;
+  background: linear-gradient(to bottom, #1a3032 0%, #0e1c1c 35%, #050d0d 100%);
+  border: 1px solid var(--sb-border);
+  border-top: none;
+  border-radius: 0 0 12px 12px;
+  position: relative;
+  box-shadow: 0 8px 18px -6px rgba(0, 0, 0, 0.6);
+}
+.sb-dp-tun-laptop-base::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 6%;
+  right: 6%;
+  height: 1px;
+  background: linear-gradient(
+    to right,
+    transparent 0%,
+    rgba(255, 255, 255, 0.1) 50%,
+    transparent 100%
+  );
+}
+.sb-dp-tun-laptop-base::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: 3px;
+  transform: translateX(-50%);
+  width: 38%;
+  height: 3px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 2px;
+}
+.sb-dp-tun-laptop-chrome {
+  display: flex;
+  gap: 5px;
+  padding-bottom: 8px;
+}
+.sb-dp-tun-laptop-chrome span {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--sb-border);
+}
+.sb-dp-tun-laptop-chrome span:nth-child(1) {
+  background: #ff6159;
+}
+.sb-dp-tun-laptop-chrome span:nth-child(2) {
+  background: #ffbd2e;
+}
+.sb-dp-tun-laptop-chrome span:nth-child(3) {
+  background: #27c93f;
+}
+.sb-dp-tun-widget {
+  border: 1px solid var(--sb-border);
+  border-radius: 8px;
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.015);
+}
+.sb-dp-tun-widget-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 10px;
+  font: 600 12.5px / 1.3 var(--font-body);
+  color: var(--sb-ink);
+}
+.sb-dp-tun-widget-row.sub {
+  margin-top: 4px;
+  font: 500 11.5px / 1.3 var(--font-body);
+  color: var(--sb-ink-mute);
+}
+.sb-dp-tun-widget-row strong {
+  color: var(--sb-accent);
+  font-weight: 700;
+}
+.sb-dp-tun-url {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  background: rgba(137, 240, 236, 0.08);
-  border: 1px solid rgba(137, 240, 236, 0.3);
-  border-radius: 8px;
-  padding: 5px 16px;
-  font: 600 11.5px / 1 var(--font-mono);
+  align-self: flex-start;
+  font: 500 11px / 1 var(--font-mono);
   color: var(--sb-accent);
-  letter-spacing: 0.01em;
+  padding: 6px 10px;
+  border: 1px solid var(--sb-border);
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.25);
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
-.sb-dp-tun-btn-dot {
+
+/* Middle: forked path with flowing packets */
+.sb-dp-tun-link {
+  position: relative;
+  width: 130px;
+  height: 220px;
+  justify-self: center;
+}
+.sb-dp-tun-svg {
+  position: absolute;
+  inset: 0;
+  width: 130px;
+  height: 220px;
+  overflow: visible;
+}
+.sb-dp-tun-path {
+  fill: none;
+  stroke: rgba(137, 240, 236, 0.18);
+  stroke-width: 1.2;
+  stroke-dasharray: 3 5;
+  stroke-linecap: round;
+}
+.sb-dp-tun-flow {
+  fill: none;
+  stroke: var(--sb-accent);
+  stroke-width: 1.4;
+  stroke-dasharray: 8 80;
+  stroke-linecap: round;
+  opacity: 0;
+}
+.sb-devpanel-card.sb-dp-tun.is-on .sb-dp-tun-flow {
+  opacity: 0.85;
+  animation: sb-tun-flow 1.4s linear infinite;
+}
+@keyframes sb-tun-flow {
+  to {
+    stroke-dashoffset: -88;
+  }
+}
+
+/* Packet dots — HTML divs riding the path via CSS motion path */
+.sb-dp-tun-packet {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 6px;
+  height: 6px;
+  margin: -3px 0 0 -3px;
+  border-radius: 50%;
+  background: var(--sb-accent);
+  box-shadow:
+    0 0 4px rgba(137, 240, 236, 0.9),
+    0 0 10px rgba(137, 240, 236, 0.4);
+  offset-rotate: 0deg;
+  opacity: 0;
+  pointer-events: none;
+}
+.sb-dp-tun-packet-top {
+  offset-path: path("M 0 110 L 40 110 C 70 110 70 30 130 30");
+}
+.sb-dp-tun-packet-bot {
+  offset-path: path("M 0 110 L 40 110 C 70 110 70 190 130 190");
+}
+.sb-devpanel-card.sb-dp-tun.is-on .sb-dp-tun-packet {
+  animation: sb-tun-packet 1.4s linear infinite;
+}
+.sb-dp-tun-packet-1 {
+  animation-delay: 0s;
+}
+.sb-dp-tun-packet-2 {
+  animation-delay: -0.5s;
+}
+.sb-dp-tun-packet-3 {
+  animation-delay: -0.95s;
+}
+.sb-dp-tun-packet-bot.sb-dp-tun-packet-1 {
+  animation-delay: -0.2s;
+}
+.sb-dp-tun-packet-bot.sb-dp-tun-packet-2 {
+  animation-delay: -0.7s;
+}
+.sb-dp-tun-packet-bot.sb-dp-tun-packet-3 {
+  animation-delay: -1.15s;
+}
+@keyframes sb-tun-packet {
+  0% {
+    offset-distance: 0%;
+    opacity: 0;
+  }
+  10% {
+    opacity: 1;
+  }
+  90% {
+    opacity: 1;
+  }
+  100% {
+    offset-distance: 100%;
+    opacity: 0;
+  }
+}
+
+/* Right: client tiles */
+.sb-dp-tun-clients {
+  display: grid;
+  grid-template-rows: 1fr 1fr;
+  gap: 14px;
+  min-width: 0;
+  align-self: stretch;
+}
+.sb-dp-tun-tile {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  border: 1px solid var(--sb-border);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.025);
+  position: relative;
+}
+.sb-dp-tun-tile img {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  flex: none;
+  object-fit: cover;
+}
+.sb-dp-tun-tile-name {
+  font: 600 14px / 1 var(--font-body);
+  color: var(--sb-ink);
+}
+.sb-dp-tun-tile-dot {
+  position: absolute;
+  top: 12px;
+  right: 14px;
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: var(--sb-accent);
-  opacity: 0.7;
+  background: var(--sb-success);
+  box-shadow: 0 0 6px rgba(108, 217, 169, 0.6);
 }
-.sb-dp-tun-arrows {
-  display: block;
-  margin: 0;
+.sb-devpanel-card.sb-dp-tun.is-on .sb-dp-tun-tile {
+  animation: sb-tun-tile-breathe 1.6s ease-in-out infinite;
 }
-.sb-dp-tun-clients {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 10px;
-  width: 100%;
+.sb-devpanel-card.sb-dp-tun.is-on .sb-dp-tun-tile-claude {
+  animation-delay: -0.8s;
 }
-.sb-dp-tun-client {
-  background: #0e1c1c;
-  border: 1px solid var(--sb-border);
-  border-radius: 10px;
-  overflow: hidden;
+@keyframes sb-tun-tile-breathe {
+  0%,
+  100% {
+    border-color: rgba(137, 240, 236, 0.28);
+    box-shadow: 0 0 0 0 rgba(137, 240, 236, 0);
+  }
+  50% {
+    border-color: rgba(137, 240, 236, 0.55);
+    box-shadow:
+      0 0 0 2px rgba(137, 240, 236, 0.1),
+      0 0 18px rgba(137, 240, 236, 0.18);
+  }
 }
-.sb-dp-tun-client--chatgpt {
-  background: #212121;
-  border-color: rgba(255, 255, 255, 0.1);
+
+/* URL strip pulse — anchors the flow's source */
+.sb-devpanel-card.sb-dp-tun.is-on .sb-dp-tun-url {
+  animation: sb-tun-url-pulse 2s ease-in-out infinite;
 }
-.sb-dp-tun-client--chatgpt .sb-dp-tun-client-chrome {
-  background: #212121;
-  border-bottom-color: rgba(255, 255, 255, 0.08);
-  color: rgba(255, 255, 255, 0.85);
-}
-.sb-dp-tun-client--claude {
-  background: #f8f8f6;
-  border-color: #ededeb;
-}
-.sb-dp-tun-client--claude .sb-dp-tun-client-chrome {
-  background: #f8f8f6;
-  border-bottom-color: #ededeb;
-  color: #3d3929;
-}
-.sb-dp-tun-client--claude .sb-dp-tun-client-chrome svg {
-  color: #da7756;
-}
-.sb-dp-tun-client--claude .sb-dp-tun-used {
-  background: rgba(0, 0, 0, 0.06);
-  color: rgba(0, 0, 0, 0.45);
-}
-.sb-dp-tun-client--claude .sb-dp-tun-used::before {
-  background: #da7756;
-}
-.sb-dp-tun-client-chrome {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 7px 10px;
-  border-bottom: 1px solid var(--sb-border);
-  font: 500 10px / 1 var(--font-body);
-  color: rgba(255, 255, 255, 0.6);
-}
-.sb-dp-tun-client-body {
-  padding: 8px 10px 10px;
-}
-.sb-dp-tun-used {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  background: rgba(255, 255, 255, 0.05);
-  border-radius: 4px;
-  padding: 3px 8px;
-  font: 500 10px / 1 var(--font-body);
-  color: rgba(255, 255, 255, 0.4);
-}
-.sb-dp-tun-used::before {
-  content: "";
-  width: 5px;
-  height: 5px;
-  border-radius: 50%;
-  background: var(--sb-accent);
-  opacity: 0.6;
+@keyframes sb-tun-url-pulse {
+  0%,
+  100% {
+    border-color: var(--sb-border);
+    box-shadow: 0 0 0 0 rgba(137, 240, 236, 0);
+  }
+  50% {
+    border-color: rgba(137, 240, 236, 0.45);
+    box-shadow: 0 0 14px rgba(137, 240, 236, 0.18);
+  }
 }
 
 .sb-devpanel-card.sb-dp-aud {

--- a/landing/app/skybridge.css
+++ b/landing/app/skybridge.css
@@ -3038,22 +3038,22 @@ body {
 .sb-devpanel-card.sb-dp-tun.is-on .sb-dp-tun-packet {
   animation: sb-tun-packet 1.4s linear infinite;
 }
-.sb-dp-tun-packet-1 {
+.sb-devpanel-card.sb-dp-tun.is-on .sb-dp-tun-packet-1 {
   animation-delay: 0s;
 }
-.sb-dp-tun-packet-2 {
+.sb-devpanel-card.sb-dp-tun.is-on .sb-dp-tun-packet-2 {
   animation-delay: -0.5s;
 }
-.sb-dp-tun-packet-3 {
+.sb-devpanel-card.sb-dp-tun.is-on .sb-dp-tun-packet-3 {
   animation-delay: -0.95s;
 }
-.sb-dp-tun-packet-bot.sb-dp-tun-packet-1 {
+.sb-devpanel-card.sb-dp-tun.is-on .sb-dp-tun-packet-bot.sb-dp-tun-packet-1 {
   animation-delay: -0.2s;
 }
-.sb-dp-tun-packet-bot.sb-dp-tun-packet-2 {
+.sb-devpanel-card.sb-dp-tun.is-on .sb-dp-tun-packet-bot.sb-dp-tun-packet-2 {
   animation-delay: -0.7s;
 }
-.sb-dp-tun-packet-bot.sb-dp-tun-packet-3 {
+.sb-devpanel-card.sb-dp-tun.is-on .sb-dp-tun-packet-bot.sb-dp-tun-packet-3 {
   animation-delay: -1.15s;
 }
 @keyframes sb-tun-packet {

--- a/landing/app/skybridge.css
+++ b/landing/app/skybridge.css
@@ -1932,6 +1932,22 @@ body {
     box-shadow: 0 0 0 0 rgba(226, 255, 198, 0);
   }
 }
+.sb-dp-diff-line-content {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  flex-wrap: wrap;
+  position: relative;
+}
+.sb-dp-diff-caret {
+  display: inline-block;
+  width: 1px;
+  height: 1em;
+  margin-left: 2px;
+  background: var(--sb-success);
+  vertical-align: -2px;
+  opacity: 0;
+}
 .sb-dp-toast-t {
   font: 600 11px / 1 var(--font-mono);
   color: var(--sb-lime);
@@ -2012,91 +2028,248 @@ body {
   font-size: 16px;
   color: var(--sb-ink-mute);
   line-height: 1;
+  position: relative;
+  height: 18px;
 }
-.sb-dp-diff-updated {
-  color: var(--sb-success);
+.sb-dp-diff-arrow-glyph {
+  display: inline-block;
+  position: relative;
+  z-index: 1;
+}
+.sb-dp-diff-arrow-beam {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 2px;
+  height: 0;
+  transform: translate(-50%, -50%);
+  background: linear-gradient(
+    to bottom,
+    rgba(108, 217, 169, 0) 0%,
+    rgba(108, 217, 169, 0.85) 50%,
+    rgba(108, 217, 169, 0) 100%
+  );
+  border-radius: 2px;
+  opacity: 0;
+  pointer-events: none;
 }
 
-/* HMR animation sequence — triggered when card is active */
+/* HMR animation sequence — 5s cycle: 4s of action (idle → edit → save → update) then 1s hold */
 @keyframes sb-hmr-del {
   0%,
-  15% {
-    opacity: 0.25;
-    background: transparent;
-  }
-  25%,
-  45% {
+  16% {
     opacity: 1;
-    background: rgba(242, 43, 121, 0.15);
+    background: rgba(242, 43, 121, 0.16);
+    text-decoration: none;
   }
-  60%,
+  28%,
+  80%,
   100% {
-    opacity: 0.35;
-    background: transparent;
+    opacity: 0.55;
+    background: rgba(242, 43, 121, 0.08);
+    text-decoration: line-through;
+    text-decoration-color: rgba(242, 43, 121, 0.6);
   }
 }
 @keyframes sb-hmr-add {
   0%,
-  35% {
-    opacity: 0.25;
-    background: transparent;
+  18% {
+    clip-path: inset(0 100% 0 0);
+    background: rgba(108, 217, 169, 0);
   }
-  50%,
+  32% {
+    clip-path: inset(0 0 0 0);
+    background: rgba(108, 217, 169, 0.16);
+  }
+  46% {
+    clip-path: inset(0 0 0 0);
+    background: rgba(108, 217, 169, 0.22);
+  }
+  58%,
+  80%,
   100% {
-    opacity: 1;
+    clip-path: inset(0 0 0 0);
     background: rgba(108, 217, 169, 0.12);
   }
 }
 @keyframes sb-hmr-ctx {
   0%,
-  40% {
-    opacity: 0.2;
+  20% {
+    opacity: 0.4;
   }
-  55%,
+  36%,
+  80%,
   100% {
-    opacity: 0.5;
+    opacity: 0.6;
   }
 }
-@keyframes sb-hmr-arrow {
+@keyframes sb-hmr-caret {
   0%,
-  50% {
-    opacity: 0.2;
-    transform: translateY(0);
+  16% {
+    opacity: 0;
   }
-  60% {
+  18%,
+  30% {
     opacity: 1;
-    transform: translateY(3px);
   }
-  70%,
+  31%,
+  33% {
+    opacity: 0;
+  }
+  34%,
+  37% {
+    opacity: 1;
+  }
+  38%,
+  80%,
   100% {
-    opacity: 0.5;
-    transform: translateY(0);
+    opacity: 0;
   }
 }
-@keyframes sb-hmr-label {
+@keyframes sb-hmr-arrow-glyph {
   0%,
-  55% {
+  38% {
+    opacity: 0.35;
     color: var(--sb-ink-mute);
+    transform: translateY(0);
   }
-  70%,
-  100% {
+  44% {
+    opacity: 1;
     color: var(--sb-success);
+    transform: translateY(2px);
+    text-shadow: 0 0 8px rgba(108, 217, 169, 0.7);
+  }
+  56%,
+  80%,
+  100% {
+    opacity: 0.5;
+    color: var(--sb-ink-mute);
+    transform: translateY(0);
+    text-shadow: none;
+  }
+}
+@keyframes sb-hmr-arrow-beam {
+  0%,
+  38% {
+    opacity: 0;
+    height: 0;
+  }
+  42% {
+    opacity: 1;
+    height: 26px;
+  }
+  50% {
+    opacity: 0.6;
+    height: 26px;
+  }
+  58%,
+  80%,
+  100% {
+    opacity: 0;
+    height: 0;
+  }
+}
+@keyframes sb-hmr-toast-flash {
+  0%,
+  40% {
+    transform: scale(1);
+    background: var(--sb-lime);
+    box-shadow: 0 0 0 0 rgba(226, 255, 198, 0.4);
+  }
+  45% {
+    transform: scale(1.55);
+    background: #ffffff;
+    box-shadow: 0 0 0 6px rgba(226, 255, 198, 0.35);
+  }
+  56%,
+  80%,
+  100% {
+    transform: scale(1);
+    background: var(--sb-lime);
+    box-shadow: 0 0 0 0 rgba(226, 255, 198, 0);
+  }
+}
+@keyframes sb-hmr-toast-label {
+  0%,
+  40% {
+    color: var(--sb-lime);
+  }
+  45% {
+    color: #ffffff;
+  }
+  56%,
+  80%,
+  100% {
+    color: var(--sb-lime);
+  }
+}
+@keyframes sb-hmr-badge-old {
+  0%,
+  45% {
+    opacity: 1;
+    transform: translateY(0);
+    filter: blur(0);
+  }
+  54%,
+  80%,
+  100% {
+    opacity: 0;
+    transform: translateY(-6px);
+    filter: blur(2px);
+  }
+}
+@keyframes sb-hmr-badge-new {
+  0%,
+  48% {
+    opacity: 0;
+    transform: translateY(6px);
+    filter: blur(2px);
+  }
+  58%,
+  80%,
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+    filter: blur(0);
   }
 }
 @keyframes sb-hmr-widget {
   0%,
-  55% {
+  44% {
     border-color: var(--sb-border);
+    box-shadow: none;
   }
-  65%,
-  75% {
-    border-color: rgba(108, 217, 169, 0.4);
-    box-shadow: 0 0 0 2px rgba(108, 217, 169, 0.08);
+  52% {
+    border-color: rgba(108, 217, 169, 0.55);
+    box-shadow:
+      0 0 0 3px rgba(108, 217, 169, 0.12),
+      0 0 28px rgba(108, 217, 169, 0.22);
   }
-  90%,
+  62% {
+    border-color: rgba(108, 217, 169, 0.35);
+    box-shadow:
+      0 0 0 1px rgba(108, 217, 169, 0.18),
+      0 0 14px rgba(108, 217, 169, 0.12);
+  }
+  74%,
+  80%,
   100% {
     border-color: var(--sb-border);
     box-shadow: none;
+  }
+}
+@keyframes sb-hmr-widget-flash {
+  0%,
+  46% {
+    opacity: 0;
+  }
+  51% {
+    opacity: 1;
+  }
+  62%,
+  80%,
+  100% {
+    opacity: 0;
   }
 }
 
@@ -2136,19 +2309,34 @@ body {
 }
 
 .sb-devpanel-card.sb-dp-hmr.is-on .sb-dp-diff-del {
-  animation: sb-hmr-del 3.5s ease-in-out infinite;
+  animation: sb-hmr-del 5s ease-in-out infinite;
 }
 .sb-devpanel-card.sb-dp-hmr.is-on .sb-dp-diff-add {
-  animation: sb-hmr-add 3.5s ease-in-out infinite;
+  animation: sb-hmr-add 5s ease-in-out infinite;
 }
 .sb-devpanel-card.sb-dp-hmr.is-on .sb-dp-diff-ctx {
-  animation: sb-hmr-ctx 3.5s ease-in-out infinite;
+  animation: sb-hmr-ctx 5s ease-in-out infinite;
 }
-.sb-devpanel-card.sb-dp-hmr.is-on .sb-dp-diff-arrow {
-  animation: sb-hmr-arrow 3.5s ease-in-out infinite;
+.sb-devpanel-card.sb-dp-hmr.is-on .sb-dp-diff-caret {
+  animation: sb-hmr-caret 5s steps(1, end) infinite;
 }
-.sb-devpanel-card.sb-dp-hmr.is-on .sb-dp-diff-updated {
-  animation: sb-hmr-label 3.5s ease-in-out infinite;
+.sb-devpanel-card.sb-dp-hmr.is-on .sb-dp-diff-arrow-glyph {
+  animation: sb-hmr-arrow-glyph 5s ease-in-out infinite;
+}
+.sb-devpanel-card.sb-dp-hmr.is-on .sb-dp-diff-arrow-beam {
+  animation: sb-hmr-arrow-beam 5s ease-in-out infinite;
+}
+.sb-devpanel-card.sb-dp-hmr.is-on .sb-dp-toast-dot {
+  animation: sb-hmr-toast-flash 5s ease-out infinite;
+}
+.sb-devpanel-card.sb-dp-hmr.is-on .sb-dp-toast-t {
+  animation: sb-hmr-toast-label 5s ease-out infinite;
+}
+.sb-devpanel-card.sb-dp-hmr.is-on .sb-dp-widget-badge-old {
+  animation: sb-hmr-badge-old 5s ease-in-out infinite;
+}
+.sb-devpanel-card.sb-dp-hmr.is-on .sb-dp-widget-badge-new {
+  animation: sb-hmr-badge-new 5s ease-in-out infinite;
 }
 .sb-devpanel-card.sb-dp-hmr.is-on .sb-dp-widget-pill {
   animation: sb-hmr-pill 3.5s ease-in-out infinite;
@@ -2160,7 +2348,10 @@ body {
   animation: sb-hmr-btn 3.5s ease-in-out infinite;
 }
 .sb-devpanel-card.sb-dp-hmr.is-on .sb-dp-widget {
-  animation: sb-hmr-widget 3.5s ease-in-out infinite;
+  animation: sb-hmr-widget 5s ease-in-out infinite;
+}
+.sb-devpanel-card.sb-dp-hmr.is-on .sb-dp-widget-flash {
+  animation: sb-hmr-widget-flash 5s ease-out infinite;
 }
 .sb-dp-widget {
   border: 1px solid var(--sb-border);
@@ -2168,6 +2359,40 @@ body {
   padding: 12px 14px;
   background: rgba(255, 255, 255, 0.02);
   align-self: end;
+  position: relative;
+  overflow: hidden;
+}
+.sb-dp-widget-flash {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    circle at 50% 50%,
+    rgba(108, 217, 169, 0.22) 0%,
+    rgba(108, 217, 169, 0) 70%
+  );
+  opacity: 0;
+  pointer-events: none;
+}
+.sb-dp-widget-badge {
+  position: relative;
+  display: inline-block;
+  min-width: 70px;
+  height: 1.3em;
+}
+.sb-dp-widget-badge-old,
+.sb-dp-widget-badge-new {
+  position: absolute;
+  inset: 0;
+  display: inline-block;
+  white-space: nowrap;
+  font-weight: 600;
+}
+.sb-dp-widget-badge-old {
+  color: var(--sb-ink-mute);
+}
+.sb-dp-widget-badge-new {
+  color: var(--sb-success);
+  opacity: 0;
 }
 .sb-dp-widget-row {
   display: flex;

--- a/landing/app/skybridge.css
+++ b/landing/app/skybridge.css
@@ -2203,36 +2203,6 @@ body {
     color: var(--sb-lime);
   }
 }
-@keyframes sb-hmr-badge-old {
-  0%,
-  45% {
-    opacity: 1;
-    transform: translateY(0);
-    filter: blur(0);
-  }
-  54%,
-  80%,
-  100% {
-    opacity: 0;
-    transform: translateY(-6px);
-    filter: blur(2px);
-  }
-}
-@keyframes sb-hmr-badge-new {
-  0%,
-  48% {
-    opacity: 0;
-    transform: translateY(6px);
-    filter: blur(2px);
-  }
-  58%,
-  80%,
-  100% {
-    opacity: 1;
-    transform: translateY(0);
-    filter: blur(0);
-  }
-}
 @keyframes sb-hmr-widget {
   0%,
   44% {
@@ -2275,11 +2245,12 @@ body {
 
 @keyframes sb-hmr-pill {
   0%,
-  52% {
+  36% {
     opacity: 0;
     transform: scale(0.75);
   }
-  62%,
+  44%,
+  80%,
   100% {
     opacity: 1;
     transform: scale(1);
@@ -2287,21 +2258,23 @@ body {
 }
 @keyframes sb-hmr-price {
   0%,
-  52% {
+  36% {
     color: var(--sb-ink);
   }
-  62%,
+  44%,
+  80%,
   100% {
     color: var(--sb-accent);
   }
 }
 @keyframes sb-hmr-btn {
   0%,
-  52% {
+  36% {
     opacity: 0;
     transform: translateY(5px);
   }
-  62%,
+  44%,
+  80%,
   100% {
     opacity: 1;
     transform: translateY(0);
@@ -2332,20 +2305,14 @@ body {
 .sb-devpanel-card.sb-dp-hmr.is-on .sb-dp-toast-t {
   animation: sb-hmr-toast-label 5s ease-out infinite;
 }
-.sb-devpanel-card.sb-dp-hmr.is-on .sb-dp-widget-badge-old {
-  animation: sb-hmr-badge-old 5s ease-in-out infinite;
-}
-.sb-devpanel-card.sb-dp-hmr.is-on .sb-dp-widget-badge-new {
-  animation: sb-hmr-badge-new 5s ease-in-out infinite;
-}
 .sb-devpanel-card.sb-dp-hmr.is-on .sb-dp-widget-pill {
-  animation: sb-hmr-pill 3.5s ease-in-out infinite;
+  animation: sb-hmr-pill 5s ease-in-out infinite;
 }
 .sb-devpanel-card.sb-dp-hmr.is-on .sb-dp-widget-price {
-  animation: sb-hmr-price 3.5s ease-in-out infinite;
+  animation: sb-hmr-price 5s ease-in-out infinite;
 }
 .sb-devpanel-card.sb-dp-hmr.is-on .sb-dp-widget-btn {
-  animation: sb-hmr-btn 3.5s ease-in-out infinite;
+  animation: sb-hmr-btn 5s ease-in-out infinite;
 }
 .sb-devpanel-card.sb-dp-hmr.is-on .sb-dp-widget {
   animation: sb-hmr-widget 5s ease-in-out infinite;
@@ -2372,27 +2339,6 @@ body {
   );
   opacity: 0;
   pointer-events: none;
-}
-.sb-dp-widget-badge {
-  position: relative;
-  display: inline-block;
-  min-width: 70px;
-  height: 1.3em;
-}
-.sb-dp-widget-badge-old,
-.sb-dp-widget-badge-new {
-  position: absolute;
-  inset: 0;
-  display: inline-block;
-  white-space: nowrap;
-  font-weight: 600;
-}
-.sb-dp-widget-badge-old {
-  color: var(--sb-ink-mute);
-}
-.sb-dp-widget-badge-new {
-  color: var(--sb-success);
-  opacity: 0;
 }
 .sb-dp-widget-row {
   display: flex;


### PR DESCRIPTION
Reworked HMR and tunnel animations

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reworks the two animated devtools card demos on the landing page: the HMR card and the tunnel card. The HMR animation cycle is extended from 3.5 s to 5 s with new sub-keyframes for a blinking caret, an arrow beam, a widget flash, and toast dot/label transitions. The tunnel card is replaced entirely — the old terminal + SVG arrows + client card layout is swapped out for a laptop mockup, a forked-path SVG with CSS motion-path packet dots, and icon tiles.

- **HMR card** – all animation selectors updated to 5 s; new elements added to `devtools.tsx` with matching keyframes and rules in `skybridge.css`.
- **Tunnel card** – completely redesigned with a laptop mockup, CSS motion-path packet dots, and `Image`-based client tiles.

<h3>Confidence Score: 4/5</h3>

Safe to merge for most of the rework, but the price badge animation targets DOM structure that was never added to devtools.tsx, so that animation will silently never fire.

The tunnel redesign and HMR timing changes are clean and internally consistent. The badge keyframes and CSS selectors were added to the stylesheet but the corresponding wrapper element was never introduced in devtools.tsx.

landing/app/components/devtools.tsx needs the badge wrapper around sb-dp-widget-price.

<sub>Reviews (4): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/alpic-ai/skybridge/commit/5929999ed8affba64440cb27c425d32ed9153a06) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32798948)</sub>

<!-- /greptile_comment -->