### PR TITLE
fix: auth0 registration endpoint

### DIFF
--- a/examples/auth-auth0/src/server.ts
+++ b/examples/auth-auth0/src/server.ts
@@ -62,7 +62,7 @@ const server = new McpServer(
         issuer: env.SERVER_URL,
         authorization_endpoint: `https://${env.AUTH0_DOMAIN}/authorize?audience=${encodeURIComponent(env.AUTH0_AUDIENCE)}`,
         token_endpoint: `https://${env.AUTH0_DOMAIN}/oauth/token`,
-        registration_endpoint: `${env.SERVER_URL}/oidc/register`,
+        registration_endpoint: `${env.NODE_ENV === "production" ? env.AUTH0_DOMAIN : env.SERVER_URL}/oidc/register`,
         response_types_supported: ["code"],
         code_challenge_methods_supported: ["S256"],
         response_modes_supported: ["query"],

--- a/examples/auth-auth0/src/server.ts
+++ b/examples/auth-auth0/src/server.ts
@@ -12,13 +12,13 @@ import { verifyAccessToken } from "./auth.js";
 import { searchCoffeeShops } from "./coffee-data.js";
 import { env } from "./env.js";
 
-const AUTH0_URL = `https://${env.AUTH0_DOMAIN}`;
+const AUTH0_BASE_URL = `https://${env.AUTH0_DOMAIN}`;
 
 // Auth0's /oidc/register endpoint does not return CORS headers, so browser-based
 // MCP clients can't call it directly. Proxy it through this server instead.
 const registrationProxy: RequestHandler = async (req, res, next) => {
   try {
-    const response = await fetch(`${AUTH0_URL}/oidc/register`, {
+    const response = await fetch(`${AUTH0_BASE_URL}/oidc/register`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(req.body),
@@ -62,9 +62,9 @@ const server = new McpServer(
     mcpAuthMetadataRouter({
       oauthMetadata: {
         issuer: env.SERVER_URL,
-        authorization_endpoint: `${AUTH0_URL}/authorize?audience=${encodeURIComponent(env.AUTH0_AUDIENCE)}`,
-        token_endpoint: `${AUTH0_URL}/oauth/token`,
-        registration_endpoint: `${env.NODE_ENV === "production" ? AUTH0_URL : env.SERVER_URL}/oidc/register`,
+        authorization_endpoint: `${AUTH0_BASE_URL}/authorize?audience=${encodeURIComponent(env.AUTH0_AUDIENCE)}`,
+        token_endpoint: `${AUTH0_BASE_URL}/oauth/token`,
+        registration_endpoint: `${env.NODE_ENV === "production" ? AUTH0_BASE_URL : env.SERVER_URL}/oidc/register`,
         response_types_supported: ["code"],
         code_challenge_methods_supported: ["S256"],
         response_modes_supported: ["query"],
@@ -126,7 +126,7 @@ const server = new McpServer(
       const auth = extra.authInfo as AuthInfo;
 
       try {
-        const userInfoResponse = await fetch(`${AUTH0_URL}/userinfo`, {
+        const userInfoResponse = await fetch(`${AUTH0_BASE_URL}/userinfo`, {
           headers: { Authorization: `Bearer ${auth.token}` },
         });
 

--- a/examples/auth-auth0/src/server.ts
+++ b/examples/auth-auth0/src/server.ts
@@ -12,11 +12,13 @@ import { verifyAccessToken } from "./auth.js";
 import { searchCoffeeShops } from "./coffee-data.js";
 import { env } from "./env.js";
 
+const AUTH0_URL = `https://${env.AUTH0_DOMAIN}`;
+
 // Auth0's /oidc/register endpoint does not return CORS headers, so browser-based
 // MCP clients can't call it directly. Proxy it through this server instead.
 const registrationProxy: RequestHandler = async (req, res, next) => {
   try {
-    const response = await fetch(`https://${env.AUTH0_DOMAIN}/oidc/register`, {
+    const response = await fetch(`${AUTH0_URL}/oidc/register`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(req.body),
@@ -60,9 +62,9 @@ const server = new McpServer(
     mcpAuthMetadataRouter({
       oauthMetadata: {
         issuer: env.SERVER_URL,
-        authorization_endpoint: `https://${env.AUTH0_DOMAIN}/authorize?audience=${encodeURIComponent(env.AUTH0_AUDIENCE)}`,
-        token_endpoint: `https://${env.AUTH0_DOMAIN}/oauth/token`,
-        registration_endpoint: `${env.NODE_ENV === "production" ? env.AUTH0_DOMAIN : env.SERVER_URL}/oidc/register`,
+        authorization_endpoint: `${AUTH0_URL}/authorize?audience=${encodeURIComponent(env.AUTH0_AUDIENCE)}`,
+        token_endpoint: `${AUTH0_URL}/oauth/token`,
+        registration_endpoint: `${env.NODE_ENV === "production" ? AUTH0_URL : env.SERVER_URL}/oidc/register`,
         response_types_supported: ["code"],
         code_challenge_methods_supported: ["S256"],
         response_modes_supported: ["query"],
@@ -124,10 +126,9 @@ const server = new McpServer(
       const auth = extra.authInfo as AuthInfo;
 
       try {
-        const userInfoResponse = await fetch(
-          `https://${env.AUTH0_DOMAIN}/userinfo`,
-          { headers: { Authorization: `Bearer ${auth.token}` } },
-        );
+        const userInfoResponse = await fetch(`${AUTH0_URL}/userinfo`, {
+          headers: { Authorization: `Bearer ${auth.token}` },
+        });
 
         const userInfo = userInfoResponse.ok
           ? ((await userInfoResponse.json()) as {


### PR DESCRIPTION
non mcp routes are not supported by alpic where this is hosted.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts a shared `AUTH0_BASE_URL` constant from the repeated `https://${env.AUTH0_DOMAIN}` template literals and adjusts `registration_endpoint` to point directly at Auth0 in production rather than routing through the server-side CORS proxy.

- The `AUTH0_BASE_URL` constant is a clean improvement that eliminates the repeated pattern and ensures the `https://` scheme is consistently applied everywhere.
- In production, `registration_endpoint` now resolves to `${AUTH0_BASE_URL}/oidc/register` (Auth0 directly) instead of the local proxy, motivated by the hosting platform not supporting non-MCP routes.
- The `userInfoResponse` fetch call is reformatted with no functional change.

<h3>Confidence Score: 4/5</h3>

The refactoring of AUTH0_BASE_URL is safe, but bypassing the CORS proxy in production means browser-based MCP clients attempting dynamic client registration will hit Auth0 directly without CORS headers.

The core change — pointing registration_endpoint directly at Auth0 in production — means browser-based clients performing OAuth dynamic client registration will receive a CORS error, breaking the registration flow. This is a deliberate trade-off given the hosting constraint, but it leaves browser client registration non-functional in production.

examples/auth-auth0/src/server.ts — specifically the production branch of registration_endpoint on line 67.

<sub>Reviews (2): Last reviewed commit: ["fix: add base url"](https://github.com/alpic-ai/skybridge/commit/11d4ec4b277f0689aa105500f1d5986feebb9afe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33747068)</sub>

<!-- /greptile_comment -->