### PR TITLE
Fix landing responsiveness

### DIFF
--- a/landing/app/components/devtools.tsx
+++ b/landing/app/components/devtools.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Icon } from "./icons";
 import { ClaudeStarSVG } from "./showcase/chatgpt-frame";
 
@@ -468,8 +468,53 @@ const VALUES: CodeValue[] = [
 export function DevToolsSection() {
   const [hover, setHover] = useState<string | null>(null);
   const [auditKey, setAuditKey] = useState(0);
+  const sectionRef = useRef<HTMLElement | null>(null);
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const mq = window.matchMedia("(max-width: 900px), (pointer: coarse)");
+    if (!mq.matches) {
+      return;
+    }
+    const node = sectionRef.current;
+    if (!node) {
+      return;
+    }
+    let interval: ReturnType<typeof setInterval> | null = null;
+    let index = 0;
+    const cycle = () => {
+      const value = VALUES[index % VALUES.length];
+      setHover(value.key);
+      if (value.key === "audit") {
+        setAuditKey((k) => k + 1);
+      }
+      index += 1;
+    };
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting && interval === null) {
+            cycle();
+            interval = setInterval(cycle, 2800);
+          } else if (!entry.isIntersecting && interval !== null) {
+            clearInterval(interval);
+            interval = null;
+          }
+        }
+      },
+      { threshold: 0.2 },
+    );
+    io.observe(node);
+    return () => {
+      io.disconnect();
+      if (interval !== null) {
+        clearInterval(interval);
+      }
+    };
+  }, []);
   return (
-    <section className="sb-section" id="integration">
+    <section className="sb-section" id="integration" ref={sectionRef}>
       <div className="sb-wrap">
         <div className="sb-section-header" style={{ maxWidth: "700px" }}>
           <div className="sb-section-eyebrow">DevTools</div>

--- a/landing/app/components/devtools.tsx
+++ b/landing/app/components/devtools.tsx
@@ -474,9 +474,6 @@ export function DevToolsSection() {
       return;
     }
     const mq = window.matchMedia("(max-width: 900px), (pointer: coarse)");
-    if (!mq.matches) {
-      return;
-    }
     const node = sectionRef.current;
     if (!node) {
       return;
@@ -491,26 +488,48 @@ export function DevToolsSection() {
       }
       index += 1;
     };
-    const io = new IntersectionObserver(
-      (entries) => {
-        for (const entry of entries) {
-          if (entry.isIntersecting && interval === null) {
-            cycle();
-            interval = setInterval(cycle, 2800);
-          } else if (!entry.isIntersecting && interval !== null) {
-            clearInterval(interval);
-            interval = null;
+    let io: IntersectionObserver | null = null;
+    const setup = () => {
+      if (!mq.matches || io) {
+        return;
+      }
+      io = new IntersectionObserver(
+        (entries) => {
+          for (const entry of entries) {
+            if (entry.isIntersecting && interval === null) {
+              cycle();
+              interval = setInterval(cycle, 2800);
+            } else if (!entry.isIntersecting && interval !== null) {
+              clearInterval(interval);
+              interval = null;
+            }
           }
-        }
-      },
-      { threshold: 0.2 },
-    );
-    io.observe(node);
-    return () => {
-      io.disconnect();
+        },
+        { threshold: 0.2 },
+      );
+      io.observe(node);
+    };
+    const teardown = () => {
+      io?.disconnect();
+      io = null;
       if (interval !== null) {
         clearInterval(interval);
+        interval = null;
       }
+    };
+    const onChange = (event: MediaQueryListEvent) => {
+      if (event.matches) {
+        setup();
+      } else {
+        teardown();
+        setHover(null);
+      }
+    };
+    mq.addEventListener("change", onChange);
+    setup();
+    return () => {
+      mq.removeEventListener("change", onChange);
+      teardown();
     };
   }, []);
   return (

--- a/landing/app/sb-showcase.css
+++ b/landing/app/sb-showcase.css
@@ -1032,7 +1032,16 @@
 
 @media (max-width: 820px) {
   .sx-submit-split {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .sx-submit-split .sx-submit-col {
+    min-width: 0;
+  }
+  .sx-submit-split .sx-submit-installs {
+    min-width: 0;
+  }
+  .sx-submit-split .sx-submit-installs .sb-install {
+    max-width: 100%;
   }
   .sx-submit-split .sx-submit-col + .sx-submit-col {
     border-left: none;
@@ -1046,7 +1055,8 @@
     padding: 32px 24px;
   }
   .sx-submit-title {
-    font-size: 32px;
+    font-size: 28px;
+    word-break: break-word;
   }
   .sx-submit-lede {
     font-size: 15px;

--- a/landing/app/skybridge.css
+++ b/landing/app/skybridge.css
@@ -243,6 +243,23 @@ body {
   color: var(--sb-ink);
   text-transform: none;
 }
+@media (max-width: 480px) {
+  .sb-nav {
+    padding: 0 8px;
+  }
+  .sb-nav-inner {
+    padding: 4px 6px 4px 8px;
+    height: 56px;
+  }
+  .sb-brand-logo {
+    height: 26px;
+  }
+  .sb-nav-right .sb-btn {
+    height: 30px;
+    padding: 0 8px;
+    font-size: 10.5px;
+  }
+}
 
 /* buttons */
 .sb-btn {
@@ -754,9 +771,16 @@ body {
     flex-direction: column-reverse;
     align-items: stretch;
     flex-wrap: wrap;
+    min-width: 0;
   }
   .sb-cta-installs {
     min-width: 0;
+    max-width: 100%;
+    width: 100%;
+  }
+  .sb-install {
+    max-width: 100%;
+    width: 100%;
   }
 }
 .sb-lede {
@@ -1833,7 +1857,18 @@ body {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 8px;
   }
+  .sb-nav-links {
+    gap: 0;
+  }
+  .sb-nav-links a,
+  .sb-nav-links button {
+    padding: 6px 6px;
+    font-size: 11px;
+  }
+}
+@media (max-width: 360px) {
   .sb-nav-links {
     display: none;
   }
@@ -3127,10 +3162,10 @@ body {
 
 @media (max-width: 900px) {
   .sb-devtools-shot {
-    display: none;
+    min-height: 320px;
   }
-  .sb-devpanel {
-    display: none;
+  .sb-devtools-window {
+    transform-origin: top left;
   }
 }
 
@@ -3284,9 +3319,53 @@ body {
     font-size: 30px;
   }
   .sb-featured {
+    gap: 10px;
+    padding: 6px 14px 6px 6px;
+    font-size: 12px;
+  }
+  .sb-featured-badge {
+    padding: 6px 10px;
+    font-size: 10px;
+    flex: none;
+  }
+  .sb-featured-text {
+    min-width: 0;
+    font-size: 12px;
+    line-height: 1.35;
+  }
+  .sb-featured-arrow {
+    flex: none;
+  }
+  .sb-demo {
+    padding: 16px;
+    min-height: 0;
+    border-radius: 14px;
+  }
+  .sb-footer {
+    padding: 56px 0 48px;
+  }
+  .sb-footer-inner {
+    grid-template-columns: 1fr 1fr;
+    gap: 28px 24px;
+  }
+  .sb-footer-bot {
+    flex-direction: column;
+    gap: 12px;
+    align-items: flex-start;
+    text-align: left;
+  }
+  .sb-final-cta {
     display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+    width: 100%;
+    max-width: 320px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+  .sb-final-cta .sb-btn {
+    justify-content: center;
   }
   .sb-value {
     padding: 36px 28px;
@@ -3297,11 +3376,5 @@ body {
   }
   .sb-final h2 {
     font-size: 34px;
-  }
-  .sb-footer-inner {
-    grid-template-columns: 1fr;
-  }
-  .sb-footer {
-    padding: 60px 0 52px;
   }
 }


### PR DESCRIPTION
Fixed overall responsiveness in the landing page

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves landing page responsiveness across multiple breakpoints by showing the devtools section on mobile (previously hidden) with an auto-cycling `IntersectionObserver` animation, compacting the nav bar at very small widths, and fixing overflow issues in the submit and install sections.

- **`devtools.tsx`**: Adds a `useEffect` that starts an `IntersectionObserver` on mobile/touch viewports to auto-cycle the devtools highlights; the media query change listener correctly handles viewport resizes between desktop and mobile.
- **`sb-showcase.css`**: Fixes the submit split grid at ≤820px with `minmax(0, 1fr)` and `min-width: 0` guards, and reduces the title font size with `word-break: break-word` to prevent overflow.
- **`skybridge.css`**: Adds nav compaction styles at ≤480px, makes `sb-devtools-shot` visible on mobile with `min-height: 320px` and correct `transform-origin`, moves nav-link hiding to ≤360px, and improves footer/final-CTA layout at small breakpoints.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are scoped to CSS layout fixes and a self-contained mobile animation enhancement with correct cleanup.

The devtools animation logic in devtools.tsx correctly sets up and tears down both the IntersectionObserver and the setInterval, and the matchMedia change listener properly handles resize transitions. The CSS changes are additive overflow guards and breakpoint adjustments with no regressions visible in the changed selectors.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["Address Greptile review: respond to view..."](https://github.com/alpic-ai/skybridge/commit/7bd549758f66f25941f3ec13e61590cd204a18c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32798949)</sub>

<!-- /greptile_comment -->