### PR TITLE
feat: add client hints to tool extra type

### DIFF
--- a/docs/api-reference/register-tool.mdx
+++ b/docs/api-reference/register-tool.mdx
@@ -90,6 +90,68 @@ The `extra` parameter exposes:
 - `extra.authInfo` — populated by auth middleware (e.g. `authInfo.clientId`, `authInfo.extra.email`)
 - `extra.requestInfo` — HTTP request details (headers, URL)
 - `extra.signal` — abort signal for cancellation
+- `extra._meta` — client-supplied hints injected by the host (see [Client hints on `_meta`](#client-hints-on-meta))
+
+### Client hints on `_meta`
+
+ChatGPT may inject context about the current conversation in tool calls. Skybridge types these fields on `extra._meta` so you can use them in the handler:
+
+```typescript
+type ClientHintsMeta = {
+  // Requested locale (BCP-47, e.g. "en-US")
+  "openai/locale"?: string;
+  // Browser user-agent string of the ChatGPT client
+  "openai/userAgent"?: string;
+  // Coarse user location
+  "openai/userLocation"?: {
+    city?: string;
+    region?: string;
+    country?: string;
+    timezone?: string;
+    longitude?: number;
+    latitude?: number;
+  };
+  // Anonymized user id (for rate limiting / identification)
+  "openai/subject"?: string;
+  // Anonymized conversation id, stable within a ChatGPT session
+  "openai/session"?: string;
+  // Anonymized organization id, when the user account is part of an organization
+  "openai/organization"?: string;
+  // Stable id for the currently mounted widget instance
+  "openai/widgetSessionId"?: string;
+};
+```
+
+```typescript
+server.registerTool(
+  {
+    name: "weather",
+    description: "Show weather for a location.",
+    inputSchema: { city: z.string().optional() },
+  },
+  async ({ city }, extra) => {
+    // Fall back to the user's current city when they didn't specify one.
+    const target =
+      city ?? extra._meta?.["openai/userLocation"]?.city ?? "Paris";
+    // Imperial for en-US, metric everywhere else.
+    const locale = extra._meta?.["openai/locale"] ?? "en-US";
+    const units = locale === "en-US" ? "imperial" : "metric";
+
+    const weather = await fetchWeather(target, units);
+    return {
+      content: `${target}: ${weather.temperature}° ${weather.conditions}`,
+    };
+  },
+);
+```
+
+<Info>
+**ChatGPT only.** These hints are injected by the OpenAI Apps SDK runtime. MCP Apps hosts do not send them on tool calls. As a fallback, use [`useUser` (/api-reference/use-user) to get session context from the view.
+</Info>
+
+<Warning>
+These are **hints**. Never use them for authorization, and tolerate their absence.
+</Warning>
 
 ## Response Fields
 

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -20,6 +20,7 @@ import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/proto
 import type {
   ContentBlock,
   Implementation,
+  RequestMeta,
   ServerNotification,
   ServerRequest,
   ServerResult,
@@ -255,12 +256,49 @@ interface ToolConfig<TInput extends ZodRawShapeCompat | AnySchema> {
   _meta?: ToolMeta;
 }
 
+/**
+ * Optional client-supplied hints attached to `params._meta` on every tool call
+ * by the Apps SDK host. Hints only: never use for authorization, and tolerate
+ * absence.
+ * @see https://developers.openai.com/apps-sdk/reference#_meta-fields-the-client-provides
+ */
+export interface ClientHintsMeta {
+  /** Requested locale (BCP-47, e.g. `"en-US"`). */
+  "openai/locale"?: string;
+  /** Browser user-agent */
+  "openai/userAgent"?: string;
+  /** Coarse user location. May be partially populated. */
+  "openai/userLocation"?: {
+    city?: string;
+    region?: string;
+    country?: string;
+    timezone?: string;
+    longitude?: number;
+    latitude?: number;
+  };
+  /** Anonymized user id. */
+  "openai/subject"?: string;
+  /** Anonymized conversation id, stable within a ChatGPT session. */
+  "openai/session"?: string;
+  /** Anonymized organization id, when the user account is part of an organization. */
+  "openai/organization"?: string;
+  /** Stable id for the currently mounted widget instance. */
+  "openai/widgetSessionId"?: string;
+}
+
+type ToolHandlerExtra = Omit<
+  RequestHandlerExtra<ServerRequest, ServerNotification>,
+  "_meta"
+> & {
+  _meta?: RequestMeta & ClientHintsMeta;
+};
+
 type ToolHandler<
   TInput extends ZodRawShapeCompat,
   TReturn extends { content?: HandlerContent } = { content?: HandlerContent },
 > = (
   args: ShapeOutput<TInput>,
-  extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
+  extra: ToolHandlerExtra,
 ) => TReturn | Promise<TReturn>;
 
 type ErrorMiddlewareConfig = {


### PR DESCRIPTION
those are injected by openai in tool calls _meta

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds typed support for OpenAI Apps SDK client hints that are injected into `params._meta` on tool calls by the ChatGPT host. The implementation introduces a `ClientHintsMeta` interface and a `ToolHandlerExtra` type that replaces the bare `RequestMeta` on `_meta` with `RequestMeta & ClientHintsMeta`, giving tool handlers first-class typed access to fields like `openai/locale` and `openai/userLocation`.

- `packages/core/src/server/server.ts`: exports `ClientHintsMeta`; defines `ToolHandlerExtra` (using `Omit` + intersection) and wires it into `ToolHandler`. Change is purely additive and backward-compatible.
- `docs/api-reference/register-tool.mdx`: adds a \"Client hints on `_meta`\" section with a type listing, a worked weather-tool example, and appropriate \"hints only / not for auth\" warnings. Contains one broken Markdown link in the `<Info>` callout.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive type-only on the server side and backward-compatible with all existing tool handlers.

The TypeScript change only widens the type of extra._meta for tool handlers; no runtime behavior is altered. All new ClientHintsMeta fields are optional, and the intersection with RequestMeta is structurally valid. The only defect is a cosmetic broken link in docs.

No files require special attention beyond the broken link in docs/api-reference/register-tool.mdx.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
docs/api-reference/register-tool.mdx:149
The Markdown link syntax is broken here. There is a space between the link text and the URL, so the closing backtick and the opening parenthesis are separated — this renders as literal text rather than a clickable hyperlink.

```suggestion
**ChatGPT only.** These hints are injected by the OpenAI Apps SDK runtime. MCP Apps hosts do not send them on tool calls. As a fallback, use [`useUser`](/api-reference/use-user) to get session context from the view.
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["feat: add doc"](https://github.com/alpic-ai/skybridge/commit/9977ea1a929ad0bd05b25ee2079222766fccdb9c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32818177)</sub>

<!-- /greptile_comment -->