### PR TITLE
feat: add useDownload

### DIFF
--- a/docs/api-reference/use-download.mdx
+++ b/docs/api-reference/use-download.mdx
@@ -1,0 +1,109 @@
+---
+title: useDownload
+description: "Trigger file downloads from a view."
+tag: "MCP Apps"
+---
+
+Views run in sandboxed iframes where direct downloads (`<a download>`, `URL.createObjectURL`) are blocked. The `useDownload` hook returns a `download` function that asks the host to save one or more files to the user's filesystem. The host shows a confirmation dialog before initiating the download.
+
+<Note>
+    This hook is not available Apps SDK. Calling `download` from ChatGPT will return `{ isError: true }`
+</Note>
+
+## Basic usage
+
+```tsx
+import { useDownload } from "skybridge/web";
+
+function ExportButton({ rows }: { rows: Row[] }) {
+  const { download } = useDownload();
+
+  const handleClick = async () => {
+    const csv = rows.map((r) => `${r.id},${r.name}`).join("\n");
+    const { isError } = await download({
+      contents: [
+        {
+          type: "resource",
+          resource: {
+            uri: "file:///orders.csv",
+            mimeType: "text/csv",
+            text: csv,
+          },
+        },
+      ],
+    });
+    if (isError) {
+      // user cancelled, host denied or not supported
+    }
+  };
+
+  return <button onClick={handleClick}>Export CSV</button>;
+}
+```
+
+## Returns
+
+```tsx
+{ download: (params: DownloadParams) => Promise<DownloadResult> }
+```
+
+### `DownloadParams`
+
+- `contents: (EmbeddedResource | ResourceLink)[]`: one or more resources to download.
+
+### `DownloadResult`
+
+- `isError?: boolean` = `true` if the user cancelled or the host denied. Transport errors (timeout, lost connection) throw an exception.
+
+## Resource shapes
+
+### Inline text — `EmbeddedResource`
+
+For content generated in the view (CSV, JSON, markdown):
+
+```tsx
+{
+  type: "resource",
+  resource: {
+    uri: "file:///export.json",      // filename hint (last path segment)
+    mimeType: "application/json",
+    text: JSON.stringify(data, null, 2),
+  },
+}
+```
+
+### Inline binary — `EmbeddedResource`
+
+For binary data, pass base64 in `blob`:
+
+```tsx
+{
+  type: "resource",
+  resource: {
+    uri: "file:///chart.png",
+    mimeType: "image/png",
+    blob: base64EncodedPng,
+  },
+}
+```
+
+### Resource link — `ResourceLink`
+
+When the file already lives on a server, let the host fetch it directly:
+
+```tsx
+{
+  type: "resource_link",
+  uri: "https://api.example.com/reports/q4.pdf",
+  name: "Q4 Report",
+  mimeType: "application/pdf",
+}
+```
+
+<Note>`resource_link`is not supported by Claude.</Note>
+
+## Notes
+
+- **Must be user-initiated** (button click, menu action). Hosts will reject calls fired from effects on mount.
+- The `uri` is a **filename hint**: the host derives the suggested save name from the last path segment.
+- For large binary content (more than a few hundred KB), prefer `resource_link` over inlining base64.

--- a/docs/api-reference/use-download.mdx
+++ b/docs/api-reference/use-download.mdx
@@ -7,7 +7,7 @@ tag: "MCP Apps"
 Views run in sandboxed iframes where direct downloads (`<a download>`, `URL.createObjectURL`) are blocked. The `useDownload` hook returns a `download` function that asks the host to save one or more files to the user's filesystem. The host shows a confirmation dialog before initiating the download.
 
 <Note>
-    This hook is not available Apps SDK. Calling `download` from ChatGPT will return `{ isError: true }`
+    This hook is not available on the Apps SDK. Calling `download` from ChatGPT will return `{ isError: true }`
 </Note>
 
 ## Basic usage
@@ -100,7 +100,7 @@ When the file already lives on a server, let the host fetch it directly:
 }
 ```
 
-<Note>`resource_link`is not supported by Claude.</Note>
+<Note>`resource_link` is not supported by Claude.</Note>
 
 ## Notes
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -103,10 +103,7 @@
           {
             "group": "Server",
             "icon": "server",
-            "pages": [
-              "api-reference/mcp-server",
-              "api-reference/register-tool"
-            ]
+            "pages": ["api-reference/mcp-server", "api-reference/register-tool"]
           },
           {
             "group": "Hooks",
@@ -124,7 +121,8 @@
               "api-reference/use-request-modal",
               "api-reference/use-request-close",
               "api-reference/use-request-size",
-              "api-reference/use-files"
+              "api-reference/use-files",
+              "api-reference/use-download"
             ]
           },
           {
@@ -139,7 +137,10 @@
           {
             "group": "Types",
             "icon": "brackets-curly",
-            "pages": ["api-reference/infer-utility-types", "api-reference/file-ref"]
+            "pages": [
+              "api-reference/infer-utility-types",
+              "api-reference/file-ref"
+            ]
           },
           {
             "group": "Advanced",
@@ -157,10 +158,7 @@
           "examples",
           {
             "group": "Basic",
-            "pages": [
-              "examples/starter",
-              "examples/everything"
-            ]
+            "pages": ["examples/starter", "examples/everything"]
           },
           {
             "group": "Use cases",
@@ -184,10 +182,7 @@
           },
           {
             "group": "UI and Component libraries",
-            "pages": [
-              "examples/manifest-ui",
-              "examples/generative-ui"
-            ]
+            "pages": ["examples/manifest-ui", "examples/generative-ui"]
           }
         ]
       }

--- a/packages/core/src/web/bridges/apps-sdk/adaptor.ts
+++ b/packages/core/src/web/bridges/apps-sdk/adaptor.ts
@@ -1,6 +1,7 @@
 import type {
   Adaptor,
   CallToolResponse,
+  DownloadResult,
   FileMetadata,
   HostContext,
   HostContextStore,
@@ -95,6 +96,11 @@ export class AppsSdkAdaptor implements Adaptor {
       prompt,
       scrollToBottom: options?.scrollToBottom,
     });
+  };
+
+  public download = async (): Promise<DownloadResult> => {
+    console.error("[skybridge] download: not supported on Apps SDK");
+    return { isError: true };
   };
 
   public openExternal(href: string, options: OpenExternalOptions = {}): void {

--- a/packages/core/src/web/bridges/apps-sdk/adaptor.ts
+++ b/packages/core/src/web/bridges/apps-sdk/adaptor.ts
@@ -1,6 +1,7 @@
 import type {
   Adaptor,
   CallToolResponse,
+  DownloadParams,
   DownloadResult,
   FileMetadata,
   HostContext,
@@ -98,7 +99,9 @@ export class AppsSdkAdaptor implements Adaptor {
     });
   };
 
-  public download = async (): Promise<DownloadResult> => {
+  public download = async (
+    _params: DownloadParams,
+  ): Promise<DownloadResult> => {
     console.error("[skybridge] download: not supported on Apps SDK");
     return { isError: true };
   };

--- a/packages/core/src/web/bridges/mcp-app/adaptor.ts
+++ b/packages/core/src/web/bridges/mcp-app/adaptor.ts
@@ -2,6 +2,8 @@ import { dequal } from "dequal/lite";
 import type {
   Adaptor,
   CallToolResponse,
+  DownloadParams,
+  DownloadResult,
   HostContext,
   HostContextStore,
   OpenExternalOptions,
@@ -118,6 +120,17 @@ export class McpAppAdaptor implements Adaptor {
         },
       ],
     });
+  };
+
+  public download = async (params: DownloadParams): Promise<DownloadResult> => {
+    const app = await McpAppBridge.getInstance().getApp();
+    if (!app.getHostCapabilities()?.downloadFile) {
+      console.error(
+        "[skybridge] download: host does not support ui/download-file",
+      );
+      return { isError: true };
+    }
+    return app.downloadFile(params);
   };
 
   public openExternal(href: string, options?: OpenExternalOptions): void {

--- a/packages/core/src/web/bridges/types.ts
+++ b/packages/core/src/web/bridges/types.ts
@@ -1,4 +1,8 @@
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type {
+  CallToolResult,
+  EmbeddedResource,
+  ResourceLink,
+} from "@modelcontextprotocol/sdk/types.js";
 import type { useSyncExternalStore } from "react";
 import type { ViewHostType } from "../../server/index.js";
 
@@ -112,6 +116,14 @@ export type RequestSizeOptions = {
   height?: number;
 };
 
+export type DownloadParams = {
+  contents: (EmbeddedResource | ResourceLink)[];
+};
+
+export type DownloadResult = {
+  isError?: boolean;
+};
+
 export interface Adaptor {
   getHostContextStore<K extends keyof HostContext>(key: K): HostContextStore<K>;
   callTool<
@@ -128,6 +140,7 @@ export interface Adaptor {
     options?: SendFollowUpMessageOptions,
   ): Promise<void>;
   openExternal(href: string, options?: OpenExternalOptions): void;
+  download(params: DownloadParams): Promise<DownloadResult>;
   setViewState(stateOrUpdater: SetViewStateAction): Promise<void>;
   uploadFile(file: File, options?: UploadFileOptions): Promise<FileMetadata>;
   getFileDownloadUrl(file: FileMetadata): Promise<{ downloadUrl: string }>;

--- a/packages/core/src/web/hooks/index.ts
+++ b/packages/core/src/web/hooks/index.ts
@@ -6,6 +6,7 @@ export {
   useCallTool,
 } from "./use-call-tool.js";
 export { useDisplayMode } from "./use-display-mode.js";
+export { type DownloadFn, useDownload } from "./use-download.js";
 export { useFiles } from "./use-files.js";
 export { type LayoutState, useLayout } from "./use-layout.js";
 export { type OpenExternalFn, useOpenExternal } from "./use-open-external.js";

--- a/packages/core/src/web/hooks/test/utils.ts
+++ b/packages/core/src/web/hooks/test/utils.ts
@@ -1,4 +1,6 @@
 import type {
+  McpUiDownloadFileResult,
+  McpUiHostCapabilities,
   McpUiHostContext,
   McpUiInitializeResult,
   McpUiToolInputNotification,
@@ -16,8 +18,14 @@ export class MockResizeObserver {
 
 const DEFAULT_CONTEXT: McpUiHostContext = {};
 
+export type McpAppHostMockOptions = {
+  hostCapabilities?: McpUiHostCapabilities;
+  downloadFileResult?: McpUiDownloadFileResult;
+};
+
 export const getMcpAppHostPostMessageMock = (
   initialContext: McpUiHostContext = DEFAULT_CONTEXT,
+  options: McpAppHostMockOptions = {},
 ) =>
   vi.fn((message: { method: string; id: number }) => {
     switch (message.method) {
@@ -25,7 +33,7 @@ export const getMcpAppHostPostMessageMock = (
         const result: McpUiInitializeResult = {
           protocolVersion: "2025-06-18",
           hostInfo: { name: "test-host", version: "1.0.0" },
-          hostCapabilities: {},
+          hostCapabilities: options.hostCapabilities ?? {},
           hostContext: initialContext,
         };
         act(() =>
@@ -62,6 +70,26 @@ export const getMcpAppHostPostMessageMock = (
                 },
               },
             ),
+          ),
+        );
+        break;
+      }
+      case "ui/download-file": {
+        act(() =>
+          fireEvent(
+            window,
+            new MessageEvent<{
+              jsonrpc: "2.0";
+              id: number;
+              result: McpUiDownloadFileResult;
+            }>("message", {
+              source: window.parent,
+              data: {
+                jsonrpc: "2.0",
+                id: message.id,
+                result: options.downloadFileResult ?? {},
+              },
+            }),
           ),
         );
         break;

--- a/packages/core/src/web/hooks/use-download.test.ts
+++ b/packages/core/src/web/hooks/use-download.test.ts
@@ -1,0 +1,132 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppsSdkAdaptor } from "../bridges/apps-sdk/adaptor.js";
+import { McpAppBridge } from "../bridges/mcp-app/bridge.js";
+import type { DownloadParams } from "../bridges/types.js";
+import {
+  getMcpAppHostPostMessageMock,
+  MockResizeObserver,
+} from "./test/utils.js";
+import { useDownload } from "./use-download.js";
+
+const params: DownloadParams = {
+  contents: [
+    {
+      type: "resource",
+      resource: {
+        uri: "file:///export.json",
+        mimeType: "application/json",
+        text: '{"hello":"world"}',
+      },
+    },
+  ],
+};
+
+describe("useDownload", () => {
+  describe("apps-sdk host", () => {
+    beforeEach(() => {
+      vi.stubGlobal("openai", {});
+      vi.stubGlobal("skybridge", { hostType: "apps-sdk" });
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      vi.resetAllMocks();
+      AppsSdkAdaptor.resetInstance();
+    });
+
+    it("returns { isError: true } and logs an error", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const { result } = renderHook(() => useDownload());
+
+      const res = await result.current.download(params);
+
+      expect(res).toEqual({ isError: true });
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("not supported on Apps SDK"),
+      );
+    });
+  });
+
+  describe("mcp-app host without downloadFile capability", () => {
+    beforeEach(() => {
+      vi.stubGlobal("skybridge", { hostType: "mcp-app" });
+      vi.stubGlobal("ResizeObserver", MockResizeObserver);
+      vi.stubGlobal("parent", { postMessage: getMcpAppHostPostMessageMock() });
+    });
+
+    afterEach(async () => {
+      vi.unstubAllGlobals();
+      vi.resetAllMocks();
+      McpAppBridge.resetInstance();
+    });
+
+    it("returns { isError: true } and logs an error", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const { result } = renderHook(() => useDownload());
+
+      const res = await result.current.download(params);
+
+      expect(res).toEqual({ isError: true });
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("does not support ui/download-file"),
+      );
+    });
+  });
+
+  describe("mcp-app host with downloadFile capability", () => {
+    let postMessageMock: ReturnType<typeof getMcpAppHostPostMessageMock>;
+
+    beforeEach(() => {
+      vi.stubGlobal("skybridge", { hostType: "mcp-app" });
+      vi.stubGlobal("ResizeObserver", MockResizeObserver);
+      postMessageMock = getMcpAppHostPostMessageMock(
+        {},
+        { hostCapabilities: { downloadFile: {} } },
+      );
+      vi.stubGlobal("parent", { postMessage: postMessageMock });
+    });
+
+    afterEach(async () => {
+      vi.unstubAllGlobals();
+      vi.resetAllMocks();
+      McpAppBridge.resetInstance();
+    });
+
+    it("sends ui/download-file with the provided contents", async () => {
+      const { result } = renderHook(() => useDownload());
+
+      const res = await result.current.download(params);
+
+      expect(res).toEqual({});
+      await waitFor(() => {
+        expect(postMessageMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            jsonrpc: "2.0",
+            method: "ui/download-file",
+            params,
+          }),
+          "*",
+        );
+      });
+    });
+
+    it("returns { isError: true } when the host denies the request", async () => {
+      McpAppBridge.resetInstance();
+      postMessageMock = getMcpAppHostPostMessageMock(
+        {},
+        {
+          hostCapabilities: { downloadFile: {} },
+          downloadFileResult: { isError: true },
+        },
+      );
+      vi.stubGlobal("parent", { postMessage: postMessageMock });
+
+      const { result } = renderHook(() => useDownload());
+
+      const res = await result.current.download(params);
+
+      expect(res).toEqual({ isError: true });
+    });
+  });
+});

--- a/packages/core/src/web/hooks/use-download.ts
+++ b/packages/core/src/web/hooks/use-download.ts
@@ -1,0 +1,15 @@
+import { useCallback } from "react";
+import { getAdaptor } from "../bridges/index.js";
+import type { DownloadParams, DownloadResult } from "../bridges/types.js";
+
+export type DownloadFn = (params: DownloadParams) => Promise<DownloadResult>;
+
+export function useDownload(): { download: DownloadFn } {
+  const adaptor = getAdaptor();
+  const download = useCallback<DownloadFn>(
+    (params) => adaptor.download(params),
+    [adaptor],
+  );
+
+  return { download };
+}

--- a/skills/chatgpt-app-builder/references/download-file.md
+++ b/skills/chatgpt-app-builder/references/download-file.md
@@ -1,0 +1,77 @@
+# Download file
+
+Save content to the user's filesystem → `useDownload`
+
+Views run in sandboxed iframes where `<a download>` and `URL.createObjectURL` are blocked. `useDownload` asks the host to perform the save; the host shows a confirmation dialog first.
+
+> MCP Apps only. On ChatGPT (Apps SDK), use `useFiles` to work with attachments instead.
+
+## Inline text (CSV, JSON, markdown)
+
+```tsx
+import { useDownload } from "skybridge/web";
+
+function ExportButton({ rows }: { rows: Row[] }) {
+  const { download } = useDownload();
+
+  const handleClick = async () => {
+    const csv = rows.map((r) => `${r.id},${r.name}`).join("\n");
+    const { isError } = await download({
+      contents: [
+        {
+          type: "resource",
+          resource: {
+            uri: "file:///orders.csv", // filename hint
+            mimeType: "text/csv",
+            text: csv,
+          },
+        },
+      ],
+    });
+    if (isError) {
+      // user cancelled or host denied — soft fail, not an exception
+    }
+  };
+
+  return <button onClick={handleClick}>Export CSV</button>;
+}
+```
+
+## Inline binary
+
+```tsx
+await download({
+  contents: [
+    {
+      type: "resource",
+      resource: {
+        uri: "file:///chart.png",
+        mimeType: "image/png",
+        blob: base64EncodedPng,
+      },
+    },
+  ],
+});
+```
+
+## Resource link (host fetches)
+
+```tsx
+await download({
+  contents: [
+    {
+      type: "resource_link",
+      uri: "https://api.example.com/reports/q4.pdf",
+      name: "Q4 Report",
+      mimeType: "application/pdf",
+    },
+  ],
+});
+```
+
+## Notes
+
+- Must be user-initiated (button/menu click). Calls from mount effects will be rejected.
+- The `uri` is a filename hint; the host derives the suggested save name from the last path segment.
+- `isError: true` is a soft signal (user cancelled / host denied). Transport errors throw.
+- For binary content above a few hundred KB, prefer `resource_link` over inline base64.

--- a/skills/mcp-app-builder/SKILL.md
+++ b/skills/mcp-app-builder/SKILL.md
@@ -34,6 +34,7 @@ Design or evolve UX flows and API shape → [architecture.md](references/archite
 - **Prompt LLM** → [prompt-llm.md](references/prompt-llm.md): when view needs to trigger LLM response
 - **UI guidelines** → [ui-guidelines.md](references/ui-guidelines.md): display modes, layout constraints, theme, device, and locale
 - **External links** → [open-external-links.md](references/open-external-links.md): when redirecting to external URLs or setting "open in app" target
+- **Download file** → [download-file.md](references/download-file.md): when saving content to the user's filesystem
 - **OAuth** → [oauth.md](references/oauth.md): when tools need user authentication to access user-specific data
 - **CSP** → [csp.md](references/csp.md): when declaring allowed domains for fetch, assets, redirects, or iframes
 

--- a/skills/skybridge/SKILL.md
+++ b/skills/skybridge/SKILL.md
@@ -34,6 +34,7 @@ Design or evolve UX flows and API shape → [architecture.md](references/archite
 - **Prompt LLM** → [prompt-llm.md](references/prompt-llm.md): when view needs to trigger LLM response
 - **UI guidelines** → [ui-guidelines.md](references/ui-guidelines.md): display modes, layout constraints, theme, device, and locale
 - **External links** → [open-external-links.md](references/open-external-links.md): when redirecting to external URLs or setting "open in app" target
+- **Download file** → [download-file.md](references/download-file.md): when saving content to the user's filesystem
 - **OAuth** → [oauth.md](references/oauth.md): when tools need user authentication to access user-specific data
 - **CSP** → [csp.md](references/csp.md): when declaring allowed domains for fetch, assets, redirects, or iframes
 


### PR DESCRIPTION
views can't trigger downloads themselves: sandboxed iframes block `<a download>` and blob URLs, so today there's no way to save a CSV/PDF/etc from a view. adds `useDownload`, backed by the MCP App `ui/download-file` spec method. host shows a save dialog and writes the file. supports inline text, inline blob (base64), and resource links (host fetches large files directly).

different from useFiles which handle ChatGPT's attachment store (cf doc)