### PR TITLE
feat: support mixed auth

### DIFF
--- a/docs/api-reference/mcp-server.mdx
+++ b/docs/api-reference/mcp-server.mdx
@@ -244,17 +244,119 @@ const server = new McpServer({ name: "my-app", version: "1.0" }, {})
 export type AppType = typeof server;
 ```
 
+## Auth middlewares
+
+### requireBearerAuth
+
+Middleware that requires a valid Bearer token on every request. Use this when every tool needs sign-in.
+
+```typescript
+import { requireBearerAuth } from "skybridge/server";
+
+server.use(
+  "/mcp",
+  requireBearerAuth({ verifier: { verifyAccessToken } }),
+);
+```
+- **Valid Bearer token**: the request goes through, `authInfo` can be access in handler `extra` argument.
+- **Missing / invalid / expired tokens**: returns a 401 (with `WWW-Authenticate`),insufficient scopes get a 403.
+
+### optionalBearerAuth
+
+Middleware that validates a Bearer token when present, and lets requests through unauthenticated when no `Authorization` header is sent. Pair with per-tool [`securitySchemes`](/api-reference/register-tool#securityschemes) for mixed-auth servers.
+
+```typescript
+import { optionalBearerAuth } from "skybridge/server";
+
+server.use(
+  "/mcp",
+  optionalBearerAuth({
+    verifier: { verifyAccessToken },
+  }),
+);
+```
+
+Behavior:
+
+- **No `Authorization` header**: the request goes through and the downstream handler decides whether to reject based on its own `securitySchemes`.
+- **Valid Bearer token**: the request goes through, `authInfo` can be access in handler `extra` argument.
+- **Missing / invalid / expired tokens**: returns a 401 (with `WWW-Authenticate`),insufficient scopes get a 403.
+
+Takes the same [Options](#options) as `requireBearerAuth`.
+
+### Options
+
+Both helpers accept the same `BearerAuthMiddlewareOptions`:
+
+```typescript
+type BearerAuthMiddlewareOptions = {
+  verifier: OAuthTokenVerifier;
+  requiredScopes?: string[];
+  resourceMetadataUrl?: string;
+};
+```
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `verifier` | `OAuthTokenVerifier` | Yes | The provider-specific token check. See [Verifier](#verifier) for the contract. |
+| `requiredScopes` | `string[]` | No | Server-wide scope floor: every accepted token must include all listed scopes, or the request is rejected with 403 `InsufficientScopeError`. Per-tool [`securitySchemes`](/api-reference/register-tool#securityschemes) enforcement layers on top of this. For `optionalBearerAuth`, this is only checked when a token is actually sent. |
+| `resourceMetadataUrl` | `string` | No | Absolute URL to your OAuth 2.0 [Protected Resource Metadata](https://datatracker.ietf.org/doc/html/rfc9728) document. When set, it's appended to the `WWW-Authenticate` header on 401 responses so clients can discover the authorization server programmatically. |
+
+### Verifier
+
+Both `requireBearerAuth` and `optionalBearerAuth` accept a `verifier` whose only required method is `verifyAccessToken(token: string): Promise<AuthInfo>`. This is the provider-specific piece you have to write.
+
+Contract:
+
+- **Resolve** with an `AuthInfo` describing the validated token. The middleware sets it so tool handlers receive it in `extra.authInfo`.
+- **Throw** `InvalidTokenError` to reject the token because of malformed, bad signature, expired, or any failed claim check (issuer, audience, etc.). The middleware returns a 401 with the right `WWW-Authenticate` header.
+
+You don't need to check scopes in the verifier: the middleware enforces `requiredScopes` against `authInfo.scopes` automatically and returns 403 if a scope is missing.
+
+Required fields on `AuthInfo`:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `token` | `string` | The raw bearer token  |
+| `clientId` | `string` | OAuth `client_id` (often the `azp` or `client_id` claim). |
+| `scopes` | `string[]` | Scopes granted to the token. Checked by middleware `requiredScopes` and by per-tool [`securitySchemes`](/api-reference/register-tool#securityschemes) checks. |
+| `expiresAt` | `number` | Unix seconds. **Required**: `requireBearerAuth` rejects tokens with no expiration. |
+| `extra` | `Record<string, unknown>` | Optional: anything else you want available in handlers (e.g. `sub`, `email`). |
+
+```typescript
+import { type AuthInfo, InvalidTokenError } from "skybridge/server";
+
+async function verifyAccessToken(token: string): Promise<AuthInfo> {
+  // 1. Verify signature / introspect / call your provider.
+  // 2. Throw `InvalidTokenError` on failure — never return null/undefined.
+  // 3. Return the AuthInfo shape below.
+  if (!isValid(token)) {
+    throw new InvalidTokenError("Token is not valid");
+  }
+  return {
+    token,
+    clientId: "client_abc",
+    scopes: ["openid", "profile"],
+    expiresAt: 1700000000,
+    extra: { sub: "user_123" },
+  };
+}
+```
+
 ## Exported Types
 
 The following middleware types are available from `skybridge/server`:
 
 ```typescript
 import type {
+  AuthInfo,
+  BearerAuthMiddlewareOptions,
   McpExtra,
   McpMiddlewareFn,
   McpMiddlewareFilter,
   McpTypedMiddlewareFn,
   McpMethodString,
+  SecurityScheme,
 } from "skybridge/server";
 ```
 

--- a/docs/api-reference/mcp-server.mdx
+++ b/docs/api-reference/mcp-server.mdx
@@ -258,8 +258,8 @@ server.use(
   requireBearerAuth({ verifier: { verifyAccessToken } }),
 );
 ```
-- **Valid Bearer token**: the request goes through, `authInfo` can be access in handler `extra` argument.
-- **Missing / invalid / expired tokens**: returns a 401 (with `WWW-Authenticate`),insufficient scopes get a 403.
+- **Valid Bearer token**: the request goes through, `authInfo` can be accessed in handler `extra` argument.
+- **Missing / invalid / expired tokens**: returns a 401 (with `WWW-Authenticate`), insufficient scopes get a 403.
 
 ### optionalBearerAuth
 
@@ -279,8 +279,8 @@ server.use(
 Behavior:
 
 - **No `Authorization` header**: the request goes through and the downstream handler decides whether to reject based on its own `securitySchemes`.
-- **Valid Bearer token**: the request goes through, `authInfo` can be access in handler `extra` argument.
-- **Missing / invalid / expired tokens**: returns a 401 (with `WWW-Authenticate`),insufficient scopes get a 403.
+- **Valid Bearer token**: the request goes through, `authInfo` can be accessed in handler `extra` argument.
+- **Missing / invalid / expired tokens**: returns a 401 (with `WWW-Authenticate`), insufficient scopes get a 403.
 
 Takes the same [Options](#options) as `requireBearerAuth`.
 
@@ -327,19 +327,22 @@ Required fields on `AuthInfo`:
 import { type AuthInfo, InvalidTokenError } from "skybridge/server";
 
 async function verifyAccessToken(token: string): Promise<AuthInfo> {
-  // 1. Verify signature / introspect / call your provider.
-  // 2. Throw `InvalidTokenError` on failure — never return null/undefined.
-  // 3. Return the AuthInfo shape below.
-  if (!isValid(token)) {
-    throw new InvalidTokenError("Token is not valid");
+  try {
+    // Validate with your provider (JWT verification, introspection, etc.).
+    const payload = await validateToken(token);
+
+    return {
+      token,
+      clientId: payload.client_id,
+      scopes: payload.scope.split(" "),
+      expiresAt: payload.exp,
+      extra: { sub: payload.sub },
+    };
+  } catch (err) {
+    throw new InvalidTokenError(
+      err instanceof Error ? err.message : "Token validation failed",
+    );
   }
-  return {
-    token,
-    clientId: "client_abc",
-    scopes: ["openid", "profile"],
-    expiresAt: 1700000000,
-    extra: { sub: "user_123" },
-  };
 }
 ```
 

--- a/docs/api-reference/register-tool.mdx
+++ b/docs/api-reference/register-tool.mdx
@@ -26,6 +26,7 @@ type ToolConfig = {
   outputSchema?: ZodRawShape;// Output type hints (Zod)
   annotations?: ToolAnnotations;
   view?: ViewConfig;         // ← present = view-tool, absent = plain tool
+  securitySchemes?: SecurityScheme[]; // Declare per-tool auth requirements
   _meta?: ToolMeta;
 };
 
@@ -38,8 +39,14 @@ type ToolMeta = {
   "openai/fileParams"?: string[]; // List of top-level input fields that references files.
   // Controls whether a tool is available to the model, the UI (app), or both.
   ui?: { visibility?: Array<"model" | "app"> };
+  // Mirror of ToolConfig.securitySchemes
+  securitySchemes?: SecurityScheme[];
   [key: string]: unknown;
 };
+
+type SecurityScheme =
+  | { type: "noauth" }
+  | { type: "oauth2"; scopes?: string[] };
 ```
 
 <Note>
@@ -70,6 +77,92 @@ type ViewConfig = {
 ```
 
 See [CSP & Domains](#csp--domains) below.
+
+### `securitySchemes`
+
+Declare which auth schemes this tool supports so clients can label it as public vs. requires-sign-in *before* invocation, and request the right OAuth scopes during sign-in.
+
+```typescript
+type SecurityScheme =
+  | { type: "noauth" }
+  | { type: "oauth2"; scopes?: string[] };
+```
+
+- **Across the array: match ANY.** Each entry is an alternative. The request is authorized if any one scheme is satisfied.
+- **Within an `oauth2` entry's `scopes`: match ALL.** The validated token must carry every listed scope.
+- **Listing `noauth` + `oauth2`** means "works anonymously, but auth gives more features."
+
+<Warning>
+This field is client-facing metadata. **Servers must still enforce auth on each call** — verify `extra.authInfo` and check `authInfo.scopes` in the handler (or use a tool-call middleware). The declaration is not self-enforcing.
+</Warning>
+
+#### Examples
+
+Protected tool:
+
+```typescript
+const SEARCH_SCOPES = ["search.read"];
+
+server.registerTool(
+  {
+    name: "search-private-docs",
+    description: "Search documents in the user's workspace.",
+    inputSchema: { q: z.string() },
+    securitySchemes: [{ type: "oauth2", scopes: SEARCH_SCOPES }],
+  },
+  async ({ q }, extra) => {
+    if (!extra.authInfo) {
+      return { content: "Sign in required.", isError: true };
+    }
+    const missing = SEARCH_SCOPES.filter(
+      (s) => !extra.authInfo!.scopes.includes(s),
+    );
+    if (missing.length > 0) {
+      return {
+        content: `Missing scope(s): ${missing.join(", ")}.`,
+        isError: true,
+      };
+    }
+    return { content: await search(q) };
+  },
+);
+```
+
+Public tool:
+
+```typescript
+server.registerTool(
+  {
+    name: "search-public-docs",
+    description: "Search public documents — no sign-in required.",
+    inputSchema: { q: z.string() },
+    securitySchemes: [{ type: "noauth" }],
+  },
+  async ({ q }) => ({ content: await search(q) }),
+);
+```
+
+Anonymous OR authenticated (single tool, different behavior):
+
+```typescript
+server.registerTool(
+  {
+    name: "search",
+    description: "Search docs. Authenticated users see their private workspace too.",
+    inputSchema: { q: z.string() },
+    securitySchemes: [
+      { type: "noauth" },
+      { type: "oauth2", scopes: ["search.read"] },
+    ],
+  },
+  async ({ q }, extra) => {
+    const includePrivate = !!extra.authInfo;
+    return { content: await search(q, { includePrivate }) };
+  },
+);
+```
+
+For the transport-level middleware that pairs with mixed-auth tools, see [`optionalBearerAuth`](/api-reference/mcp-server#optionalbearerauth).
 
 ## Handler
 

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -1,0 +1,39 @@
+import {
+  type BearerAuthMiddlewareOptions,
+  requireBearerAuth,
+} from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js";
+
+import type { RequestHandler } from "express";
+
+export { InvalidTokenError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
+export {
+  type BearerAuthMiddlewareOptions,
+  requireBearerAuth,
+} from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js";
+export type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+
+/**
+ * Like `requireBearerAuth`, but lets requests through when no
+ * `Authorization` header is present. Used for mixed-auth servers where some
+ * tools are public and others require sign-in: each tool enforces its own
+ * `securitySchemes` against `extra.authInfo`.
+ *
+ * Behavior:
+ * - No `Authorization` header → `next()` without `req.auth`.
+ * - Valid Bearer token → `req.auth` set, same as `requireBearerAuth`.
+ * - Invalid / malformed / expired / insufficient-scope → same error response
+ *   as `requireBearerAuth` (401/403). Sending a bad token is still a client
+ *   error.
+ */
+export function optionalBearerAuth(
+  options: BearerAuthMiddlewareOptions,
+): RequestHandler {
+  const required = requireBearerAuth(options);
+  return (req, res, next) => {
+    if (!req.headers.authorization) {
+      next();
+      return;
+    }
+    return required(req, res, next);
+  };
+}

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -1,4 +1,11 @@
 export {
+  type AuthInfo,
+  type BearerAuthMiddlewareOptions,
+  InvalidTokenError,
+  optionalBearerAuth,
+  requireBearerAuth,
+} from "./auth.js";
+export {
   audio,
   embeddedResource,
   image,
@@ -27,6 +34,7 @@ export type {
   HandlerContent,
   KnownToolMeta,
   McpServerTypes,
+  SecurityScheme,
   ToolDef,
   ToolMeta,
   ViewConfig,

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -101,12 +101,17 @@ export interface ViewConfig {
   _meta?: Record<string, unknown>;
 }
 
+export type SecurityScheme =
+  | { type: "noauth" }
+  | { type: "oauth2"; scopes?: string[] };
+
 export interface KnownToolMeta {
   "openai/widgetAccessible"?: boolean;
   "openai/toolInvocation/invoking"?: string;
   "openai/toolInvocation/invoked"?: string;
   "openai/fileParams"?: string[];
   ui?: Pick<McpUiToolMeta, "visibility">;
+  securitySchemes?: SecurityScheme[];
 }
 
 export type ToolMeta = KnownToolMeta & Record<string, unknown>;
@@ -139,7 +144,13 @@ type McpAppsToolMeta = {
   ui: McpUiToolMeta;
 };
 
-type InternalToolMeta = Partial<OpenaiToolMeta & McpAppsToolMeta>;
+type SecuritySchemesToolMeta = {
+  securitySchemes: SecurityScheme[];
+};
+
+type InternalToolMeta = Partial<
+  OpenaiToolMeta & McpAppsToolMeta & SecuritySchemesToolMeta
+>;
 
 /** @see https://developers.openai.com/apps-sdk/reference#component-resource-_meta-fields */
 type OpenaiViewCSP = {
@@ -252,6 +263,14 @@ interface ToolConfig<TInput extends ZodRawShapeCompat | AnySchema> {
   outputSchema?: ZodRawShapeCompat | AnySchema;
   annotations?: ToolAnnotations;
   view?: ViewConfig;
+  /**
+   * Declares which auth schemes this tool supports (e.g. `noauth`, `oauth2`).
+   * Lets clients label tools that require sign-in before calling, and pass
+   * the right scopes through the OAuth flow. Listing both `noauth` and
+   * `oauth2` signals that the tool works for anonymous callers and gives
+   * enhanced behavior to authenticated ones.
+   */
+  securitySchemes?: SecurityScheme[];
   _meta?: ToolMeta;
 }
 
@@ -923,9 +942,24 @@ export class McpServer<
     const config = args[0] as ToolConfig<ZodRawShapeCompat>;
     const cb = args[1] as ToolHandler<ZodRawShapeCompat>;
 
-    const { name, view, _meta: userToolMeta, ...toolFields } = config;
+    const {
+      name,
+      view,
+      securitySchemes,
+      _meta: userToolMeta,
+      ...toolFields
+    } = config;
 
     const toolMeta: InternalToolMeta = { ...userToolMeta };
+
+    if (securitySchemes) {
+      // SEP-1488 puts `securitySchemes` at the top level of the tool
+      // descriptor, but the SDK's `registerTool` drops unknown top-level
+      // fields, so the canonical spot isn't reachable without intercepting
+      // `tools/list`. Use the `_meta` back-compat mirror documented in the
+      // Apps SDK reference until SEP-1488 lands in the spec.
+      toolMeta.securitySchemes = securitySchemes;
+    }
 
     if (view) {
       this.enforceOneToolPerView(view.component, name);


### PR DESCRIPTION
By adding a new optionalBearerAuth middleware and securitySchemes to registerTool args. Those are mirrored in tool meta for clients to know which tool need auth or not. Then it's up to the user to actually check auth in the handler. Also reworked the types a bit so user don't have to pull stuff from the mcp package in addition of skybridge. And added a bunch of doc to explicit auth (mixed or not) work.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an `optionalBearerAuth` Express middleware for mixed-auth MCP servers and a `securitySchemes` field on `registerTool` so clients can discover per-tool auth requirements before invocation. It also re-exports `AuthInfo`, `InvalidTokenError`, and related types from `skybridge/server` to eliminate the need for users to import directly from the MCP SDK.

- **`optionalBearerAuth`** (`packages/core/src/server/auth.ts`): skips auth when no `Authorization` header is present and delegates to `requireBearerAuth` otherwise — implementation is straightforward and correct.
- **`securitySchemes`** (`packages/core/src/server/server.ts`): stored in `_meta` as a back-compat mirror until the upstream spec lands support for top-level tool fields; merge logic correctly preserves other user-supplied `_meta` fields.
- **Docs** (`mcp-server.mdx`, `register-tool.mdx`): comprehensive reference for both middlewares and the new `securitySchemes` config, including three worked handler examples.

<h3>Confidence Score: 5/5</h3>

The auth implementation is correct and the new field wires cleanly into the existing meta-merge path. Safe to merge.

All logic changes are well-scoped: `optionalBearerAuth` is a thin wrapper around the existing `requireBearerAuth` with a single early-exit guard, and `securitySchemes` is stored only as client-facing metadata with no enforcement side-effects. No runtime behaviour in the auth path is altered. The one issue found is a contradictory word ("Missing") in a docs bullet that could confuse readers but has no effect on the code.

No files require special attention beyond the minor wording fix in `docs/api-reference/mcp-server.mdx`.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
docs/api-reference/mcp-server.mdx:283-285
The word "Missing" in the third bullet contradicts the first bullet above it. For `optionalBearerAuth`, a missing `Authorization` header is explicitly supposed to pass through (bullet 1), so including "Missing" in the 401-path bullet tells readers two opposite things about the same case. Only invalid/expired/malformed tokens that are actually present should trigger a 401 here.

```suggestion
- **Invalid / expired tokens**: returns a 401 (with `WWW-Authenticate`), insufficient scopes get a 403.

Takes the same [Options](#options) as `requireBearerAuth`.
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: review"](https://github.com/alpic-ai/skybridge/commit/49438a7089de3f1e89ce6c52dfbde9d0acaaf192) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33196663)</sub>

<!-- /greptile_comment -->