### PR TITLE
feat: open tunnel URL in browser when `--tunnel` flag is used

### DIFF
--- a/packages/core/src/cli/use-open-tunnel-browser.ts
+++ b/packages/core/src/cli/use-open-tunnel-browser.ts
@@ -18,7 +18,7 @@ export function useOpenTunnelBrowser(
     }
     if (tunnelState.status === "connected") {
       opened.current = true;
-      void open(`${tunnelState.url}/try`).catch(() => {});
+      void open(tunnelState.url).catch(() => {});
     }
   }, [tunnelState, enabled]);
 }

--- a/packages/core/src/cli/use-open-tunnel-browser.ts
+++ b/packages/core/src/cli/use-open-tunnel-browser.ts
@@ -13,7 +13,7 @@ export function useOpenTunnelBrowser(
   const opened = useRef(false);
 
   useEffect(() => {
-    if (!enabled || opened.current) return;
+    if (!enabled || opened.current) { return; }
     if (tunnelState.status === "connected") {
       opened.current = true;
       void open(`${tunnelState.url}/try`).catch(() => {});

--- a/packages/core/src/cli/use-open-tunnel-browser.ts
+++ b/packages/core/src/cli/use-open-tunnel-browser.ts
@@ -1,0 +1,22 @@
+import open from "open";
+import { useEffect, useRef } from "react";
+import type { TunnelState } from "./use-tunnel.js";
+
+/**
+ * Opens the tunnel URL in the browser once the tunnel reaches "connected"
+ * state. Fires at most once per mount.
+ */
+export function useOpenTunnelBrowser(
+  tunnelState: TunnelState,
+  enabled: boolean,
+): void {
+  const opened = useRef(false);
+
+  useEffect(() => {
+    if (!enabled || opened.current) return;
+    if (tunnelState.status === "connected") {
+      opened.current = true;
+      void open(`${tunnelState.url}/try`).catch(() => {});
+    }
+  }, [tunnelState, enabled]);
+}

--- a/packages/core/src/cli/use-open-tunnel-browser.ts
+++ b/packages/core/src/cli/use-open-tunnel-browser.ts
@@ -13,7 +13,9 @@ export function useOpenTunnelBrowser(
   const opened = useRef(false);
 
   useEffect(() => {
-    if (!enabled || opened.current) { return; }
+    if (!enabled || opened.current) {
+      return;
+    }
     if (tunnelState.status === "connected") {
       opened.current = true;
       void open(`${tunnelState.url}/try`).catch(() => {});

--- a/packages/core/src/commands/dev.tsx
+++ b/packages/core/src/commands/dev.tsx
@@ -7,6 +7,7 @@ import { startTunnelControlServer } from "../cli/tunnel-control-server.js";
 import { useMessages } from "../cli/use-messages.js";
 import { useNodemon } from "../cli/use-nodemon.js";
 import { useOpenBrowser } from "../cli/use-open-browser.js";
+import { useOpenTunnelBrowser } from "../cli/use-open-tunnel-browser.js";
 import { useTunnel } from "../cli/use-tunnel.js";
 import { useTypeScriptCheck } from "../cli/use-typescript-check.js";
 import { scanAndWriteViewsDts } from "../web/plugin/scan-views.js";
@@ -74,13 +75,14 @@ export default class Dev extends Command {
       const tsErrors = useTypeScriptCheck();
       const [messages, pushMessage] = useMessages();
       useNodemon(env, pushMessage);
-      useOpenBrowser(port, flags.open);
+      useOpenBrowser(port, flags.open && !flags.tunnel);
       const tunnelState = useTunnel(
         port,
         pushMessage,
         flags.verbose,
         flags.tunnel,
       );
+      useOpenTunnelBrowser(tunnelState, flags.open && flags.tunnel);
 
       return (
         <Box flexDirection="column" padding={1} marginLeft={1}>


### PR DESCRIPTION
Closes #824

Prev:

- `pnpm dev` - opens localhost url (correct)
- `pnpm dev --tunnel` still opens localhost url instead of tunnel url (fixed now)

## Working


https://github.com/user-attachments/assets/28cb83c1-ca13-45a3-af13-6fb2619724d7

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the `--tunnel` flag so that when both `--open` and `--tunnel` are used, the tunnel URL (not localhost) is opened in the browser once the tunnel connects.

- Adds a new `useOpenTunnelBrowser` hook that watches `TunnelState` and opens the tunnel URL in the browser exactly once when status reaches `"connected"`, mirroring the guard pattern in `useOpenBrowser`.
- Updates `dev.tsx` to gate `useOpenBrowser` away when `--tunnel` is active and route to the new hook instead, correctly handling all four `--open`/`--tunnel` flag combinations.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is small, well-scoped, and correctly gates both browser-open hooks across all flag combinations.

The new hook is a straightforward lift-and-shift of the existing useOpenBrowser pattern, with correct ref-guarding to prevent double-opens. The flag logic in dev.tsx correctly handles every combination of --open and --tunnel. The only nuance is that if the tunnel errors, no browser opens at all, but this is a minor UX edge case rather than a defect in the core path.

No files require special attention.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/core/src/commands/dev.tsx:81
**No browser opens if tunnel errors out**

When `--open --tunnel` is used, `useOpenBrowser` is now disabled unconditionally (`flags.open && !flags.tunnel` is `false`), and `useOpenTunnelBrowser` only fires when `tunnelState.status === "connected"`. If the tunnel transitions to `"error"` instead (e.g. network or auth failure), no browser window is ever opened — whereas before this fix, at least the localhost URL would open. Users might be left with no browser and no clear indication that they need to navigate manually.

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["Change tunnel URL to open devtool and no..."](https://github.com/alpic-ai/skybridge/commit/8169906387c9c42614c2d98047fff3c2b038a17f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34094095)</sub>

<!-- /greptile_comment -->