### PR TITLE
fix(core): generate .skybridge/views.d.ts before dev spawns tsc --watch

### DIFF
--- a/packages/core/src/cli/resolve-views-dir.ts
+++ b/packages/core/src/cli/resolve-views-dir.ts
@@ -1,0 +1,26 @@
+export async function resolveViewsDir(
+  root: string,
+): Promise<string | undefined> {
+  const { loadConfigFromFile } = await import("vite");
+  const loaded = await loadConfigFromFile(
+    { command: "build", mode: "production" },
+    undefined,
+    root,
+  );
+
+  const isPluginCandidate = (
+    value: unknown,
+  ): value is { name?: string; api?: { viewsDir?: string } } =>
+    typeof value === "object" && value !== null;
+
+  const plugins: Array<{ name?: string; api?: { viewsDir?: string } }> = [];
+  const walk = (value: unknown) => {
+    if (Array.isArray(value)) {
+      value.forEach(walk);
+    } else if (isPluginCandidate(value)) {
+      plugins.push(value);
+    }
+  };
+  walk(loaded?.config.plugins ?? []);
+  return plugins.find((p) => p.name === "skybridge")?.api?.viewsDir;
+}

--- a/packages/core/src/commands/build.tsx
+++ b/packages/core/src/commands/build.tsx
@@ -4,33 +4,9 @@ import { Command } from "@oclif/core";
 import { Box, render, Text } from "ink";
 import { useEffect } from "react";
 import { Header } from "../cli/header.js";
+import { resolveViewsDir } from "../cli/resolve-views-dir.js";
 import { type CommandStep, useExecuteSteps } from "../cli/use-execute-steps.js";
 import { scanAndWriteViewsDts } from "../web/plugin/scan-views.js";
-
-async function resolveViewsDir(root: string): Promise<string | undefined> {
-  const { loadConfigFromFile } = await import("vite");
-  const loaded = await loadConfigFromFile(
-    { command: "build", mode: "production" },
-    undefined,
-    root,
-  );
-
-  const isPluginCandidate = (
-    value: unknown,
-  ): value is { name?: string; api?: { viewsDir?: string } } =>
-    typeof value === "object" && value !== null;
-
-  const plugins: Array<{ name?: string; api?: { viewsDir?: string } }> = [];
-  const walk = (value: unknown) => {
-    if (Array.isArray(value)) {
-      value.forEach(walk);
-    } else if (isPluginCandidate(value)) {
-      plugins.push(value);
-    }
-  };
-  walk(loaded?.config.plugins ?? []);
-  return plugins.find((p) => p.name === "skybridge")?.api?.viewsDir;
-}
 
 export const commandSteps: CommandStep[] = [
   {

--- a/packages/core/src/commands/dev.tsx
+++ b/packages/core/src/commands/dev.tsx
@@ -45,7 +45,13 @@ export default class Dev extends Command {
     // exist at tsc startup, its watcher never picks up the late-created file
     // and the dev UI reports phantom TS errors forever.
     const root = process.cwd();
-    scanAndWriteViewsDts(root, await resolveViewsDir(root));
+    try {
+      scanAndWriteViewsDts(root, await resolveViewsDir(root));
+    } catch {
+      // Best-effort: if the scan fails (e.g. broken vite config, duplicate
+      // view names) tsc may show phantom errors, but the dev server should
+      // still start so the developer can fix the underlying issue.
+    }
 
     const { port, fallback, envWarning } = await resolvePort(flags.port);
     if (envWarning) {

--- a/packages/core/src/commands/dev.tsx
+++ b/packages/core/src/commands/dev.tsx
@@ -2,12 +2,14 @@ import { Command, Flags } from "@oclif/core";
 import { Box, render, Text } from "ink";
 import { resolvePort } from "../cli/detect-port.js";
 import { Header } from "../cli/header.js";
+import { resolveViewsDir } from "../cli/resolve-views-dir.js";
 import { startTunnelControlServer } from "../cli/tunnel-control-server.js";
 import { useMessages } from "../cli/use-messages.js";
 import { useNodemon } from "../cli/use-nodemon.js";
 import { useOpenBrowser } from "../cli/use-open-browser.js";
 import { useTunnel } from "../cli/use-tunnel.js";
 import { useTypeScriptCheck } from "../cli/use-typescript-check.js";
+import { scanAndWriteViewsDts } from "../web/plugin/scan-views.js";
 
 export default class Dev extends Command {
   static override description = "Start development server";
@@ -36,6 +38,14 @@ export default class Dev extends Command {
 
   public async run(): Promise<void> {
     const { flags } = await this.parse(Dev);
+
+    // Generate .skybridge/views.d.ts before render() spawns `tsc --noEmit
+    // --watch`. Vite's plugin config hook writes the same file when nodemon
+    // boots the server, but tsc starts in parallel — if .skybridge/ doesn't
+    // exist at tsc startup, its watcher never picks up the late-created file
+    // and the dev UI reports phantom TS errors forever.
+    const root = process.cwd();
+    scanAndWriteViewsDts(root, await resolveViewsDir(root));
 
     const { port, fallback, envWarning } = await resolvePort(flags.port);
     if (envWarning) {


### PR DESCRIPTION
### Summary

- Fix `skybridge dev` leaving phantom TS errors in the dev UI on first run.
- Root cause — `useTypeScriptCheck` spawns `tsc --noEmit --watch` in parallel with Vite, so tsc starts before the plugin's `config` hook writes `.skybridge/views.d.ts`.
- `tsc --watch` does not pick up files created inside a directory absent at startup, so the augmentation is never seen and the 2 starter-template errors stick forever.
- `dev` now calls `scanAndWriteViewsDts` before `render()` — mirrors what `build`'s first step already does.
- Side-effect cleanup: extracted `resolveViewsDir` out of `build.tsx` into `cli/resolve-views-dir.ts` so both commands share it.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a race condition in `skybridge dev` where `tsc --watch` would start before the Vite plugin wrote `.skybridge/views.d.ts`, causing permanent phantom TypeScript errors in the dev UI. It resolves this by eagerly calling `scanAndWriteViewsDts` before `render()` spawns the TSC watcher, and also extracts `resolveViewsDir` from `build.tsx` into a shared `cli/resolve-views-dir.ts` module.

- `dev.tsx`: adds a best-effort pre-warm call to `scanAndWriteViewsDts` (wrapped in try/catch so a broken Vite config or duplicate view names won't prevent the dev UI from starting) before `render()` is invoked.
- `cli/resolve-views-dir.ts`: new shared module containing `resolveViewsDir`, previously duplicated inside `build.tsx`.
- `build.tsx`: removes the now-local `resolveViewsDir` and imports it from the shared module instead.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted fix for a well-understood race condition with no new unchecked code paths.

The pre-warm call in `dev.tsx` is synchronous and fully wrapped in a try/catch that intentionally degrades gracefully, so a failure there leaves the dev server in the same state as before this PR. The extraction of `resolveViewsDir` into a shared module is a pure refactor with identical logic. The previous concern about unhandled errors crashing before the Ink UI renders has been addressed directly by the try/catch block.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["fix(core): tolerate scan failures in dev..."](https://github.com/alpic-ai/skybridge/commit/c0dcaece212b3ae51924041afe890409af984c05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33957691)</sub>

<!-- /greptile_comment -->