### PR TITLE
feat(devtools): allow collapsing the open tool in the tools list

### DIFF
--- a/packages/devtools/src/components/layout/tools-list/accordion-trigger.tsx
+++ b/packages/devtools/src/components/layout/tools-list/accordion-trigger.tsx
@@ -27,7 +27,6 @@ export function AccordionTrigger({
           "type-text-md font-semibold text-foreground text-left",
           "outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-sm",
           "disabled:pointer-events-none disabled:opacity-50",
-          "data-[state=open]:cursor-default",
           "[&[data-state=open]>svg]:rotate-90",
           className,
         )}

--- a/packages/devtools/src/components/layout/tools-list/index.tsx
+++ b/packages/devtools/src/components/layout/tools-list/index.tsx
@@ -2,7 +2,7 @@ import { Accordion } from "@alpic-ai/ui/components/accordion";
 import { Button } from "@alpic-ai/ui/components/button";
 import { useTimeout } from "ahooks";
 import { RefreshCw } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useSuspenseTools } from "@/lib/mcp/index.js";
 import { useSelectedToolName } from "@/lib/nuqs.js";
 import { queryClient } from "@/lib/query-client.js";
@@ -20,8 +20,10 @@ function ToolsList() {
     setTailDelay(undefined);
   }, tailDelay);
 
+  const didInit = useRef(false);
   useEffect(() => {
-    if (openTool == null && tools[0]) {
+    if (!didInit.current && openTool == null && tools[0]) {
+      didInit.current = true;
       setOpenTool(tools[0].name);
     }
   }, [openTool, tools, setOpenTool]);
@@ -37,7 +39,7 @@ function ToolsList() {
   };
 
   const handleToolClick = (toolName: string) => {
-    setOpenTool(toolName);
+    setOpenTool(toolName || null);
   };
 
   return (
@@ -55,6 +57,7 @@ function ToolsList() {
       </header>
       <Accordion
         type="single"
+        collapsible
         value={openTool ?? ""}
         onValueChange={handleToolClick}
         className="min-h-0 overflow-y-auto"

--- a/packages/devtools/src/components/layout/tools-list/index.tsx
+++ b/packages/devtools/src/components/layout/tools-list/index.tsx
@@ -22,9 +22,11 @@ function ToolsList() {
 
   const didInit = useRef(false);
   useEffect(() => {
-    if (!didInit.current && openTool == null && tools[0]) {
+    if (!didInit.current && tools.length > 0) {
       didInit.current = true;
-      setOpenTool(tools[0].name);
+      if (openTool == null) {
+        setOpenTool(tools[0].name);
+      }
     }
   }, [openTool, tools, setOpenTool]);
 


### PR DESCRIPTION
Set the tools accordion to collapsible so clicking the chevron on the open tool closes it. Gate the first-tool auto-open effect behind a mount-only ref so a manual collapse isn't immediately reverted, and normalize Radix's empty-string close signal to null so the URL tool param is cleared. Drop the open-state cursor-default style so the trigger no longer looks non-interactive.

## Demo VIdeo


https://github.com/user-attachments/assets/1546dfe2-310a-4ec3-8837-77af554e4e86

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables collapsing an open accordion item in the tools list and prevents the first-tool auto-open effect from fighting against a manual collapse.

- `index.tsx`: Adds `collapsible` to the Accordion, introduces a `didInit` ref so the auto-open effect runs at most once (and correctly marks initialization even when a tool is already selected via URL param), and normalizes Radix's empty-string close signal to `null` in `handleToolClick`.
- `accordion-trigger.tsx`: Removes the `data-[state=open]:cursor-default` style so the open trigger continues to look interactive and signals it can be clicked to collapse.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are small, well-scoped, and the previously identified edge case with URL-preselected tools is correctly handled by the new guard placement.

The didInit.current = true assignment now fires whenever tools.length > 0, regardless of whether openTool is null, so arriving with a URL-selected tool correctly arms the guard before the user can trigger a manual collapse that would previously re-open the first tool. The empty-string-to-null normalization and collapsible prop addition are straightforward and correct.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["Update packages/devtools/src/components/..."](https://github.com/alpic-ai/skybridge/commit/84bf9a081314decd67823086229569371322bb64) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33634467)</sub>

<!-- /greptile_comment -->