### PR TITLE
feat(everything): add `flip-coin` to be used as target call on Everything example app

### DIFF
--- a/examples/everything/src/index.css
+++ b/examples/everything/src/index.css
@@ -177,6 +177,77 @@ code.dark {
   opacity: 1;
 }
 
+.coin-box {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1rem 1.25rem;
+  background: var(--bg-surface);
+}
+
+.coin-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.coin-result {
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.coin-result--won {
+  color: #3d7a4f;
+}
+
+.coin-result--lost {
+  color: #c0392b;
+}
+
+.coin-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.segmented {
+  display: flex;
+  border: 1px solid #c7d2fe;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.segmented-btn {
+  padding: 0.5rem 1.25rem;
+  background: transparent;
+  color: #4338ca;
+  border: none;
+  font-size: 0.875rem;
+  font-family: inherit;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.segmented-btn:not(:last-child) {
+  border-right: 1px solid #c7d2fe;
+}
+
+.segmented-btn--active {
+  background: #4f46e5;
+  color: #fff;
+}
+
+.segmented-btn:hover:not(.segmented-btn--active):not(:disabled) {
+  background: #eef2ff;
+}
+
+.segmented-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 .input {
   padding: 0.5rem 0.75rem;
   border: 1px solid var(--border);

--- a/examples/everything/src/index.css
+++ b/examples/everything/src/index.css
@@ -214,7 +214,7 @@ code.dark {
 
 .segmented {
   display: flex;
-  border: 1px solid #c7d2fe;
+  border: 1px solid var(--border);
   border-radius: 6px;
   overflow: hidden;
 }
@@ -222,7 +222,7 @@ code.dark {
 .segmented-btn {
   padding: 0.5rem 1.25rem;
   background: transparent;
-  color: #4338ca;
+  color: var(--accent, #4338ca);
   border: none;
   font-size: 0.875rem;
   font-family: inherit;
@@ -231,16 +231,16 @@ code.dark {
 }
 
 .segmented-btn:not(:last-child) {
-  border-right: 1px solid #c7d2fe;
+  border-right: 1px solid var(--border);
 }
 
 .segmented-btn--active {
-  background: #4f46e5;
+  background: var(--accent, #4f46e5);
   color: #fff;
 }
 
 .segmented-btn:hover:not(.segmented-btn--active):not(:disabled) {
-  background: #eef2ff;
+  background: var(--bg-surface);
 }
 
 .segmented-btn:disabled {

--- a/examples/everything/src/server.ts
+++ b/examples/everything/src/server.ts
@@ -1,5 +1,5 @@
 import { intentMiddleware } from "@alpic-ai/insights";
-import { McpServer } from "skybridge/server";
+import { McpServer, text } from "skybridge/server";
 import { z } from "zod";
 
 const server = new McpServer(
@@ -53,6 +53,11 @@ const server = new McpServer(
       inputSchema: {
         guess: z.enum(["heads", "tails"]).describe("The user's guess"),
       },
+      outputSchema: {
+        flip: z.enum(["heads", "tails"]).describe("The side the coin landed on"),
+        guess: z.enum(["heads", "tails"]).describe("The user's guess"),
+        won: z.boolean().describe("Whether the user won"),
+      },
       _meta: {
         "openai/widgetAccessible": true,
       },
@@ -63,7 +68,7 @@ const server = new McpServer(
       const structuredContent = { flip, guess, won };
       return {
         structuredContent,
-        content: [{ type: "text", text: JSON.stringify(structuredContent) }],
+        content: [text(`Coin landed on ${flip}. User guessed ${guess} and ${won ? "won" : "lost"}.`)],
         isError: false,
       };
     },

--- a/examples/everything/src/server.ts
+++ b/examples/everything/src/server.ts
@@ -45,30 +45,29 @@ const server = new McpServer(
         },
       };
     },
+  )
+  .registerTool(
+    {
+      name: "flip-coin",
+      description: "Flips a coin and checks if the user's guess is correct",
+      inputSchema: {
+        guess: z.enum(["heads", "tails"]).describe("The user's guess"),
+      },
+      _meta: {
+        "openai/widgetAccessible": true,
+      },
+    },
+    async ({ guess }) => {
+      const flip = Math.random() < 0.5 ? "heads" : "tails";
+      const won = guess === flip;
+      const structuredContent = { flip, guess, won };
+      return {
+        structuredContent,
+        content: [{ type: "text", text: JSON.stringify(structuredContent) }],
+        isError: false,
+      };
+    },
   );
-
-server.registerTool(
-  {
-    name: "flip-coin",
-    description: "Flips a coin and checks if the user's guess is correct",
-    inputSchema: {
-      guess: z.enum(["heads", "tails"]).describe("The user's guess"),
-    },
-    _meta: {
-      "openai/widgetAccessible": true,
-    },
-  },
-  async ({ guess }) => {
-    const flip = Math.random() < 0.5 ? "heads" : "tails";
-    const won = guess === flip;
-    const structuredContent = { flip, guess, won };
-    return {
-      structuredContent,
-      content: [{ type: "text", text: JSON.stringify(structuredContent) }],
-      isError: false,
-    };
-  },
-);
 
 server.run();
 

--- a/examples/everything/src/server.ts
+++ b/examples/everything/src/server.ts
@@ -47,6 +47,29 @@ const server = new McpServer(
     },
   );
 
+server.registerTool(
+  {
+    name: "flip-coin",
+    description: "Flips a coin and checks if the user's guess is correct",
+    inputSchema: {
+      guess: z.enum(["heads", "tails"]).describe("The user's guess"),
+    },
+    _meta: {
+      "openai/widgetAccessible": true,
+    },
+  },
+  async ({ guess }) => {
+    const flip = Math.random() < 0.5 ? "heads" : "tails";
+    const won = guess === flip;
+    const structuredContent = { flip, guess, won };
+    return {
+      structuredContent,
+      content: [{ type: "text", text: JSON.stringify(structuredContent) }],
+      isError: false,
+    };
+  },
+);
+
 server.run();
 
 export type AppType = typeof server;

--- a/examples/everything/src/views/tabs/use-call-tool-tab.tsx
+++ b/examples/everything/src/views/tabs/use-call-tool-tab.tsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
 import { useCallTool } from "../../helpers.js";
 
+type Guess = "heads" | "tails";
+
 export function UseCallToolTab() {
-  const [name, setName] = useState("");
-  const { data, isPending, callTool } = useCallTool("show-everything");
+  const [guess, setGuess] = useState<Guess | null>(null);
+  const { data, isPending, callTool } = useCallTool("flip-coin");
 
   return (
     <div className="tab-content">
@@ -13,35 +15,45 @@ export function UseCallToolTab() {
         <code>openai/widgetAccessible</code> property is set to true.
       </p>
 
-      <form
-        className="button-row"
-        onSubmit={(e) => {
-          e.preventDefault();
-          if (name.trim()) {
-            callTool({ name });
-            setName("");
-          }
-        }}
-      >
-        <input
-          type="text"
-          className="input"
-          value={name}
-          placeholder="Enter a name"
-          disabled={isPending}
-          onChange={(e) => setName(e.target.value)}
-        />
-        <button
-          type="submit"
-          className="btn"
-          disabled={isPending || name.length === 0}
-        >
-          {isPending ? "Calling..." : "Call"}
-        </button>
-      </form>
+      <div className="coin-box">
+        <p className="coin-title">Choose Heads or Tails?</p>
+        <div className="coin-controls">
+          <div className="segmented">
+            {(["heads", "tails"] as Guess[]).map((side) => (
+              <button
+                key={side}
+                type="button"
+                className={`segmented-btn${guess === side ? " segmented-btn--active" : ""}`}
+                disabled={isPending}
+                onClick={() => setGuess(side)}
+              >
+                {side.charAt(0).toUpperCase() + side.slice(1)}
+              </button>
+            ))}
+          </div>
+          <button
+            type="button"
+            className="btn"
+            disabled={isPending || guess === null}
+            onClick={() => {
+              if (guess) callTool({ guess });
+            }}
+          >
+            {isPending ? "Flipping..." : "Flip"}
+          </button>
+        </div>
+      </div>
 
       {data && (
         <div className="field">
+          {(() => {
+            const won = (data.structuredContent as { won?: boolean }).won === true;
+            return (
+              <p className={`coin-result ${won ? "coin-result--won" : "coin-result--lost"}`}>
+                {won ? "You Won!" : "You Lost!"}
+              </p>
+            );
+          })()}
           <span className="field-label">response</span>
           <pre>{JSON.stringify(data, null, 2)}</pre>
         </div>

--- a/examples/everything/src/views/tabs/use-call-tool-tab.tsx
+++ b/examples/everything/src/views/tabs/use-call-tool-tab.tsx
@@ -47,7 +47,9 @@ export function UseCallToolTab() {
       {data && (
         <div className="field">
           {(() => {
-            const won = (data.structuredContent as { won?: boolean }).won === true;
+            const sc = data.structuredContent as { won?: boolean } | undefined;
+            if (!sc) return null;
+            const won = sc.won === true;
             return (
               <p className={`coin-result ${won ? "coin-result--won" : "coin-result--lost"}`}>
                 {won ? "You Won!" : "You Lost!"}

--- a/examples/everything/src/views/tabs/use-call-tool-tab.tsx
+++ b/examples/everything/src/views/tabs/use-call-tool-tab.tsx
@@ -47,9 +47,9 @@ export function UseCallToolTab() {
       {data && (
         <div className="field">
           {(() => {
-            const sc = data.structuredContent as { won?: boolean } | undefined;
-            if (!sc) return null;
-            const won = sc.won === true;
+            const structuredContent = data.structuredContent;
+            if (!structuredContent) return null;
+            const won = structuredContent.won === true;
             return (
               <p className={`coin-result ${won ? "coin-result--won" : "coin-result--lost"}`}>
                 {won ? "You Won!" : "You Lost!"}


### PR DESCRIPTION
Closes #369 

## Result 

https://github.com/user-attachments/assets/4592818a-aa67-457f-ad63-06da678c570f

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `flip-coin` tool to the Everything example app, replacing the old `show-everything` name-input form in the "Use Call Tool" tab with a segmented heads/tails selector and flip button.

- **Server** (`server.ts`): Registers `flip-coin` with a Zod-typed `inputSchema`/`outputSchema`, uses `Math.random()` for the coin flip, and returns both `structuredContent` and a text content entry.
- **UI** (`use-call-tool-tab.tsx`): Introduces a segmented control for guess selection, disables the Flip button until a side is chosen, and renders a win/loss result after guarding against a missing `structuredContent`.
- **Styles** (`index.css`): Adds `.coin-box`, `.segmented`, `.segmented-btn`, and `.coin-result` classes to support the new UI layout.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are additive, isolated to the Everything example app, and the core logic is straightforward.

The coin-flip tool is simple and self-contained: server-side randomness is correct, the Zod schemas match the returned data, and the UI properly guards against a missing `structuredContent` before rendering the result. No existing tools or shared code paths are modified.

No files require special attention.

<sub>Reviews (4): Last reviewed commit: ["fix: add outputSchema to flip-coin and u..."](https://github.com/alpic-ai/skybridge/commit/6fc2ca39d3d28ae2120a89d2f45f7e432adae9c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33978916)</sub>

<!-- /greptile_comment -->