### PR TITLE
ci: deploy landing on release instead of merge to main

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -1,12 +1,8 @@
 name: Deploy landing page to Pages
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "landing/**"
-      - ".github/workflows/deploy-landing.yml"
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- Switch `deploy-landing.yml` trigger from `push` on `main` to `release: [published]`
- Aligns landing deploys with the release cadence already used by `publish.yml`, so the live site only changes when we cut a release

`workflow_dispatch` is preserved for manual runs.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes `deploy-landing.yml` to trigger on `release: [published]` instead of `push` to `main` with a path filter, aligning the landing page deploy cadence with `publish.yml`.

- The `push`/`paths` trigger (scoped to `landing/**` and the workflow file) is removed and replaced with a `release: types: [published]` event, so the live site only updates when a release is explicitly cut.
- `workflow_dispatch` is preserved, keeping manual deploys available.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a minimal, intentional change to a CI workflow trigger with no functional logic altered.

The only change is swapping a push-on-main trigger (with path filters) for release: [published], mirroring the pattern already used by publish.yml. The rest of the workflow — checkout, build, and deploy steps — is untouched. The release event will check out the tagged commit, which is the correct behavior for deploying a versioned site.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["ci: deploy landing on release instead of..."](https://github.com/alpic-ai/skybridge/commit/640ecaffe8404fecf9d4848a77f7d3b85537e4f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33958283)</sub>

<!-- /greptile_comment -->