### PR TITLE
chore: bump alpic-ai insights package for all example apps

### DIFF
--- a/examples/auth-auth0/package.json
+++ b/examples/auth-auth0/package.json
@@ -12,7 +12,7 @@
     "deploy": "alpic deploy"
   },
   "dependencies": {
-    "@alpic-ai/insights": "^1.120.1",
+    "@alpic-ai/insights": "^1.127.1",
     "@auth0/auth0-api-js": "^1.4.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.6",

--- a/examples/auth-auth0/src/server.ts
+++ b/examples/auth-auth0/src/server.ts
@@ -1,4 +1,4 @@
-import { userPromptMiddleware } from "@alpic-ai/insights";
+import { intentMiddleware } from "@alpic-ai/insights";
 import { requireBearerAuth } from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js";
 import { mcpAuthMetadataRouter } from "@modelcontextprotocol/sdk/server/auth/router.js";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
@@ -61,7 +61,7 @@ const server = new McpServer(
       requiredScopes: ["openid", "email", "profile"],
     }),
   )
-  .mcpMiddleware(userPromptMiddleware())
+  .mcpMiddleware(intentMiddleware())
   .registerTool(
     {
       name: "search-coffee-paris",

--- a/examples/auth-clerk/package.json
+++ b/examples/auth-clerk/package.json
@@ -12,7 +12,7 @@
     "deploy": "alpic deploy"
   },
   "dependencies": {
-    "@alpic-ai/insights": "^1.120.1",
+    "@alpic-ai/insights": "^1.127.1",
     "@clerk/express": "^2.0.7",
     "@clerk/mcp-tools": "^0.3.1",
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/examples/auth-clerk/src/server.ts
+++ b/examples/auth-clerk/src/server.ts
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import { userPromptMiddleware } from "@alpic-ai/insights";
+import { intentMiddleware } from "@alpic-ai/insights";
 import { clerkMiddleware } from "@clerk/express";
 import {
   mcpAuthClerk,
@@ -33,7 +33,7 @@ const server = new McpServer(
     protectedResourceHandlerClerk({ scopes_supported: ["profile", "email"] }),
   )
   .use("/mcp", mcpAuthClerk)
-  .mcpMiddleware(userPromptMiddleware())
+  .mcpMiddleware(intentMiddleware())
   .registerTool(
     {
       name: "search-coffee-paris",

--- a/examples/auth-stytch/package.json
+++ b/examples/auth-stytch/package.json
@@ -12,7 +12,7 @@
     "deploy": "alpic deploy"
   },
   "dependencies": {
-    "@alpic-ai/insights": "^1.120.1",
+    "@alpic-ai/insights": "^1.127.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.6",
     "dotenv": "^16.5.0",

--- a/examples/auth-stytch/src/server.ts
+++ b/examples/auth-stytch/src/server.ts
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import { userPromptMiddleware } from "@alpic-ai/insights";
+import { intentMiddleware } from "@alpic-ai/insights";
 import { requireBearerAuth } from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import cors from "cors";
@@ -68,7 +68,7 @@ const server = new McpServer(
       resourceMetadataUrl: `${env.SERVER_URL}/.well-known/oauth-protected-resource`,
     }),
   )
-  .mcpMiddleware(userPromptMiddleware())
+  .mcpMiddleware(intentMiddleware())
   .registerTool(
     {
       name: "search-coffee-paris",

--- a/examples/auth-workos/package.json
+++ b/examples/auth-workos/package.json
@@ -12,7 +12,7 @@
     "deploy": "alpic deploy"
   },
   "dependencies": {
-    "@alpic-ai/insights": "^1.120.1",
+    "@alpic-ai/insights": "^1.127.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@workos-inc/node": "^7.72.2",
     "dotenv": "^16.5.0",

--- a/examples/auth-workos/src/server.ts
+++ b/examples/auth-workos/src/server.ts
@@ -1,4 +1,4 @@
-import { userPromptMiddleware } from "@alpic-ai/insights";
+import { intentMiddleware } from "@alpic-ai/insights";
 import { requireBearerAuth } from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js";
 import { mcpAuthMetadataRouter } from "@modelcontextprotocol/sdk/server/auth/router.js";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
@@ -49,7 +49,7 @@ const server = new McpServer(
     }),
   )
   .use("/mcp", requireBearerAuth({ verifier: { verifyAccessToken } }))
-  .mcpMiddleware(userPromptMiddleware())
+  .mcpMiddleware(intentMiddleware())
   .registerTool(
     {
       name: "search-coffee-paris",

--- a/examples/capitals/package.json
+++ b/examples/capitals/package.json
@@ -12,7 +12,7 @@
     "deploy": "alpic deploy"
   },
   "dependencies": {
-    "@alpic-ai/insights": "^1.120.1",
+    "@alpic-ai/insights": "^1.127.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@t3-oss/env-core": "^0.13.8",
     "clsx": "^2.1.1",

--- a/examples/capitals/src/server.ts
+++ b/examples/capitals/src/server.ts
@@ -1,4 +1,4 @@
-import { userPromptMiddleware } from "@alpic-ai/insights";
+import { intentMiddleware } from "@alpic-ai/insights";
 import { type Request, type Response, Router } from "express";
 import { McpServer } from "skybridge/server";
 import * as z from "zod";
@@ -28,7 +28,7 @@ const server = new McpServer(
   },
   { capabilities: {} },
 )
-  .mcpMiddleware(userPromptMiddleware())
+  .mcpMiddleware(intentMiddleware())
   .registerTool(
     {
       name: "explore-capitals",

--- a/examples/ecom-carousel/package.json
+++ b/examples/ecom-carousel/package.json
@@ -12,7 +12,7 @@
     "deploy": "alpic deploy"
   },
   "dependencies": {
-    "@alpic-ai/insights": "^1.120.1",
+    "@alpic-ai/insights": "^1.127.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@t3-oss/env-core": "^0.13.11",
     "dotenv": "^17.4.1",

--- a/examples/ecom-carousel/src/server.ts
+++ b/examples/ecom-carousel/src/server.ts
@@ -1,4 +1,4 @@
-import { userPromptMiddleware } from "@alpic-ai/insights";
+import { intentMiddleware } from "@alpic-ai/insights";
 import { McpServer } from "skybridge/server";
 import { z } from "zod";
 import { products } from "./products.js";
@@ -24,7 +24,7 @@ const server = new McpServer(
   },
   { capabilities: {} },
 )
-  .mcpMiddleware(userPromptMiddleware())
+  .mcpMiddleware(intentMiddleware())
   .registerTool(
     {
       name: "browse-catalog",

--- a/examples/everything/package.json
+++ b/examples/everything/package.json
@@ -12,7 +12,7 @@
     "deploy": "alpic deploy"
   },
   "dependencies": {
-    "@alpic-ai/insights": "^1.120.1",
+    "@alpic-ai/insights": "^1.127.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",

--- a/examples/everything/src/server.ts
+++ b/examples/everything/src/server.ts
@@ -1,4 +1,4 @@
-import { userPromptMiddleware } from "@alpic-ai/insights";
+import { intentMiddleware } from "@alpic-ai/insights";
 import { McpServer } from "skybridge/server";
 import { z } from "zod";
 
@@ -9,7 +9,7 @@ const server = new McpServer(
   },
   { capabilities: {} },
 )
-  .mcpMiddleware(userPromptMiddleware())
+  .mcpMiddleware(intentMiddleware())
   .registerTool(
     {
       name: "show-everything",

--- a/examples/flight-booking/package.json
+++ b/examples/flight-booking/package.json
@@ -12,7 +12,7 @@
     "deploy": "alpic deploy"
   },
   "dependencies": {
-    "@alpic-ai/insights": "^1.120.1",
+    "@alpic-ai/insights": "^1.127.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/examples/flight-booking/src/server.ts
+++ b/examples/flight-booking/src/server.ts
@@ -1,4 +1,4 @@
-import { userPromptMiddleware } from "@alpic-ai/insights";
+import { intentMiddleware } from "@alpic-ai/insights";
 import { McpServer } from "skybridge/server";
 import { z } from "zod";
 import { generateFlights } from "./flights.js";
@@ -17,7 +17,7 @@ const server = new McpServer(
   },
   { capabilities: {} },
 )
-  .mcpMiddleware(userPromptMiddleware())
+  .mcpMiddleware(intentMiddleware())
   .registerTool(
     {
       name: "flight-booking",

--- a/examples/generative-ui/package.json
+++ b/examples/generative-ui/package.json
@@ -12,7 +12,7 @@
     "deploy": "alpic deploy"
   },
   "dependencies": {
-    "@alpic-ai/insights": "^1.120.1",
+    "@alpic-ai/insights": "^1.127.1",
     "@json-render/core": "^0.14.1",
     "@json-render/react": "^0.14.1",
     "@json-render/shadcn": "^0.14.1",

--- a/examples/generative-ui/src/server.ts
+++ b/examples/generative-ui/src/server.ts
@@ -1,4 +1,4 @@
-import { userPromptMiddleware } from "@alpic-ai/insights";
+import { intentMiddleware } from "@alpic-ai/insights";
 import type { Spec } from "@json-render/core";
 import {
   autoFixSpec,
@@ -25,7 +25,7 @@ const server = new McpServer(
   },
   { capabilities: {} },
 )
-  .mcpMiddleware(userPromptMiddleware())
+  .mcpMiddleware(intentMiddleware())
   .registerTool(
     {
       name: "get-ui-catalog",

--- a/examples/investigation-game/package.json
+++ b/examples/investigation-game/package.json
@@ -12,7 +12,7 @@
     "deploy": "alpic deploy"
   },
   "dependencies": {
-    "@alpic-ai/insights": "^1.120.1",
+    "@alpic-ai/insights": "^1.127.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "clsx": "^2.1.1",
     "react": "^19.2.3",

--- a/examples/investigation-game/src/server.ts
+++ b/examples/investigation-game/src/server.ts
@@ -1,4 +1,4 @@
-import { userPromptMiddleware } from "@alpic-ai/insights";
+import { intentMiddleware } from "@alpic-ai/insights";
 import { McpServer } from "skybridge/server";
 
 const server = new McpServer(
@@ -8,7 +8,7 @@ const server = new McpServer(
   },
   { capabilities: {} },
 )
-  .mcpMiddleware(userPromptMiddleware())
+  .mcpMiddleware(intentMiddleware())
   .registerTool(
     {
       name: "murder-in-the-valley",

--- a/examples/manifest-ui/package.json
+++ b/examples/manifest-ui/package.json
@@ -12,7 +12,7 @@
     "deploy": "alpic deploy"
   },
   "dependencies": {
-    "@alpic-ai/insights": "^1.120.1",
+    "@alpic-ai/insights": "^1.127.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@radix-ui/react-slot": "^1.2.4",
     "@tailwindcss/vite": "^4.1.18",

--- a/examples/manifest-ui/src/server.ts
+++ b/examples/manifest-ui/src/server.ts
@@ -1,4 +1,4 @@
-import { userPromptMiddleware } from "@alpic-ai/insights";
+import { intentMiddleware } from "@alpic-ai/insights";
 import { McpServer } from "skybridge/server";
 import { z } from "zod";
 
@@ -9,7 +9,7 @@ const server = new McpServer(
   },
   { capabilities: {} },
 )
-  .mcpMiddleware(userPromptMiddleware())
+  .mcpMiddleware(intentMiddleware())
   .registerTool(
     {
       name: "hello-world",

--- a/examples/productivity/package.json
+++ b/examples/productivity/package.json
@@ -12,7 +12,7 @@
     "deploy": "alpic deploy"
   },
   "dependencies": {
-    "@alpic-ai/insights": "^1.120.1",
+    "@alpic-ai/insights": "^1.127.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",

--- a/examples/productivity/src/server.ts
+++ b/examples/productivity/src/server.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { userPromptMiddleware } from "@alpic-ai/insights";
+import { intentMiddleware } from "@alpic-ai/insights";
 import { McpServer } from "skybridge/server";
 import { z } from "zod";
 
@@ -27,8 +27,8 @@ function getWeeks(weekOffset: number, duration: number): Week {
       const total = weeks.reduce(
         (sum, week) =>
           sum +
-          (week.days[dayIndex].activities.find((a) => a.type === type)
-            ?.hours ?? 0),
+          (week.days[dayIndex].activities.find((a) => a.type === type)?.hours ??
+            0),
         0,
       );
       return { type, hours: Math.round(total / duration) };
@@ -41,8 +41,7 @@ function getWeeks(weekOffset: number, duration: number): Week {
   const activities: Activity[] = ActivityTypes.map((type) => ({
     type,
     hours: days.reduce(
-      (sum, d) =>
-        sum + (d.activities.find((a) => a.type === type)?.hours ?? 0),
+      (sum, d) => sum + (d.activities.find((a) => a.type === type)?.hours ?? 0),
       0,
     ),
   }));
@@ -88,7 +87,7 @@ const server = new McpServer(
   },
   { capabilities: {} },
 )
-  .mcpMiddleware(userPromptMiddleware())
+  .mcpMiddleware(intentMiddleware())
   .registerTool(
     {
       name: "show-productivity-insights",

--- a/examples/times-up/package.json
+++ b/examples/times-up/package.json
@@ -12,7 +12,7 @@
     "deploy": "alpic deploy"
   },
   "dependencies": {
-    "@alpic-ai/insights": "^1.120.1",
+    "@alpic-ai/insights": "^1.127.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@openai/apps-sdk-ui": "^0.2.1",
     "react": "^19.2.4",

--- a/examples/times-up/src/server.ts
+++ b/examples/times-up/src/server.ts
@@ -1,4 +1,4 @@
-import { userPromptMiddleware } from "@alpic-ai/insights";
+import { intentMiddleware } from "@alpic-ai/insights";
 import { McpServer } from "skybridge/server";
 import { z } from "zod";
 import { drawCard, getCard } from "./cards.js";
@@ -19,7 +19,7 @@ const server = new McpServer(
 - Always keep the tone energetic and encouraging—never silently invoke a tool or leave the user waiting without a spoken response.`,
   },
 )
-  .mcpMiddleware(userPromptMiddleware())
+  .mcpMiddleware(intentMiddleware())
   .registerTool(
     {
       name: "play",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
   examples/auth-auth0:
     dependencies:
       '@alpic-ai/insights':
-        specifier: ^1.120.1
-        version: 1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
+        specifier: ^1.127.1
+        version: 1.127.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
       '@auth0/auth0-api-js':
         specifier: ^1.4.0
         version: 1.4.0
@@ -121,8 +121,8 @@ importers:
   examples/auth-clerk:
     dependencies:
       '@alpic-ai/insights':
-        specifier: ^1.120.1
-        version: 1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
+        specifier: ^1.127.1
+        version: 1.127.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
       '@clerk/express':
         specifier: ^2.0.7
         version: 2.0.7(express@5.2.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -185,8 +185,8 @@ importers:
   examples/auth-stytch:
     dependencies:
       '@alpic-ai/insights':
-        specifier: ^1.120.1
-        version: 1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
+        specifier: ^1.127.1
+        version: 1.127.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
@@ -252,8 +252,8 @@ importers:
   examples/auth-workos:
     dependencies:
       '@alpic-ai/insights':
-        specifier: ^1.120.1
-        version: 1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
+        specifier: ^1.127.1
+        version: 1.127.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
@@ -316,8 +316,8 @@ importers:
   examples/capitals:
     dependencies:
       '@alpic-ai/insights':
-        specifier: ^1.120.1
-        version: 1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
+        specifier: ^1.127.1
+        version: 1.127.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
@@ -407,8 +407,8 @@ importers:
   examples/ecom-carousel:
     dependencies:
       '@alpic-ai/insights':
-        specifier: ^1.120.1
-        version: 1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.5))(skybridge@packages+core)
+        specifier: ^1.127.1
+        version: 1.127.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.5))(skybridge@packages+core)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.5)
@@ -465,8 +465,8 @@ importers:
   examples/everything:
     dependencies:
       '@alpic-ai/insights':
-        specifier: ^1.120.1
-        version: 1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.5))(skybridge@packages+core)
+        specifier: ^1.127.1
+        version: 1.127.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.5))(skybridge@packages+core)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.5)
@@ -514,8 +514,8 @@ importers:
   examples/flight-booking:
     dependencies:
       '@alpic-ai/insights':
-        specifier: ^1.120.1
-        version: 1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
+        specifier: ^1.127.1
+        version: 1.127.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
@@ -563,8 +563,8 @@ importers:
   examples/generative-ui:
     dependencies:
       '@alpic-ai/insights':
-        specifier: ^1.120.1
-        version: 1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
+        specifier: ^1.127.1
+        version: 1.127.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
       '@json-render/core':
         specifier: ^0.14.1
         version: 0.14.1(zod@4.3.6)
@@ -627,8 +627,8 @@ importers:
   examples/investigation-game:
     dependencies:
       '@alpic-ai/insights':
-        specifier: ^1.120.1
-        version: 1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
+        specifier: ^1.127.1
+        version: 1.127.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
@@ -691,8 +691,8 @@ importers:
   examples/manifest-ui:
     dependencies:
       '@alpic-ai/insights':
-        specifier: ^1.120.1
-        version: 1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
+        specifier: ^1.127.1
+        version: 1.127.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
@@ -767,8 +767,8 @@ importers:
   examples/productivity:
     dependencies:
       '@alpic-ai/insights':
-        specifier: ^1.120.1
-        version: 1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.5))(skybridge@packages+core)
+        specifier: ^1.127.1
+        version: 1.127.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.5))(skybridge@packages+core)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.5)
@@ -816,8 +816,8 @@ importers:
   examples/times-up:
     dependencies:
       '@alpic-ai/insights':
-        specifier: ^1.120.1
-        version: 1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
+        specifier: ^1.127.1
+        version: 1.127.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
@@ -1296,8 +1296,8 @@ packages:
   '@alpic-ai/api@1.104.1':
     resolution: {integrity: sha512-HNN+CblD+cefHelMk5NZMAOAJ1V0B3/ubDC6T+xxAQrrd3NeQj3U1q4XijynmIamgWYYDEVXUld8LgriqwdeMw==}
 
-  '@alpic-ai/insights@1.122.1':
-    resolution: {integrity: sha512-Mac+UjnpsemaNCioTOkF4NpYc8h2R4gxHO7OKEvM9MtiL1QnbbTSUMmEKIjqfe86xnjur76A0/7+RYuydXoJ6g==}
+  '@alpic-ai/insights@1.127.1':
+    resolution: {integrity: sha512-VLeva10Ft30MeQhZnGTBbyU8rXp2I3Oqpv9gfyEUIbmu6k4lkGcAnpE834rJ7RI0/yT8JHTW5a21MrloUzj5tQ==}
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.29.0 <2'
       skybridge: workspace:*
@@ -10080,13 +10080,13 @@ snapshots:
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
-  '@alpic-ai/insights@1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.5))(skybridge@packages+core)':
+  '@alpic-ai/insights@1.127.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.5))(skybridge@packages+core)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.5)
     optionalDependencies:
       skybridge: link:packages/core
 
-  '@alpic-ai/insights@1.122.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)':
+  '@alpic-ai/insights@1.127.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
     optionalDependencies:


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps `@alpic-ai/insights` from `^1.120.1` to `^1.127.1` across all 13 example apps and updates the API call-site to match the renamed export in the new version.

- All `package.json` files are updated to `^1.127.1`, and the lock file resolves to `1.127.1` for every workspace, replacing the previously pinned `1.122.1`.
- Every `server.ts` import and usage of `userPromptMiddleware` is renamed to `intentMiddleware`, which is the new export name introduced in `1.127.1`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a mechanical rename applied consistently across all 13 example apps with no logic alterations.

Every import and usage of userPromptMiddleware is replaced by intentMiddleware in lock-step with the version bump, and the lock file resolves the new version correctly for all workspaces. The only other diff in productivity/src/server.ts is a pure whitespace/line-wrapping reformat with no semantic change. Nothing in the changed files touches auth logic, data handling, or runtime behaviour.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["chore: bump alpic-ai insights package fo..."](https://github.com/alpic-ai/skybridge/commit/bbef16b63015f933e9299c049ca8c3419c381d15) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32817070)</sub>

<!-- /greptile_comment -->