### PR TITLE
Add Vercel deployment support

### DIFF
--- a/docs/quickstart/deploy.mdx
+++ b/docs/quickstart/deploy.mdx
@@ -123,6 +123,60 @@ bunx wrangler dev
 Skybridge's local dev server (`skybridge dev`) and the Cloudflare path are independent. Use `skybridge dev` for fast iteration on Node with HMR; use `wrangler dev` to validate the production worker bundle before shipping.
 </Note>
 
+## Vercel
+
+Skybridge builds emit a Vercel-compatible function entry (`api/mcp.js`) and a static asset tree (`public/assets/`) on every build. You only need to add a `vercel.json` at your project root so Vercel knows not to auto-detect Vite.
+
+### Configure
+
+Create `vercel.json` at your project root:
+
+```json
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "installCommand": "true",
+  "buildCommand": "true",
+  "outputDirectory": "public",
+  "rewrites": [{ "source": "/(.*)", "destination": "/api/mcp" }],
+  "headers": [
+    {
+      "source": "/assets/(.*)",
+      "headers": [{ "key": "Access-Control-Allow-Origin", "value": "*" }]
+    }
+  ]
+}
+```
+
+Each field is load-bearing:
+
+- **`framework: null`** — without this Vercel detects `vite.config.ts` and runs `vite` instead of your function.
+- **`installCommand` / `buildCommand: "true"`** — no-ops, so Vercel's sandbox doesn't re-run install/build and overwrite the pre-built `public/assets/`.
+- **`outputDirectory: "public"`** — Vercel serves `public/assets/*` via its CDN (filesystem precedence over rewrites keeps `/assets/*` off the function).
+- **`rewrites`** — every other path lands on `api/mcp.js`, which re-exports the Express app from `dist/server.js`.
+- **`headers`** — CORS on `/assets/*` for view iframes loading bundled JS/CSS.
+
+### Build and deploy
+
+<CodeGroup>
+```bash npm
+npm run build
+npx vercel deploy
+```
+```bash pnpm
+pnpm build
+pnpm dlx vercel deploy
+```
+```bash yarn
+yarn build
+yarn dlx vercel deploy
+```
+```bash bun
+bun run build
+bunx vercel deploy
+```
+</CodeGroup>
+
 ## Docker
 
 Projects created with the [Skybridge scaffolder](/quickstart/create-new-app#scaffold-your-project) include a multi-stage `Dockerfile` so you can self-host on any container platform:

--- a/docs/quickstart/deploy.mdx
+++ b/docs/quickstart/deploy.mdx
@@ -125,57 +125,32 @@ Skybridge's local dev server (`skybridge dev`) and the Cloudflare path are indep
 
 ## Vercel
 
-Skybridge builds emit a Vercel-compatible function entry (`api/mcp.js`) and a static asset tree (`public/assets/`) on every build. You only need to add a `vercel.json` at your project root so Vercel knows not to auto-detect Vite.
-
-### Configure
-
-Create `vercel.json` at your project root:
-
-```json
-{
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": null,
-  "installCommand": "true",
-  "buildCommand": "true",
-  "outputDirectory": "public",
-  "rewrites": [{ "source": "/(.*)", "destination": "/api/mcp" }],
-  "headers": [
-    {
-      "source": "/assets/(.*)",
-      "headers": [{ "key": "Access-Control-Allow-Origin", "value": "*" }]
-    }
-  ]
-}
-```
-
-Each field is load-bearing:
-
-- **`framework: null`** — without this Vercel detects `vite.config.ts` and runs `vite` instead of your function.
-- **`installCommand` / `buildCommand: "true"`** — no-ops, so Vercel's sandbox doesn't re-run install/build and overwrite the pre-built `public/assets/`.
-- **`outputDirectory: "public"`** — Vercel serves `public/assets/*` via its CDN (filesystem precedence over rewrites keeps `/assets/*` off the function).
-- **`rewrites`** — every other path lands on `api/mcp.js`, which re-exports the Express app from `dist/server.js`.
-- **`headers`** — CORS on `/assets/*` for view iframes loading bundled JS/CSS.
+`skybridge build` emits a [Build Output API](https://vercel.com/docs/build-output-api) tree under `.vercel/output/` — a bundled serverless function plus the static asset tree, along with the routing config. Deploy it with `vercel deploy --prebuilt`; no `vercel.json` is required.
 
 ### Build and deploy
 
 <CodeGroup>
 ```bash npm
 npm run build
-npx vercel deploy
+npx vercel deploy --prebuilt
 ```
 ```bash pnpm
 pnpm build
-pnpm dlx vercel deploy
+pnpm dlx vercel deploy --prebuilt
 ```
 ```bash yarn
 yarn build
-yarn dlx vercel deploy
+yarn dlx vercel deploy --prebuilt
 ```
 ```bash bun
 bun run build
-bunx vercel deploy
+bunx vercel deploy --prebuilt
 ```
 </CodeGroup>
+
+<Note>
+`.vercel/` is gitignored by Vercel CLI convention, so the build artifacts stay out of your tracked working tree.
+</Note>
 
 ## Docker
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/alpic-ai/skybridge.git"
   },
   "type": "module",
+  "sideEffects": false,
   "engines": {
     "node": ">=22.0.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,6 +65,7 @@
     "cross-spawn": "^7.0.6",
     "dequal": "^2.0.3",
     "es-toolkit": "^1.45.1",
+    "esbuild": "^0.27.0",
     "express": "^5.2.1",
     "handlebars": "^4.7.9",
     "ink": "^7.0.0",

--- a/packages/core/src/cli/build-helpers.test.ts
+++ b/packages/core/src/cli/build-helpers.test.ts
@@ -1,0 +1,40 @@
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  emitManifestModule,
+  emitVercelFunction,
+  VERCEL_API_ENTRY_CONTENT,
+} from "./build-helpers.js";
+
+function mkTmp(prefix = "skybridge-build-helpers-") {
+  return mkdtempSync(path.join(tmpdir(), prefix));
+}
+
+describe("emitManifestModule", () => {
+  it("inlines the JSON manifest as an ESM default export", () => {
+    const dir = mkTmp();
+    const inPath = path.join(dir, "manifest.json");
+    const outPath = path.join(dir, "vite-manifest.js");
+    const manifest = { "src/views/foo.tsx": { file: "assets/foo-abc.js" } };
+    writeFileSync(inPath, JSON.stringify(manifest));
+    emitManifestModule(inPath, outPath);
+    const out = readFileSync(outPath, "utf-8");
+    expect(out.startsWith("export default ")).toBe(true);
+    const literal = out
+      .slice("export default ".length)
+      .trim()
+      .replace(/;$/, "");
+    expect(JSON.parse(literal)).toEqual(manifest);
+  });
+});
+
+describe("emitVercelFunction", () => {
+  it("writes api/mcp.js pointing at dist/server.js", () => {
+    const dir = mkTmp();
+    emitVercelFunction(dir);
+    const out = readFileSync(path.join(dir, "api", "mcp.js"), "utf-8");
+    expect(out).toBe(VERCEL_API_ENTRY_CONTENT);
+  });
+});

--- a/packages/core/src/cli/build-helpers.test.ts
+++ b/packages/core/src/cli/build-helpers.test.ts
@@ -1,11 +1,20 @@
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+// @vitest-environment node
+// esbuild's invariant check on TextEncoder/Uint8Array trips jsdom's polyfill.
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   emitManifestModule,
-  emitVercelFunction,
-  VERCEL_API_ENTRY_CONTENT,
+  emitVercelBuildOutput,
+  VERCEL_CONFIG,
+  VERCEL_VC_CONFIG,
 } from "./build-helpers.js";
 
 function mkTmp(prefix = "skybridge-build-helpers-") {
@@ -30,11 +39,39 @@ describe("emitManifestModule", () => {
   });
 });
 
-describe("emitVercelFunction", () => {
-  it("writes api/mcp.js pointing at dist/server.js", () => {
-    const dir = mkTmp();
-    emitVercelFunction(dir);
-    const out = readFileSync(path.join(dir, "api", "mcp.js"), "utf-8");
-    expect(out).toBe(VERCEL_API_ENTRY_CONTENT);
+describe("emitVercelBuildOutput", () => {
+  it("emits a Build Output API tree with bundled function and static assets", async () => {
+    const root = mkTmp();
+    mkdirSync(path.join(root, "dist", "assets"), { recursive: true });
+    writeFileSync(
+      path.join(root, "dist", "server.js"),
+      "export default function handler(_req, res) { res.end('ok'); }\n",
+    );
+    writeFileSync(
+      path.join(root, "dist", "assets", "view-abc.js"),
+      "/* bundled view */\n",
+    );
+
+    await emitVercelBuildOutput(root);
+
+    const outputDir = path.join(root, ".vercel", "output");
+    const funcDir = path.join(outputDir, "functions", "mcp.func");
+
+    expect(existsSync(path.join(funcDir, "index.js"))).toBe(true);
+    expect(
+      JSON.parse(readFileSync(path.join(funcDir, ".vc-config.json"), "utf-8")),
+    ).toEqual(VERCEL_VC_CONFIG);
+    expect(
+      JSON.parse(readFileSync(path.join(funcDir, "package.json"), "utf-8")),
+    ).toEqual({ type: "module" });
+    expect(
+      JSON.parse(readFileSync(path.join(outputDir, "config.json"), "utf-8")),
+    ).toEqual(VERCEL_CONFIG);
+    expect(
+      readFileSync(
+        path.join(outputDir, "static", "assets", "view-abc.js"),
+        "utf-8",
+      ),
+    ).toContain("bundled view");
   });
 });

--- a/packages/core/src/cli/build-helpers.ts
+++ b/packages/core/src/cli/build-helpers.ts
@@ -1,0 +1,18 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+export function emitManifestModule(
+  manifestPath: string,
+  outPath: string,
+): void {
+  const manifest = readFileSync(manifestPath, "utf-8");
+  writeFileSync(outPath, `export default ${manifest};\n`);
+}
+
+export const VERCEL_API_ENTRY_CONTENT = `export { default } from "../dist/server.js";\n`;
+
+export function emitVercelFunction(root: string): void {
+  const apiDir = path.join(root, "api");
+  mkdirSync(apiDir, { recursive: true });
+  writeFileSync(path.join(apiDir, "mcp.js"), VERCEL_API_ENTRY_CONTENT);
+}

--- a/packages/core/src/cli/build-helpers.ts
+++ b/packages/core/src/cli/build-helpers.ts
@@ -62,6 +62,9 @@ export async function emitVercelBuildOutput(root: string): Promise<void> {
     outfile: path.join(funcDir, "index.js"),
     // Lets esbuild DCE dev-only branches that pull in vite/devtools.
     define: { "process.env.NODE_ENV": '"production"' },
+    // Dev-only deps reachable from re-exports; safe to leave unresolved since
+    // the code paths that touch them are eliminated by the NODE_ENV define.
+    external: ["vite", "@skybridge/devtools"],
     banner: {
       // ESM bundles miss CJS interop globals that some deps reach for.
       js: "import{createRequire}from'node:module';const require=createRequire(import.meta.url);",

--- a/packages/core/src/cli/build-helpers.ts
+++ b/packages/core/src/cli/build-helpers.ts
@@ -60,6 +60,8 @@ export async function emitVercelBuildOutput(root: string): Promise<void> {
     target: "node22",
     format: "esm",
     outfile: path.join(funcDir, "index.js"),
+    // Lets esbuild DCE dev-only branches that pull in vite/devtools.
+    define: { "process.env.NODE_ENV": '"production"' },
     banner: {
       // ESM bundles miss CJS interop globals that some deps reach for.
       js: "import{createRequire}from'node:module';const require=createRequire(import.meta.url);",

--- a/packages/core/src/cli/build-helpers.ts
+++ b/packages/core/src/cli/build-helpers.ts
@@ -1,4 +1,10 @@
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  cpSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 
 export function emitManifestModule(
@@ -9,10 +15,72 @@ export function emitManifestModule(
   writeFileSync(outPath, `export default ${manifest};\n`);
 }
 
-export const VERCEL_API_ENTRY_CONTENT = `export { default } from "../dist/server.js";\n`;
+export const VERCEL_FUNCTION_NAME = "mcp";
 
-export function emitVercelFunction(root: string): void {
-  const apiDir = path.join(root, "api");
-  mkdirSync(apiDir, { recursive: true });
-  writeFileSync(path.join(apiDir, "mcp.js"), VERCEL_API_ENTRY_CONTENT);
+export const VERCEL_CONFIG: unknown = {
+  version: 3,
+  routes: [
+    {
+      src: "/assets/(.*)",
+      headers: { "Access-Control-Allow-Origin": "*" },
+      continue: true,
+    },
+    { handle: "filesystem" },
+    { src: "/(.*)", dest: `/${VERCEL_FUNCTION_NAME}` },
+  ],
+};
+
+export const VERCEL_VC_CONFIG: unknown = {
+  runtime: "nodejs22.x",
+  handler: "index.js",
+  launcherType: "Nodejs",
+  shouldAddHelpers: true,
+};
+
+// Emit a Build Output API tree under `.vercel/output/`. Bundling the server
+// with esbuild produces a self-contained function bundle, so we don't ship
+// `node_modules` and don't touch tracked paths like `api/` or `public/`.
+export async function emitVercelBuildOutput(root: string): Promise<void> {
+  const outputDir = path.join(root, ".vercel", "output");
+  const funcDir = path.join(
+    outputDir,
+    "functions",
+    `${VERCEL_FUNCTION_NAME}.func`,
+  );
+  const staticAssetsDir = path.join(outputDir, "static", "assets");
+
+  rmSync(outputDir, { recursive: true, force: true });
+  mkdirSync(funcDir, { recursive: true });
+
+  const { build } = await import("esbuild");
+  await build({
+    entryPoints: [path.join(root, "dist", "server.js")],
+    bundle: true,
+    platform: "node",
+    target: "node22",
+    format: "esm",
+    outfile: path.join(funcDir, "index.js"),
+    banner: {
+      // ESM bundles miss CJS interop globals that some deps reach for.
+      js: "import{createRequire}from'node:module';const require=createRequire(import.meta.url);",
+    },
+  });
+
+  writeFileSync(
+    path.join(funcDir, ".vc-config.json"),
+    `${JSON.stringify(VERCEL_VC_CONFIG, null, 2)}\n`,
+  );
+  writeFileSync(
+    path.join(funcDir, "package.json"),
+    `${JSON.stringify({ type: "module" }, null, 2)}\n`,
+  );
+
+  cpSync(path.join(root, "dist", "assets"), staticAssetsDir, {
+    recursive: true,
+  });
+
+  writeFileSync(
+    path.join(outputDir, "config.json"),
+    `${JSON.stringify(VERCEL_CONFIG, null, 2)}\n`,
+  );
 }

--- a/packages/core/src/commands/build.tsx
+++ b/packages/core/src/commands/build.tsx
@@ -1,89 +1,93 @@
-import { readFileSync, rmSync, writeFileSync } from "node:fs";
+import { cpSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { Command } from "@oclif/core";
 import { Box, render, Text } from "ink";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
+import {
+  emitManifestModule,
+  emitVercelFunction,
+} from "../cli/build-helpers.js";
 import { Header } from "../cli/header.js";
 import { resolveViewsDir } from "../cli/resolve-views-dir.js";
 import { type CommandStep, useExecuteSteps } from "../cli/use-execute-steps.js";
 import { scanAndWriteViewsDts } from "../web/plugin/scan-views.js";
 
-export const commandSteps: CommandStep[] = [
-  {
-    label: "Scanning views",
-    run: async () => {
-      const root = process.cwd();
-      const viewsDir = await resolveViewsDir(root);
-      scanAndWriteViewsDts(root, viewsDir);
+export function buildSteps(): CommandStep[] {
+  return [
+    {
+      label: "Scanning views",
+      run: async () => {
+        const root = process.cwd();
+        const viewsDir = await resolveViewsDir(root);
+        scanAndWriteViewsDts(root, viewsDir);
+      },
     },
-  },
-  {
-    label: "Compiling server",
-    run: () => rmSync("dist", { recursive: true, force: true }),
-    command: "tsc -b --force",
-  },
-  {
-    label: "Building views",
-    command: "vite build",
-  },
-  {
-    label: "Emitting manifest module",
-    // Inline the Vite manifest as a JS module so the server can `import` it
-    // instead of `readFileSync(process.cwd() + ...)` at runtime — required for
-    // workerd, where neither cwd nor the assets directory is readable.
-    // The path mirrors `skybridge start`'s entry convention (dist/server.js)
-    // so the import in the user's entry resolves to a sibling file.
-    run: () => {
-      const root = process.cwd();
-      const manifest = readFileSync(
-        path.join(root, "dist", "assets", ".vite", "manifest.json"),
-        "utf-8",
-      );
-      writeFileSync(
-        path.join(root, "dist", "vite-manifest.js"),
-        `export default ${manifest};\n`,
-      );
+    {
+      label: "Compiling server",
+      run: () => rmSync("dist", { recursive: true, force: true }),
+      command: "tsc -b --force",
     },
-  },
+    {
+      label: "Building views",
+      command: "vite build",
+    },
+    {
+      label: "Emitting manifest module",
+      run: () => {
+        const root = process.cwd();
+        emitManifestModule(
+          path.join(root, "dist", "assets", ".vite", "manifest.json"),
+          path.join(root, "dist", "vite-manifest.js"),
+        );
+      },
+    },
+    {
+      label: "Copying assets to public/ for Vercel",
+      run: () => {
+        const root = process.cwd();
+        const src = path.join(root, "dist", "assets");
+        const dst = path.join(root, "public", "assets");
+        rmSync(dst, { recursive: true, force: true });
+        cpSync(src, dst, { recursive: true });
+      },
+    },
+    {
+      label: "Emitting Cloudflare redirects",
+      run: () => {
+        const root = process.cwd();
+        writeFileSync(
+          path.join(root, "dist", "assets", "_redirects"),
+          "/assets/assets/* /assets/:splat 200\n",
+        );
+      },
+    },
+    {
+      label: "Emitting Cloudflare headers",
+      run: () => {
+        const root = process.cwd();
+        writeFileSync(
+          path.join(root, "dist", "assets", "_headers"),
+          "/assets/*\n  Access-Control-Allow-Origin: *\n",
+        );
+      },
+    },
+    {
+      label: "Emitting Vercel function",
+      run: () => emitVercelFunction(process.cwd()),
+    },
+  ];
+}
 
-  {
-    label: "Emitting Cloudflare redirects",
-    // Cloudflare's `assets.directory` maps URL → file literally — no
-    // mount-strip like `app.use("/assets", express.static(...))`. Rewrite
-    // `/assets/assets/*` to `/assets/*` before lookup; status 200 =
-    // server-side rewrite, not HTTP redirect.
-    run: () => {
-      const root = process.cwd();
-      writeFileSync(
-        path.join(root, "dist", "assets", "_redirects"),
-        "/assets/assets/* /assets/:splat 200\n",
-      );
-    },
-  },
-  {
-    label: "Emitting Cloudflare headers",
-    // Cloudflare's static asset handler bypasses the worker entirely, so
-    // `app.use("/assets", cors())` never fires for asset requests. Attach
-    // CORS at the edge so cross-origin view iframes can load JS/CSS.
-    run: () => {
-      const root = process.cwd();
-      writeFileSync(
-        path.join(root, "dist", "assets", "_headers"),
-        "/assets/*\n  Access-Control-Allow-Origin: *\n",
-      );
-    },
-  },
-];
+export const commandSteps: CommandStep[] = buildSteps();
 
 export default class Build extends Command {
   static override description = "Build the views and MCP server";
   static override examples = ["skybridge build"];
-  static override flags = {};
 
   public async run(): Promise<void> {
     const App = () => {
-      const { currentStep, status, error, execute } =
-        useExecuteSteps(commandSteps);
+      const steps = useMemo(() => buildSteps(), []);
+      const { currentStep, status, error, execute } = useExecuteSteps(steps);
 
       useEffect(() => {
         execute();
@@ -95,7 +99,7 @@ export default class Build extends Command {
             <Text color="green"> → building for production…</Text>
           </Header>
 
-          {commandSteps.map((step, index) => {
+          {steps.map((step, index) => {
             const isCurrent = index === currentStep && status === "running";
             const isCompleted = index < currentStep || status === "success";
             const isError = status === "error" && index === currentStep;

--- a/packages/core/src/commands/build.tsx
+++ b/packages/core/src/commands/build.tsx
@@ -1,11 +1,11 @@
-import { cpSync, rmSync, writeFileSync } from "node:fs";
+import { rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { Command } from "@oclif/core";
 import { Box, render, Text } from "ink";
 import { useEffect, useMemo } from "react";
 import {
   emitManifestModule,
-  emitVercelFunction,
+  emitVercelBuildOutput,
 } from "../cli/build-helpers.js";
 import { Header } from "../cli/header.js";
 import { resolveViewsDir } from "../cli/resolve-views-dir.js";
@@ -42,16 +42,6 @@ export function buildSteps(): CommandStep[] {
       },
     },
     {
-      label: "Copying assets to public/ for Vercel",
-      run: () => {
-        const root = process.cwd();
-        const src = path.join(root, "dist", "assets");
-        const dst = path.join(root, "public", "assets");
-        rmSync(dst, { recursive: true, force: true });
-        cpSync(src, dst, { recursive: true });
-      },
-    },
-    {
       label: "Emitting Cloudflare redirects",
       run: () => {
         const root = process.cwd();
@@ -72,8 +62,8 @@ export function buildSteps(): CommandStep[] {
       },
     },
     {
-      label: "Emitting Vercel function",
-      run: () => emitVercelFunction(process.cwd()),
+      label: "Emitting Vercel build output",
+      run: () => emitVercelBuildOutput(process.cwd()),
     },
   ];
 }

--- a/packages/core/src/commands/build.tsx
+++ b/packages/core/src/commands/build.tsx
@@ -2,7 +2,7 @@ import { rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { Command } from "@oclif/core";
 import { Box, render, Text } from "ink";
-import { useEffect, useMemo } from "react";
+import { useEffect } from "react";
 import {
   emitManifestModule,
   emitVercelBuildOutput,
@@ -12,63 +12,59 @@ import { resolveViewsDir } from "../cli/resolve-views-dir.js";
 import { type CommandStep, useExecuteSteps } from "../cli/use-execute-steps.js";
 import { scanAndWriteViewsDts } from "../web/plugin/scan-views.js";
 
-export function buildSteps(): CommandStep[] {
-  return [
-    {
-      label: "Scanning views",
-      run: async () => {
-        const root = process.cwd();
-        const viewsDir = await resolveViewsDir(root);
-        scanAndWriteViewsDts(root, viewsDir);
-      },
+export const commandSteps: CommandStep[] = [
+  {
+    label: "Scanning views",
+    run: async () => {
+      const root = process.cwd();
+      const viewsDir = await resolveViewsDir(root);
+      scanAndWriteViewsDts(root, viewsDir);
     },
-    {
-      label: "Compiling server",
-      run: () => rmSync("dist", { recursive: true, force: true }),
-      command: "tsc -b --force",
+  },
+  {
+    label: "Compiling server",
+    run: () => rmSync("dist", { recursive: true, force: true }),
+    command: "tsc -b --force",
+  },
+  {
+    label: "Building views",
+    command: "vite build",
+  },
+  {
+    label: "Emitting manifest module",
+    run: () => {
+      const root = process.cwd();
+      emitManifestModule(
+        path.join(root, "dist", "assets", ".vite", "manifest.json"),
+        path.join(root, "dist", "vite-manifest.js"),
+      );
     },
-    {
-      label: "Building views",
-      command: "vite build",
+  },
+  {
+    label: "Emitting Cloudflare redirects",
+    run: () => {
+      const root = process.cwd();
+      writeFileSync(
+        path.join(root, "dist", "assets", "_redirects"),
+        "/assets/assets/* /assets/:splat 200\n",
+      );
     },
-    {
-      label: "Emitting manifest module",
-      run: () => {
-        const root = process.cwd();
-        emitManifestModule(
-          path.join(root, "dist", "assets", ".vite", "manifest.json"),
-          path.join(root, "dist", "vite-manifest.js"),
-        );
-      },
+  },
+  {
+    label: "Emitting Cloudflare headers",
+    run: () => {
+      const root = process.cwd();
+      writeFileSync(
+        path.join(root, "dist", "assets", "_headers"),
+        "/assets/*\n  Access-Control-Allow-Origin: *\n",
+      );
     },
-    {
-      label: "Emitting Cloudflare redirects",
-      run: () => {
-        const root = process.cwd();
-        writeFileSync(
-          path.join(root, "dist", "assets", "_redirects"),
-          "/assets/assets/* /assets/:splat 200\n",
-        );
-      },
-    },
-    {
-      label: "Emitting Cloudflare headers",
-      run: () => {
-        const root = process.cwd();
-        writeFileSync(
-          path.join(root, "dist", "assets", "_headers"),
-          "/assets/*\n  Access-Control-Allow-Origin: *\n",
-        );
-      },
-    },
-    {
-      label: "Emitting Vercel build output",
-      run: () => emitVercelBuildOutput(process.cwd()),
-    },
-  ];
-}
-
-export const commandSteps: CommandStep[] = buildSteps();
+  },
+  {
+    label: "Emitting Vercel build output",
+    run: () => emitVercelBuildOutput(process.cwd()),
+  },
+];
 
 export default class Build extends Command {
   static override description = "Build the views and MCP server";
@@ -76,8 +72,8 @@ export default class Build extends Command {
 
   public async run(): Promise<void> {
     const App = () => {
-      const steps = useMemo(() => buildSteps(), []);
-      const { currentStep, status, error, execute } = useExecuteSteps(steps);
+      const { currentStep, status, error, execute } =
+        useExecuteSteps(commandSteps);
 
       useEffect(() => {
         execute();
@@ -89,7 +85,7 @@ export default class Build extends Command {
             <Text color="green"> → building for production…</Text>
           </Header>
 
-          {steps.map((step, index) => {
+          {commandSteps.map((step, index) => {
             const isCurrent = index === currentStep && status === "running";
             const isCompleted = index < currentStep || status === "success";
             const isError = status === "error" && index === currentStep;

--- a/packages/core/src/server/express.test.ts
+++ b/packages/core/src/server/express.test.ts
@@ -483,6 +483,62 @@ describe("createApp", () => {
   });
 });
 
+describe("createApp Vercel mode", () => {
+  it("does not mount /assets in production when VERCEL=1", async () => {
+    const prevVercel = process.env.VERCEL;
+    const prevEnv = process.env.NODE_ENV;
+    process.env.VERCEL = "1";
+    process.env.NODE_ENV = "production";
+    try {
+      vi.resetModules();
+      const { createApp } = await import("./express.js");
+      const { McpServer: Reloaded } = await import("./server.js");
+      const server = new Reloaded({ name: "t", version: "0.0.0" });
+      const httpServer = http.createServer();
+      const app = await createApp({ mcpServer: server, httpServer });
+      const { port, server: listening } = await listen(app);
+      openServer = listening;
+      const res = await fetch(`http://localhost:${port}/assets/foo.js`);
+      expect(res.status).toBe(404);
+    } finally {
+      if (prevVercel === undefined) {
+        delete process.env.VERCEL;
+      } else {
+        process.env.VERCEL = prevVercel;
+      }
+      process.env.NODE_ENV = prevEnv;
+      vi.resetModules();
+    }
+  });
+
+  it("server.run() returns the Express app without binding a port when VERCEL=1", async () => {
+    const prevVercel = process.env.VERCEL;
+    const prevEnv = process.env.NODE_ENV;
+    process.env.VERCEL = "1";
+    process.env.NODE_ENV = "production";
+    try {
+      vi.resetModules();
+      const { McpServer: Reloaded } = await import("./server.js");
+      const server = new Reloaded({ name: "t", version: "0.0.0" });
+      const result = await server.run();
+      expect(typeof result).toBe("function");
+      expect(result).toBe(server.express);
+      const { port, server: listening } = await listen(server.express);
+      openServer = listening;
+      const res = await postMcp(port);
+      expect(res.status).not.toBe(404);
+    } finally {
+      if (prevVercel === undefined) {
+        delete process.env.VERCEL;
+      } else {
+        process.env.VERCEL = prevVercel;
+      }
+      process.env.NODE_ENV = prevEnv;
+      vi.resetModules();
+    }
+  });
+});
+
 describe("createApp tunnel routes", () => {
   it("proxies POST /__skybridge/tunnel to the cli control server in dev mode", async () => {
     // Stand up a fake control listener that returns a known JSON body.

--- a/packages/core/src/server/express.test.ts
+++ b/packages/core/src/server/express.test.ts
@@ -484,33 +484,6 @@ describe("createApp", () => {
 });
 
 describe("createApp Vercel mode", () => {
-  it("does not mount /assets in production when VERCEL=1", async () => {
-    const prevVercel = process.env.VERCEL;
-    const prevEnv = process.env.NODE_ENV;
-    process.env.VERCEL = "1";
-    process.env.NODE_ENV = "production";
-    try {
-      vi.resetModules();
-      const { createApp } = await import("./express.js");
-      const { McpServer: Reloaded } = await import("./server.js");
-      const server = new Reloaded({ name: "t", version: "0.0.0" });
-      const httpServer = http.createServer();
-      const app = await createApp({ mcpServer: server, httpServer });
-      const { port, server: listening } = await listen(app);
-      openServer = listening;
-      const res = await fetch(`http://localhost:${port}/assets/foo.js`);
-      expect(res.status).toBe(404);
-    } finally {
-      if (prevVercel === undefined) {
-        delete process.env.VERCEL;
-      } else {
-        process.env.VERCEL = prevVercel;
-      }
-      process.env.NODE_ENV = prevEnv;
-      vi.resetModules();
-    }
-  });
-
   it("server.run() returns the Express app without binding a port when VERCEL=1", async () => {
     const prevVercel = process.env.VERCEL;
     const prevEnv = process.env.NODE_ENV;

--- a/packages/core/src/server/express.ts
+++ b/packages/core/src/server/express.ts
@@ -81,7 +81,9 @@ export async function createApp({
         `Ignoring invalid __TUNNEL_CONTROL_PORT=${process.env.__TUNNEL_CONTROL_PORT}`,
       );
     }
-  } else {
+  } else if (process.env.VERCEL !== "1") {
+    // On Vercel the CDN serves /assets/* directly (filesystem precedence
+    // over the catch-all rewrite to /api/mcp); skip the Express static mount.
     const assetsPath = path.join(process.cwd(), "dist", "assets");
 
     app.use("/assets", cors());

--- a/packages/core/src/server/express.ts
+++ b/packages/core/src/server/express.ts
@@ -81,9 +81,7 @@ export async function createApp({
         `Ignoring invalid __TUNNEL_CONTROL_PORT=${process.env.__TUNNEL_CONTROL_PORT}`,
       );
     }
-  } else if (process.env.VERCEL !== "1") {
-    // On Vercel the CDN serves /assets/* directly (filesystem precedence
-    // over the catch-all rewrite to /api/mcp); skip the Express static mount.
+  } else {
     const assetsPath = path.join(process.cwd(), "dist", "assets");
 
     app.use("/assets", cors());

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -720,10 +720,28 @@ export class McpServer<
    *
    * On Cloudflare Workers / workerd, returns an object exposing `fetch` so
    * the runtime can bridge incoming requests to the Node HTTP server. On
+   * Vercel (`VERCEL === "1"`), returns the Express app directly so the
+   * serverless function entry can call it as a `(req, res)` handler. On
    * Node, returns `undefined` once listening.
    */
-  async run(): Promise<{ fetch: (...args: unknown[]) => unknown } | undefined> {
+  async run(): Promise<
+    { fetch: (...args: unknown[]) => unknown } | Express | undefined
+  > {
     this.applyMcpMiddleware();
+
+    if (process.env.VERCEL === "1") {
+      // createApp only reads httpServer inside its dev-only branch
+      // (viewsDevServer); under VERCEL=1 + NODE_ENV=production it's a
+      // bare object passed to satisfy the required parameter.
+      const httpServer = http.createServer();
+      await createApp({
+        mcpServer: this,
+        httpServer,
+        errorMiddleware: this.customErrorMiddleware,
+      });
+      return this.express;
+    }
+
     const httpServer = http.createServer();
 
     await createApp({

--- a/packages/create-skybridge/templates/blank/_gitignore
+++ b/packages/create-skybridge/templates/blank/_gitignore
@@ -4,6 +4,4 @@ dist/
 .DS_store
 *.tsbuildinfo
 .skybridge/
-api/
-public/
 .vercel/

--- a/packages/create-skybridge/templates/blank/_gitignore
+++ b/packages/create-skybridge/templates/blank/_gitignore
@@ -4,3 +4,6 @@ dist/
 .DS_store
 *.tsbuildinfo
 .skybridge/
+api/
+public/
+.vercel/

--- a/packages/create-skybridge/templates/demo/_gitignore
+++ b/packages/create-skybridge/templates/demo/_gitignore
@@ -4,6 +4,4 @@ dist/
 .DS_store
 *.tsbuildinfo
 .skybridge/
-api/
-public/
 .vercel/

--- a/packages/create-skybridge/templates/demo/_gitignore
+++ b/packages/create-skybridge/templates/demo/_gitignore
@@ -4,3 +4,6 @@ dist/
 .DS_store
 *.tsbuildinfo
 .skybridge/
+api/
+public/
+.vercel/

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -944,6 +944,9 @@ importers:
       es-toolkit:
         specifier: ^1.45.1
         version: 1.45.1
+      esbuild:
+        specifier: ^0.27.0
+        version: 0.27.2
       express:
         specifier: ^5.2.1
         version: 5.2.1


### PR DESCRIPTION
## Summary

- `skybridge build` emits a Vercel [Build Output API](https://vercel.com/docs/build-output-api) tree under `.vercel/output/` — esbuild-bundled function, static assets, and routing config — alongside the existing Cloudflare/Docker output.
- Runtime: `VERCEL=1` makes `McpServer.run()` return the Express app instead of opening a port.
- No user-owned `vercel.json` needed; deploy with `vercel deploy --prebuilt`.

## Architecture Notes

- **Build Output API over `api/` + `public/`** — the build writes into `.vercel/` (already gitignored by Vercel CLI convention) instead of tracked paths. Routing/CORS live in the emitted `config.json`, so users don't author or maintain a `vercel.json`.
- **esbuild bundling with DCE** — `NODE_ENV` is pinned to `"production"` and `vite` + `@skybridge/devtools` are marked external so dev-only branches (devtools, viewsDevServer) are dead-code-eliminated from the function bundle.

## Verification

Deployed the branch's dev snapshot (`skybridge@0.0.0-dev.9a208db`) to `harijoee/everything` via `vercel deploy --prebuilt`.

URL: https://everything-qfktxwmzz-harijoee.vercel.app

8/8 HTTP assertions green:

- `POST /mcp initialize` → 200, valid `serverInfo`
- `POST /mcp tools/list` → `show-everything` present
- `POST /mcp resources/list` → view URIs returned, CSP rewritten to deploy host
- `POST /mcp resources/read` → HTML references hashed assets from manifest
- `POST /mcp tools/call show-everything` → 200, structured response + `viewUUID`
- `GET /assets/*.js` → 200 + `Access-Control-Allow-Origin: *` + cache HIT
- `GET /assets/*.css` → 200 + CORS + cache HIT
- `GET /mcp` → 405 (POST-only transport)

Two gaps surfaced that aren't fixed in this PR — both need a docs/example follow-up before users hit them:

- Example apps call `server.run()` fire-and-forget; serverless needs `export default await server.run()` so the bundle has a default handler.
- Example apps don't `setViteManifest(manifest)`; without it, `resources/read` crashes with `ENOENT` on `/var/task/dist/assets/.vite/manifest.json` (the same path Cloudflare can't read).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Vercel serverless deployment support to Skybridge. `skybridge build` now always emits a Vercel [Build Output API](https://vercel.com/docs/build-output-api) tree under `.vercel/output/` (esbuild-bundled function + static assets + routing config), and `McpServer.run()` returns the Express app directly when `VERCEL=1` is set, enabling `vercel deploy --prebuilt` without a user-authored `vercel.json`.

- **`build-helpers.ts`** — new module handles esbuild bundling, `.vc-config.json`/`config.json` emission, and static asset copy into the Build Output API directory layout.
- **`server.ts`** — Vercel branch added to `run()`, returning `this.express` rather than binding a port; a dummy `http.Server` is passed to `createApp` only to satisfy the TypeScript parameter signature (safe because the production `createApp` path doesn't use it).
- **Template `.gitignore`** files updated to ignore `.vercel/` in scaffolded projects.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changed paths are well-tested and the deployed verification passed 8/8 HTTP assertions.

The Vercel build output path, esbuild bundling, and Express app return from run() are all covered by dedicated unit/integration tests, and the PR author validated the full deployment. The only finding is a minor env-var cleanup asymmetry in a test's finally block that has no real-world impact given Vitest's default NODE_ENV=test.

No files require special attention; express.test.ts has a trivial cleanup inconsistency in the new Vercel mode test.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/core/src/server/express.test.ts:504-509
The `finally` block restores `NODE_ENV` with a direct assignment, but unlike the `VERCEL` variable, it doesn't handle the case where `prevEnv` is `undefined`. In Node.js, `process.env.X = undefined` stringifies to `"undefined"`, which would leave `NODE_ENV` set to the literal string `"undefined"` for any subsequent tests in the same worker. Vitest defaults `NODE_ENV` to `"test"`, so this won't bite in normal CI, but the pattern is asymmetric with the `VERCEL` cleanup above it.

```suggestion
      if (prevVercel === undefined) {
        delete process.env.VERCEL;
      } else {
        process.env.VERCEL = prevVercel;
      }
      if (prevEnv === undefined) {
        delete process.env.NODE_ENV;
      } else {
        process.env.NODE_ENV = prevEnv;
      }
```

`````

</details>

<sub>Reviews (11): Last reviewed commit: ["refactor(core): revert build steps to st..."](https://github.com/alpic-ai/skybridge/commit/4208d177874bd352e3b1a1f8931f3bd52f1f9b5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33956720)</sub>

<!-- /greptile_comment -->