### PR TITLE
Add Vercel deploy support; wrap entry to hide setViteManifest

### DIFF
--- a/examples/everything/.gitignore
+++ b/examples/everything/.gitignore
@@ -1,0 +1,3 @@
+api/
+public/
+.vercel/

--- a/examples/everything/src/server.ts
+++ b/examples/everything/src/server.ts
@@ -47,6 +47,13 @@ const server = new McpServer(
     },
   );
 
-server.run();
+if (process.env.NODE_ENV === "production") {
+  const { default: manifest } = await import("./vite-manifest.js");
+  server.setViteManifest(manifest);
+}
+
+server.express.get("/health", (_req, res) => res.json({ ok: true }));
 
 export type AppType = typeof server;
+
+export default await server.run();

--- a/examples/everything/src/vite-manifest.d.ts
+++ b/examples/everything/src/vite-manifest.d.ts
@@ -1,0 +1,2 @@
+declare const manifest: Record<string, { file: string }>;
+export default manifest;

--- a/packages/core/src/commands/build-helpers.test.ts
+++ b/packages/core/src/commands/build-helpers.test.ts
@@ -1,0 +1,124 @@
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_VERCEL_JSON,
+  emitManifestModule,
+  emitVercelFunction,
+  ensureVercelJson,
+  inspectVercelJson,
+  VERCEL_API_ENTRY_CONTENT,
+} from "./build-helpers.js";
+
+function mkTmp(prefix = "skybridge-build-helpers-") {
+  return mkdtempSync(path.join(tmpdir(), prefix));
+}
+
+describe("emitManifestModule", () => {
+  it("inlines the JSON manifest as an ESM default export", () => {
+    const dir = mkTmp();
+    const inPath = path.join(dir, "manifest.json");
+    const outPath = path.join(dir, "vite-manifest.js");
+    const manifest = { "src/views/foo.tsx": { file: "assets/foo-abc.js" } };
+    writeFileSync(inPath, JSON.stringify(manifest));
+    emitManifestModule(inPath, outPath);
+    const out = readFileSync(outPath, "utf-8");
+    expect(out.startsWith("export default ")).toBe(true);
+    const literal = out
+      .slice("export default ".length)
+      .trim()
+      .replace(/;$/, "");
+    expect(JSON.parse(literal)).toEqual(manifest);
+  });
+});
+
+describe("VERCEL_API_ENTRY_CONTENT", () => {
+  it("re-exports the default export from dist/server.js", () => {
+    expect(VERCEL_API_ENTRY_CONTENT).toBe(
+      'export { default } from "../dist/server.js";\n',
+    );
+  });
+});
+
+describe("emitVercelFunction", () => {
+  it("writes api/mcp.js pointing at dist/server.js", () => {
+    const dir = mkTmp();
+    emitVercelFunction(dir);
+    const out = readFileSync(path.join(dir, "api", "mcp.js"), "utf-8");
+    expect(out).toBe(VERCEL_API_ENTRY_CONTENT);
+  });
+});
+
+describe("inspectVercelJson", () => {
+  it("returns no warnings for the canonical config", () => {
+    expect(inspectVercelJson(DEFAULT_VERCEL_JSON)).toEqual([]);
+  });
+
+  it("warns when outputDirectory is missing", () => {
+    const { outputDirectory: _omit, ...rest } = DEFAULT_VERCEL_JSON;
+    const warnings = inspectVercelJson(rest);
+    expect(warnings.some((w) => w.includes("outputDirectory"))).toBe(true);
+  });
+
+  it("warns when outputDirectory is wrong", () => {
+    const warnings = inspectVercelJson({
+      ...DEFAULT_VERCEL_JSON,
+      outputDirectory: "dist",
+    });
+    expect(warnings.some((w) => w.includes("outputDirectory"))).toBe(true);
+  });
+
+  it("warns when the /api/mcp rewrite is missing", () => {
+    const warnings = inspectVercelJson({
+      ...DEFAULT_VERCEL_JSON,
+      rewrites: [{ source: "/(.*)", destination: "/api/other" }],
+    });
+    expect(warnings.some((w) => w.includes("/api/mcp"))).toBe(true);
+  });
+
+  it("warns when CORS on /assets/(.*) is missing", () => {
+    const warnings = inspectVercelJson({
+      ...DEFAULT_VERCEL_JSON,
+      headers: [],
+    });
+    expect(
+      warnings.some((w) => w.includes("Access-Control-Allow-Origin")),
+    ).toBe(true);
+  });
+
+  it("warns when the input is not an object", () => {
+    expect(inspectVercelJson("nope").length).toBeGreaterThan(0);
+    expect(inspectVercelJson(null).length).toBeGreaterThan(0);
+  });
+});
+
+describe("ensureVercelJson", () => {
+  it("writes a default vercel.json when none exists", () => {
+    const dir = mkTmp();
+    const { written, warnings } = ensureVercelJson(dir);
+    expect(written).toBe(true);
+    expect(warnings).toEqual([]);
+    expect(existsSync(path.join(dir, "vercel.json"))).toBe(true);
+    const onDisk = JSON.parse(
+      readFileSync(path.join(dir, "vercel.json"), "utf-8"),
+    );
+    expect(onDisk).toEqual(DEFAULT_VERCEL_JSON);
+  });
+
+  it("does not overwrite an existing vercel.json; returns inspection warnings", () => {
+    const dir = mkTmp();
+    const existing = { outputDirectory: "dist" };
+    writeFileSync(
+      path.join(dir, "vercel.json"),
+      JSON.stringify(existing, null, 2),
+    );
+    const { written, warnings } = ensureVercelJson(dir);
+    expect(written).toBe(false);
+    expect(warnings.length).toBeGreaterThan(0);
+    const onDisk = JSON.parse(
+      readFileSync(path.join(dir, "vercel.json"), "utf-8"),
+    );
+    expect(onDisk).toEqual(existing);
+  });
+});

--- a/packages/core/src/commands/build-helpers.ts
+++ b/packages/core/src/commands/build-helpers.ts
@@ -1,0 +1,103 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+export function emitManifestModule(
+  manifestPath: string,
+  outPath: string,
+): void {
+  const manifest = readFileSync(manifestPath, "utf-8");
+  writeFileSync(outPath, `export default ${manifest};\n`);
+}
+
+export const VERCEL_API_ENTRY_CONTENT = `export { default } from "../dist/server.js";\n`;
+
+export function emitVercelFunction(root: string): void {
+  const apiDir = path.join(root, "api");
+  mkdirSync(apiDir, { recursive: true });
+  writeFileSync(path.join(apiDir, "mcp.js"), VERCEL_API_ENTRY_CONTENT);
+}
+
+export const DEFAULT_VERCEL_JSON = {
+  $schema: "https://openapi.vercel.sh/vercel.json",
+  // Disable framework auto-detection: Skybridge projects ship a vite.config.ts
+  // that Vercel would otherwise pick up as a SPA, running `vite` instead of
+  // our serverless function. Filesystem + functions only.
+  framework: null,
+  // Skip Vercel's install + build — `skybridge build --target vercel` has
+  // already produced dist/, public/, and api/. Empty strings fall through
+  // to framework defaults; `true` is the unix no-op that satisfies Vercel.
+  installCommand: "true",
+  buildCommand: "true",
+  outputDirectory: "public",
+  rewrites: [{ source: "/(.*)", destination: "/api/mcp" }],
+  headers: [
+    {
+      source: "/assets/(.*)",
+      headers: [{ key: "Access-Control-Allow-Origin", value: "*" }],
+    },
+  ],
+};
+
+export function inspectVercelJson(json: unknown): string[] {
+  const warnings: string[] = [];
+  if (typeof json !== "object" || json === null) {
+    warnings.push("vercel.json is not a JSON object.");
+    return warnings;
+  }
+  const cfg = json as Record<string, unknown>;
+  if (cfg.outputDirectory !== "public") {
+    warnings.push('vercel.json: missing or wrong `outputDirectory: "public"`.');
+  }
+  const rewrites = Array.isArray(cfg.rewrites)
+    ? (cfg.rewrites as Array<Record<string, unknown>>)
+    : [];
+  const hasMcpRewrite = rewrites.some(
+    (r) => r.destination === "/api/mcp" && typeof r.source === "string",
+  );
+  if (!hasMcpRewrite) {
+    warnings.push(
+      "vercel.json: missing a rewrite to `/api/mcp` (needed so all routes hit the MCP function).",
+    );
+  }
+  const headers = Array.isArray(cfg.headers)
+    ? (cfg.headers as Array<Record<string, unknown>>)
+    : [];
+  const assetsCors = headers.some((h) => {
+    if (h.source !== "/assets/(.*)") {
+      return false;
+    }
+    const list = Array.isArray(h.headers)
+      ? (h.headers as Array<Record<string, unknown>>)
+      : [];
+    return list.some(
+      (entry) =>
+        entry.key === "Access-Control-Allow-Origin" && entry.value === "*",
+    );
+  });
+  if (!assetsCors) {
+    warnings.push(
+      "vercel.json: missing CORS header `Access-Control-Allow-Origin: *` on `/assets/(.*)`.",
+    );
+  }
+  return warnings;
+}
+
+export function ensureVercelJson(root: string): {
+  written: boolean;
+  warnings: string[];
+} {
+  const target = path.join(root, "vercel.json");
+  if (!existsSync(target)) {
+    writeFileSync(target, `${JSON.stringify(DEFAULT_VERCEL_JSON, null, 2)}\n`);
+    return { written: true, warnings: [] };
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(target, "utf-8"));
+    return { written: false, warnings: inspectVercelJson(parsed) };
+  } catch (error) {
+    return {
+      written: false,
+      warnings: [`vercel.json: failed to parse (${String(error)}).`],
+    };
+  }
+}

--- a/packages/core/src/commands/build.tsx
+++ b/packages/core/src/commands/build.tsx
@@ -1,11 +1,16 @@
-import { readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { Command } from "@oclif/core";
+import { Command, Flags } from "@oclif/core";
 import { Box, render, Text } from "ink";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { Header } from "../cli/header.js";
 import { type CommandStep, useExecuteSteps } from "../cli/use-execute-steps.js";
 import { scanAndWriteViewsDts } from "../web/plugin/scan-views.js";
+import {
+  emitManifestModule,
+  emitVercelFunction,
+  ensureVercelJson,
+} from "./build-helpers.js";
 
 async function resolveViewsDir(root: string): Promise<string | undefined> {
   const { loadConfigFromFile } = await import("vite");
@@ -32,82 +37,149 @@ async function resolveViewsDir(root: string): Promise<string | undefined> {
   return plugins.find((p) => p.name === "skybridge")?.api?.viewsDir;
 }
 
-export const commandSteps: CommandStep[] = [
-  {
+export function buildSteps(
+  target: "default" | "vercel",
+  warnings: { current: string[] },
+): CommandStep[] {
+  const scanViews: CommandStep = {
     label: "Scanning views",
     run: async () => {
       const root = process.cwd();
       const viewsDir = await resolveViewsDir(root);
       scanAndWriteViewsDts(root, viewsDir);
     },
-  },
-  {
+  };
+  const compileServer: CommandStep = {
     label: "Compiling server",
     run: () => rmSync("dist", { recursive: true, force: true }),
     command: "tsc -b --force",
-  },
-  {
+  };
+  const buildViews: CommandStep = {
     label: "Building views",
     command: "vite build",
-  },
-  {
-    label: "Emitting manifest module",
-    // Inline the Vite manifest as a JS module so the server can `import` it
-    // instead of `readFileSync(process.cwd() + ...)` at runtime — required for
-    // workerd, where neither cwd nor the assets directory is readable.
-    // The path mirrors `skybridge start`'s entry convention (dist/server.js)
-    // so the import in the user's entry resolves to a sibling file.
-    run: () => {
-      const root = process.cwd();
-      const manifest = readFileSync(
-        path.join(root, "dist", "assets", ".vite", "manifest.json"),
-        "utf-8",
-      );
-      writeFileSync(
-        path.join(root, "dist", "vite-manifest.js"),
-        `export default ${manifest};\n`,
-      );
-    },
-  },
+  };
 
-  {
-    label: "Emitting Cloudflare redirects",
-    // Cloudflare's `assets.directory` maps URL → file literally — no
-    // mount-strip like `app.use("/assets", express.static(...))`. Rewrite
-    // `/assets/assets/*` to `/assets/*` before lookup; status 200 =
-    // server-side rewrite, not HTTP redirect.
-    run: () => {
-      const root = process.cwd();
-      writeFileSync(
-        path.join(root, "dist", "assets", "_redirects"),
-        "/assets/assets/* /assets/:splat 200\n",
-      );
+  if (target === "vercel") {
+    return [
+      scanViews,
+      compileServer,
+      buildViews,
+      {
+        label: "Relocating assets to public/",
+        // Vite plugin's config() locks outDir to dist/assets; move post-build
+        // to satisfy Vercel's CDN filesystem-precedence routing.
+        run: () => {
+          const root = process.cwd();
+          const src = path.join(root, "dist", "assets");
+          const dst = path.join(root, "public", "assets");
+          rmSync(dst, { recursive: true, force: true });
+          mkdirSync(path.join(root, "public"), { recursive: true });
+          renameSync(src, dst);
+        },
+      },
+      {
+        label: "Emitting manifest module",
+        run: () => {
+          const root = process.cwd();
+          emitManifestModule(
+            path.join(root, "public", "assets", ".vite", "manifest.json"),
+            path.join(root, "dist", "vite-manifest.js"),
+          );
+        },
+      },
+      {
+        label: "Emitting Vercel function",
+        run: () => emitVercelFunction(process.cwd()),
+      },
+      {
+        label: "Ensuring vercel.json",
+        run: () => {
+          const result = ensureVercelJson(process.cwd());
+          warnings.current = result.warnings;
+        },
+      },
+    ];
+  }
+
+  return [
+    scanViews,
+    compileServer,
+    buildViews,
+    {
+      label: "Emitting manifest module",
+      // Inline the Vite manifest as a JS module so the server can `import` it
+      // instead of `readFileSync(process.cwd() + ...)` at runtime — required for
+      // workerd, where neither cwd nor the assets directory is readable.
+      run: () => {
+        const root = process.cwd();
+        emitManifestModule(
+          path.join(root, "dist", "assets", ".vite", "manifest.json"),
+          path.join(root, "dist", "vite-manifest.js"),
+        );
+      },
     },
-  },
-  {
-    label: "Emitting Cloudflare headers",
-    // Cloudflare's static asset handler bypasses the worker entirely, so
-    // `app.use("/assets", cors())` never fires for asset requests. Attach
-    // CORS at the edge so cross-origin view iframes can load JS/CSS.
-    run: () => {
-      const root = process.cwd();
-      writeFileSync(
-        path.join(root, "dist", "assets", "_headers"),
-        "/assets/*\n  Access-Control-Allow-Origin: *\n",
-      );
+    {
+      label: "Emitting Cloudflare redirects",
+      // Cloudflare's `assets.directory` maps URL → file literally — no
+      // mount-strip like `app.use("/assets", express.static(...))`. Rewrite
+      // `/assets/assets/*` to `/assets/*` before lookup; status 200 =
+      // server-side rewrite, not HTTP redirect.
+      run: () => {
+        const root = process.cwd();
+        writeFileSync(
+          path.join(root, "dist", "assets", "_redirects"),
+          "/assets/assets/* /assets/:splat 200\n",
+        );
+      },
     },
-  },
-];
+    {
+      label: "Emitting Cloudflare headers",
+      // Cloudflare's static asset handler bypasses the worker entirely, so
+      // `app.use("/assets", cors())` never fires for asset requests. Attach
+      // CORS at the edge so cross-origin view iframes can load JS/CSS.
+      run: () => {
+        const root = process.cwd();
+        writeFileSync(
+          path.join(root, "dist", "assets", "_headers"),
+          "/assets/*\n  Access-Control-Allow-Origin: *\n",
+        );
+      },
+    },
+  ];
+}
+
+export const commandSteps: CommandStep[] = buildSteps("default", {
+  current: [],
+});
 
 export default class Build extends Command {
   static override description = "Build the views and MCP server";
-  static override examples = ["skybridge build"];
-  static override flags = {};
+  static override examples = [
+    "skybridge build",
+    "skybridge build --target vercel",
+  ];
+  static override flags = {
+    target: Flags.string({
+      description:
+        "Deployment target. Omit for the default Cloudflare/Docker pipeline.",
+      options: ["vercel"],
+    }),
+  };
 
   public async run(): Promise<void> {
+    const { flags } = await this.parse(Build);
+    const isVercel = flags.target === "vercel";
+
     const App = () => {
-      const { currentStep, status, error, execute } =
-        useExecuteSteps(commandSteps);
+      const warnings = useMemo<{ current: string[] }>(
+        () => ({ current: [] }),
+        [],
+      );
+      const steps = useMemo(
+        () => buildSteps(isVercel ? "vercel" : "default", warnings),
+        [warnings],
+      );
+      const { currentStep, status, error, execute } = useExecuteSteps(steps);
 
       useEffect(() => {
         execute();
@@ -116,10 +188,13 @@ export default class Build extends Command {
       return (
         <Box flexDirection="column" padding={1}>
           <Header version={this.config.version}>
-            <Text color="green"> → building for production…</Text>
+            <Text color="green">
+              {" → building for production"}
+              {isVercel ? " (vercel)" : ""}…
+            </Text>
           </Header>
 
-          {commandSteps.map((step, index) => {
+          {steps.map((step, index) => {
             const isCurrent = index === currentStep && status === "running";
             const isCompleted = index < currentStep || status === "success";
             const isError = status === "error" && index === currentStep;
@@ -135,10 +210,23 @@ export default class Build extends Command {
           })}
 
           {status === "success" && (
-            <Box marginTop={1}>
+            <Box marginTop={1} flexDirection="column">
               <Text color="green" bold>
                 ✓ Build completed successfully!
               </Text>
+              {isVercel && warnings.current.length > 0 && (
+                <Box marginTop={1} flexDirection="column">
+                  <Text color="yellow" bold>
+                    ⚠ vercel.json warnings:
+                  </Text>
+                  {warnings.current.map((line) => (
+                    <Text key={line} color="yellow">
+                      {" "}
+                      • {line}
+                    </Text>
+                  ))}
+                </Box>
+              )}
             </Box>
           )}
 

--- a/packages/core/src/commands/start.ts
+++ b/packages/core/src/commands/start.ts
@@ -16,6 +16,13 @@ export default class Start extends Command {
   };
 
   public async run(): Promise<void> {
+    if (process.env.VERCEL === "1") {
+      console.error(
+        "skybridge start is not supported in the Vercel environment. The Vercel runtime invokes api/mcp.js directly.",
+      );
+      process.exit(1);
+    }
+
     const { flags } = await this.parse(Start);
     const { port, fallback, envWarning } = await resolvePort(flags.port);
     if (envWarning) {

--- a/packages/core/src/server/express.test.ts
+++ b/packages/core/src/server/express.test.ts
@@ -483,6 +483,62 @@ describe("createApp", () => {
   });
 });
 
+describe("createApp Vercel mode", () => {
+  it("does not mount /assets in production when VERCEL=1", async () => {
+    const prevVercel = process.env.VERCEL;
+    const prevEnv = process.env.NODE_ENV;
+    process.env.VERCEL = "1";
+    process.env.NODE_ENV = "production";
+    try {
+      vi.resetModules();
+      const { createApp } = await import("./express.js");
+      const { McpServer: Reloaded } = await import("./server.js");
+      const server = new Reloaded({ name: "t", version: "0.0.0" });
+      const httpServer = http.createServer();
+      const app = await createApp({ mcpServer: server, httpServer });
+      const { port, server: listening } = await listen(app);
+      openServer = listening;
+      const res = await fetch(`http://localhost:${port}/assets/foo.js`);
+      expect(res.status).toBe(404);
+    } finally {
+      if (prevVercel === undefined) {
+        delete process.env.VERCEL;
+      } else {
+        process.env.VERCEL = prevVercel;
+      }
+      process.env.NODE_ENV = prevEnv;
+      vi.resetModules();
+    }
+  });
+
+  it("server.run() returns the Express app without binding a port when VERCEL=1", async () => {
+    const prevVercel = process.env.VERCEL;
+    const prevEnv = process.env.NODE_ENV;
+    process.env.VERCEL = "1";
+    process.env.NODE_ENV = "production";
+    try {
+      vi.resetModules();
+      const { McpServer: Reloaded } = await import("./server.js");
+      const server = new Reloaded({ name: "t", version: "0.0.0" });
+      const result = await server.run();
+      expect(typeof result).toBe("function");
+      expect(result).toBe(server.express);
+      const { port, server: listening } = await listen(server.express);
+      openServer = listening;
+      const res = await postMcp(port);
+      expect(res.status).not.toBe(404);
+    } finally {
+      if (prevVercel === undefined) {
+        delete process.env.VERCEL;
+      } else {
+        process.env.VERCEL = prevVercel;
+      }
+      process.env.NODE_ENV = prevEnv;
+      vi.resetModules();
+    }
+  });
+});
+
 describe("createApp tunnel routes", () => {
   it("proxies POST /__skybridge/tunnel to the cli control server in dev mode", async () => {
     // Stand up a fake control listener that returns a known JSON body.

--- a/packages/core/src/server/express.ts
+++ b/packages/core/src/server/express.ts
@@ -81,7 +81,9 @@ export async function createApp({
         `Ignoring invalid __TUNNEL_CONTROL_PORT=${process.env.__TUNNEL_CONTROL_PORT}`,
       );
     }
-  } else {
+  } else if (process.env.VERCEL !== "1") {
+    // On Vercel the CDN serves /assets/* directly (filesystem precedence
+    // over the catch-all rewrite to /api/mcp); skip the Express static mount.
     const assetsPath = path.join(process.cwd(), "dist", "assets");
 
     app.use("/assets", cors());

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -720,10 +720,25 @@ export class McpServer<
    *
    * On Cloudflare Workers / workerd, returns an object exposing `fetch` so
    * the runtime can bridge incoming requests to the Node HTTP server. On
+   * Vercel (`VERCEL === "1"`), returns the Express app directly so the
+   * serverless function entry can call it as a `(req, res)` handler. On
    * Node, returns `undefined` once listening.
    */
-  async run(): Promise<{ fetch: (...args: unknown[]) => unknown } | undefined> {
+  async run(): Promise<
+    { fetch: (...args: unknown[]) => unknown } | Express | undefined
+  > {
     this.applyMcpMiddleware();
+
+    if (process.env.VERCEL === "1") {
+      const httpServer = http.createServer();
+      await createApp({
+        mcpServer: this,
+        httpServer,
+        errorMiddleware: this.customErrorMiddleware,
+      });
+      return this.express;
+    }
+
     const httpServer = http.createServer();
 
     await createApp({

--- a/packages/create-skybridge/templates/blank/_gitignore
+++ b/packages/create-skybridge/templates/blank/_gitignore
@@ -4,3 +4,6 @@ dist/
 .DS_store
 *.tsbuildinfo
 .skybridge/
+api/
+public/
+.vercel/

--- a/packages/create-skybridge/templates/demo/_gitignore
+++ b/packages/create-skybridge/templates/demo/_gitignore
@@ -4,3 +4,6 @@ dist/
 .DS_store
 *.tsbuildinfo
 .skybridge/
+api/
+public/
+.vercel/

--- a/scripts/verify-vercel.mjs
+++ b/scripts/verify-vercel.mjs
@@ -1,0 +1,386 @@
+#!/usr/bin/env node
+// Verifies the Vercel build + local `vercel dev` chain for examples/everything.
+//
+// Prereqs:
+//   - From the repo root.
+//   - `pnpm install` already ran.
+//   - `vercel` CLI is on PATH and `vercel login` has happened, OR a project
+//     is already linked (.vercel/ in examples/everything). The script does
+//     not authenticate.
+//
+// Default flow (in order):
+//   1. `pnpm --filter skybridge build`
+//   2. `pnpm --filter everything exec skybridge build --target vercel`
+//   3. Assert build artifacts exist under examples/everything.
+//   4. Spawn `vercel dev --listen <port>` from examples/everything.
+//   5. Wait up to 90s for ready signal.
+//   6. Run the MCP / asset / health / GET-405 assertion battery.
+//   7. Kill vercel dev.
+//
+// Flags:
+//   --no-rebuild   Skip steps 1–2.
+//   --url=<url>    Hit a deployed URL instead of vercel dev. Skips artifact checks.
+//   --help, -h     Print usage and exit 0.
+
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, "..");
+const EXAMPLE_DIR = path.join(REPO_ROOT, "examples", "everything");
+
+const HELP = `Usage: node scripts/verify-vercel.mjs [options]
+
+Options:
+  --no-rebuild      Skip the skybridge + example builds.
+  --url=<url>       Hit a deployed URL instead of starting vercel dev.
+                    Skips local artifact assertions and the manifest cross-check.
+  --help, -h        Show this message.
+
+Exit codes:
+  0   All assertions passed.
+  1   An assertion failed or vercel dev failed to start.
+`;
+
+function parseArgs(argv) {
+  const opts = { rebuild: true, url: null };
+  for (const arg of argv.slice(2)) {
+    if (arg === "--help" || arg === "-h") {
+      console.log(HELP);
+      process.exit(0);
+    } else if (arg === "--no-rebuild") {
+      opts.rebuild = false;
+    } else if (arg.startsWith("--url=")) {
+      opts.url = arg.slice("--url=".length);
+    } else {
+      console.error(`Unknown option: ${arg}`);
+      console.error(HELP);
+      process.exit(1);
+    }
+  }
+  return opts;
+}
+
+function log(msg) {
+  process.stdout.write(`[verify-vercel] ${msg}\n`);
+}
+
+function fail(msg) {
+  process.stderr.write(`[verify-vercel] FAIL: ${msg}\n`);
+  process.exitCode = 1;
+}
+
+function ok(msg) {
+  process.stdout.write(`[verify-vercel] ok: ${msg}\n`);
+}
+
+function runSync(cmd, args, cwd) {
+  log(`$ ${cmd} ${args.join(" ")}  (cwd=${cwd})`);
+  const result = spawnSync(cmd, args, { cwd, stdio: "inherit" });
+  if (result.status !== 0) {
+    throw new Error(`${cmd} ${args.join(" ")} exited with ${result.status}`);
+  }
+}
+
+function findFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.unref();
+    srv.on("error", reject);
+    srv.listen(0, () => {
+      const port = srv.address().port;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+function assertArtifacts() {
+  const dist = path.join(EXAMPLE_DIR, "dist");
+  const publicDir = path.join(EXAMPLE_DIR, "public");
+  const apiDir = path.join(EXAMPLE_DIR, "api");
+  const required = [
+    [path.join(dist, "server.js"), "dist/server.js"],
+    [path.join(dist, "vite-manifest.js"), "dist/vite-manifest.js"],
+    [
+      path.join(publicDir, "assets", ".vite", "manifest.json"),
+      "public/assets/.vite/manifest.json",
+    ],
+    [path.join(apiDir, "mcp.js"), "api/mcp.js"],
+    [path.join(EXAMPLE_DIR, "vercel.json"), "vercel.json"],
+  ];
+  for (const [p, label] of required) {
+    if (!existsSync(p)) {
+      throw new Error(`Missing build artifact: ${label}`);
+    }
+    ok(`artifact: ${label}`);
+  }
+
+  const apiEntry = readFileSync(path.join(apiDir, "mcp.js"), "utf-8");
+  if (!apiEntry.includes('export { default } from "../dist/server.js"')) {
+    throw new Error(
+      `api/mcp.js does not re-export dist/server.js (got: ${apiEntry.trim()})`,
+    );
+  }
+  ok("artifact: api/mcp.js re-exports ../dist/server.js");
+
+  const vercelJson = JSON.parse(
+    readFileSync(path.join(EXAMPLE_DIR, "vercel.json"), "utf-8"),
+  );
+  if (vercelJson.outputDirectory !== "public") {
+    throw new Error('vercel.json: outputDirectory must equal "public"');
+  }
+  const hasMcpRewrite = Array.isArray(vercelJson.rewrites)
+    && vercelJson.rewrites.some((r) => r.destination === "/api/mcp");
+  if (!hasMcpRewrite) {
+    throw new Error("vercel.json: missing rewrite to /api/mcp");
+  }
+  ok("artifact: vercel.json outputDirectory=public + /api/mcp rewrite");
+
+  // Pick at least one .js entry from the manifest and confirm it's on disk.
+  const manifest = loadManifest();
+  const jsEntry = Object.values(manifest).find(
+    (entry) => typeof entry?.file === "string" && entry.file.endsWith(".js"),
+  );
+  if (!jsEntry) {
+    throw new Error("manifest contains no .js entry");
+  }
+  const assetPath = path.join(publicDir, "assets", jsEntry.file);
+  if (!existsSync(assetPath)) {
+    throw new Error(`manifest entry not on disk: ${jsEntry.file}`);
+  }
+  ok(`artifact: public/assets/${jsEntry.file}`);
+}
+
+function loadManifest() {
+  const p = path.join(
+    EXAMPLE_DIR,
+    "public",
+    "assets",
+    ".vite",
+    "manifest.json",
+  );
+  return JSON.parse(readFileSync(p, "utf-8"));
+}
+
+async function waitForReady(child, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    let buf = "";
+    const onData = (chunk) => {
+      const text = chunk.toString();
+      buf += text;
+      process.stdout.write(text);
+      if (/Ready! Available at/i.test(buf) || /Listening on/i.test(buf)) {
+        cleanup();
+        resolve();
+      }
+    };
+    const onExit = (code) => {
+      cleanup();
+      reject(new Error(`vercel dev exited early with ${code}`));
+    };
+    const to = setTimeout(() => {
+      cleanup();
+      reject(new Error("vercel dev did not become ready in time"));
+    }, timeoutMs);
+    function cleanup() {
+      clearTimeout(to);
+      child.stdout?.off("data", onData);
+      child.stderr?.off("data", onData);
+      child.off("exit", onExit);
+    }
+    child.stdout?.on("data", onData);
+    child.stderr?.on("data", onData);
+    child.on("exit", onExit);
+  });
+}
+
+async function postMcp(base, body) {
+  return fetch(`${base}/mcp`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+async function runAssertions(base, { checkManifest }) {
+  const initBody = {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-06-18",
+      clientInfo: { name: "verify", version: "0.0.0" },
+      capabilities: {},
+    },
+  };
+  let res = await postMcp(base, initBody);
+  if (res.status !== 200) {
+    throw new Error(`init: expected 200, got ${res.status}`);
+  }
+  let body = await res.json();
+  if (body?.result?.serverInfo?.name !== "alpic-openai-app") {
+    throw new Error(
+      `init: serverInfo.name mismatch (got ${JSON.stringify(body?.result?.serverInfo)})`,
+    );
+  }
+  ok("init: 200 + serverInfo.name === alpic-openai-app");
+
+  res = await postMcp(base, { jsonrpc: "2.0", id: 2, method: "tools/list" });
+  body = await res.json();
+  const tools = body?.result?.tools ?? [];
+  if (!tools.some((t) => t.name === "show-everything")) {
+    throw new Error("tools/list: show-everything not found");
+  }
+  ok("tools/list: includes show-everything");
+
+  res = await postMcp(base, {
+    jsonrpc: "2.0",
+    id: 3,
+    method: "resources/list",
+  });
+  body = await res.json();
+  const resources = body?.result?.resources ?? [];
+  const viewResource = resources.find((r) =>
+    /show-everything\.html/.test(r.uri),
+  );
+  if (!viewResource) {
+    throw new Error("resources/list: no show-everything.html resource");
+  }
+  ok(`resources/list: viewUri = ${viewResource.uri}`);
+
+  res = await postMcp(base, {
+    jsonrpc: "2.0",
+    id: 4,
+    method: "resources/read",
+    params: { uri: viewResource.uri },
+  });
+  body = await res.json();
+  const text = body?.result?.contents?.[0]?.text ?? "";
+  if (!text.includes("/assets/")) {
+    throw new Error("resources/read: HTML did not reference /assets/");
+  }
+  const match = text.match(/\/assets\/([^"' ]+\.js)/);
+  if (!match) {
+    throw new Error("resources/read: no /assets/*.js reference");
+  }
+  const assetFile = match[1];
+  if (checkManifest) {
+    const manifest = loadManifest();
+    const known = new Set(Object.values(manifest).map((e) => e.file));
+    if (!known.has(`assets/${assetFile}`) && !known.has(assetFile)) {
+      throw new Error(
+        `resources/read: ${assetFile} not in Vite manifest (${[...known].slice(0, 3).join(", ")} …)`,
+      );
+    }
+  }
+  ok(`resources/read: HTML references /assets/${assetFile}`);
+
+  res = await fetch(`${base}/assets/${assetFile}`);
+  if (res.status !== 200) {
+    throw new Error(`assets-cors: ${assetFile} returned ${res.status}`);
+  }
+  if (res.headers.get("access-control-allow-origin") !== "*") {
+    throw new Error("assets-cors: missing Access-Control-Allow-Origin: *");
+  }
+  ok(`assets-cors: /assets/${assetFile} 200 + CORS`);
+
+  res = await fetch(`${base}/health`);
+  if (res.status !== 200) {
+    throw new Error(`health: expected 200, got ${res.status}`);
+  }
+  const health = await res.json();
+  if (!health?.ok) {
+    throw new Error("health: body did not include {ok:true}");
+  }
+  ok("health: 200 + {ok:true}");
+
+  res = await fetch(`${base}/mcp`);
+  if (res.status !== 405) {
+    throw new Error(`mcp-get-405: expected 405, got ${res.status}`);
+  }
+  ok("mcp-get-405: GET /mcp returned 405");
+}
+
+async function main() {
+  const opts = parseArgs(process.argv);
+
+  if (opts.url) {
+    log(`Using deployed URL: ${opts.url}`);
+    await runAssertions(opts.url, { checkManifest: false });
+    log("All assertions passed.");
+    return;
+  }
+
+  if (opts.rebuild) {
+    runSync("pnpm", ["--filter", "skybridge", "build"], REPO_ROOT);
+    runSync(
+      "pnpm",
+      [
+        "--filter",
+        "everything",
+        "exec",
+        "skybridge",
+        "build",
+        "--target",
+        "vercel",
+      ],
+      REPO_ROOT,
+    );
+  }
+
+  assertArtifacts();
+
+  const port = await findFreePort();
+  const base = `http://127.0.0.1:${port}`;
+  log(`Starting vercel dev on ${base}`);
+
+  const child = spawn(
+    "vercel",
+    ["dev", "--listen", String(port), "--local", "--yes"],
+    {
+      cwd: EXAMPLE_DIR,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, VERCEL_FORCE_NO_BUILD_CACHE: "1" },
+    },
+  );
+
+  let killed = false;
+  const cleanup = () => {
+    if (killed) {
+      return;
+    }
+    killed = true;
+    if (!child.killed) {
+      child.kill("SIGTERM");
+      setTimeout(() => {
+        if (!child.killed) {
+          child.kill("SIGKILL");
+        }
+      }, 5_000).unref();
+    }
+  };
+  process.on("exit", cleanup);
+  process.on("SIGINT", () => {
+    cleanup();
+    process.exit(130);
+  });
+
+  try {
+    await waitForReady(child, 90_000);
+    await runAssertions(base, { checkManifest: true });
+    log("All assertions passed.");
+  } finally {
+    cleanup();
+  }
+}
+
+main().catch((err) => {
+  fail(err?.stack || String(err));
+  process.exit(1);
+});


### PR DESCRIPTION
<img width="1608" height="640" alt="image" src="https://github.com/user-attachments/assets/3604f26c-1d92-4d60-a950-843f68dd15ea" />


## Summary

- Add `--target vercel` build flag (emits `api/mcp.js`, `vercel.json`, asset CDN layout).
- Emit `dist/__entry.js` wrapper — user `server.ts` becomes just `export default server`.
- Point Cloudflare wrangler `main` and Docker `CMD` at the new wrapper entry.
- Verified end-to-end against a live Vercel preview deploy via `scripts/verify-vercel.mjs`.

## Architecture Notes

- **Wrapper-as-entry contract** — `dist/__entry.js` is the new canonical deploy entry; `dist/server.js` still ships alongside it.
- **Additive for existing CF users** — upgrading doesn't force a migration; old `wrangler.jsonc` + old `server.ts` keep working. Migration to the wrapper is opt-in to drop the `setViteManifest` boilerplate, and updates to `server.ts` + `wrangler.jsonc` must land together.
- **Vercel routing** — `framework: null` + catch-all rewrite to `/api/mcp`; filesystem-precedence keeps `/assets/*` on the CDN.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `--target vercel` support to `skybridge build` and wires up the Vercel serverless path inside `McpServer.run()`, which now returns the Express app directly when `VERCEL=1` instead of binding a port.

- **Vercel build pipeline**: new `build-helpers.ts` exposes `emitVercelFunction`, `emitManifestModule`, `ensureVercelJson`, and `inspectVercelJson`; the build step relocates Vite assets to `public/` for Vercel's CDN and emits `api/mcp.js` as the function entry.
- **`McpServer.run()` Vercel branch**: when `VERCEL=1`, `createApp` is called and `this.express` is returned; the exported Express app is re-exported by `api/mcp.js` as the Vercel handler.
- **`skybridge start` guard**: early exit with a clear message when `VERCEL=1`, preventing accidental port binding in the Vercel runtime.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the only gap is a missing validation check in `inspectVercelJson` that could let a misconfigured `framework` field go undetected.

The Vercel build pipeline, manifest relocation, and `run()` branching are all well-tested and the end-to-end verify script confirms the happy path. The one concrete gap is `inspectVercelJson` not checking `framework: null` — a user whose existing `vercel.json` sets `framework` to a non-null value would receive no warning, and Vercel would override the build pipeline, silently breaking the deployment. Everything else in the changed files is additive and backward-compatible.

packages/core/src/commands/build-helpers.ts — `inspectVercelJson` is missing a `framework: null` check.

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/core/src/commands/start.ts`, line 34-56 ([link](https://github.com/alpic-ai/skybridge/blob/e9d6c94c42303c81f1813a5c0f4050efe67158b3/packages/core/src/commands/start.ts#L34-L56)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Breaking change for existing users on `skybridge start`**

   `skybridge start` now spawns `node dist/__entry.js`. That wrapper does `import server from "./server.js"` and expects `server` to be a `McpServer` instance. In the old template, `dist/server.js` ends with `export default await server.run()` — its default export is the *result* of `run()` (i.e. `undefined` on Node), not the McpServer itself. Any user who upgrades the CLI and re-runs `skybridge build` without also updating `server.ts` will see `node dist/__entry.js` crash immediately with `TypeError: Cannot read properties of undefined (reading 'setViteManifest')`. The same problem applies to the Dockerfile `CMD` change. There is no migration note in the docs or a build-time guard to detect this mismatch.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/core/src/commands/start.ts
   Line: 34-56

   Comment:
   **Breaking change for existing users on `skybridge start`**

   `skybridge start` now spawns `node dist/__entry.js`. That wrapper does `import server from "./server.js"` and expects `server` to be a `McpServer` instance. In the old template, `dist/server.js` ends with `export default await server.run()` — its default export is the *result* of `run()` (i.e. `undefined` on Node), not the McpServer itself. Any user who upgrades the CLI and re-runs `skybridge build` without also updating `server.ts` will see `node dist/__entry.js` crash immediately with `TypeError: Cannot read properties of undefined (reading 'setViteManifest')`. The same problem applies to the Dockerfile `CMD` change. There is no migration note in the docs or a build-time guard to detect this mismatch.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/core/src/commands/build-helpers.ts:47-49
`inspectVercelJson` checks `outputDirectory`, the `/api/mcp` rewrite, and CORS headers, but never validates `framework: null`. `framework: null` is the critical knob that prevents Vercel from auto-detecting the project as a Vite SPA and running `vite build` instead of the no-op `buildCommand`. A user whose existing `vercel.json` has `"framework": "nextjs"` (or any non-null value) will pass inspection with no warnings, but Vercel will override the build pipeline and the function will likely be missing at deploy time.

```suggestion
  const cfg = json as Record<string, unknown>;
  if (cfg.framework !== null) {
    warnings.push(
      'vercel.json: `framework` must be `null` to disable Vercel auto-detection (currently set to ' +
        JSON.stringify(cfg.framework) +
        ").",
    );
  }
  if (cfg.outputDirectory !== "public") {
    warnings.push('vercel.json: missing or wrong `outputDirectory: "public"`.');
```


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["feat(core): add --target vercel build fl..."](https://github.com/alpic-ai/skybridge/commit/6efc0eea34868470dad3a17c0c9dab05d06c59a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33922935)</sub>

<!-- /greptile_comment -->