### PR TITLE
feat(landing): add changelog page generated from github releases

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -47,6 +47,7 @@ jobs:
         run: pnpm run build
         env:
           PAGES_BASE_PATH: ${{ steps.setup_pages.outputs.base_path }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5

--- a/landing/app/changelog.md/route.ts
+++ b/landing/app/changelog.md/route.ts
@@ -1,0 +1,41 @@
+import { cleanBodyForMarkdown, getReleases } from "../changelog/lib";
+
+export const dynamic = "force-static";
+
+function formatDate(iso: string | null): string {
+  if (!iso) {
+    return "";
+  }
+  return new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export async function GET() {
+  const releases = await getReleases();
+  const sections = releases.map((release) => {
+    const date = formatDate(release.published_at);
+    const title =
+      release.name && release.name !== release.tag_name ? release.name : null;
+    const heading = title
+      ? `## ${release.tag_name} — ${title}${date ? ` (${date})` : ""}`
+      : `## ${release.tag_name}${date ? ` (${date})` : ""}`;
+    const body = release.body ? cleanBodyForMarkdown(release.body).trim() : "";
+    return body ? `${heading}\n\n${body}` : heading;
+  });
+  const md = [
+    "# Skybridge changelog",
+    "",
+    "Open-source TypeScript framework for building MCP Apps that run in Claude, ChatGPT, VSCode, and any MCP client.",
+    "",
+    "Source: https://github.com/alpic-ai/skybridge/releases",
+    "",
+    ...sections,
+    "",
+  ].join("\n");
+  return new Response(md, {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+}

--- a/landing/app/changelog.md/route.ts
+++ b/landing/app/changelog.md/route.ts
@@ -13,7 +13,7 @@ export async function GET() {
     const title =
       release.name && release.name !== release.tag_name ? release.name : null;
     const heading = title
-      ? `## ${release.tag_name} — ${title}${date ? ` (${date})` : ""}`
+      ? `## ${release.tag_name}: ${title}${date ? ` (${date})` : ""}`
       : `## ${release.tag_name}${date ? ` (${date})` : ""}`;
     const body = release.body ? cleanBodyForMarkdown(release.body).trim() : "";
     return body ? `${heading}\n\n${body}` : heading;

--- a/landing/app/changelog.md/route.ts
+++ b/landing/app/changelog.md/route.ts
@@ -1,17 +1,10 @@
-import { cleanBodyForMarkdown, getReleases } from "../changelog/lib";
+import {
+  cleanBodyForMarkdown,
+  formatDate,
+  getReleases,
+} from "../changelog/lib";
 
 export const dynamic = "force-static";
-
-function formatDate(iso: string | null): string {
-  if (!iso) {
-    return "";
-  }
-  return new Date(iso).toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
-}
 
 export async function GET() {
   const releases = await getReleases();

--- a/landing/app/changelog.md/route.ts
+++ b/landing/app/changelog.md/route.ts
@@ -2,6 +2,7 @@ import {
   cleanBodyForMarkdown,
   formatDate,
   getReleases,
+  splitChanges,
 } from "../changelog/lib";
 
 export const dynamic = "force-static";
@@ -16,7 +17,15 @@ export async function GET() {
       ? `## ${release.tag_name}: ${title}${date ? ` (${date})` : ""}`
       : `## ${release.tag_name}${date ? ` (${date})` : ""}`;
     const body = release.body ? cleanBodyForMarkdown(release.body).trim() : "";
-    return body ? `${heading}\n\n${body}` : heading;
+    const patches = (release.patches ?? []).map((patch) => {
+      const patchDate = formatDate(patch.published_at);
+      const patchHeading = `### ${patch.tag_name}${patchDate ? ` (${patchDate})` : ""}`;
+      const patchBody = patch.body
+        ? cleanBodyForMarkdown(splitChanges(patch.body).intro).trim()
+        : "";
+      return patchBody ? `${patchHeading}\n\n${patchBody}` : patchHeading;
+    });
+    return [body ? `${heading}\n\n${body}` : heading, ...patches].join("\n\n");
   });
   const md = [
     "# Skybridge changelog",

--- a/landing/app/changelog/ChangelogControls.tsx
+++ b/landing/app/changelog/ChangelogControls.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { type ChangeEvent, useEffect, useState } from "react";
+
+const MOBILE_VISIBLE_COUNT = 5;
+
+export function ChangelogControls({ totalCount }: { totalCount: number }) {
+  const [query, setQuery] = useState("");
+  const [showAll, setShowAll] = useState(false);
+
+  useEffect(() => {
+    const q = query.trim().toLowerCase();
+    const items = document.querySelectorAll<HTMLElement>("[data-cl-search]");
+    let visible = 0;
+    items.forEach((el) => {
+      const haystack = (el.dataset.clSearch ?? "").toLowerCase();
+      const match = q === "" || haystack.includes(q);
+      el.hidden = !match;
+      if (match) {
+        visible += 1;
+      }
+    });
+    const empty = document.getElementById("sx-cl-empty");
+    if (empty) {
+      empty.hidden = visible !== 0;
+    }
+  }, [query]);
+
+  useEffect(() => {
+    const list = document.querySelector<HTMLElement>(".sx-cl-toc-list");
+    if (!list) {
+      return;
+    }
+    const expanded = showAll || query.trim() !== "";
+    list.classList.toggle("is-collapsed", !expanded);
+  }, [showAll, query]);
+
+  const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setQuery(event.target.value);
+  };
+
+  const showMoreButton =
+    totalCount > MOBILE_VISIBLE_COUNT && query.trim() === "" ? (
+      <button
+        type="button"
+        className="sx-cl-toc-more"
+        onClick={() => setShowAll((v) => !v)}
+      >
+        {showAll ? "Show fewer" : `Show all ${totalCount} versions`}
+      </button>
+    ) : null;
+
+  return (
+    <div className="sx-cl-controls">
+      <label className="sx-cl-search">
+        <span className="sb-sr-only">Search releases</span>
+        <span className="sx-cl-search-icon" aria-hidden>
+          ⌕
+        </span>
+        <input
+          type="search"
+          placeholder="Search releases"
+          value={query}
+          onChange={onChange}
+          className="sx-cl-search-input"
+        />
+      </label>
+      {showMoreButton}
+    </div>
+  );
+}

--- a/landing/app/changelog/ChangelogControls.tsx
+++ b/landing/app/changelog/ChangelogControls.tsx
@@ -1,71 +1,31 @@
 "use client";
 
-import { type ChangeEvent, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 const MOBILE_VISIBLE_COUNT = 5;
 
 export function ChangelogControls({ totalCount }: { totalCount: number }) {
-  const [query, setQuery] = useState("");
   const [showAll, setShowAll] = useState(false);
-
-  useEffect(() => {
-    const q = query.trim().toLowerCase();
-    const items = document.querySelectorAll<HTMLElement>("[data-cl-search]");
-    let visible = 0;
-    items.forEach((el) => {
-      const haystack = (el.dataset.clSearch ?? "").toLowerCase();
-      const match = q === "" || haystack.includes(q);
-      el.hidden = !match;
-      if (match) {
-        visible += 1;
-      }
-    });
-    const empty = document.getElementById("sx-cl-empty");
-    if (empty) {
-      empty.hidden = visible !== 0;
-    }
-  }, [query]);
 
   useEffect(() => {
     const list = document.querySelector<HTMLElement>(".sx-cl-toc-list");
     if (!list) {
       return;
     }
-    const expanded = showAll || query.trim() !== "";
-    list.classList.toggle("is-collapsed", !expanded);
-  }, [showAll, query]);
+    list.classList.toggle("is-collapsed", !showAll);
+  }, [showAll]);
 
-  const onChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setQuery(event.target.value);
-  };
-
-  const showMoreButton =
-    totalCount > MOBILE_VISIBLE_COUNT && query.trim() === "" ? (
-      <button
-        type="button"
-        className="sx-cl-toc-more"
-        onClick={() => setShowAll((v) => !v)}
-      >
-        {showAll ? "Show fewer" : `Show all ${totalCount} versions`}
-      </button>
-    ) : null;
+  if (totalCount <= MOBILE_VISIBLE_COUNT) {
+    return null;
+  }
 
   return (
-    <div className="sx-cl-controls">
-      <label className="sx-cl-search">
-        <span className="sb-sr-only">Search releases</span>
-        <span className="sx-cl-search-icon" aria-hidden>
-          ⌕
-        </span>
-        <input
-          type="search"
-          placeholder="Search releases"
-          value={query}
-          onChange={onChange}
-          className="sx-cl-search-input"
-        />
-      </label>
-      {showMoreButton}
-    </div>
+    <button
+      type="button"
+      className="sx-cl-toc-more"
+      onClick={() => setShowAll((v) => !v)}
+    >
+      {showAll ? "Show fewer" : `Show all ${totalCount} versions`}
+    </button>
   );
 }

--- a/landing/app/changelog/LazyChanges.tsx
+++ b/landing/app/changelog/LazyChanges.tsx
@@ -50,7 +50,7 @@ export function LazyChanges({ slug, count }: { slug: string; count: number }) {
         </span>
       </summary>
       <div className="sx-cl-body sx-cl-changes-body">
-        {html ? (
+        {html !== null ? (
           // biome-ignore lint/security/noDangerouslySetInnerHtml: html is generated at build time from our own repo
           <div dangerouslySetInnerHTML={{ __html: html }} />
         ) : status === "error" ? (

--- a/landing/app/changelog/LazyChanges.tsx
+++ b/landing/app/changelog/LazyChanges.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+const cache = new Map<string, string>();
+
+export function LazyChanges({ slug, count }: { slug: string; count: number }) {
+  const [html, setHtml] = useState<string | null>(
+    () => cache.get(slug) ?? null,
+  );
+  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
+  const inFlight = useRef(false);
+
+  const label =
+    count > 0
+      ? `Show ${count} merged PR${count === 1 ? "" : "s"}`
+      : "Show changes";
+
+  const onToggle = async (event: React.SyntheticEvent<HTMLDetailsElement>) => {
+    if (!event.currentTarget.open || html || inFlight.current) {
+      return;
+    }
+    inFlight.current = true;
+    setStatus("loading");
+    try {
+      const base = window.location.pathname.replace(/\/+$/, "");
+      const res = await fetch(`${base}/data/${slug}`);
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const text = await res.text();
+      cache.set(slug, text);
+      setHtml(text);
+      setStatus("idle");
+    } catch {
+      setStatus("error");
+    } finally {
+      inFlight.current = false;
+    }
+  };
+
+  return (
+    <details className="sx-cl-changes" onToggle={onToggle}>
+      <summary className="sx-cl-changes-summary">
+        <span className="sx-cl-changes-label">{label}</span>
+        <span className="sx-cl-changes-chev" aria-hidden>
+          ▾
+        </span>
+      </summary>
+      <div className="sx-cl-body sx-cl-changes-body">
+        {html ? (
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: html is generated at build time from our own repo
+          <div dangerouslySetInnerHTML={{ __html: html }} />
+        ) : status === "error" ? (
+          <p className="sx-cl-empty-body">Couldn&apos;t load this list.</p>
+        ) : (
+          <p className="sx-cl-empty-body">Loading…</p>
+        )}
+      </div>
+    </details>
+  );
+}

--- a/landing/app/changelog/LazyChanges.tsx
+++ b/landing/app/changelog/LazyChanges.tsx
@@ -8,16 +8,18 @@ export function LazyChanges({ slug, count }: { slug: string; count: number }) {
   const [html, setHtml] = useState<string | null>(
     () => cache.get(slug) ?? null,
   );
+  const [open, setOpen] = useState(false);
   const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
   const inFlight = useRef(false);
 
-  const label =
-    count > 0
-      ? `Show ${count} merged PR${count === 1 ? "" : "s"}`
-      : "Show changes";
+  const noun =
+    count > 0 ? `${count} merged PR${count === 1 ? "" : "s"}` : "changes";
+  const label = `${open ? "Hide" : "Show"} ${noun}`;
 
   const onToggle = async (event: React.SyntheticEvent<HTMLDetailsElement>) => {
-    if (!event.currentTarget.open || html || inFlight.current) {
+    const isOpen = event.currentTarget.open;
+    setOpen(isOpen);
+    if (!isOpen || html || inFlight.current) {
       return;
     }
     inFlight.current = true;

--- a/landing/app/changelog/PatchChanges.tsx
+++ b/landing/app/changelog/PatchChanges.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+export function PatchChanges({
+  count,
+  markdown,
+}: {
+  count: number;
+  markdown: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const noun =
+    count > 0 ? `${count} merged PR${count === 1 ? "" : "s"}` : "changes";
+  const label = `${open ? "Hide" : "Show"} ${noun}`;
+
+  return (
+    <details
+      className="sx-cl-changes"
+      onToggle={(event) => setOpen(event.currentTarget.open)}
+    >
+      <summary className="sx-cl-changes-summary">
+        <span className="sx-cl-changes-label">{label}</span>
+        <span className="sx-cl-changes-chev" aria-hidden>
+          ▾
+        </span>
+      </summary>
+      <div className="sx-cl-body sx-cl-changes-body">
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm]}
+          components={{
+            a: ({ href, children }) => (
+              <a href={href} target="_blank" rel="noreferrer">
+                {children}
+              </a>
+            ),
+          }}
+        >
+          {markdown}
+        </ReactMarkdown>
+      </div>
+    </details>
+  );
+}

--- a/landing/app/changelog/data/[slug]/route.ts
+++ b/landing/app/changelog/data/[slug]/route.ts
@@ -4,8 +4,8 @@ import remarkParse from "remark-parse";
 import remarkRehype from "remark-rehype";
 import { unified } from "unified";
 import {
+  cleanBodyForMarkdown,
   getReleases,
-  linkifyReferences,
   slugifyTag,
   splitChanges,
 } from "../../lib";
@@ -17,13 +17,6 @@ const processor = unified()
   .use(remarkGfm)
   .use(remarkRehype)
   .use(rehypeStringify);
-
-function withExternalLinks(html: string): string {
-  return html.replace(
-    /<a\s+href=/g,
-    '<a target="_blank" rel="noreferrer" href=',
-  );
-}
 
 export async function generateStaticParams() {
   const releases = await getReleases();
@@ -43,14 +36,14 @@ export async function GET(
       headers: { "Content-Type": "text/html; charset=utf-8" },
     });
   }
-  const { changes } = splitChanges(linkifyReferences(release.body));
+  const { changes } = splitChanges(release.body);
   if (!changes) {
     return new Response("", {
       headers: { "Content-Type": "text/html; charset=utf-8" },
     });
   }
-  const file = await processor.process(changes);
-  return new Response(withExternalLinks(String(file)), {
+  const file = await processor.process(cleanBodyForMarkdown(changes));
+  return new Response(String(file), {
     headers: { "Content-Type": "text/html; charset=utf-8" },
   });
 }

--- a/landing/app/changelog/data/[slug]/route.ts
+++ b/landing/app/changelog/data/[slug]/route.ts
@@ -1,0 +1,56 @@
+import rehypeStringify from "rehype-stringify";
+import remarkGfm from "remark-gfm";
+import remarkParse from "remark-parse";
+import remarkRehype from "remark-rehype";
+import { unified } from "unified";
+import {
+  getReleases,
+  linkifyReferences,
+  slugifyTag,
+  splitChanges,
+} from "../../lib";
+
+export const dynamic = "force-static";
+
+const processor = unified()
+  .use(remarkParse)
+  .use(remarkGfm)
+  .use(remarkRehype)
+  .use(rehypeStringify);
+
+function withExternalLinks(html: string): string {
+  return html.replace(
+    /<a\s+href=/g,
+    '<a target="_blank" rel="noreferrer" href=',
+  );
+}
+
+export async function generateStaticParams() {
+  const releases = await getReleases();
+  return releases.map((release) => ({ slug: slugifyTag(release.tag_name) }));
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await params;
+  const releases = await getReleases();
+  const release = releases.find((r) => slugifyTag(r.tag_name) === slug);
+  if (!release || !release.body) {
+    return new Response("", {
+      status: 404,
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+  }
+  const { changes } = splitChanges(linkifyReferences(release.body));
+  if (!changes) {
+    return new Response("", {
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+  }
+  const file = await processor.process(changes);
+  return new Response(withExternalLinks(String(file)), {
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}

--- a/landing/app/changelog/data/[slug]/route.ts
+++ b/landing/app/changelog/data/[slug]/route.ts
@@ -1,3 +1,4 @@
+import rehypeSanitize from "rehype-sanitize";
 import rehypeStringify from "rehype-stringify";
 import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
@@ -16,6 +17,7 @@ const processor = unified()
   .use(remarkParse)
   .use(remarkGfm)
   .use(remarkRehype)
+  .use(rehypeSanitize)
   .use(rehypeStringify);
 
 export async function generateStaticParams() {

--- a/landing/app/changelog/lib.ts
+++ b/landing/app/changelog/lib.ts
@@ -49,6 +49,17 @@ async function fetchReleases(): Promise<Release[]> {
   }
 }
 
+export function formatDate(iso: string | null): string {
+  if (!iso) {
+    return "";
+  }
+  return new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
 export function slugifyTag(tag: string): string {
   return tag.toLowerCase().replace(/[^a-z0-9.-]+/g, "-");
 }

--- a/landing/app/changelog/lib.ts
+++ b/landing/app/changelog/lib.ts
@@ -9,6 +9,8 @@ export type Release = {
   html_url: string;
   draft: boolean;
   prerelease: boolean;
+  // On a merged minor (v1.2), the patch releases (1.2.1…) newest-first.
+  patches?: Release[];
 };
 
 let releasesPromise: Promise<Release[]> | null = null;
@@ -37,16 +39,69 @@ async function fetchReleases(): Promise<Release[]> {
       return [];
     }
     const data = (await res.json()) as Release[];
-    return data
-      .filter((r) => !r.draft && !r.prerelease)
+    const stable = data
+      .filter(
+        (r) => !r.draft && !r.prerelease && parseVersion(r.tag_name).major >= 1,
+      )
       .sort((a, b) => {
         const aT = a.published_at ? Date.parse(a.published_at) : 0;
         const bT = b.published_at ? Date.parse(b.published_at) : 0;
         return bT - aT;
       });
+    return mergeByMinor(stable);
   } catch {
     return [];
   }
+}
+
+function parseVersion(tag: string): {
+  major: number;
+  minor: number;
+  patch: number;
+} {
+  const [major = 0, minor = 0, patch = 0] = tag
+    .replace(/^v/i, "")
+    .split(".")
+    .map((n) => Number.parseInt(n, 10) || 0);
+  return { major, minor, patch };
+}
+
+// Collapse a minor line into one section: `v1.2` keeps the `.0` release as its
+// body and hangs the patch releases (1.2.1…) off `.patches`, newest-first.
+// `releases` must be sorted newest-first.
+function mergeByMinor(releases: Release[]): Release[] {
+  const groups = new Map<string, Release[]>();
+  for (const r of releases) {
+    const { major, minor } = parseVersion(r.tag_name);
+    const key = `v${major}.${minor}`;
+    const group = groups.get(key);
+    if (group) {
+      group.push(r);
+    } else {
+      groups.set(key, [r]);
+    }
+  }
+  return [...groups].map(([tag_name, patches]) =>
+    mergePatches(tag_name, patches),
+  );
+}
+
+function mergePatches(tag_name: string, patches: Release[]): Release {
+  const latest = patches[0];
+  const codename = patches
+    .map((p) => p.name?.match(/:\s*(.+)$/)?.[1])
+    .find(Boolean);
+  const base =
+    patches.find((p) => parseVersion(p.tag_name).patch === 0) ?? latest;
+  const patchReleases = patches.filter((p) => p !== base);
+  return {
+    ...base,
+    tag_name,
+    name: codename ?? null,
+    published_at: latest.published_at,
+    html_url: latest.html_url,
+    patches: patchReleases,
+  };
 }
 
 export function formatDate(iso: string | null): string {

--- a/landing/app/changelog/lib.ts
+++ b/landing/app/changelog/lib.ts
@@ -1,0 +1,109 @@
+export const REPO = "alpic-ai/skybridge";
+export const GITHUB_REPO_URL = `https://github.com/${REPO}`;
+
+export type Release = {
+  tag_name: string;
+  name: string | null;
+  body: string | null;
+  published_at: string | null;
+  html_url: string;
+  draft: boolean;
+  prerelease: boolean;
+};
+
+let releasesPromise: Promise<Release[]> | null = null;
+
+export function getReleases(): Promise<Release[]> {
+  if (!releasesPromise) {
+    releasesPromise = fetchReleases();
+  }
+  return releasesPromise;
+}
+
+async function fetchReleases(): Promise<Release[]> {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/${REPO}/releases?per_page=100`,
+      { headers, cache: "force-cache" },
+    );
+    if (!res.ok) {
+      return [];
+    }
+    const data = (await res.json()) as Release[];
+    return data
+      .filter((r) => !r.draft && !r.prerelease)
+      .sort((a, b) => {
+        const aT = a.published_at ? Date.parse(a.published_at) : 0;
+        const bT = b.published_at ? Date.parse(b.published_at) : 0;
+        return bT - aT;
+      });
+  } catch {
+    return [];
+  }
+}
+
+export function slugifyTag(tag: string): string {
+  return tag.toLowerCase().replace(/[^a-z0-9.-]+/g, "-");
+}
+
+export function linkifyReferences(body: string): string {
+  return body
+    .replace(/(^|[\s(])#(\d+)\b/g, `$1[#$2](${GITHUB_REPO_URL}/pull/$2)`)
+    .replace(
+      /(^|[\s(])@([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,38})?)\b/g,
+      "$1[@$2](https://github.com/$2)",
+    );
+}
+
+// Strip GitHub noise from a release body so the markdown is readable
+// for LLMs and skimmers: @mentions, PR refs, the old `by @user in <url>`
+// form, and conventional-commit prefixes.
+export function cleanBodyForMarkdown(body: string): string {
+  return body
+    .replace(
+      /^#{1,6}[ \t]+(Changes|What['’]?s?[ \t]+Changed|Changelog)[ \t]*\r?\n+/gim,
+      "",
+    )
+    .replace(/^\*\*Full Changelog\*\*:.*$/gim, "")
+    .replace(/[ \t]+by[ \t]+@[a-zA-Z0-9-]+[ \t]+in[ \t]+https?:\/\/\S+/g, "")
+    .replace(/[ \t]*\(#\d+\)/g, "")
+    .replace(/[ \t]+@[a-zA-Z0-9-]+\b/g, "")
+    .replace(
+      /^([ \t]*[-*][ \t]+)(?:feat|fix|chore|docs|ci|refactor|test|style|perf|build|revert)(?:\([^)]*\))?:[ \t]*/gim,
+      (_, lead: string) => lead,
+    )
+    .replace(
+      /^([ \t]*[-*][ \t]+)([a-z])/gm,
+      (_, lead: string, ch: string) => `${lead}${ch.toUpperCase()}`,
+    )
+    .replace(
+      /^(#{1,5})([ \t]+)/gm,
+      (_, hashes: string, ws: string) => `#${hashes}${ws}`,
+    )
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+export function splitChanges(body: string): {
+  intro: string;
+  changes: string | null;
+  count: number;
+} {
+  const match = body.match(
+    /(^|\r?\n)#{1,6}[ \t]+(Changes|What['’]?s?[ \t]+Changed|Changelog)[ \t]*\r?\n+/i,
+  );
+  if (!match || match.index === undefined) {
+    return { intro: body, changes: null, count: 0 };
+  }
+  const intro = body.slice(0, match.index).trim();
+  const changes = body.slice(match.index + match[0].length).trim();
+  const count = (changes.match(/^[ \t]*[-*][ \t]+/gm) ?? []).length;
+  return { intro, changes, count };
+}

--- a/landing/app/changelog/page.tsx
+++ b/landing/app/changelog/page.tsx
@@ -13,6 +13,7 @@ import {
   slugifyTag,
   splitChanges,
 } from "./lib";
+import { PatchChanges } from "./PatchChanges";
 
 const description =
   "Every Skybridge release, sourced directly from GitHub. New features, fixes, and breaking changes.";
@@ -48,6 +49,14 @@ export const metadata: Metadata = {
 };
 
 export const dynamic = "force-static";
+
+const mdComponents = {
+  a: ({ href, children }: { href?: string; children?: React.ReactNode }) => (
+    <a href={href} target="_blank" rel="noreferrer">
+      {children}
+    </a>
+  ),
+};
 
 export default async function ChangelogPage() {
   const releases = await getReleases();
@@ -156,17 +165,7 @@ export default async function ChangelogPage() {
                           <div className="sx-cl-body">
                             <ReactMarkdown
                               remarkPlugins={[remarkGfm]}
-                              components={{
-                                a: ({ href, children }) => (
-                                  <a
-                                    href={href}
-                                    target="_blank"
-                                    rel="noreferrer"
-                                  >
-                                    {children}
-                                  </a>
-                                ),
-                              }}
+                              components={mdComponents}
                             >
                               {intro}
                             </ReactMarkdown>
@@ -175,7 +174,68 @@ export default async function ChangelogPage() {
                         {changes && <LazyChanges slug={id} count={count} />}
                       </>
                     ) : (
-                      <p className="sx-cl-empty-body">No release notes.</p>
+                      !release.patches?.length && (
+                        <p className="sx-cl-empty-body">No release notes.</p>
+                      )
+                    )}
+                    {release.patches && release.patches.length > 0 && (
+                      <div className="sx-cl-patches">
+                        {release.patches.map((patch) => {
+                          const patchLinkified = patch.body
+                            ? linkifyReferences(patch.body)
+                            : "";
+                          const {
+                            intro: patchBody,
+                            changes: patchChanges,
+                            count: patchCount,
+                          } = splitChanges(patchLinkified);
+                          const patchId = slugifyTag(patch.tag_name);
+                          return (
+                            <section
+                              key={patch.tag_name}
+                              id={patchId}
+                              className="sx-cl-patch"
+                            >
+                              <div className="sx-cl-patch-head">
+                                <a
+                                  href={`#${patchId}`}
+                                  className="sx-cl-patch-tag"
+                                >
+                                  {patch.tag_name}
+                                </a>
+                                <time
+                                  className="sx-cl-date"
+                                  dateTime={patch.published_at ?? undefined}
+                                >
+                                  {formatDate(patch.published_at)}
+                                </time>
+                              </div>
+                              {patchBody ? (
+                                <div className="sx-cl-body">
+                                  <ReactMarkdown
+                                    remarkPlugins={[remarkGfm]}
+                                    components={mdComponents}
+                                  >
+                                    {patchBody}
+                                  </ReactMarkdown>
+                                </div>
+                              ) : (
+                                !patchChanges && (
+                                  <p className="sx-cl-empty-body">
+                                    No release notes.
+                                  </p>
+                                )
+                              )}
+                              {patchChanges && (
+                                <PatchChanges
+                                  count={patchCount}
+                                  markdown={patchChanges}
+                                />
+                              )}
+                            </section>
+                          );
+                        })}
+                      </div>
                     )}
                   </li>
                 );

--- a/landing/app/changelog/page.tsx
+++ b/landing/app/changelog/page.tsx
@@ -14,7 +14,7 @@ import {
 } from "./lib";
 
 const description =
-  "Every Skybridge release, sourced directly from GitHub. New features, fixes, and breaking changes — all in one place.";
+  "Every Skybridge release, sourced directly from GitHub. New features, fixes, and breaking changes.";
 
 const OG_IMAGE = {
   url: "/assets/Skybridge-og.jpg",
@@ -24,7 +24,7 @@ const OG_IMAGE = {
 };
 
 export const metadata: Metadata = {
-  title: "Changelog — Skybridge releases",
+  title: "Skybridge changelog",
   description,
   alternates: {
     canonical: "/changelog",
@@ -32,7 +32,7 @@ export const metadata: Metadata = {
   },
   openGraph: {
     type: "website",
-    title: "Changelog — Skybridge releases",
+    title: "Skybridge changelog",
     description,
     url: "/changelog",
     images: [OG_IMAGE],
@@ -40,7 +40,7 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     site: "@alpic_ai",
-    title: "Changelog — Skybridge releases",
+    title: "Skybridge changelog",
     description,
     images: [OG_IMAGE.url],
   },

--- a/landing/app/changelog/page.tsx
+++ b/landing/app/changelog/page.tsx
@@ -3,8 +3,10 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { SiteNav } from "../components/site-nav";
 import { SiteFooter } from "../components/trust-final";
+import { ChangelogControls } from "./ChangelogControls";
 import { LazyChanges } from "./LazyChanges";
 import {
+  cleanBodyForMarkdown,
   formatDate,
   GITHUB_REPO_URL,
   getReleases,
@@ -90,10 +92,14 @@ export default async function ChangelogPage() {
           <div className="sx-cl-layout">
             <aside className="sx-cl-toc" aria-label="Releases">
               <div className="sx-cl-toc-h">Releases</div>
+              <ChangelogControls totalCount={releases.length} />
               <nav>
-                <ul className="sx-cl-toc-list">
+                <ul className="sx-cl-toc-list is-collapsed">
                   {releases.map((release) => (
-                    <li key={release.tag_name}>
+                    <li
+                      key={release.tag_name}
+                      data-cl-search={`${release.tag_name} ${release.name ?? ""}`}
+                    >
                       <a
                         href={`#${slugifyTag(release.tag_name)}`}
                         className="sx-cl-toc-link"
@@ -104,6 +110,9 @@ export default async function ChangelogPage() {
                   ))}
                 </ul>
               </nav>
+              <p id="sx-cl-empty" className="sx-cl-empty-search" hidden>
+                No releases match.
+              </p>
             </aside>
             <ol className="sx-cl-list">
               {releases.map((release) => {
@@ -113,8 +122,21 @@ export default async function ChangelogPage() {
                   : "";
                 const { intro, changes, count } = splitChanges(linkified);
                 const title = release.name || release.tag_name;
+                const searchHay = [
+                  release.tag_name,
+                  release.name ?? "",
+                  intro,
+                  changes ? cleanBodyForMarkdown(changes) : "",
+                ]
+                  .join(" ")
+                  .replace(/[#@*`_~>[\]()]/g, " ");
                 return (
-                  <li key={release.tag_name} id={id} className="sx-cl-item">
+                  <li
+                    key={release.tag_name}
+                    id={id}
+                    className="sx-cl-item"
+                    data-cl-search={searchHay}
+                  >
                     <header className="sx-cl-head">
                       <a
                         href={`#${id}`}

--- a/landing/app/changelog/page.tsx
+++ b/landing/app/changelog/page.tsx
@@ -5,6 +5,7 @@ import { SiteNav } from "../components/site-nav";
 import { SiteFooter } from "../components/trust-final";
 import { LazyChanges } from "./LazyChanges";
 import {
+  formatDate,
   GITHUB_REPO_URL,
   getReleases,
   linkifyReferences,
@@ -46,17 +47,6 @@ export const metadata: Metadata = {
 };
 
 export const dynamic = "force-static";
-
-function formatDate(iso: string | null): string {
-  if (!iso) {
-    return "";
-  }
-  return new Date(iso).toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
-}
 
 export default async function ChangelogPage() {
   const releases = await getReleases();

--- a/landing/app/changelog/page.tsx
+++ b/landing/app/changelog/page.tsx
@@ -3,9 +3,14 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { SiteNav } from "../components/site-nav";
 import { SiteFooter } from "../components/trust-final";
-
-const REPO = "alpic-ai/skybridge";
-const GITHUB_REPO_URL = `https://github.com/${REPO}`;
+import { LazyChanges } from "./LazyChanges";
+import {
+  GITHUB_REPO_URL,
+  getReleases,
+  linkifyReferences,
+  slugifyTag,
+  splitChanges,
+} from "./lib";
 
 const description =
   "Every Skybridge release, sourced directly from GitHub. New features, fixes, and breaking changes — all in one place.";
@@ -20,7 +25,10 @@ const OG_IMAGE = {
 export const metadata: Metadata = {
   title: "Changelog — Skybridge releases",
   description,
-  alternates: { canonical: "/changelog" },
+  alternates: {
+    canonical: "/changelog",
+    types: { "text/markdown": "/changelog.md" },
+  },
   openGraph: {
     type: "website",
     title: "Changelog — Skybridge releases",
@@ -38,78 +46,6 @@ export const metadata: Metadata = {
 };
 
 export const dynamic = "force-static";
-
-type Release = {
-  tag_name: string;
-  name: string | null;
-  body: string | null;
-  published_at: string | null;
-  html_url: string;
-  draft: boolean;
-  prerelease: boolean;
-};
-
-async function getReleases(): Promise<Release[]> {
-  const headers: Record<string, string> = {
-    Accept: "application/vnd.github+json",
-    "X-GitHub-Api-Version": "2022-11-28",
-  };
-  if (process.env.GITHUB_TOKEN) {
-    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
-  }
-  try {
-    const res = await fetch(
-      `https://api.github.com/repos/${REPO}/releases?per_page=100`,
-      { headers },
-    );
-    if (!res.ok) {
-      return [];
-    }
-    const data = (await res.json()) as Release[];
-    return data
-      .filter((r) => !r.draft && !r.prerelease)
-      .sort((a, b) => {
-        const aT = a.published_at ? Date.parse(a.published_at) : 0;
-        const bT = b.published_at ? Date.parse(b.published_at) : 0;
-        return bT - aT;
-      });
-  } catch {
-    return [];
-  }
-}
-
-function slugifyTag(tag: string): string {
-  return tag.toLowerCase().replace(/[^a-z0-9.-]+/g, "-");
-}
-
-// GitHub release bodies use bare `#NNN` and `@user` — turn them into links.
-function linkifyReferences(body: string): string {
-  return body
-    .replace(/(^|[\s(])#(\d+)\b/g, `$1[#$2](${GITHUB_REPO_URL}/pull/$2)`)
-    .replace(
-      /(^|[\s(])@([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,38})?)\b/g,
-      "$1[@$2](https://github.com/$2)",
-    );
-}
-
-// Split a release body at a `## Changes` (or any heading depth) heading so
-// the PR list can be rendered inside a collapsible <details>.
-function splitChanges(body: string): {
-  intro: string;
-  changes: string | null;
-  count: number;
-} {
-  const match = body.match(
-    /(^|\r?\n)#{1,6}[ \t]+(Changes|What['’]?s?[ \t]+Changed|Changelog)[ \t]*\r?\n+/i,
-  );
-  if (!match || match.index === undefined) {
-    return { intro: body, changes: null, count: 0 };
-  }
-  const intro = body.slice(0, match.index).trim();
-  const changes = body.slice(match.index + match[0].length).trim();
-  const count = (changes.match(/^[ \t]*[-*][ \t]+/gm) ?? []).length;
-  return { intro, changes, count };
-}
 
 function formatDate(iso: string | null): string {
   if (!iso) {
@@ -187,19 +123,6 @@ export default async function ChangelogPage() {
                   : "";
                 const { intro, changes, count } = splitChanges(linkified);
                 const title = release.name || release.tag_name;
-                const markdownComponents = {
-                  a: ({
-                    href,
-                    children,
-                  }: {
-                    href?: string;
-                    children?: React.ReactNode;
-                  }) => (
-                    <a href={href} target="_blank" rel="noreferrer">
-                      {children}
-                    </a>
-                  ),
-                };
                 return (
                   <li key={release.tag_name} id={id} className="sx-cl-item">
                     <header className="sx-cl-head">
@@ -234,34 +157,23 @@ export default async function ChangelogPage() {
                           <div className="sx-cl-body">
                             <ReactMarkdown
                               remarkPlugins={[remarkGfm]}
-                              components={markdownComponents}
+                              components={{
+                                a: ({ href, children }) => (
+                                  <a
+                                    href={href}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                  >
+                                    {children}
+                                  </a>
+                                ),
+                              }}
                             >
                               {intro}
                             </ReactMarkdown>
                           </div>
                         )}
-                        {changes && (
-                          <details className="sx-cl-changes">
-                            <summary className="sx-cl-changes-summary">
-                              <span className="sx-cl-changes-label">
-                                {count > 0
-                                  ? `Show ${count} merged PR${count === 1 ? "" : "s"}`
-                                  : "Show changes"}
-                              </span>
-                              <span className="sx-cl-changes-chev" aria-hidden>
-                                ▾
-                              </span>
-                            </summary>
-                            <div className="sx-cl-body sx-cl-changes-body">
-                              <ReactMarkdown
-                                remarkPlugins={[remarkGfm]}
-                                components={markdownComponents}
-                              >
-                                {changes}
-                              </ReactMarkdown>
-                            </div>
-                          </details>
-                        )}
+                        {changes && <LazyChanges slug={id} count={count} />}
                       </>
                     ) : (
                       <p className="sx-cl-empty-body">No release notes.</p>
@@ -272,6 +184,10 @@ export default async function ChangelogPage() {
             </ol>
           </div>
         )}
+        <div className="sx-cl-foot">
+          Prefer plain text?{" "}
+          <a href="/changelog.md">Read this changelog as markdown</a>.
+        </div>
       </div>
       <SiteFooter />
     </div>

--- a/landing/app/changelog/page.tsx
+++ b/landing/app/changelog/page.tsx
@@ -1,0 +1,279 @@
+import type { Metadata } from "next";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { SiteNav } from "../components/site-nav";
+import { SiteFooter } from "../components/trust-final";
+
+const REPO = "alpic-ai/skybridge";
+const GITHUB_REPO_URL = `https://github.com/${REPO}`;
+
+const description =
+  "Every Skybridge release, sourced directly from GitHub. New features, fixes, and breaking changes — all in one place.";
+
+const OG_IMAGE = {
+  url: "/assets/Skybridge-og.jpg",
+  width: 1200,
+  height: 630,
+  alt: "Skybridge changelog",
+};
+
+export const metadata: Metadata = {
+  title: "Changelog — Skybridge releases",
+  description,
+  alternates: { canonical: "/changelog" },
+  openGraph: {
+    type: "website",
+    title: "Changelog — Skybridge releases",
+    description,
+    url: "/changelog",
+    images: [OG_IMAGE],
+  },
+  twitter: {
+    card: "summary_large_image",
+    site: "@alpic_ai",
+    title: "Changelog — Skybridge releases",
+    description,
+    images: [OG_IMAGE.url],
+  },
+};
+
+export const dynamic = "force-static";
+
+type Release = {
+  tag_name: string;
+  name: string | null;
+  body: string | null;
+  published_at: string | null;
+  html_url: string;
+  draft: boolean;
+  prerelease: boolean;
+};
+
+async function getReleases(): Promise<Release[]> {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/${REPO}/releases?per_page=100`,
+      { headers },
+    );
+    if (!res.ok) {
+      return [];
+    }
+    const data = (await res.json()) as Release[];
+    return data
+      .filter((r) => !r.draft && !r.prerelease)
+      .sort((a, b) => {
+        const aT = a.published_at ? Date.parse(a.published_at) : 0;
+        const bT = b.published_at ? Date.parse(b.published_at) : 0;
+        return bT - aT;
+      });
+  } catch {
+    return [];
+  }
+}
+
+function slugifyTag(tag: string): string {
+  return tag.toLowerCase().replace(/[^a-z0-9.-]+/g, "-");
+}
+
+// GitHub release bodies use bare `#NNN` and `@user` — turn them into links.
+function linkifyReferences(body: string): string {
+  return body
+    .replace(/(^|[\s(])#(\d+)\b/g, `$1[#$2](${GITHUB_REPO_URL}/pull/$2)`)
+    .replace(
+      /(^|[\s(])@([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,38})?)\b/g,
+      "$1[@$2](https://github.com/$2)",
+    );
+}
+
+// Split a release body at a `## Changes` (or any heading depth) heading so
+// the PR list can be rendered inside a collapsible <details>.
+function splitChanges(body: string): {
+  intro: string;
+  changes: string | null;
+  count: number;
+} {
+  const match = body.match(
+    /(^|\r?\n)#{1,6}[ \t]+(Changes|What['’]?s?[ \t]+Changed|Changelog)[ \t]*\r?\n+/i,
+  );
+  if (!match || match.index === undefined) {
+    return { intro: body, changes: null, count: 0 };
+  }
+  const intro = body.slice(0, match.index).trim();
+  const changes = body.slice(match.index + match[0].length).trim();
+  const count = (changes.match(/^[ \t]*[-*][ \t]+/gm) ?? []).length;
+  return { intro, changes, count };
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) {
+    return "";
+  }
+  return new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export default async function ChangelogPage() {
+  const releases = await getReleases();
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: "Skybridge changelog",
+    description,
+    url: "https://skybridge.tech/changelog",
+    itemListElement: releases.slice(0, 20).map((release, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: release.name || release.tag_name,
+      url: `https://skybridge.tech/changelog#${slugifyTag(release.tag_name)}`,
+    })),
+  };
+
+  return (
+    <div className="sb-root" data-theme="dark">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <SiteNav />
+      <div className="sx-page">
+        <div className="sx-page-head">
+          <div className="sx-page-eyebrow">Changelog</div>
+          <h1 className="sx-page-title">
+            What&apos;s new in <span className="sb-accent">Skybridge.</span>
+          </h1>
+          <p className="sx-page-lede">{description}</p>
+        </div>
+
+        {releases.length === 0 ? (
+          <div className="sx-cl-empty">
+            Couldn&apos;t load releases right now. Browse them on{" "}
+            <a href={`${GITHUB_REPO_URL}/releases`}>GitHub</a>.
+          </div>
+        ) : (
+          <div className="sx-cl-layout">
+            <aside className="sx-cl-toc" aria-label="Releases">
+              <div className="sx-cl-toc-h">Releases</div>
+              <nav>
+                <ul className="sx-cl-toc-list">
+                  {releases.map((release) => (
+                    <li key={release.tag_name}>
+                      <a
+                        href={`#${slugifyTag(release.tag_name)}`}
+                        className="sx-cl-toc-link"
+                      >
+                        {release.tag_name}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </nav>
+            </aside>
+            <ol className="sx-cl-list">
+              {releases.map((release) => {
+                const id = slugifyTag(release.tag_name);
+                const linkified = release.body
+                  ? linkifyReferences(release.body)
+                  : "";
+                const { intro, changes, count } = splitChanges(linkified);
+                const title = release.name || release.tag_name;
+                const markdownComponents = {
+                  a: ({
+                    href,
+                    children,
+                  }: {
+                    href?: string;
+                    children?: React.ReactNode;
+                  }) => (
+                    <a href={href} target="_blank" rel="noreferrer">
+                      {children}
+                    </a>
+                  ),
+                };
+                return (
+                  <li key={release.tag_name} id={id} className="sx-cl-item">
+                    <header className="sx-cl-head">
+                      <a
+                        href={`#${id}`}
+                        className="sx-cl-tag"
+                        aria-label={`Permalink to ${release.tag_name}`}
+                      >
+                        {release.tag_name}
+                      </a>
+                      <time
+                        className="sx-cl-date"
+                        dateTime={release.published_at ?? undefined}
+                      >
+                        {formatDate(release.published_at)}
+                      </time>
+                      <a
+                        className="sx-cl-source"
+                        href={release.html_url}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        View on GitHub →
+                      </a>
+                    </header>
+                    {title !== release.tag_name && (
+                      <h2 className="sx-cl-title">{title}</h2>
+                    )}
+                    {intro || changes ? (
+                      <>
+                        {intro && (
+                          <div className="sx-cl-body">
+                            <ReactMarkdown
+                              remarkPlugins={[remarkGfm]}
+                              components={markdownComponents}
+                            >
+                              {intro}
+                            </ReactMarkdown>
+                          </div>
+                        )}
+                        {changes && (
+                          <details className="sx-cl-changes">
+                            <summary className="sx-cl-changes-summary">
+                              <span className="sx-cl-changes-label">
+                                {count > 0
+                                  ? `Show ${count} merged PR${count === 1 ? "" : "s"}`
+                                  : "Show changes"}
+                              </span>
+                              <span className="sx-cl-changes-chev" aria-hidden>
+                                ▾
+                              </span>
+                            </summary>
+                            <div className="sx-cl-body sx-cl-changes-body">
+                              <ReactMarkdown
+                                remarkPlugins={[remarkGfm]}
+                                components={markdownComponents}
+                              >
+                                {changes}
+                              </ReactMarkdown>
+                            </div>
+                          </details>
+                        )}
+                      </>
+                    ) : (
+                      <p className="sx-cl-empty-body">No release notes.</p>
+                    )}
+                  </li>
+                );
+              })}
+            </ol>
+          </div>
+        )}
+      </div>
+      <SiteFooter />
+    </div>
+  );
+}

--- a/landing/app/changelog/page.tsx
+++ b/landing/app/changelog/page.tsx
@@ -66,7 +66,7 @@ export default async function ChangelogPage() {
   };
 
   return (
-    <div className="sb-root" data-theme="dark">
+    <div className="sb-root sb-root-flat" data-theme="dark">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}

--- a/landing/app/changelog/page.tsx
+++ b/landing/app/changelog/page.tsx
@@ -6,7 +6,6 @@ import { SiteFooter } from "../components/trust-final";
 import { ChangelogControls } from "./ChangelogControls";
 import { LazyChanges } from "./LazyChanges";
 import {
-  cleanBodyForMarkdown,
   formatDate,
   GITHUB_REPO_URL,
   getReleases,
@@ -96,10 +95,7 @@ export default async function ChangelogPage() {
               <nav>
                 <ul className="sx-cl-toc-list is-collapsed">
                   {releases.map((release) => (
-                    <li
-                      key={release.tag_name}
-                      data-cl-search={`${release.tag_name} ${release.name ?? ""}`}
-                    >
+                    <li key={release.tag_name}>
                       <a
                         href={`#${slugifyTag(release.tag_name)}`}
                         className="sx-cl-toc-link"
@@ -110,9 +106,6 @@ export default async function ChangelogPage() {
                   ))}
                 </ul>
               </nav>
-              <p id="sx-cl-empty" className="sx-cl-empty-search" hidden>
-                No releases match.
-              </p>
             </aside>
             <ol className="sx-cl-list">
               {releases.map((release) => {
@@ -122,21 +115,8 @@ export default async function ChangelogPage() {
                   : "";
                 const { intro, changes, count } = splitChanges(linkified);
                 const title = release.name || release.tag_name;
-                const searchHay = [
-                  release.tag_name,
-                  release.name ?? "",
-                  intro,
-                  changes ? cleanBodyForMarkdown(changes) : "",
-                ]
-                  .join(" ")
-                  .replace(/[#@*`_~>[\]()]/g, " ");
                 return (
-                  <li
-                    key={release.tag_name}
-                    id={id}
-                    className="sx-cl-item"
-                    data-cl-search={searchHay}
-                  >
+                  <li key={release.tag_name} id={id} className="sx-cl-item">
                     <header className="sx-cl-head">
                       <a
                         href={`#${id}`}

--- a/landing/app/changelog/page.tsx
+++ b/landing/app/changelog/page.tsx
@@ -70,7 +70,14 @@ export default async function ChangelogPage() {
     <div className="sb-root sb-root-flat" data-theme="dark">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        // JSON.stringify leaves </script> intact; escape <,>,/ to keep
+        // the inline script un-breakable by free-text release fields.
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(jsonLd)
+            .replace(/</g, "\\u003c")
+            .replace(/>/g, "\\u003e")
+            .replace(/\//g, "\\u002f"),
+        }}
       />
       <SiteNav />
       <div className="sx-page">

--- a/landing/app/components/site-nav.tsx
+++ b/landing/app/components/site-nav.tsx
@@ -65,6 +65,7 @@ export async function SiteNav() {
         <div className="sb-nav-links">
           <a href="https://docs.skybridge.tech">Docs</a>
           <a href="/showcase">Showcase</a>
+          <a href="/changelog">Changelog</a>
         </div>
         <div className="sb-nav-right">
           <a

--- a/landing/app/llms.txt/route.ts
+++ b/landing/app/llms.txt/route.ts
@@ -1,0 +1,23 @@
+export const dynamic = "force-static";
+
+const BODY = `# Skybridge
+
+> Open-source TypeScript framework for building MCP Apps that run in Claude, ChatGPT, VSCode, and any MCP client. Write one server and view; Skybridge adapts to each host's runtime.
+
+## Docs
+
+- [Documentation](https://docs.skybridge.tech): Full developer docs, guides, and API reference.
+- [Changelog](https://skybridge.tech/changelog.md): All releases as plain markdown.
+- [Showcase](https://skybridge.tech/showcase): MCP Apps built with Skybridge, shipping in ChatGPT and Claude.
+
+## Source
+
+- [GitHub repository](https://github.com/alpic-ai/skybridge)
+- [npm package](https://www.npmjs.com/package/skybridge)
+`;
+
+export async function GET() {
+  return new Response(BODY, {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+}

--- a/landing/app/sb-showcase.css
+++ b/landing/app/sb-showcase.css
@@ -1043,6 +1043,48 @@
   letter-spacing: 0.08em;
   margin: 0 0 14px;
 }
+.sx-cl-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+.sx-cl-search {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+.sx-cl-search-icon {
+  position: absolute;
+  left: 10px;
+  font-size: 14px;
+  color: var(--sb-ink-mute);
+  pointer-events: none;
+}
+.sx-cl-search-input {
+  width: 100%;
+  background: var(--sb-surface-2);
+  border: 1px solid var(--sb-border);
+  border-radius: 8px;
+  padding: 8px 10px 8px 30px;
+  color: var(--sb-ink);
+  font: 400 13px / 1.2 var(--font-body);
+  outline: none;
+}
+.sx-cl-search-input::placeholder {
+  color: var(--sb-ink-mute);
+}
+.sx-cl-search-input:focus {
+  border-color: var(--sb-accent);
+}
+.sx-cl-toc-more {
+  display: none;
+}
+.sx-cl-empty-search {
+  margin: 16px 0 0;
+  color: var(--sb-ink-mute);
+  font: 400 13px / 1.4 var(--font-body);
+}
 .sx-cl-toc-list {
   list-style: none;
   margin: 0;
@@ -1254,15 +1296,19 @@
   }
   .sx-cl-toc {
     position: static;
-    max-height: 200px;
+    max-height: none;
     padding-right: 0;
     padding-bottom: 8px;
+    overflow: visible;
   }
   .sx-cl-toc-list {
     flex-direction: row;
     flex-wrap: wrap;
     border-left: 0;
     gap: 8px;
+  }
+  .sx-cl-toc-list.is-collapsed > li:nth-child(n + 6) {
+    display: none;
   }
   .sx-cl-toc-link {
     padding: 6px 10px;
@@ -1272,6 +1318,22 @@
   }
   .sx-cl-toc-link:hover {
     border-color: var(--sb-accent);
+  }
+  .sx-cl-toc-more {
+    display: inline-flex;
+    align-items: center;
+    align-self: flex-start;
+    background: transparent;
+    border: 1px solid var(--sb-border);
+    border-radius: 999px;
+    padding: 6px 12px;
+    font: 500 12px / 1 var(--font-body);
+    color: var(--sb-ink-soft);
+    cursor: pointer;
+  }
+  .sx-cl-toc-more:hover {
+    border-color: var(--sb-accent);
+    color: var(--sb-accent);
   }
 }
 

--- a/landing/app/sb-showcase.css
+++ b/landing/app/sb-showcase.css
@@ -1201,7 +1201,7 @@
   align-items: center;
   gap: 8px;
   font: 600 12px / 1 var(--font-body);
-  color: var(--sb-ink-soft);
+  color: var(--sb-ink-mute);
   text-transform: uppercase;
   letter-spacing: 0.06em;
   padding: 6px 0;
@@ -1223,6 +1223,33 @@
 }
 .sx-cl-changes-body {
   margin-top: 12px;
+}
+
+.sx-cl-patches {
+  margin-top: 24px;
+  border-top: 1px solid var(--sb-border);
+}
+.sx-cl-patch {
+  padding-top: 20px;
+  margin-top: 20px;
+  scroll-margin-top: 120px;
+}
+.sx-cl-patch + .sx-cl-patch {
+  border-top: 1px solid var(--sb-border);
+}
+.sx-cl-patch-head {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+.sx-cl-patch-tag {
+  font: 600 14px / 1 var(--font-mono);
+  color: var(--sb-ink-soft);
+  text-decoration: none;
+}
+.sx-cl-patch-tag:hover {
+  color: var(--sb-accent);
 }
 
 .sx-cl-foot {

--- a/landing/app/sb-showcase.css
+++ b/landing/app/sb-showcase.css
@@ -1051,47 +1051,8 @@
   letter-spacing: 0.08em;
   margin: 0 0 14px;
 }
-.sx-cl-controls {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  margin-bottom: 14px;
-}
-.sx-cl-search {
-  position: relative;
-  display: flex;
-  align-items: center;
-}
-.sx-cl-search-icon {
-  position: absolute;
-  left: 10px;
-  font-size: 14px;
-  color: var(--sb-ink-mute);
-  pointer-events: none;
-}
-.sx-cl-search-input {
-  width: 100%;
-  background: var(--sb-surface-2);
-  border: 1px solid var(--sb-border);
-  border-radius: 8px;
-  padding: 8px 10px 8px 30px;
-  color: var(--sb-ink);
-  font: 400 13px / 1.2 var(--font-body);
-  outline: none;
-}
-.sx-cl-search-input::placeholder {
-  color: var(--sb-ink-mute);
-}
-.sx-cl-search-input:focus {
-  border-color: var(--sb-accent);
-}
 .sx-cl-toc-more {
   display: none;
-}
-.sx-cl-empty-search {
-  margin: 16px 0 0;
-  color: var(--sb-ink-mute);
-  font: 400 13px / 1.4 var(--font-body);
 }
 .sx-cl-toc-list {
   list-style: none;

--- a/landing/app/sb-showcase.css
+++ b/landing/app/sb-showcase.css
@@ -1021,6 +1021,14 @@
 .sb-root-flat::before {
   display: none;
 }
+.sb-root-flat .sx-page {
+  padding-top: 144px;
+}
+@media (max-width: 600px) {
+  .sb-root-flat .sx-page {
+    padding-top: 112px;
+  }
+}
 .sx-cl-layout {
   display: grid;
   grid-template-columns: 200px minmax(0, 1fr);

--- a/landing/app/sb-showcase.css
+++ b/landing/app/sb-showcase.css
@@ -1291,7 +1291,7 @@
 
 @media (max-width: 880px) {
   .sx-cl-layout {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
     gap: 24px;
   }
   .sx-cl-toc {

--- a/landing/app/sb-showcase.css
+++ b/landing/app/sb-showcase.css
@@ -1018,6 +1018,9 @@
 }
 
 /* ===== Changelog (sx-cl-*) ===== */
+.sb-root-flat::before {
+  display: none;
+}
 .sx-cl-layout {
   display: grid;
   grid-template-columns: 200px minmax(0, 1fr);
@@ -1028,8 +1031,8 @@
 }
 .sx-cl-toc {
   position: sticky;
-  top: 96px;
-  max-height: calc(100vh - 120px);
+  top: 104px;
+  max-height: calc(100vh - 128px);
   overflow-y: auto;
   padding-right: 8px;
 }
@@ -1081,7 +1084,7 @@
   border: 1px solid var(--sb-border);
   border-radius: 18px;
   padding: 32px;
-  scroll-margin-top: 96px;
+  scroll-margin-top: 120px;
 }
 .sx-cl-head {
   display: flex;

--- a/landing/app/sb-showcase.css
+++ b/landing/app/sb-showcase.css
@@ -1212,6 +1212,23 @@
   margin-top: 12px;
 }
 
+.sx-cl-foot {
+  margin: 56px auto 0;
+  text-align: center;
+  font: 400 13.5px / 1.5 var(--font-body);
+  color: var(--sb-ink-mute);
+}
+.sx-cl-foot a {
+  color: var(--sb-ink-soft);
+  text-decoration: underline;
+  text-decoration-color: var(--sb-border);
+  text-underline-offset: 3px;
+}
+.sx-cl-foot a:hover {
+  color: var(--sb-accent);
+  text-decoration-color: var(--sb-accent);
+}
+
 .sx-cl-empty,
 .sx-cl-empty-body {
   text-align: center;

--- a/landing/app/sb-showcase.css
+++ b/landing/app/sb-showcase.css
@@ -1016,6 +1016,259 @@
   text-align: left;
   margin: 0;
 }
+
+/* ===== Changelog (sx-cl-*) ===== */
+.sx-cl-layout {
+  display: grid;
+  grid-template-columns: 200px minmax(0, 1fr);
+  gap: 56px;
+  max-width: 1100px;
+  margin: 0 auto;
+  align-items: start;
+}
+.sx-cl-toc {
+  position: sticky;
+  top: 96px;
+  max-height: calc(100vh - 120px);
+  overflow-y: auto;
+  padding-right: 8px;
+}
+.sx-cl-toc-h {
+  font: 600 12px / 1 var(--font-body);
+  color: var(--sb-ink-mute);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 0 0 14px;
+}
+.sx-cl-toc-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  border-left: 1px solid var(--sb-border);
+}
+.sx-cl-toc-link {
+  display: block;
+  padding: 6px 12px;
+  font: 500 13px / 1.3 var(--font-mono);
+  color: var(--sb-ink-soft);
+  text-decoration: none;
+  border-left: 2px solid transparent;
+  margin-left: -1px;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease;
+}
+.sx-cl-toc-link:hover {
+  color: var(--sb-accent);
+  border-left-color: var(--sb-accent);
+}
+.sx-cl-toc-link:target,
+.sx-cl-item:target ~ .sx-cl-toc .sx-cl-toc-link {
+  color: var(--sb-accent);
+}
+.sx-cl-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+.sx-cl-item {
+  background: var(--sb-surface);
+  border: 1px solid var(--sb-border);
+  border-radius: 18px;
+  padding: 32px;
+  scroll-margin-top: 96px;
+}
+.sx-cl-head {
+  display: flex;
+  align-items: baseline;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+.sx-cl-tag {
+  font: 600 18px / 1 var(--font-mono);
+  color: var(--sb-accent);
+  background: rgba(137, 240, 236, 0.08);
+  border: 1px solid rgba(137, 240, 236, 0.25);
+  border-radius: 999px;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+.sx-cl-tag:hover {
+  background: rgba(137, 240, 236, 0.16);
+}
+.sx-cl-date {
+  font: 400 14px / 1 var(--font-body);
+  color: var(--sb-ink-mute);
+}
+.sx-cl-source {
+  margin-left: auto;
+  font: 500 13px / 1 var(--font-body);
+  color: var(--sb-ink-soft);
+  text-decoration: none;
+}
+.sx-cl-source:hover {
+  color: var(--sb-accent);
+}
+.sx-cl-title {
+  font: 500 24px / 1.25 var(--font-display);
+  margin: 0 0 16px;
+  color: var(--sb-ink);
+}
+.sx-cl-body {
+  font: 400 15.5px / 1.65 var(--font-body);
+  color: var(--sb-ink-soft);
+}
+.sx-cl-body h1,
+.sx-cl-body h2,
+.sx-cl-body h3 {
+  font: 600 16px / 1.3 var(--font-body);
+  color: var(--sb-ink);
+  margin: 24px 0 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.sx-cl-body h1:first-child,
+.sx-cl-body h2:first-child,
+.sx-cl-body h3:first-child {
+  margin-top: 0;
+}
+.sx-cl-body ul,
+.sx-cl-body ol {
+  padding-left: 22px;
+  margin: 0 0 12px;
+}
+.sx-cl-body li {
+  margin: 4px 0;
+}
+.sx-cl-body p {
+  margin: 0 0 12px;
+}
+.sx-cl-body a {
+  color: var(--sb-accent);
+  text-decoration: none;
+}
+.sx-cl-body a:hover {
+  text-decoration: underline;
+}
+.sx-cl-body code {
+  font: 400 0.92em / 1.4 var(--font-mono);
+  background: var(--sb-surface-2);
+  border: 1px solid var(--sb-border);
+  padding: 1px 6px;
+  border-radius: 6px;
+}
+.sx-cl-body pre {
+  background: var(--sb-surface-2);
+  border: 1px solid var(--sb-border);
+  padding: 14px 16px;
+  border-radius: 10px;
+  overflow-x: auto;
+}
+.sx-cl-body pre code {
+  background: transparent;
+  border: 0;
+  padding: 0;
+}
+.sx-cl-changes {
+  margin-top: 4px;
+  border-top: 1px solid var(--sb-border);
+  padding-top: 16px;
+}
+.sx-cl-changes-summary {
+  list-style: none;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font: 600 12px / 1 var(--font-body);
+  color: var(--sb-ink-soft);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 6px 0;
+  user-select: none;
+}
+.sx-cl-changes-summary::-webkit-details-marker {
+  display: none;
+}
+.sx-cl-changes-summary:hover {
+  color: var(--sb-accent);
+}
+.sx-cl-changes-chev {
+  display: inline-block;
+  font-size: 10px;
+  transition: transform 0.15s ease;
+}
+.sx-cl-changes[open] .sx-cl-changes-chev {
+  transform: rotate(180deg);
+}
+.sx-cl-changes-body {
+  margin-top: 12px;
+}
+
+.sx-cl-empty,
+.sx-cl-empty-body {
+  text-align: center;
+  color: var(--sb-ink-mute);
+  font: 400 15px / 1.5 var(--font-body);
+  max-width: 640px;
+  margin: 0 auto;
+}
+.sx-cl-empty-body {
+  margin: 0;
+  text-align: left;
+}
+.sx-cl-empty a {
+  color: var(--sb-accent);
+}
+
+@media (max-width: 880px) {
+  .sx-cl-layout {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+  .sx-cl-toc {
+    position: static;
+    max-height: 200px;
+    padding-right: 0;
+    padding-bottom: 8px;
+  }
+  .sx-cl-toc-list {
+    flex-direction: row;
+    flex-wrap: wrap;
+    border-left: 0;
+    gap: 8px;
+  }
+  .sx-cl-toc-link {
+    padding: 6px 10px;
+    border: 1px solid var(--sb-border);
+    border-radius: 999px;
+    margin-left: 0;
+  }
+  .sx-cl-toc-link:hover {
+    border-color: var(--sb-accent);
+  }
+}
+
+@media (max-width: 600px) {
+  .sx-cl-item {
+    padding: 24px 20px;
+    border-radius: 14px;
+  }
+  .sx-cl-source {
+    margin-left: 0;
+  }
+  .sx-cl-title {
+    font-size: 20px;
+  }
+}
+
 @media (max-width: 960px) {
   .sxA-grid {
     grid-template-columns: repeat(2, 1fr);

--- a/landing/app/sb-showcase.css
+++ b/landing/app/sb-showcase.css
@@ -1065,10 +1065,9 @@
   color: var(--sb-accent);
   border-left-color: var(--sb-accent);
 }
-.sx-cl-toc-link:target,
-.sx-cl-item:target ~ .sx-cl-toc .sx-cl-toc-link {
-  color: var(--sb-accent);
-}
+/* Active TOC highlight would need JS (IntersectionObserver) or a
+   data-attribute toggle; pure-CSS :target can't cross the DOM boundary
+   between .sx-cl-item and .sx-cl-toc here. */
 .sx-cl-list {
   list-style: none;
   margin: 0;

--- a/landing/app/sitemap.ts
+++ b/landing/app/sitemap.ts
@@ -22,6 +22,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "weekly",
       priority: 0.8,
     },
+    {
+      url: `${BASE}/changelog`,
+      lastModified: SITE_UPDATED,
+      changeFrequency: "weekly",
+      priority: 0.7,
+    },
     ...SHOWCASE.map((app) => ({
       url: `${BASE}/showcase/${app.slug}`,
       lastModified: app.updatedAt ?? SITE_UPDATED,

--- a/landing/app/skybridge.css
+++ b/landing/app/skybridge.css
@@ -274,6 +274,11 @@ body {
   color: var(--sb-ink);
   text-transform: none;
 }
+@media (max-width: 600px) {
+  .sb-nav-links {
+    display: none;
+  }
+}
 @media (max-width: 480px) {
   .sb-nav {
     padding: 0 8px;

--- a/landing/package.json
+++ b/landing/package.json
@@ -16,7 +16,11 @@
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-markdown": "^10.1.0",
-    "remark-gfm": "^4.0.1"
+    "rehype-stringify": "^10.0.1",
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.2",
+    "unified": "^11.0.5"
   },
   "devDependencies": {
     "@types/node": "^24.13.3",

--- a/landing/package.json
+++ b/landing/package.json
@@ -14,7 +14,9 @@
     "next": "16.2.10",
     "next-image-export-optimizer": "^1.20.1",
     "react": "19.2.7",
-    "react-dom": "19.2.7"
+    "react-dom": "19.2.7",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@types/node": "^24.13.3",

--- a/landing/package.json
+++ b/landing/package.json
@@ -16,6 +16,7 @@
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-markdown": "^10.1.0",
+    "rehype-sanitize": "^6.0.0",
     "rehype-stringify": "^10.0.1",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",

--- a/landing/public/assets/next-image-export-optimizer-hashes.json
+++ b/landing/public/assets/next-image-export-optimizer-hashes.json
@@ -1,4 +1,6 @@
 {
+    "/Skybridge-og.jpg": "bJnh40j9JtNpQmJS5Ge5F1bkN6TP12m3rwbr2CWd5QM=",
+    "/Skybridge-showcase-apps-og.jpg": "GhK3Djyr38mpDKr+HBPZSA-4MT8tkT-kQ2eQfTIi2WU=",
     "/alpic-mountain-bg.webp": "2zYm36DlMI9iRAVR2WdtagNgPfxlUkyMjPy-8rZhgvc=",
     "/banner.jpg": "P1uEsEYl+axSXGtOZmae8uqcw4ZsoCqjR1jTrtNEj0I=",
     "clients/chatgpt.webp": "kKTh0cG5AtU7bHs-TrmW01o0Il1EYZeUkSLw16Zo6mY=",
@@ -20,6 +22,8 @@
     "people/meir.webp": "uUGoCxMTNRKfXZmFHcYMWE3+6riQAHxUraC2LAbk+pg=",
     "people/pierre-loic.webp": "hHT7+GFImatj4VQWgBNN5G2SmTNNm1EEyDngVtEQqxU=",
     "people/stefan.webp": "IF6arrzBIgDzJ8fbES6eemaaZV7R0FXjr5bvRnJuoeE=",
+    "showcase/alpic-inline-1.webp": "cBKo6ENCPfW-+E9UMjRgmzRJRkpnn7k4GrxAswPuJFI=",
+    "showcase/alpic-inline-2.webp": "tLDsnJtvGTM5xNknePQMB2rqUMz5gCYE0rBM+YF+f8s=",
     "showcase/auth0.webp": "OQVN+Y0qsjq8KNPCQ+MB0pfZnHZkvgkNcFvpoq0p+Uk=",
     "showcase/capitals.webp": "iCkNuEOur3cqtOCzIJzR1xkZGonwbENlDcE5n6+fPII=",
     "showcase/clerk.webp": "9CmDUvkY4S44SmRkGPqPpp2Sb3IZpnZcllAna9hTNcM=",
@@ -29,10 +33,14 @@
     "showcase/evaneos-fullscreen.webp": "owIPIsRVoVNGupKXoSpJhZMuJ1A4yWEwKplMM0RHOMI=",
     "showcase/evaneos.webp": "PZXlN+DqeQZRDyHvWvfnevFh1Ua1BimiE8Tzpwtabws=",
     "showcase/everything.webp": "lzn4Z6HjYjRxRQaM+zYhohSDTtyugGelkQuLqcVFAfI=",
+    "showcase/facile-inline-1.webp": "SqZanFiW8hzCtLGSTuoqxBhVCxpTrqZrzgSbapAlhlk=",
+    "showcase/facile-inline-2.webp": "1D4StIwRDNwPJGk1xieWXFuln8gs+y9ApDZyj+m0gpg=",
     "showcase/flight-booking.webp": "NS02uXdggLUNWdNRb2c-bRSU9tdaMfPLtreYRblP6ks=",
     "showcase/generative-ui.webp": "FeYR+1K+4v0dpDtkA4r5d2qLGPm4bgjxJPfIf1Td2Vk=",
+    "showcase/icons/alpic.webp": "sdvvUBslClwYENHIGjLSoL+LNCgJOfzdCdBBTgL0EKU=",
     "showcase/icons/cottages.webp": "bxwcQeG85+xi1SG7zbHGSsD-pxToodCxRUpBLSifpUs=",
     "showcase/icons/evaneos.webp": "njOdN+yVzcnu+UyEKUBq8s7Sy+hDpgpSaYvi-yHMIHo=",
+    "showcase/icons/facile.webp": "y9uMbvGekbzY2ewAkVkEHMFvAjlnsKHkl8Eg4TNdPe8=",
     "showcase/icons/kiwi.webp": "y0u7yzu-xhWLW+5oznU07-7CnqjQVdi3rMHJzCXRpw0=",
     "showcase/icons/recommerce-tradein.webp": "TkJxIxFCpXyh8dmWb8P5gt2CeClBpxh8VatJb5i7BSw=",
     "showcase/icons/recommerce.webp": "91kg5UWGK0Nl8TJ4BSpZHPdGQSTqm2huG3MVTcslQbA=",
@@ -52,5 +60,7 @@
     "showcase/times-up.webp": "5raUKHaLcYwoqfXKM-rwdPunsQug5hLDL90nIcOJvi0=",
     "showcase/vpfullscreen.webp": "EvNfdahzwlvAThG-vPL-QTp7Ndc5JflZDLue25CnquU=",
     "showcase/vpinline.webp": "fBvdy8VnqQIrqjgx+m7Cw3T4Nyfb5Xq78Mho8e7H0ug=",
-    "showcase/workos.webp": "rtUGk3IINa9USGJgu0nFauF6-IC8628HKuEV3MU+4Zw="
+    "showcase/workos.webp": "rtUGk3IINa9USGJgu0nFauF6-IC8628HKuEV3MU+4Zw=",
+    "/tokyo.jpg": "6fiIUMa2q7dKR9ypuH+g80DN1dSVaIHbl99jjcnNomo=",
+    "/video-poster.jpg": "--WSfEt+kB9jq1oaxKYUQt1pMNPsVTu+mn6uEWbLEb4="
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1301,6 +1301,12 @@ importers:
       react-dom:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
     devDependencies:
       '@types/node':
         specifier: ^24.13.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,7 +46,7 @@ importers:
     devDependencies:
       mintlify:
         specifier: ^4.2.687
-        version: 4.2.687(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/node@24.13.3)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
+        version: 4.2.687(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/node@25.9.5)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
 
   examples/auth-auth0:
     dependencies:
@@ -1304,6 +1304,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
+      rehype-sanitize:
+        specifier: ^6.0.0
+        version: 6.0.0
       rehype-stringify:
         specifier: ^10.0.1
         version: 10.0.1
@@ -8124,6 +8127,9 @@ packages:
   hast-util-phrasing@3.0.1:
     resolution: {integrity: sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ==}
 
+  hast-util-sanitize@5.0.2:
+    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
+
   hast-util-to-estree@3.1.3:
     resolution: {integrity: sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==}
 
@@ -10185,6 +10191,9 @@ packages:
 
   rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
+
+  rehype-sanitize@6.0.0:
+    resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
 
   rehype-stringify@10.0.1:
     resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
@@ -12796,15 +12805,15 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
-  '@inquirer/checkbox@4.3.2(@types/node@24.13.3)':
+  '@inquirer/checkbox@4.3.2(@types/node@25.9.5)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.13.3
+      '@types/node': 25.9.5
 
   '@inquirer/confirm@5.1.21(@types/node@24.13.3)':
     dependencies:
@@ -12812,6 +12821,7 @@ snapshots:
       '@inquirer/type': 3.0.10(@types/node@24.13.3)
     optionalDependencies:
       '@types/node': 24.13.3
+    optional: true
 
   '@inquirer/confirm@5.1.21(@types/node@25.9.5)':
     dependencies:
@@ -12819,7 +12829,6 @@ snapshots:
       '@inquirer/type': 3.0.10(@types/node@25.9.5)
     optionalDependencies:
       '@types/node': 25.9.5
-    optional: true
 
   '@inquirer/core@10.3.2(@types/node@24.13.3)':
     dependencies:
@@ -12833,6 +12842,7 @@ snapshots:
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 24.13.3
+    optional: true
 
   '@inquirer/core@10.3.2(@types/node@25.9.5)':
     dependencies:
@@ -12846,105 +12856,104 @@ snapshots:
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 25.9.5
-    optional: true
 
-  '@inquirer/editor@4.2.23(@types/node@24.13.3)':
+  '@inquirer/editor@4.2.23(@types/node@25.9.5)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.13.3)
-      '@inquirer/external-editor': 1.0.3(@types/node@24.13.3)
-      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
+      '@inquirer/external-editor': 1.0.3(@types/node@25.9.5)
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
     optionalDependencies:
-      '@types/node': 24.13.3
+      '@types/node': 25.9.5
 
-  '@inquirer/expand@4.0.23(@types/node@24.13.3)':
+  '@inquirer/expand@4.0.23(@types/node@25.9.5)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.13.3)
-      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.13.3
+      '@types/node': 25.9.5
 
-  '@inquirer/external-editor@1.0.3(@types/node@24.13.3)':
+  '@inquirer/external-editor@1.0.3(@types/node@25.9.5)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.1
     optionalDependencies:
-      '@types/node': 24.13.3
+      '@types/node': 25.9.5
 
   '@inquirer/figures@1.0.15': {}
 
-  '@inquirer/input@4.3.1(@types/node@24.13.3)':
+  '@inquirer/input@4.3.1(@types/node@25.9.5)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.13.3)
-      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
     optionalDependencies:
-      '@types/node': 24.13.3
+      '@types/node': 25.9.5
 
-  '@inquirer/number@3.0.23(@types/node@24.13.3)':
+  '@inquirer/number@3.0.23(@types/node@25.9.5)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.13.3)
-      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
     optionalDependencies:
-      '@types/node': 24.13.3
+      '@types/node': 25.9.5
 
-  '@inquirer/password@4.0.23(@types/node@24.13.3)':
+  '@inquirer/password@4.0.23(@types/node@25.9.5)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@24.13.3)
-      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
     optionalDependencies:
-      '@types/node': 24.13.3
+      '@types/node': 25.9.5
 
-  '@inquirer/prompts@7.9.0(@types/node@24.13.3)':
+  '@inquirer/prompts@7.9.0(@types/node@25.9.5)':
     dependencies:
-      '@inquirer/checkbox': 4.3.2(@types/node@24.13.3)
-      '@inquirer/confirm': 5.1.21(@types/node@24.13.3)
-      '@inquirer/editor': 4.2.23(@types/node@24.13.3)
-      '@inquirer/expand': 4.0.23(@types/node@24.13.3)
-      '@inquirer/input': 4.3.1(@types/node@24.13.3)
-      '@inquirer/number': 3.0.23(@types/node@24.13.3)
-      '@inquirer/password': 4.0.23(@types/node@24.13.3)
-      '@inquirer/rawlist': 4.1.11(@types/node@24.13.3)
-      '@inquirer/search': 3.2.2(@types/node@24.13.3)
-      '@inquirer/select': 4.4.2(@types/node@24.13.3)
+      '@inquirer/checkbox': 4.3.2(@types/node@25.9.5)
+      '@inquirer/confirm': 5.1.21(@types/node@25.9.5)
+      '@inquirer/editor': 4.2.23(@types/node@25.9.5)
+      '@inquirer/expand': 4.0.23(@types/node@25.9.5)
+      '@inquirer/input': 4.3.1(@types/node@25.9.5)
+      '@inquirer/number': 3.0.23(@types/node@25.9.5)
+      '@inquirer/password': 4.0.23(@types/node@25.9.5)
+      '@inquirer/rawlist': 4.1.11(@types/node@25.9.5)
+      '@inquirer/search': 3.2.2(@types/node@25.9.5)
+      '@inquirer/select': 4.4.2(@types/node@25.9.5)
     optionalDependencies:
-      '@types/node': 24.13.3
+      '@types/node': 25.9.5
 
-  '@inquirer/rawlist@4.1.11(@types/node@24.13.3)':
+  '@inquirer/rawlist@4.1.11(@types/node@25.9.5)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.13.3)
-      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.13.3
+      '@types/node': 25.9.5
 
-  '@inquirer/search@3.2.2(@types/node@24.13.3)':
+  '@inquirer/search@3.2.2(@types/node@25.9.5)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.13.3
+      '@types/node': 25.9.5
 
-  '@inquirer/select@4.4.2(@types/node@24.13.3)':
+  '@inquirer/select@4.4.2(@types/node@25.9.5)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.13.3
+      '@types/node': 25.9.5
 
   '@inquirer/type@3.0.10(@types/node@24.13.3)':
     optionalDependencies:
       '@types/node': 24.13.3
+    optional: true
 
   '@inquirer/type@3.0.10(@types/node@25.9.5)':
     optionalDependencies:
       '@types/node': 25.9.5
-    optional: true
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
@@ -13073,14 +13082,14 @@ snapshots:
       '@types/react': 19.2.17
       react: 19.2.3
 
-  '@mintlify/cli@4.0.1290(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/node@24.13.3)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)':
+  '@mintlify/cli@4.0.1290(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/node@25.9.5)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
-      '@inquirer/prompts': 7.9.0(@types/node@24.13.3)
-      '@mintlify/common': 1.0.1003(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
-      '@mintlify/link-rot': 3.0.1193(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
+      '@inquirer/prompts': 7.9.0(@types/node@25.9.5)
+      '@mintlify/common': 1.0.1003(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
+      '@mintlify/link-rot': 3.0.1193(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
       '@mintlify/models': 0.0.335
-      '@mintlify/prebuild': 1.0.1150(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
-      '@mintlify/previewing': 4.0.1218(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
+      '@mintlify/prebuild': 1.0.1150(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
+      '@mintlify/previewing': 4.0.1218(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
       '@mintlify/validation': 0.1.778(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       adm-zip: 0.5.16
       chalk: 5.2.0
@@ -13089,7 +13098,7 @@ snapshots:
       front-matter: 4.0.2
       fs-extra: 11.2.0
       ink: 6.3.0(@types/react@19.2.17)(react@19.2.3)
-      inquirer: 12.3.0(@types/node@24.13.3)
+      inquirer: 12.3.0(@types/node@25.9.5)
       js-yaml: 4.1.1
       mdast-util-mdx-jsx: 3.2.0
       open: 8.4.2
@@ -13119,7 +13128,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@mintlify/common@1.0.1003(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)':
+  '@mintlify/common@1.0.1003(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
       '@asyncapi/parser': 3.4.0
       '@asyncapi/specs': 6.8.1
@@ -13161,7 +13170,7 @@ snapshots:
       remark-rehype: 11.1.1
       remark-stringify: 11.0.0
       sucrase: 3.34.0
-      tailwindcss-v3: tailwindcss@3.4.17(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))
+      tailwindcss-v3: tailwindcss@3.4.17(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))
       unified: 11.0.5
       unist-builder: 4.0.0
       unist-util-map: 4.0.0
@@ -13182,13 +13191,13 @@ snapshots:
       - ts-node
       - typescript
 
-  '@mintlify/link-rot@3.0.1193(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)':
+  '@mintlify/link-rot@3.0.1193(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
-      '@mintlify/common': 1.0.1003(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
+      '@mintlify/common': 1.0.1003(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
       '@mintlify/models': 0.0.335
-      '@mintlify/prebuild': 1.0.1150(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
-      '@mintlify/previewing': 4.0.1218(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
-      '@mintlify/scraping': 4.0.868(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
+      '@mintlify/prebuild': 1.0.1150(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
+      '@mintlify/previewing': 4.0.1218(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
+      '@mintlify/scraping': 4.0.868(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
       '@mintlify/validation': 0.1.778(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       fs-extra: 11.1.0
       unist-util-visit: 4.1.2
@@ -13251,11 +13260,11 @@ snapshots:
       leven: 4.1.0
       yaml: 2.9.0
 
-  '@mintlify/prebuild@1.0.1150(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)':
+  '@mintlify/prebuild@1.0.1150(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
-      '@mintlify/common': 1.0.1003(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
+      '@mintlify/common': 1.0.1003(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
       '@mintlify/openapi-parser': 0.0.8
-      '@mintlify/scraping': 4.0.868(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
+      '@mintlify/scraping': 4.0.868(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
       '@mintlify/validation': 0.1.778(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       chalk: 5.3.0
       favicons: 7.2.0
@@ -13283,10 +13292,10 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@mintlify/previewing@4.0.1218(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)':
+  '@mintlify/previewing@4.0.1218(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
-      '@mintlify/common': 1.0.1003(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
-      '@mintlify/prebuild': 1.0.1150(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
+      '@mintlify/common': 1.0.1003(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
+      '@mintlify/prebuild': 1.0.1150(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
       '@mintlify/validation': 0.1.778(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       adm-zip: 0.5.16
       better-opn: 3.0.2
@@ -13322,9 +13331,9 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@mintlify/scraping@4.0.868(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)':
+  '@mintlify/scraping@4.0.868(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
-      '@mintlify/common': 1.0.1003(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
+      '@mintlify/common': 1.0.1003(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
       '@mintlify/openapi-parser': 0.0.8
       fs-extra: 11.1.1
       hast-util-to-mdast: 10.1.0
@@ -19153,6 +19162,12 @@ snapshots:
       hast-util-is-body-ok-link: 3.0.1
       hast-util-is-element: 3.0.0
 
+  hast-util-sanitize@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.0
+      unist-util-position: 5.0.0
+
   hast-util-to-estree@3.1.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -19461,12 +19476,12 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
-  inquirer@12.3.0(@types/node@24.13.3):
+  inquirer@12.3.0(@types/node@25.9.5):
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.13.3)
-      '@inquirer/prompts': 7.9.0(@types/node@24.13.3)
-      '@inquirer/type': 3.0.10(@types/node@24.13.3)
-      '@types/node': 24.13.3
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
+      '@inquirer/prompts': 7.9.0(@types/node@25.9.5)
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
+      '@types/node': 25.9.5
       ansi-escapes: 4.3.2
       mute-stream: 2.0.0
       run-async: 3.0.0
@@ -20570,9 +20585,9 @@ snapshots:
     dependencies:
       minipass: 7.1.2
 
-  mintlify@4.2.687(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/node@24.13.3)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3):
+  mintlify@4.2.687(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/node@25.9.5)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3):
     dependencies:
-      '@mintlify/cli': 4.0.1290(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/node@24.13.3)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
+      '@mintlify/cli': 4.0.1290(@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/node@25.9.5)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
     transitivePeerDependencies:
       - '@radix-ui/react-popover'
       - '@types/node'
@@ -21083,13 +21098,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.17
 
-  postcss-load-config@4.0.2(postcss@8.5.17)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3)):
+  postcss-load-config@4.0.2(postcss@8.5.17)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.9.0
     optionalDependencies:
       postcss: 8.5.17
-      ts-node: 10.9.2(@types/node@24.13.3)(typescript@6.0.3)
+      ts-node: 10.9.2(@types/node@25.9.5)(typescript@6.0.3)
 
   postcss-nested@6.2.0(postcss@8.5.17):
     dependencies:
@@ -21852,6 +21867,11 @@ snapshots:
       hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
       - supports-color
+
+  rehype-sanitize@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-sanitize: 5.0.2
 
   rehype-stringify@10.0.1:
     dependencies:
@@ -22797,7 +22817,7 @@ snapshots:
     dependencies:
       tailwindcss: 4.3.2
 
-  tailwindcss@3.4.17(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3)):
+  tailwindcss@3.4.17(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -22816,7 +22836,7 @@ snapshots:
       postcss: 8.5.17
       postcss-import: 15.1.0(postcss@8.5.17)
       postcss-js: 4.1.0(postcss@8.5.17)
-      postcss-load-config: 4.0.2(postcss@8.5.17)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))
+      postcss-load-config: 4.0.2(postcss@8.5.17)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))
       postcss-nested: 6.2.0(postcss@8.5.17)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1304,9 +1304,21 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
+      rehype-stringify:
+        specifier: ^10.0.1
+        version: 10.0.1
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
+      remark-rehype:
+        specifier: ^11.1.2
+        version: 11.1.2
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
     devDependencies:
       '@types/node':
         specifier: ^24.13.3

--- a/skills/chatgpt-app-builder/SKILL.md
+++ b/skills/chatgpt-app-builder/SKILL.md
@@ -45,3 +45,5 @@ Design or evolve UX flows and API shape → [architecture.md](references/archite
 - **Publish to ChatGPT Directory** → [publish.md](references/publish.md): when ready to submit for review
 
 Full API docs: [https://docs.skybridge.tech/api-reference.md](https://docs.skybridge.tech/api-reference.md)
+
+Release notes & changelog: [https://skybridge.tech/changelog.md](https://skybridge.tech/changelog.md)

--- a/skills/mcp-app-builder/SKILL.md
+++ b/skills/mcp-app-builder/SKILL.md
@@ -46,3 +46,5 @@ Design or evolve UX flows and API shape → [architecture.md](references/archite
 - **Publish to ChatGPT/Claude Directories** → [publish.md](references/publish.md): when ready to submit for review
 
 Full API docs: [https://docs.skybridge.tech/api-reference.md](https://docs.skybridge.tech/api-reference.md)
+
+Release notes & changelog: [https://skybridge.tech/changelog.md](https://skybridge.tech/changelog.md)

--- a/skills/skybridge/SKILL.md
+++ b/skills/skybridge/SKILL.md
@@ -46,3 +46,5 @@ Design or evolve UX flows and API shape → [architecture.md](references/archite
 - **Publish to ChatGPT/Claude Directories** → [publish.md](references/publish.md): when ready to submit for review
 
 Full API docs: [https://docs.skybridge.tech/api-reference.md](https://docs.skybridge.tech/api-reference.md)
+
+Release notes & changelog: [https://skybridge.tech/changelog.md](https://skybridge.tech/changelog.md)


### PR DESCRIPTION
Adding changelog to landing page : Useful to make content for SEO and also features an optimized LLM markdown file that we could target in the skybridge skill to make an LLM aware of changes and migration notes.

<img width="1234" height="890" alt="image" src="https://github.com/user-attachments/assets/f4ee373e-e845-4022-bcd0-c742a453b907" />
<img width="921" height="897" alt="image" src="https://github.com/user-attachments/assets/88610ee4-7c93-4ced-8e3d-c8c9eeba7e87" />


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new `/changelog` page to the landing site that pulls all published GitHub releases and renders them as a two-column layout with a sticky TOC, lazy-loaded PR lists, and a machine-readable `/changelog.md` endpoint. It also adds an `llms.txt` route and wires the three SKILL.md files to the new markdown changelog so LLM agents can discover recent releases.

- **Changelog page** (`landing/app/changelog/`): static Next.js page with `getReleases()` fetching GitHub's releases API, `ReactMarkdown`-rendered intro sections, and a `LazyChanges` client component that fetches pre-generated HTML from `/changelog/data/[slug]` on demand. JSON-LD structured data is properly escaped against `</script>` injection.
- **`/changelog.md` and `/llms.txt` routes**: both are `force-static` endpoints that expose the release history as plain text for LLMs and direct linking; the deploy workflow gains a `release: published` trigger and the `GITHUB_TOKEN` env var so the site rebuilds automatically on each new release.
- **Dependencies**: adds `react-markdown`, `unified`, `remark-*`, and `rehype-*` for markdown-to-HTML rendering; `@ungap/structured-clone@1.3.0` is pulled in transitively and is deprecated with a CWE-502 advisory — bumping to 1.3.1 via a lockfile override is recommended.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is an additive feature (new pages, new routes, new nav link) with no changes to existing logic paths. The JSON-LD XSS risk has been handled, and the dangerouslySetInnerHTML in LazyChanges is backed by the remark-rehype pipeline with allowDangerousHtml: false.

All changes are new, additive routes and components. The two findings are cosmetic/quality issues: PR-number links rendered inconsistently between the intro and the lazy-loaded changes panel, and a deprecated transitive dependency in the lockfile. Neither affects correctness of the page for the vast majority of release notes, and neither poses a runtime risk.

landing/app/changelog/data/[slug]/route.ts (missing linkifyReferences) and pnpm-lock.yaml (deprecated @ungap/structured-clone@1.3.0).

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
landing/app/changelog/data/[slug]/route.ts:39-45
**`linkifyReferences` not applied to lazily-loaded changes**

`splitChanges` is called on the raw `release.body` here, so any standalone `#123` issue/PR references written in manually-authored release notes will be rendered as plain text in the "Show X PRs" panel. In `page.tsx`, `linkifyReferences` is applied before `splitChanges`, so the same references in the intro section become clickable links — creating inconsistent behaviour between the two halves of the same release card. Passing `linkifyReferences(release.body)` to `splitChanges` would make the changes panel consistent with the intro.

### Issue 2 of 2
pnpm-lock.yaml:1035-1036
**Deprecated transitive dependency with CWE-502 advisory**

`@ungap/structured-clone@1.3.0` is pulled in by the new `unified`/`remark`/`rehype` packages and is flagged as deprecated with `Potential CWE-502` (prototype pollution during object cloning). Version 1.3.1 contains the fix. Bumping the resolution in `pnpm-lock.yaml` (or adding an `overrides` entry in the root `package.json`) will pull in the patched version.

`````

</details>

<sub>Reviews (8): Last reviewed commit: ["fix(landing/changelog): escape JSON-LD s..."](https://github.com/alpic-ai/skybridge/commit/12248d87a8cdf94bb5690691e02acad59c92c21c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33782278)</sub>

<!-- /greptile_comment -->