### PR TITLE
Fix relative path import in generative UI exemple

### DIFF
--- a/examples/generative-ui/src/index.css
+++ b/examples/generative-ui/src/index.css
@@ -1,5 +1,5 @@
 @import "tailwindcss";
-@source "../../node_modules/@json-render/shadcn/dist";
+@source "../node_modules/@json-render/shadcn/dist";
 
 @theme inline {
   --color-background: var(--background);


### PR DESCRIPTION
During rearchiture of v1 exemples apps, relative import of tailwind in generative UI exemple stylesheet got forgotten
This fixes the rendering of this exemple app

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a broken relative path in the generative UI example's stylesheet so that Tailwind's `@source` directive correctly points to `@json-render/shadcn`'s dist folder.

- Changes `../../node_modules/@json-render/shadcn/dist` to `../node_modules/@json-render/shadcn/dist`, aligning the path with the package's own `node_modules` directory (one level up from `src/`, not two).

<h3>Confidence Score: 5/5</h3>

This is a safe, minimal one-line path correction in an example app's stylesheet.

The change corrects a single relative path so @source resolves to the package's own node_modules instead of a non-existent parent directory. The package.json confirms @json-render/shadcn is a direct dependency of this example, so ../node_modules is the right target. No logic, runtime code, or shared infrastructure is touched.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["Fix relative path import in generative U..."](https://github.com/alpic-ai/skybridge/commit/5aeb9e2b9370be1253a70b71954eafefaafde43c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33918498)</sub>

<!-- /greptile_comment -->