### PR TITLE
fix(create-skybridge): make demo template pass MCP extended apps checks

### DIFF
--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -370,6 +370,10 @@ export class McpServer<
   private mcpMiddlewareEntries: McpMiddlewareEntry[] = [];
   private mcpMiddlewareApplied = false;
   private claimedViews = new Map<string, string>();
+  private viewMetaBuilders = new Map<
+    string,
+    (extra: McpExtra | undefined) => ResourceMeta
+  >();
   private viteManifest: Record<string, ViteManifestEntry> | null = null;
   private readonly serverInfo: Implementation;
   private readonly serverOptions?: ServerOptions;
@@ -498,10 +502,35 @@ export class McpServer<
     }
     this.mcpMiddlewareApplied = true;
 
+    // Surface view-resource _meta on `resources/list` (per ext-apps spec:
+    // hosts/checkers read CSP & domain at list time before fetching content).
+    const viewListMetaEntry: McpMiddlewareEntry = {
+      filter: "resources/list",
+      handler: async (_req, extra, next) => {
+        const result = (await next()) as {
+          resources: Array<Record<string, unknown> & { uri: string }>;
+        };
+        for (const resource of result.resources) {
+          const builder = this.viewMetaBuilders.get(resource.uri);
+          if (!builder) {
+            continue;
+          }
+          const meta = builder(extra);
+          resource._meta = {
+            ...((resource._meta as Record<string, unknown>) ?? {}),
+            ...meta,
+          };
+        }
+        return result;
+      },
+    };
+
     const monitoringEntry = createMiddlewareEntry();
-    const entries = monitoringEntry
-      ? [monitoringEntry, ...this.mcpMiddlewareEntries]
-      : this.mcpMiddlewareEntries;
+    const entries = [
+      ...(monitoringEntry ? [monitoringEntry] : []),
+      viewListMetaEntry,
+      ...this.mcpMiddlewareEntries,
+    ];
 
     if (entries.length === 0) {
       return;
@@ -629,6 +658,65 @@ export class McpServer<
       );
     }
     this.claimedViews.set(component, toolName);
+  }
+
+  private resolveViewRequestContext(extra: McpExtra | undefined): {
+    serverUrl: string;
+    connectDomains: string[];
+    contentMetaOverrides: { domain?: string };
+  } {
+    const isProduction = process.env.NODE_ENV === "production";
+    const headers = extra?.requestInfo?.headers || {};
+    const header = (key: string) => {
+      const val = headers[key];
+      return Array.isArray(val) ? val[0] : val;
+    };
+    const isClaude = header("user-agent") === "Claude-User";
+
+    let serverUrl: string;
+    const forwardedHost = header("x-forwarded-host");
+    const origin = header("origin");
+    const host = header("host");
+
+    if (forwardedHost) {
+      const proto = header("x-forwarded-proto") || "https";
+      serverUrl = `${proto}://${forwardedHost}`;
+    } else if (origin) {
+      serverUrl = origin;
+    } else if (host) {
+      const proto = ["127.0.0.1:", "localhost:"].some((p) => host.startsWith(p))
+        ? "http"
+        : "https";
+      serverUrl = `${proto}://${host}`;
+    } else {
+      const devPort = process.env.__PORT || "3000";
+      serverUrl = `http://localhost:${devPort}`;
+    }
+
+    const connectDomains = [serverUrl];
+    if (!isProduction) {
+      const wsUrl = new URL(serverUrl);
+      wsUrl.protocol = wsUrl.protocol === "https:" ? "wss:" : "ws:";
+      connectDomains.push(wsUrl.origin);
+    }
+
+    let contentMetaOverrides: { domain?: string } = {};
+    if (isClaude) {
+      const pathname = extra?.requestInfo?.url?.pathname ?? "";
+      const rawUrl =
+        header("x-alpic-forwarded-url") ?? `${serverUrl}${pathname}`;
+      // Strip a lone trailing slash so the hash matches the connector URL
+      // as registered with Claude (which has no trailing slash on bare origins).
+      const url = rawUrl.endsWith("/") ? rawUrl.slice(0, -1) : rawUrl;
+      const hash = crypto
+        .createHash("sha256")
+        .update(url)
+        .digest("hex")
+        .slice(0, 32);
+      contentMetaOverrides = { domain: `${hash}.claudemcpcontent.com` };
+    }
+
+    return { serverUrl, connectDomains, contentMetaOverrides };
   }
 
   private registerViewResources(
@@ -777,43 +865,28 @@ export class McpServer<
   }): void {
     const { hostType, uri: viewUri, mimeType, buildContentMeta } = viewResource;
 
+    const buildMeta = (extra: McpExtra | undefined): ResourceMeta => {
+      const { serverUrl, connectDomains, contentMetaOverrides } =
+        this.resolveViewRequestContext(extra);
+      return buildContentMeta(
+        {
+          resourceDomains: [serverUrl],
+          connectDomains,
+          domain: serverUrl,
+          baseUriDomains: [serverUrl],
+        },
+        contentMetaOverrides,
+      );
+    };
+    this.viewMetaBuilders.set(viewUri, buildMeta);
+
     this.registerResource(
       name,
       viewUri,
       { description: view.description },
       async (uri, extra) => {
         const isProduction = process.env.NODE_ENV === "production";
-        const isClaude =
-          extra?.requestInfo?.headers?.["user-agent"] === "Claude-User";
-
-        const headers = extra?.requestInfo?.headers || {};
-        const header = (key: string) => {
-          const val = headers[key];
-          return Array.isArray(val) ? val[0] : val;
-        };
-
-        let serverUrl: string;
-
-        const forwardedHost = header("x-forwarded-host");
-        const origin = header("origin");
-        const host = header("host");
-
-        if (forwardedHost) {
-          const proto = header("x-forwarded-proto") || "https";
-          serverUrl = `${proto}://${forwardedHost}`;
-        } else if (origin) {
-          serverUrl = origin;
-        } else if (host) {
-          const proto = ["127.0.0.1:", "localhost:"].some((p) =>
-            host.startsWith(p),
-          )
-            ? "http"
-            : "https";
-          serverUrl = `${proto}://${host}`;
-        } else {
-          const devPort = process.env.__PORT || "3000";
-          serverUrl = `http://localhost:${devPort}`;
-        }
+        const { serverUrl } = this.resolveViewRequestContext(extra);
 
         const html = isProduction
           ? templateHelper.renderProduction({
@@ -828,42 +901,9 @@ export class McpServer<
               viewName: view.component,
             });
 
-        const connectDomains = [serverUrl];
-        if (!isProduction) {
-          const wsUrl = new URL(serverUrl);
-          wsUrl.protocol = wsUrl.protocol === "https:" ? "wss:" : "ws:";
-          connectDomains.push(wsUrl.origin);
-        }
-
-        let contentMetaOverrides: { domain?: string } = {};
-        if (isClaude) {
-          const pathname = extra?.requestInfo?.url?.pathname ?? "";
-          const rawUrl =
-            header("x-alpic-forwarded-url") ?? `${serverUrl}${pathname}`;
-          // Strip a lone trailing slash so the hash matches the connector URL
-          // as registered with Claude (which has no trailing slash on bare origins).
-          const url = rawUrl.endsWith("/") ? rawUrl.slice(0, -1) : rawUrl;
-          const hash = crypto
-            .createHash("sha256")
-            .update(url)
-            .digest("hex")
-            .slice(0, 32);
-          contentMetaOverrides = { domain: `${hash}.claudemcpcontent.com` };
-        }
-
-        const contentMeta = buildContentMeta(
-          {
-            resourceDomains: [serverUrl],
-            connectDomains,
-            domain: serverUrl,
-            baseUriDomains: [serverUrl],
-          },
-          contentMetaOverrides,
-        );
-
         return {
           contents: [
-            { uri: uri.href, mimeType, text: html, _meta: contentMeta },
+            { uri: uri.href, mimeType, text: html, _meta: buildMeta(extra) },
           ],
         };
       },

--- a/packages/core/src/test/view.test.ts
+++ b/packages/core/src/test/view.test.ts
@@ -1,4 +1,6 @@
 import crypto from "node:crypto";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import type {
   ServerNotification,
@@ -14,6 +16,7 @@ import {
   vi,
 } from "vitest";
 import type { McpServer, ViewName } from "../server/server.js";
+import { McpServer as McpServerClass } from "../server/server.js";
 import {
   createMockExtra,
   createMockMcpServer,
@@ -872,5 +875,77 @@ describe("McpServer.registerTool (unified API)", () => {
       "Loading...",
     );
     expect(toolConfig._meta?.["acme.com/category"]).toBe("utility");
+  });
+});
+
+describe("resources/list view _meta injection", () => {
+  afterEach(() => resetTestEnv());
+
+  it("attaches CSP, domain, and connectDomains _meta to view resources at list time", async () => {
+    setTestEnv({ NODE_ENV: "production" });
+
+    const server = new McpServerClass(
+      { name: "test", version: "1.0.0" },
+      { capabilities: {} },
+    );
+    server.registerTool(
+      {
+        name: "start",
+        description: "Start",
+        view: {
+          component: "my-view" as ViewName,
+          description: "Onboarding deck",
+          domain: "skybridge.tech",
+          csp: {
+            resourceDomains: ["https://fonts.googleapis.com"],
+            redirectDomains: ["https://docs.skybridge.tech"],
+          },
+        },
+      },
+      vi.fn().mockResolvedValue({
+        content: [{ type: "text", text: "ok" }],
+        structuredContent: {},
+      }),
+    );
+
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    const { resources } = await client.listResources();
+    await client.close();
+    await server.close();
+
+    const appsSdk = resources.find((r) => r.uri.includes("apps-sdk"));
+    const extApps = resources.find((r) => r.uri.includes("ext-apps"));
+    expect(appsSdk?._meta).toBeDefined();
+    expect(extApps?._meta).toBeDefined();
+
+    const appsSdkCsp = (appsSdk?._meta as Record<string, unknown>)?.[
+      "openai/widgetCSP"
+    ] as { resource_domains?: string[]; connect_domains?: string[] };
+    expect(appsSdkCsp.connect_domains?.length).toBeGreaterThan(0);
+    expect(appsSdkCsp.resource_domains).toContain(
+      "https://fonts.googleapis.com",
+    );
+    expect(
+      (appsSdk?._meta as Record<string, unknown>)?.["openai/widgetDomain"],
+    ).toBe("skybridge.tech");
+
+    const extUi = (
+      extApps?._meta as {
+        ui?: {
+          csp?: { connectDomains?: string[]; resourceDomains?: string[] };
+          domain?: string;
+        };
+      }
+    ).ui;
+    expect(extUi?.csp?.connectDomains?.length).toBeGreaterThan(0);
+    expect(extUi?.csp?.resourceDomains).toContain(
+      "https://fonts.googleapis.com",
+    );
+    expect(extUi?.domain).toBe("skybridge.tech");
   });
 });

--- a/packages/create-skybridge/templates/demo/src/server.ts
+++ b/packages/create-skybridge/templates/demo/src/server.ts
@@ -34,16 +34,14 @@ const server = new McpServer(
             "https://fonts.googleapis.com",
             "https://fonts.gstatic.com",
           ],
-          connectDomains: [],
           redirectDomains: ["https://docs.skybridge.tech"],
         },
       },
     },
     async ({ name }) => {
-      const displayName = name?.trim() || "friend";
       return {
-        structuredContent: { name: displayName },
-        content: [{ type: "text", text: `User name: ${displayName}` }],
+        structuredContent: { name },
+        content: [{ type: "text", text: `User name: ${name ?? "friend"}` }],
         isError: false,
       };
     },

--- a/packages/create-skybridge/templates/demo/src/server.ts
+++ b/packages/create-skybridge/templates/demo/src/server.ts
@@ -16,6 +16,7 @@ const server = new McpServer(
         name: z.string().optional().describe("The user name."),
       },
       annotations: {
+        title: "Start Skybridge onboarding",
         readOnlyHint: true,
         destructiveHint: false,
         openWorldHint: false,
@@ -26,8 +27,8 @@ const server = new McpServer(
       },
       view: {
         component: "onboarding",
-        // Replace with the domain your widget will be served from in production.
-        domain: "skybridge.tech",
+        // Replace with the URL your widget will be served from in production.
+        domain: "https://skybridge.tech",
         description: "Onboarding deck",
         csp: {
           resourceDomains: [
@@ -51,6 +52,7 @@ const server = new McpServer(
       name: "get-fortune-cookie",
       description: "Get fortune cookie",
       annotations: {
+        title: "Get a fortune cookie",
         readOnlyHint: true,
         destructiveHint: false,
         openWorldHint: false,

--- a/packages/create-skybridge/templates/demo/src/server.ts
+++ b/packages/create-skybridge/templates/demo/src/server.ts
@@ -15,22 +15,35 @@ const server = new McpServer(
       inputSchema: {
         name: z.string().optional().describe("The user name."),
       },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+      _meta: {
+        "openai/toolInvocation/invoking": "Starting the Skybridge onboarding…",
+        "openai/toolInvocation/invoked": "Onboarding ready.",
+      },
       view: {
         component: "onboarding",
+        // Replace with the domain your widget will be served from in production.
+        domain: "skybridge.tech",
         description: "Onboarding deck",
         csp: {
           resourceDomains: [
             "https://fonts.googleapis.com",
             "https://fonts.gstatic.com",
           ],
+          connectDomains: [],
           redirectDomains: ["https://docs.skybridge.tech"],
         },
       },
     },
     async ({ name }) => {
+      const displayName = name?.trim() || "friend";
       return {
-        structuredContent: { name },
-        content: [{ type: "text", text: `User name: ${name}` }],
+        structuredContent: { name: displayName },
+        content: [{ type: "text", text: `User name: ${displayName}` }],
         isError: false,
       };
     },
@@ -39,6 +52,15 @@ const server = new McpServer(
     {
       name: "get-fortune-cookie",
       description: "Get fortune cookie",
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+      _meta: {
+        "openai/toolInvocation/invoking": "Cracking open a fortune cookie…",
+        "openai/toolInvocation/invoked": "Fortune revealed.",
+      },
     },
     async () => {
       const predictions = [

--- a/packages/create-skybridge/templates/demo/src/views/components/steps/tool-output.tsx
+++ b/packages/create-skybridge/templates/demo/src/views/components/steps/tool-output.tsx
@@ -23,8 +23,8 @@ export default function ToolOutput() {
         ) : (
           <p>
             The view reads the <strong>tool output</strong>, but no{" "}
-            <code>name</code> was passed this time. Try again with you surname
-            to see with this view personalize.
+            <code>name</code> was passed this time. Try again with your surname
+            to see how this view personalizes.
           </p>
         )}
       </div>


### PR DESCRIPTION
Fixes template to comply with beacon report (add a few metadata and annotations)

Also changes the way skybridge handle resources/list metadata :

> The Alpic Beacon checker (alpic-ai/alpic repo, backends/marketplace/src/beacon/checks/view/) reads _meta
>   from the resource definition returned by resources/list (per SEP‑1865: "_meta.ui may appear at two levels: in
>   resources/list response — static defaults for host review at connection time, and in resources/read"). Skybridge was
>   only attaching _meta to the content inside resources/read, so the checker saw empty resource definitions and reported "no CSP declared / no domain declared / no connectDomains".
>   
> Fix in packages/core/src/server/server.ts:
>   - Extracted the request-context computation (serverUrl, connectDomains, Claude claudemcpcontent.com domain override)
>   into resolveViewRequestContext() so it can be reused.
>   - Stored per-URI view-meta builders in a new viewMetaBuilders map at registerViewResource time.
>   - Added an internal MCP middleware on resources/list that, for each view resource, computes the same _meta we already
>   produce in resources/read and merges it into the listed resource definition.
>   - Refactored resources/read to reuse the helper so both paths produce identical _meta.

The last warning on the beacon is specific to dev (usage of wss:// content)

<img width="2974" height="1690" alt="image" src="https://github.com/user-attachments/assets/bd42084f-bb90-4203-9ab6-ec88c09e938f" />

<img width="1484" height="793" alt="image" src="https://github.com/user-attachments/assets/24d4aebb-67d6-47ac-9efb-97655ffdf5dd" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the demo template to pass Alpic Beacon extended-app checks (adding `annotations`, `_meta`, and a `domain` to views) and addresses the root cause by surfacing `_meta` (CSP, domain, connectDomains) in `resources/list` responses so checkers can see it at connection time, not just at `resources/read` time.

- **`packages/core/src/server/server.ts`**: Extracts request-context resolution into `resolveViewRequestContext()`, stores per-URI meta builders in `viewMetaBuilders`, and adds a `resources/list` middleware that injects the same `_meta` already produced by `resources/read` into each listed view resource.
- **`packages/core/src/test/view.test.ts`**: Adds an integration test using an in-memory transport to verify that both `apps-sdk` and `ext-apps` view resources carry the expected CSP and domain fields in the list response.
- **`packages/create-skybridge/templates/demo/src/server.ts`**: Adds `annotations`, `_meta` invoking/invoked labels, and a `domain` value to both tools to satisfy the beacon checker; also fixes the `name ?? \"friend\"` fallback.

<h3>Confidence Score: 5/5</h3>

The changes are safe to merge; the refactor is well-scoped and the new middleware is additive with no impact on existing functionality when no view resources are registered.

The core refactoring is a clean extraction of existing logic with an integration test that validates the new list-time meta injection end-to-end. The demo-template changes are purely additive metadata. The only blemish is an unreachable guard left over after viewListMetaEntry was made unconditional.

No files require special attention.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/core/src/server/server.ts:529-537
The `entries.length === 0` early-return guard is now permanently unreachable. `viewListMetaEntry` is unconditionally added to the array, so `entries` always has at least one element. The check can be removed to keep the code honest.

```suggestion
    const entries = [
      ...(monitoringEntry ? [monitoringEntry] : []),
      viewListMetaEntry,
      ...this.mcpMiddlewareEntries,
    ];
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into julien/fix-demo..."](https://github.com/alpic-ai/skybridge/commit/4d2db350115ebbfffb938e78c698a2404ef95c42) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33239355)</sub>

<!-- /greptile_comment -->