### PR TITLE
fix: use 'pnpm run deploy' instead of 'pnpm deploy' in devtools.

### DIFF
--- a/docs/quickstart/deploy.mdx
+++ b/docs/quickstart/deploy.mdx
@@ -26,7 +26,7 @@ To deploy your App on Alpic you can:
 npm run deploy
 ```
 ```bash pnpm
-pnpm deploy
+pnpm run deploy
 ```
 ```bash yarn
 yarn deploy


### PR DESCRIPTION
Fixes #816 

## Fix

<img width="1920" height="1080" alt="Screenshot (410)" src="https://github.com/user-attachments/assets/6718772e-29fe-4c31-95f7-9a97df08ea4a" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a documentation error in the deploy quickstart guide where `pnpm deploy` was incorrectly used instead of `pnpm run deploy`. `pnpm deploy` is a built-in pnpm command that copies a project to a deployment directory, not a script runner, so it would not execute the project's `deploy` script as intended.

- Replaces `pnpm deploy` with `pnpm run deploy` in the Alpic Cloud code group, making the pnpm tab consistent with the `npm run deploy`, `bun run deploy`, and `yarn deploy` equivalents shown alongside it.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a single documentation line corrected to use the proper pnpm script-runner form.

The change is a one-line doc fix that swaps a pnpm built-in command for the correct script-runner invocation, directly matching the behavior of the npm and bun equivalents already present in the same code group. No logic, configuration, or runtime code is touched.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix: use &#39;pnpm run deploy&#39; instead of &#39;p..."](https://github.com/alpic-ai/skybridge/commit/c090e03802fd93ea904766de9aeeae27dd5b85cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33877772)</sub>

<!-- /greptile_comment -->