### PR TITLE
test(devtools): add e2e test for authenticated server

### DIFF
--- a/docs/devtools/devtools.mdx
+++ b/docs/devtools/devtools.mdx
@@ -65,6 +65,12 @@ These logs show **Apps SDK** (`window.openai`) calls. In MCP Apps, views use the
 
 <img src="/images/devtools-view.png" alt="DevTools View Inspection Panel" style={{maxWidth: '100%', borderRadius: '8px', border: '1px solid #e0e0e0'}} />
 
+## Authenticated servers
+
+When your MCP server requires OAuth, DevTools registers itself as an OAuth client via [Dynamic Client Registration](https://datatracker.ietf.org/doc/html/rfc7591) on first connect and walks the full PKCE flow. The resulting `client_id` and access token are cached in browser `localStorage` so subsequent sessions reconnect silently.
+
+If you ever see `invalid_client` or other authorization errors after switching servers, rotating credentials on the auth server, or otherwise leaving DevTools holding stale state, click **Sign out** in the header to clear the cache and trigger a fresh registration on the next connect.
+
 ## Limitations
 
 DevTools uses the **Apps SDK runtime** (mocked `window.openai`) but has some differences from production:

--- a/packages/devtools/.gitignore
+++ b/packages/devtools/.gitignore
@@ -29,3 +29,4 @@ dist-ssr
 playwright-report
 test-results
 e2e/fixtures/web/dist
+e2e/fixtures/.mock-auth-clients-*.json

--- a/packages/devtools/e2e/fixtures/mock-auth-server.ts
+++ b/packages/devtools/e2e/fixtures/mock-auth-server.ts
@@ -1,0 +1,301 @@
+/**
+ * Mock OAuth 2.1 Authorization Server for the devtools e2e fixture.
+ * Implements DCR (RFC 7591), PKCE-S256 /authorize, and the authorization_code
+ * /token grant — enough to drive the MCP SDK's discovery + token flow.
+ * State is in-memory, tokens never refresh, /authorize auto-approves.
+ *
+ * Why hand-rolled instead of `mcpAuthRouter`? The MCP TS SDK v2 removed the
+ * AS helpers (mcpAuthRouter, OAuthServerProvider, …) per its migration notes;
+ * building on them would land on a deprecated path. The Resource Server
+ * pieces (`requireBearerAuth`) are staying, so the consumer in `server.ts`
+ * keeps using those — only the AS-side endpoints live here.
+ */
+
+import crypto from "node:crypto";
+import express, { type Router } from "express";
+import { type AuthInfo, InvalidTokenError } from "skybridge/server";
+
+export interface MockAuthServerOptions {
+  /** Base URL of the fixture (e.g. `http://localhost:4102`). */
+  serverUrl: string;
+  /**
+   * Tokens to accept on top of any dynamically issued ones. Used by tests
+   * that pre-seed `localStorage` to bypass the OAuth flow entirely.
+   */
+  seedTokens?: Array<{ token: string; clientId: string; scopes?: string[] }>;
+}
+
+export interface MockAuthServer {
+  /**
+   * Express router exposing the AS endpoints + well-known metadata.
+   * Mount on the MCP server before `requireBearerAuth("/mcp", …)`.
+   */
+  readonly router: Router;
+  /**
+   * `verifyAccessToken` implementation for
+   * `requireBearerAuth({ verifier: { verifyAccessToken } })`.
+   */
+  verifyAccessToken(token: string): Promise<AuthInfo>;
+}
+
+export function createMockAuthServer(
+  options: MockAuthServerOptions,
+): MockAuthServer {
+  const stores = createStores(options.seedTokens);
+  const router = buildRouter(options.serverUrl, stores);
+
+  return {
+    router,
+    async verifyAccessToken(token: string): Promise<AuthInfo> {
+      const info = stores.tokens.get(token);
+      if (!info) {
+        throw new InvalidTokenError("invalid token");
+      }
+      return {
+        token,
+        clientId: info.clientId,
+        scopes: info.scopes,
+        expiresAt: info.expiresAt,
+      };
+    },
+  };
+}
+
+interface ClientInfo {
+  client_id: string;
+  redirect_uris: string[];
+  [key: string]: unknown;
+}
+
+interface AuthCodeInfo {
+  clientId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  scope?: string;
+  resource?: string;
+}
+
+interface TokenInfo {
+  clientId: string;
+  scopes: string[];
+  expiresAt: number;
+}
+
+interface Stores {
+  clients: Map<string, ClientInfo>;
+  codes: Map<string, AuthCodeInfo>;
+  tokens: Map<string, TokenInfo>;
+}
+
+const TOKEN_TTL_SECONDS = 3600;
+
+function createStores(seedTokens: MockAuthServerOptions["seedTokens"]): Stores {
+  const tokens = new Map<string, TokenInfo>();
+  const expiresAt = Math.floor(Date.now() / 1000) + TOKEN_TTL_SECONDS;
+  for (const seed of seedTokens ?? []) {
+    tokens.set(seed.token, {
+      clientId: seed.clientId,
+      scopes: seed.scopes ?? [],
+      expiresAt,
+    });
+  }
+  return {
+    clients: new Map(),
+    codes: new Map(),
+    tokens,
+  };
+}
+
+function verifyPkceS256(verifier: string, challenge: string): boolean {
+  const computed = crypto
+    .createHash("sha256")
+    .update(verifier)
+    .digest("base64url");
+  if (computed.length !== challenge.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(Buffer.from(computed), Buffer.from(challenge));
+}
+
+function randomToken(): string {
+  return crypto.randomBytes(32).toString("hex");
+}
+
+function oauthError(
+  res: express.Response,
+  status: number,
+  error: string,
+  description: string,
+): void {
+  res.status(status).json({ error, error_description: description });
+}
+
+function buildRouter(serverUrl: string, stores: Stores): Router {
+  const router = express.Router();
+
+  router.get("/.well-known/oauth-protected-resource/mcp", (_req, res) => {
+    res.json({
+      resource: `${serverUrl}/mcp`,
+      authorization_servers: [serverUrl],
+    });
+  });
+
+  router.get("/.well-known/oauth-authorization-server", (_req, res) => {
+    res.json({
+      issuer: serverUrl,
+      authorization_endpoint: `${serverUrl}/authorize`,
+      token_endpoint: `${serverUrl}/token`,
+      registration_endpoint: `${serverUrl}/register`,
+      response_types_supported: ["code"],
+      response_modes_supported: ["query"],
+      grant_types_supported: ["authorization_code"],
+      code_challenge_methods_supported: ["S256"],
+      token_endpoint_auth_methods_supported: ["none"],
+      authorization_response_iss_parameter_supported: true,
+    });
+  });
+
+  router.post("/register", express.json(), (req, res) => {
+    const body = req.body as Partial<ClientInfo> | undefined;
+    if (!body || !Array.isArray(body.redirect_uris)) {
+      oauthError(
+        res,
+        400,
+        "invalid_client_metadata",
+        "redirect_uris is required",
+      );
+      return;
+    }
+    const client: ClientInfo = {
+      ...body,
+      client_id: crypto.randomUUID(),
+      redirect_uris: body.redirect_uris,
+    };
+    stores.clients.set(client.client_id, client);
+    res
+      .status(201)
+      .json({ ...client, client_id_issued_at: Math.floor(Date.now() / 1000) });
+  });
+
+  router.get("/authorize", (req, res) => {
+    const {
+      response_type,
+      client_id,
+      redirect_uri,
+      code_challenge,
+      code_challenge_method,
+      state,
+      scope,
+      resource,
+    } = req.query as Record<string, string | undefined>;
+
+    if (response_type !== "code") {
+      oauthError(
+        res,
+        400,
+        "unsupported_response_type",
+        "response_type must be 'code'",
+      );
+      return;
+    }
+    if (!client_id) {
+      oauthError(res, 400, "invalid_request", "client_id is required");
+      return;
+    }
+    const client = stores.clients.get(client_id);
+    if (!client) {
+      oauthError(res, 400, "invalid_client", "unknown client_id");
+      return;
+    }
+    if (!redirect_uri || !client.redirect_uris.includes(redirect_uri)) {
+      oauthError(res, 400, "invalid_request", "redirect_uri not registered");
+      return;
+    }
+    if (!code_challenge || code_challenge_method !== "S256") {
+      oauthError(res, 400, "invalid_request", "PKCE S256 is required");
+      return;
+    }
+
+    const code = crypto.randomUUID();
+    stores.codes.set(code, {
+      clientId: client_id,
+      redirectUri: redirect_uri,
+      codeChallenge: code_challenge,
+      scope,
+      resource,
+    });
+
+    const callback = new URL(redirect_uri);
+    callback.searchParams.set("code", code);
+    if (state) {
+      callback.searchParams.set("state", state);
+    }
+    // RFC 9207 — strongly recommended by the MCP spec.
+    callback.searchParams.set("iss", serverUrl);
+    res.redirect(302, callback.toString());
+  });
+
+  router.post("/token", express.urlencoded({ extended: false }), (req, res) => {
+    const body = req.body as Record<string, string | undefined>;
+    if (body.grant_type !== "authorization_code") {
+      oauthError(
+        res,
+        400,
+        "unsupported_grant_type",
+        `unsupported grant_type: ${body.grant_type}`,
+      );
+      return;
+    }
+    handleAuthorizationCodeGrant(body, res, stores);
+  });
+
+  return router;
+}
+
+function handleAuthorizationCodeGrant(
+  body: Record<string, string | undefined>,
+  res: express.Response,
+  stores: Stores,
+): void {
+  const { code, code_verifier, redirect_uri, client_id } = body;
+  if (!code || !code_verifier || !client_id) {
+    oauthError(res, 400, "invalid_request", "missing required parameters");
+    return;
+  }
+  const entry = stores.codes.get(code);
+  if (!entry) {
+    oauthError(res, 400, "invalid_grant", "unknown authorization code");
+    return;
+  }
+  // Codes are one-shot regardless of outcome — prevents replay.
+  stores.codes.delete(code);
+
+  if (entry.clientId !== client_id) {
+    oauthError(res, 400, "invalid_grant", "client_id mismatch");
+    return;
+  }
+  if (entry.redirectUri !== redirect_uri) {
+    oauthError(res, 400, "invalid_grant", "redirect_uri mismatch");
+    return;
+  }
+  if (!verifyPkceS256(code_verifier, entry.codeChallenge)) {
+    oauthError(res, 400, "invalid_grant", "PKCE verification failed");
+    return;
+  }
+
+  const scopes = entry.scope ? entry.scope.split(" ") : [];
+  const accessToken = randomToken();
+
+  stores.tokens.set(accessToken, {
+    clientId: entry.clientId,
+    scopes,
+    expiresAt: Math.floor(Date.now() / 1000) + TOKEN_TTL_SECONDS,
+  });
+
+  res.json({
+    access_token: accessToken,
+    token_type: "Bearer",
+    expires_in: TOKEN_TTL_SECONDS,
+    ...(entry.scope ? { scope: entry.scope } : {}),
+  });
+}

--- a/packages/devtools/e2e/fixtures/mock-auth-server.ts
+++ b/packages/devtools/e2e/fixtures/mock-auth-server.ts
@@ -12,6 +12,8 @@
  */
 
 import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
 import express, { type Router } from "express";
 import { type AuthInfo, InvalidTokenError } from "skybridge/server";
 
@@ -23,6 +25,14 @@ export interface MockAuthServerOptions {
    * that pre-seed `localStorage` to bypass the OAuth flow entirely.
    */
   seedTokens?: Array<{ token: string; clientId: string; scopes?: string[] }>;
+  /**
+   * Optional path to persist DCR client registrations across fixture
+   * restarts. Without this, an interactive dev workflow that survives the
+   * fixture process (the browser holds a `client_id` in localStorage) hits
+   * `invalid_client` when the fixture restarts. Auth codes and tokens stay
+   * in-memory — only the client registry is persisted.
+   */
+  clientsFile?: string;
 }
 
 export interface MockAuthServer {
@@ -41,7 +51,7 @@ export interface MockAuthServer {
 export function createMockAuthServer(
   options: MockAuthServerOptions,
 ): MockAuthServer {
-  const stores = createStores(options.seedTokens);
+  const stores = createStores(options.seedTokens, options.clientsFile);
   const router = buildRouter(options.serverUrl, stores);
 
   return {
@@ -85,11 +95,15 @@ interface Stores {
   clients: Map<string, ClientInfo>;
   codes: Map<string, AuthCodeInfo>;
   tokens: Map<string, TokenInfo>;
+  persistClients?: () => void;
 }
 
 const TOKEN_TTL_SECONDS = 3600;
 
-function createStores(seedTokens: MockAuthServerOptions["seedTokens"]): Stores {
+function createStores(
+  seedTokens: MockAuthServerOptions["seedTokens"],
+  clientsFile: string | undefined,
+): Stores {
   const tokens = new Map<string, TokenInfo>();
   const expiresAt = Math.floor(Date.now() / 1000) + TOKEN_TTL_SECONDS;
   for (const seed of seedTokens ?? []) {
@@ -99,11 +113,30 @@ function createStores(seedTokens: MockAuthServerOptions["seedTokens"]): Stores {
       expiresAt,
     });
   }
-  return {
-    clients: new Map(),
-    codes: new Map(),
-    tokens,
-  };
+
+  const clients = new Map<string, ClientInfo>();
+  let persistClients: (() => void) | undefined;
+  if (clientsFile) {
+    if (fs.existsSync(clientsFile)) {
+      try {
+        const raw = fs.readFileSync(clientsFile, "utf8");
+        for (const entry of JSON.parse(raw) as ClientInfo[]) {
+          clients.set(entry.client_id, entry);
+        }
+      } catch {
+        // Malformed file — start fresh; next /register rewrites it.
+      }
+    }
+    persistClients = () => {
+      fs.mkdirSync(path.dirname(clientsFile), { recursive: true });
+      fs.writeFileSync(
+        clientsFile,
+        JSON.stringify(Array.from(clients.values()), null, 2),
+      );
+    };
+  }
+
+  return { clients, codes: new Map(), tokens, persistClients };
 }
 
 function verifyPkceS256(verifier: string, challenge: string): boolean {
@@ -172,6 +205,7 @@ function buildRouter(serverUrl: string, stores: Stores): Router {
       redirect_uris: body.redirect_uris,
     };
     stores.clients.set(client.client_id, client);
+    stores.persistClients?.();
     res
       .status(201)
       .json({ ...client, client_id_issued_at: Math.floor(Date.now() / 1000) });

--- a/packages/devtools/e2e/fixtures/ports.ts
+++ b/packages/devtools/e2e/fixtures/ports.ts
@@ -1,0 +1,6 @@
+export const FIXTURE_PORT = 4101;
+export const FIXTURE_AUTH_PORT = 4102;
+export const DEVTOOLS_PORT = 5173;
+export const DEVTOOLS_AUTH_PORT = 5174;
+
+export const DEVTOOLS_AUTH_URL = `http://localhost:${DEVTOOLS_AUTH_PORT}`;

--- a/packages/devtools/e2e/fixtures/seed-auth.ts
+++ b/packages/devtools/e2e/fixtures/seed-auth.ts
@@ -1,0 +1,42 @@
+import type { Page } from "@playwright/test";
+
+export const SEED_TOKEN = "e2e-auth-valid-token";
+export const SEED_CLIENT_ID = "e2e-auth-client";
+
+const TOKENS_KEY = "skybridge-devtools-oauth:tokens";
+const CLIENT_INFO_KEY = "skybridge-devtools-oauth:client-info";
+
+export async function seedAuthInLocalStorage(
+  page: Page,
+  token: string = SEED_TOKEN,
+): Promise<void> {
+  await page.addInitScript(
+    ({ token, clientId, tokensKey, clientInfoKey }) => {
+      window.localStorage.setItem(
+        tokensKey,
+        JSON.stringify({
+          access_token: token,
+          token_type: "Bearer",
+          expires_in: 3600,
+        }),
+      );
+      window.localStorage.setItem(
+        clientInfoKey,
+        JSON.stringify({
+          client_id: clientId,
+          redirect_uris: [`${window.location.origin}/?oauth_callback=true`],
+        }),
+      );
+    },
+    {
+      token,
+      clientId: SEED_CLIENT_ID,
+      tokensKey: TOKENS_KEY,
+      clientInfoKey: CLIENT_INFO_KEY,
+    },
+  );
+}
+
+export async function readStoredTokens(page: Page): Promise<string | null> {
+  return page.evaluate((key) => window.localStorage.getItem(key), TOKENS_KEY);
+}

--- a/packages/devtools/e2e/fixtures/server.ts
+++ b/packages/devtools/e2e/fixtures/server.ts
@@ -1,7 +1,10 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { McpServer } from "skybridge/server";
+import cors from "cors";
+import { McpServer, requireBearerAuth } from "skybridge/server";
 import { z } from "zod";
+import { createMockAuthServer } from "./mock-auth-server.js";
+import { SEED_CLIENT_ID, SEED_TOKEN } from "./seed-auth.js";
 
 // Run from the web/ subdir so viewsDevServer finds vite.config.ts there.
 const fixtureDir = path.dirname(fileURLToPath(import.meta.url));
@@ -9,13 +12,34 @@ process.chdir(path.join(fixtureDir, "web"));
 
 process.env.__PORT = process.env.__PORT ?? "4101";
 
-const server = new McpServer(
+const REQUIRES_AUTH = process.argv.includes("--auth");
+
+const baseServer = new McpServer(
   {
-    name: "e2e-fixture",
+    name: REQUIRES_AUTH ? "e2e-auth-fixture" : "e2e-fixture",
     version: "0.0.0",
   },
   { capabilities: {} },
-)
+);
+
+if (REQUIRES_AUTH) {
+  const serverUrl = `http://localhost:${process.env.__PORT}`;
+  const mockAuth = createMockAuthServer({
+    serverUrl,
+    seedTokens: [{ token: SEED_TOKEN, clientId: SEED_CLIENT_ID }],
+  });
+  baseServer
+    .use(cors())
+    .use(mockAuth.router)
+    .use(
+      "/mcp",
+      requireBearerAuth({
+        verifier: { verifyAccessToken: mockAuth.verifyAccessToken },
+      }),
+    );
+}
+
+const server = baseServer
   .registerTool(
     {
       name: "echo",
@@ -91,6 +115,23 @@ const server = new McpServer(
       content: [{ type: "text", text: "ok" }],
       isError: false,
     }),
+  )
+  .registerTool(
+    {
+      name: "whoami",
+      description:
+        "Returns the authenticated client id, or 'anonymous' when called without a bearer token.",
+      inputSchema: {},
+      securitySchemes: [{ type: "oauth2" }],
+    },
+    async (_args, extra) => {
+      const clientId = extra.authInfo?.clientId ?? "anonymous";
+      return {
+        structuredContent: { clientId },
+        content: [{ type: "text", text: clientId }],
+        isError: false,
+      };
+    },
   );
 
 export type AppType = typeof server;

--- a/packages/devtools/e2e/fixtures/server.ts
+++ b/packages/devtools/e2e/fixtures/server.ts
@@ -24,9 +24,16 @@ const baseServer = new McpServer(
 
 if (REQUIRES_AUTH) {
   const serverUrl = `http://localhost:${process.env.__PORT}`;
+  // Persist DCR client registrations across fixture restarts in interactive
+  // dev (not CI), so a long-lived browser tab doesn't get stranded with a
+  // stale `client_id` in localStorage. Auth codes and tokens stay ephemeral.
+  const clientsFile = process.env.CI
+    ? undefined
+    : path.join(fixtureDir, `.mock-auth-clients-${process.env.__PORT}.json`);
   const mockAuth = createMockAuthServer({
     serverUrl,
     seedTokens: [{ token: SEED_TOKEN, clientId: SEED_CLIENT_ID }],
+    clientsFile,
   });
   baseServer
     .use(cors())

--- a/packages/devtools/e2e/playwright.config.ts
+++ b/packages/devtools/e2e/playwright.config.ts
@@ -1,7 +1,29 @@
 import { defineConfig, devices } from "@playwright/test";
 
 const FIXTURE_PORT = 4101;
+const FIXTURE_AUTH_PORT = 4102;
 const DEVTOOLS_PORT = 5173;
+const DEVTOOLS_AUTH_PORT = 5174;
+
+const fixture = (port: number, args = "") => ({
+  command: `pnpm e2e:fixture${args ? ` ${args}` : ""}`,
+  port,
+  reuseExistingServer: !process.env.CI,
+  env: { __PORT: String(port) },
+  stdout: "pipe" as const,
+  stderr: "pipe" as const,
+  timeout: 60_000,
+});
+
+const devtools = (port: number, fixturePort: number) => ({
+  command: `pnpm dev -- --port ${port} --strictPort`,
+  port,
+  reuseExistingServer: !process.env.CI,
+  env: { VITE_MCP_SERVER_URL: `http://localhost:${fixturePort}/mcp` },
+  stdout: "pipe" as const,
+  stderr: "pipe" as const,
+  timeout: 60_000,
+});
 
 export default defineConfig({
   testDir: "./tests",
@@ -20,27 +42,9 @@ export default defineConfig({
     },
   ],
   webServer: [
-    {
-      command: "pnpm e2e:fixture",
-      port: FIXTURE_PORT,
-      reuseExistingServer: !process.env.CI,
-      env: {
-        __PORT: String(FIXTURE_PORT),
-      },
-      stdout: "pipe",
-      stderr: "pipe",
-      timeout: 60_000,
-    },
-    {
-      command: `pnpm dev -- --port ${DEVTOOLS_PORT} --strictPort`,
-      port: DEVTOOLS_PORT,
-      reuseExistingServer: !process.env.CI,
-      env: {
-        VITE_MCP_SERVER_URL: `http://localhost:${FIXTURE_PORT}/mcp`,
-      },
-      stdout: "pipe",
-      stderr: "pipe",
-      timeout: 60_000,
-    },
+    fixture(FIXTURE_PORT),
+    fixture(FIXTURE_AUTH_PORT, "--auth"),
+    devtools(DEVTOOLS_PORT, FIXTURE_PORT),
+    devtools(DEVTOOLS_AUTH_PORT, FIXTURE_AUTH_PORT),
   ],
 });

--- a/packages/devtools/e2e/playwright.config.ts
+++ b/packages/devtools/e2e/playwright.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig, devices } from "@playwright/test";
-
-const FIXTURE_PORT = 4101;
-const FIXTURE_AUTH_PORT = 4102;
-const DEVTOOLS_PORT = 5173;
-const DEVTOOLS_AUTH_PORT = 5174;
+import {
+  DEVTOOLS_AUTH_PORT,
+  DEVTOOLS_PORT,
+  FIXTURE_AUTH_PORT,
+  FIXTURE_PORT,
+} from "./fixtures/ports.js";
 
 const fixture = (port: number, args = "") => ({
   command: `pnpm e2e:fixture${args ? ` ${args}` : ""}`,

--- a/packages/devtools/e2e/tests/auth.spec.ts
+++ b/packages/devtools/e2e/tests/auth.spec.ts
@@ -1,11 +1,10 @@
 import { expect, test } from "@playwright/test";
+import { DEVTOOLS_AUTH_URL } from "../fixtures/ports.js";
 import {
   readStoredTokens,
   SEED_CLIENT_ID,
   seedAuthInLocalStorage,
 } from "../fixtures/seed-auth.js";
-
-const DEVTOOLS_AUTH_URL = "http://localhost:5174";
 
 test.describe("devtools auth", () => {
   test("connects to an authenticated server when a token is pre-seeded", async ({

--- a/packages/devtools/e2e/tests/auth.spec.ts
+++ b/packages/devtools/e2e/tests/auth.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "@playwright/test";
+import {
+  readStoredTokens,
+  SEED_CLIENT_ID,
+  seedAuthInLocalStorage,
+} from "../fixtures/seed-auth.js";
+
+const DEVTOOLS_AUTH_URL = "http://localhost:5174";
+
+test.describe("devtools auth", () => {
+  test("connects to an authenticated server when a token is pre-seeded", async ({
+    page,
+  }) => {
+    await seedAuthInLocalStorage(page);
+
+    await page.goto(`${DEVTOOLS_AUTH_URL}/?tool=whoami`);
+
+    await expect(page.getByText("e2e-auth-fixture")).toBeVisible();
+    await expect(page.getByText("Connected")).toBeVisible();
+    await expect(page.getByRole("button", { name: /sign out/i })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "whoami", exact: true }),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: /^run$/i }).click();
+    await expect(page.getByRole("main")).toContainText(SEED_CLIENT_ID);
+  });
+
+  test("performs the full OAuth flow when no token is pre-seeded", async ({
+    page,
+  }) => {
+    // Clean localStorage forces the SDK to walk the full RFC 7591 + OAuth 2.1
+    // path: POST /register → GET /authorize (302 with code) → POST /token.
+    await page.goto(`${DEVTOOLS_AUTH_URL}/`);
+
+    await expect(page.getByText("e2e-auth-fixture")).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByText("Connected")).toBeVisible();
+
+    await page.getByRole("button", { name: "whoami", exact: true }).click();
+    await page.getByRole("button", { name: /^run$/i }).click();
+
+    // The clientId is whatever the mock AS minted during DCR — a UUID, not
+    // the pre-seeded client id. Asserting the UUID shape verifies that the
+    // dynamically-issued access token reached the tool handler intact.
+    await expect(page.getByRole("main")).toContainText(
+      /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/,
+    );
+  });
+
+  test("clicking sign out clears tokens and returns to the disconnected state", async ({
+    page,
+  }) => {
+    await seedAuthInLocalStorage(page);
+
+    await page.goto(`${DEVTOOLS_AUTH_URL}/`);
+    await expect(page.getByText("Connected")).toBeVisible();
+
+    await page.getByRole("button", { name: /sign out/i }).click();
+
+    // logout() resets requiresAuth to false, so the UI shows the generic
+    // "Not connected" prompt instead of the auth-required one. The status
+    // badge and Sign out button both disappear.
+    await expect(page.getByText(/not connected to a server/i)).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /^connect$/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("Connected", { exact: true }),
+    ).not.toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /sign out/i }),
+    ).not.toBeVisible();
+
+    expect(await readStoredTokens(page)).toBeNull();
+  });
+});


### PR DESCRIPTION
Authenticated server on the devtools have been supported but still a dead angle that didn't receive much love.
This PR adds a dedicated e2e test with a stub auth server as a first step.

## Summary

- Add a mock OAuth 2.1 Authorization Server fixture (DCR, PKCE-S256, auth-code grant) for devtools e2e.
- Wire an authenticated MCP fixture and Playwright entries for it (`--auth` flag, devtools on port 5174).
- Cover three scenarios: pre-seeded token, full OAuth flow, sign-out clears tokens.

Split from #803. PR2 (mixed-auth deferred sign-in) stacks on this branch.

Compared to the original implementation:
- Mock AS slimmed (~70 lines): dropped unused `refresh_token` grant, compacted docstring.
- `seedAuthInLocalStorage` extracted to a shared fixture helper so PR2's mixed-auth spec reuses it.
- Playwright `webServer` entries built from a `fixture()` / `devtools()` factory.

## Test plan

- [ ] `pnpm --filter @skybridge/devtools test` passes
- [ ] `pnpm --filter @skybridge/devtools test:e2e auth.spec.ts` passes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds e2e test coverage for DevTools authenticated server connections. It introduces a self-contained mock OAuth 2.1 Authorization Server (DCR, PKCE-S256, auth-code grant), a shared fixture helper for pre-seeding `localStorage`, and three Playwright scenarios covering pre-seeded token, full OAuth flow, and sign-out.

- A new `mock-auth-server.ts` fixture implements the OAuth AS endpoints as an Express router, mounted alongside `requireBearerAuth` in a new `--auth` mode of the existing fixture server.
- `playwright.config.ts` is refactored with `fixture()` / `devtools()` factory helpers and now spins up four `webServer` entries (plain + auth variants for both the MCP fixture and the Vite devtools).
- Shared port constants in `ports.ts` keep the Playwright config and test spec in sync, and `seed-auth.ts` extracts `seedAuthInLocalStorage` for reuse in follow-on PRs.

<h3>Confidence Score: 5/5</h3>

The change is entirely additive test infrastructure — a mock OAuth server, new Playwright config entries, and three e2e scenarios. No production code is modified.

All changes are isolated to the e2e fixture layer. The mock auth server correctly implements one-shot auth codes, PKCE-S256 verification, and in-memory token storage. Port constants are derived from a single shared module, keeping the config and spec in sync. No regressions are introduced in existing smoke tests.

No files require special attention.

<sub>Reviews (3): Last reviewed commit: ["test(devtools): persist mock AS clients ..."](https://github.com/alpic-ai/skybridge/commit/af0bf3e62c88cf1f9ed55c6d5008471c0354e551) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33764046)</sub>

<!-- /greptile_comment -->