### PR TITLE
feat: re-export mcpAuthMetadataRouter from skybridge/server

### DIFF
--- a/docs/api-reference/mcp-server.mdx
+++ b/docs/api-reference/mcp-server.mdx
@@ -346,6 +346,31 @@ async function verifyAccessToken(token: string): Promise<AuthInfo> {
 }
 ```
 
+### mcpAuthMetadataRouter
+
+Express router that serves the OAuth 2.0 [Protected Resource Metadata](https://datatracker.ietf.org/doc/html/rfc9728) document at `/.well-known/oauth-protected-resource`, so clients can discover the authorization server programmatically.
+
+**Example:**
+```typescript
+import { mcpAuthMetadataRouter } from "skybridge/server";
+
+server.use(
+  mcpAuthMetadataRouter({
+    oauthMetadata: {
+      issuer: "https://auth.example.com",
+      authorization_endpoint: "https://auth.example.com/authorize",
+      token_endpoint: "https://auth.example.com/token",
+      response_types_supported: ["code"],
+    },
+    resourceServerUrl: new URL("https://api.example.com/mcp"),
+    scopesSupported: ["search.read"],
+  }),
+);
+```
+<Note>
+Values above are illustrative. See [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414) and [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728), and check your auth provider docs for the actual values.
+</Note>
+
 ## Exported Types
 
 The following middleware types are available from `skybridge/server`:
@@ -353,6 +378,7 @@ The following middleware types are available from `skybridge/server`:
 ```typescript
 import type {
   AuthInfo,
+  AuthMetadataOptions,
   BearerAuthMiddlewareOptions,
   McpExtra,
   McpMiddlewareFn,

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -10,6 +10,10 @@ export {
   type BearerAuthMiddlewareOptions,
   requireBearerAuth,
 } from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js";
+export {
+  type AuthMetadataOptions,
+  mcpAuthMetadataRouter,
+} from "@modelcontextprotocol/sdk/server/auth/router.js";
 export type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 
 /**

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -1,7 +1,9 @@
 export {
   type AuthInfo,
+  type AuthMetadataOptions,
   type BearerAuthMiddlewareOptions,
   InvalidTokenError,
+  mcpAuthMetadataRouter,
   optionalBearerAuth,
   requireBearerAuth,
 } from "./auth.js";


### PR DESCRIPTION
Re-export mcpAuthMetadataRouter (and AuthMetadataOptions) from skybridge/server so users don't have to import from @modelcontextprotocol/sdk. Adds a short doc section under McpServer's auth middlewares.