### PR TITLE
fix(devtools): use 'pnpm run deploy' to avoid built-in pnpm deploy co…

### DIFF
--- a/packages/devtools/src/components/layout/toolbar-actions.tsx
+++ b/packages/devtools/src/components/layout/toolbar-actions.tsx
@@ -33,7 +33,7 @@ import { cn } from "@/lib/utils.js";
 type PackageManager = "pnpm" | "npm" | "yarn" | "bun";
 
 const RUN_PREFIX_BY_PM: Record<PackageManager, string> = {
-  pnpm: "pnpm",
+  pnpm: "pnpm run",
   npm: "npm run",
   yarn: "yarn",
   bun: "bun run",


### PR DESCRIPTION
…llision

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a command collision where `pnpm deploy` was being generated for the deploy button, which conflicts with pnpm's built-in `deploy` subcommand (used to copy packages to a target directory). The fix changes the prefix to `pnpm run deploy` to explicitly invoke the project's `deploy` script from `package.json`.

- The one-line change in `RUN_PREFIX_BY_PM` corrects the pnpm entry from `"pnpm"` to `"pnpm run"`, matching the pattern already used by npm (`"npm run"`) and bun (`"bun run"`).
- The `useDeployCommand` hook that appends `" deploy"` to this prefix is otherwise untouched, so the generated command shown to users in the Deploy popover will now correctly read `pnpm run deploy`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, clearly correct one-line fix with no side effects beyond the intended behavior.

The only change is correcting "pnpm" to "pnpm run" in the prefix map, which matches what npm and bun already use. The rest of the file is untouched and the fix directly solves the stated collision with pnpm's built-in deploy command.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix(devtools): use &#39;pnpm run deploy&#39; to ..."](https://github.com/alpic-ai/skybridge/commit/fa28ddd9e59590cfbee7137fc3f7c10b43152277) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33776770)</sub>

<!-- /greptile_comment -->