### PR TITLE
feat: update auth example

### DIFF
--- a/examples/auth-auth0/package.json
+++ b/examples/auth-auth0/package.json
@@ -14,13 +14,12 @@
   "dependencies": {
     "@alpic-ai/insights": "^1.127.1",
     "@auth0/auth0-api-js": "^1.4.0",
-    "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.6",
     "dotenv": "^16.5.0",
     "jose": "^6.2.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "skybridge": "^1.0.0",
+    "skybridge": "^1.0.2",
     "vite": "^7.3.1",
     "zod": "^4.3.6"
   },

--- a/examples/auth-auth0/src/auth.ts
+++ b/examples/auth-auth0/src/auth.ts
@@ -3,8 +3,7 @@ import {
   InvalidRequestError,
   VerifyAccessTokenError,
 } from "@auth0/auth0-api-js";
-import { InvalidTokenError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
-import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import { type AuthInfo, InvalidTokenError } from "skybridge/server";
 import { env } from "./env.js";
 
 const apiClient = new ApiClient({

--- a/examples/auth-auth0/src/server.ts
+++ b/examples/auth-auth0/src/server.ts
@@ -1,5 +1,6 @@
 import { intentMiddleware } from "@alpic-ai/insights";
 import cors from "cors";
+import type { RequestHandler } from "express";
 import {
   type AuthInfo,
   McpServer,
@@ -10,6 +11,25 @@ import * as z from "zod";
 import { verifyAccessToken } from "./auth.js";
 import { searchCoffeeShops } from "./coffee-data.js";
 import { env } from "./env.js";
+
+// Auth0's /oidc/register endpoint does not return CORS headers, so browser-based
+// MCP clients can't call it directly. Proxy it through this server instead.
+const registrationProxy: RequestHandler = async (req, res, next) => {
+  try {
+    const response = await fetch(`https://${env.AUTH0_DOMAIN}/oidc/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(req.body),
+    });
+    const body = await response.text();
+    res
+      .status(response.status)
+      .type(response.headers.get("content-type") ?? "application/json")
+      .send(body);
+  } catch (err) {
+    next(err);
+  }
+};
 
 /**
  * Auth Example - Full OAuth Authentication with Auth0
@@ -34,6 +54,7 @@ const server = new McpServer(
   { capabilities: {} },
 )
   .use(cors())
+  .use("/oidc/register", registrationProxy)
   // Mount OAuth metadata so MCP clients can discover auth endpoints
   .use(
     mcpAuthMetadataRouter({
@@ -41,7 +62,7 @@ const server = new McpServer(
         issuer: env.SERVER_URL,
         authorization_endpoint: `https://${env.AUTH0_DOMAIN}/authorize?audience=${encodeURIComponent(env.AUTH0_AUDIENCE)}`,
         token_endpoint: `https://${env.AUTH0_DOMAIN}/oauth/token`,
-        registration_endpoint: `https://${env.AUTH0_DOMAIN}/oidc/register`,
+        registration_endpoint: `${env.SERVER_URL}/oidc/register`,
         response_types_supported: ["code"],
         code_challenge_methods_supported: ["S256"],
         response_modes_supported: ["query"],

--- a/examples/auth-auth0/src/server.ts
+++ b/examples/auth-auth0/src/server.ts
@@ -1,9 +1,11 @@
 import { intentMiddleware } from "@alpic-ai/insights";
-import { requireBearerAuth } from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js";
-import { mcpAuthMetadataRouter } from "@modelcontextprotocol/sdk/server/auth/router.js";
-import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import cors from "cors";
-import { McpServer } from "skybridge/server";
+import {
+  type AuthInfo,
+  McpServer,
+  mcpAuthMetadataRouter,
+  requireBearerAuth,
+} from "skybridge/server";
 import * as z from "zod";
 import { verifyAccessToken } from "./auth.js";
 import { searchCoffeeShops } from "./coffee-data.js";

--- a/examples/auth-clerk/package.json
+++ b/examples/auth-clerk/package.json
@@ -15,11 +15,10 @@
     "@alpic-ai/insights": "^1.127.1",
     "@clerk/express": "^2.0.7",
     "@clerk/mcp-tools": "^0.3.1",
-    "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^16.5.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "skybridge": "^1.0.0",
+    "skybridge": "^1.0.2",
     "vite": "^8.0.0",
     "zod": "^4.3.6"
   },

--- a/examples/auth-clerk/src/server.ts
+++ b/examples/auth-clerk/src/server.ts
@@ -5,8 +5,7 @@ import {
   mcpAuthClerk,
   protectedResourceHandlerClerk,
 } from "@clerk/mcp-tools/express";
-import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
-import { McpServer } from "skybridge/server";
+import { type AuthInfo, McpServer } from "skybridge/server";
 import * as z from "zod";
 import { searchCoffeeShops } from "./coffee-data.js";
 

--- a/examples/auth-stytch/package.json
+++ b/examples/auth-stytch/package.json
@@ -13,13 +13,12 @@
   },
   "dependencies": {
     "@alpic-ai/insights": "^1.127.1",
-    "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.6",
     "dotenv": "^16.5.0",
     "jose": "^6.1.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "skybridge": "^1.0.0",
+    "skybridge": "^1.0.2",
     "vite": "^8.0.0",
     "zod": "^4.3.6"
   },

--- a/examples/auth-stytch/src/auth.ts
+++ b/examples/auth-stytch/src/auth.ts
@@ -1,6 +1,5 @@
-import { InvalidTokenError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
-import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import * as jose from "jose";
+import { type AuthInfo, InvalidTokenError } from "skybridge/server";
 import { env } from "./env.js";
 
 let jwks: ReturnType<typeof jose.createRemoteJWKSet> | null = null;

--- a/examples/auth-stytch/src/server.ts
+++ b/examples/auth-stytch/src/server.ts
@@ -1,10 +1,8 @@
 import "dotenv/config";
 import { intentMiddleware } from "@alpic-ai/insights";
-import { requireBearerAuth } from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js";
-import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import cors from "cors";
 import type { RequestHandler } from "express";
-import { McpServer } from "skybridge/server";
+import { type AuthInfo, McpServer, requireBearerAuth } from "skybridge/server";
 import * as z from "zod";
 import { verifyAccessToken } from "./auth.js";
 import { searchCoffeeShops } from "./coffee-data.js";

--- a/examples/auth-workos/package.json
+++ b/examples/auth-workos/package.json
@@ -13,13 +13,12 @@
   },
   "dependencies": {
     "@alpic-ai/insights": "^1.127.1",
-    "@modelcontextprotocol/sdk": "^1.29.0",
     "@workos-inc/node": "^7.72.2",
     "dotenv": "^16.5.0",
     "jose": "^6.0.11",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "skybridge": "^1.0.0",
+    "skybridge": "^1.0.2",
     "vite": "^8.0.0",
     "zod": "^4.3.6"
   },

--- a/examples/auth-workos/src/auth.ts
+++ b/examples/auth-workos/src/auth.ts
@@ -1,6 +1,6 @@
-import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import { WorkOS } from "@workos-inc/node";
 import * as jose from "jose";
+import type { AuthInfo } from "skybridge/server";
 import { env } from "./env.js";
 
 // Initialize JWKS client for AuthKit public key verification

--- a/examples/auth-workos/src/server.ts
+++ b/examples/auth-workos/src/server.ts
@@ -1,8 +1,10 @@
 import { intentMiddleware } from "@alpic-ai/insights";
-import { requireBearerAuth } from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js";
-import { mcpAuthMetadataRouter } from "@modelcontextprotocol/sdk/server/auth/router.js";
-import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
-import { McpServer } from "skybridge/server";
+import {
+  type AuthInfo,
+  McpServer,
+  mcpAuthMetadataRouter,
+  requireBearerAuth,
+} from "skybridge/server";
 import * as z from "zod";
 import { verifyAccessToken } from "./auth.js";
 import { searchCoffeeShops } from "./coffee-data.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,9 +56,6 @@ importers:
       '@auth0/auth0-api-js':
         specifier: ^1.4.0
         version: 1.4.0
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.29.0
-        version: 1.29.0(zod@4.3.6)
       cors:
         specifier: ^2.8.6
         version: 2.8.6
@@ -129,9 +126,6 @@ importers:
       '@clerk/mcp-tools':
         specifier: ^0.3.1
         version: 0.3.1(zod@4.3.6)
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.29.0
-        version: 1.29.0(zod@4.3.6)
       dotenv:
         specifier: ^16.5.0
         version: 16.6.1
@@ -187,9 +181,6 @@ importers:
       '@alpic-ai/insights':
         specifier: ^1.127.1
         version: 1.127.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.29.0
-        version: 1.29.0(zod@4.3.6)
       cors:
         specifier: ^2.8.6
         version: 2.8.6
@@ -254,9 +245,6 @@ importers:
       '@alpic-ai/insights':
         specifier: ^1.127.1
         version: 1.127.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(skybridge@packages+core)
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.29.0
-        version: 1.29.0(zod@4.3.6)
       '@workos-inc/node':
         specifier: ^7.72.2
         version: 7.82.0(express@5.2.1)(koa@3.1.2)(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
@@ -1306,70 +1294,6 @@ importers:
       zustand:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@19.2.14)(immer@9.0.21)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
-
-  packages/hey:
-    dependencies:
-      '@alpic-ai/ui':
-        specifier: ^1.122.0
-        version: 1.123.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-hook-form@7.75.0(react@19.2.4))(react@19.2.4)(sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tailwindcss@4.2.4)(tw-animate-css@1.4.0)
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.29.0
-        version: 1.29.0(zod@4.3.6)
-      lucide-react:
-        specifier: ^1.14.0
-        version: 1.14.0(react@19.2.4)
-      react:
-        specifier: ^19.2.4
-        version: 19.2.4
-      react-dom:
-        specifier: ^19.2.4
-        version: 19.2.4(react@19.2.4)
-      skybridge:
-        specifier: workspace:*
-        version: link:../core
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      tw-animate-css:
-        specifier: ^1.4.0
-        version: 1.4.0
-      vite:
-        specifier: ^8.0.3
-        version: 8.0.3(@types/node@24.12.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
-      zod:
-        specifier: ^4.3.6
-        version: 4.3.6
-    devDependencies:
-      '@skybridge/devtools':
-        specifier: ^1.0.0
-        version: 1.0.0(arktype@2.1.27)(typescript@6.0.2)
-      '@tailwindcss/vite':
-        specifier: ^4.2.4
-        version: 4.2.4(vite@8.0.3(@types/node@24.12.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
-      '@types/node':
-        specifier: ^24.12.0
-        version: 24.12.0
-      '@types/react':
-        specifier: ^19.2.14
-        version: 19.2.14
-      '@types/react-dom':
-        specifier: ^19.2.3
-        version: 19.2.3(@types/react@19.2.14)
-      '@vitejs/plugin-react':
-        specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.3(@types/node@24.12.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
-      alpic:
-        specifier: ^1.104.1
-        version: 1.104.1(@opentelemetry/api@1.9.0)(arktype@2.1.27)(rxjs@7.8.2)(typescript@6.0.2)
-      tailwindcss:
-        specifier: ^4.2.4
-        version: 4.2.4
-      tsx:
-        specifier: ^4.21.0
-        version: 4.21.0
-      typescript:
-        specifier: ^6.0.2
-        version: 6.0.2
 
 packages:
 


### PR DESCRIPTION
since 1.0.2 they don't need to import @modelcontextprotocol/sdk anymore. also fixes the auth0 example which was not working with the devtools