### PR TITLE
refactor(core): wrap user entry to hide setViteManifest from src/server.ts

### DIFF
--- a/docs/quickstart/deploy.mdx
+++ b/docs/quickstart/deploy.mdx
@@ -59,7 +59,7 @@ Add a `wrangler.jsonc` at your project root:
 ```jsonc
 {
   "name": "your-skybridge-app",
-  "main": "dist/server.js",
+  "main": "dist/__entry.js",
   "compatibility_date": "2025-09-01",
   "compatibility_flags": ["nodejs_compat"],
   "assets": { "directory": "dist/assets" },

--- a/examples/auth-auth0/src/server.ts
+++ b/examples/auth-auth0/src/server.ts
@@ -172,6 +172,6 @@ const server = new McpServer(
     },
   );
 
-server.run();
+export default server;
 
 export type AppType = typeof server;

--- a/examples/auth-clerk/src/server.ts
+++ b/examples/auth-clerk/src/server.ts
@@ -99,6 +99,6 @@ const server = new McpServer(
     },
   );
 
-server.run();
+export default server;
 
 export type AppType = typeof server;

--- a/examples/auth-stytch/src/server.ts
+++ b/examples/auth-stytch/src/server.ts
@@ -133,6 +133,6 @@ const server = new McpServer(
     },
   );
 
-server.run();
+export default server;
 
 export type AppType = typeof server;

--- a/examples/auth-workos/src/server.ts
+++ b/examples/auth-workos/src/server.ts
@@ -118,6 +118,6 @@ const server = new McpServer(
     },
   );
 
-server.run();
+export default server;
 
 export type AppType = typeof server;

--- a/examples/capitals/src/server.ts
+++ b/examples/capitals/src/server.ts
@@ -148,6 +148,6 @@ router.get("/api/capital/:cca2", async (req: Request, res: Response) => {
 
 server.use(router);
 
-server.run();
+export default server;
 
 export type AppType = typeof server;

--- a/examples/ecom-carousel/src/server.ts
+++ b/examples/ecom-carousel/src/server.ts
@@ -183,6 +183,6 @@ const server = new McpServer(
     },
   );
 
-server.run();
+export default server;
 
 export type AppType = typeof server;

--- a/examples/everything/src/server.ts
+++ b/examples/everything/src/server.ts
@@ -47,6 +47,6 @@ const server = new McpServer(
     },
   );
 
-server.run();
+export default server;
 
 export type AppType = typeof server;

--- a/examples/flight-booking/src/server.ts
+++ b/examples/flight-booking/src/server.ts
@@ -95,6 +95,6 @@ const server = new McpServer(
     },
   );
 
-server.run();
+export default server;
 
 export type AppType = typeof server;

--- a/examples/generative-ui/src/server.ts
+++ b/examples/generative-ui/src/server.ts
@@ -90,6 +90,6 @@ const server = new McpServer(
     },
   );
 
-server.run();
+export default server;
 
 export type AppType = typeof server;

--- a/examples/investigation-game/src/server.ts
+++ b/examples/investigation-game/src/server.ts
@@ -101,6 +101,6 @@ const server = new McpServer(
     },
   );
 
-server.run();
+export default server;
 
 export type AppType = typeof server;

--- a/examples/manifest-ui/src/server.ts
+++ b/examples/manifest-ui/src/server.ts
@@ -35,6 +35,6 @@ const server = new McpServer(
     },
   );
 
-server.run();
+export default server;
 
 export type AppType = typeof server;

--- a/examples/productivity/src/server.ts
+++ b/examples/productivity/src/server.ts
@@ -134,6 +134,6 @@ const server = new McpServer(
     },
   );
 
-server.run();
+export default server;
 
 export type AppType = typeof server;

--- a/examples/times-up/src/server.ts
+++ b/examples/times-up/src/server.ts
@@ -129,6 +129,6 @@ server.registerTool(
   },
 );
 
-server.run();
+export default server;
 
 export type AppType = typeof server;

--- a/packages/core/src/cli/build-helpers.test.ts
+++ b/packages/core/src/cli/build-helpers.test.ts
@@ -1,0 +1,24 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { ENTRY_WRAPPER_CONTENT, emitEntryWrapper } from "./build-helpers.js";
+
+function mkTmp(prefix = "skybridge-build-helpers-") {
+  return mkdtempSync(path.join(tmpdir(), prefix));
+}
+
+describe("emitEntryWrapper", () => {
+  it("writes dist/__entry.js with backward-compatible manifest + run() wiring", () => {
+    const dir = mkTmp();
+    emitEntryWrapper(dir);
+    const out = readFileSync(path.join(dir, "__entry.js"), "utf-8");
+    expect(out).toBe(ENTRY_WRAPPER_CONTENT);
+    expect(out).toContain('import manifest from "./vite-manifest.js"');
+    expect(out).toContain('import userExport from "./server.js"');
+    expect(out).toContain('typeof userExport.setViteManifest === "function"');
+    expect(out).toContain("userExport.setViteManifest(manifest)");
+    expect(out).toContain("await userExport.run()");
+    expect(out).toContain("export default resolved");
+  });
+});

--- a/packages/core/src/cli/build-helpers.ts
+++ b/packages/core/src/cli/build-helpers.ts
@@ -1,0 +1,33 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+// Handles two `dist/server.js` shapes:
+// - new: `export default server` — wrapper sets the manifest and awaits run().
+// - legacy: `export default await server.run()` (pre-wrapper templates) —
+//   wrapper passes the value through so existing projects keep booting after
+//   a skybridge upgrade without rebuilding.
+export const ENTRY_WRAPPER_CONTENT = `import manifest from "./vite-manifest.js";
+import userExport from "./server.js";
+
+let resolved;
+if (userExport && typeof userExport.setViteManifest === "function") {
+  userExport.setViteManifest(manifest);
+  resolved = await userExport.run();
+} else {
+  resolved = userExport;
+}
+
+export default resolved;
+`;
+
+export function emitEntryWrapper(distDir: string): void {
+  writeFileSync(path.join(distDir, "__entry.js"), ENTRY_WRAPPER_CONTENT);
+}
+
+export function emitManifestModule(
+  manifestPath: string,
+  outPath: string,
+): void {
+  const manifest = readFileSync(manifestPath, "utf-8");
+  writeFileSync(outPath, `export default ${manifest};\n`);
+}

--- a/packages/core/src/cli/dev-entry.ts
+++ b/packages/core/src/cli/dev-entry.ts
@@ -1,0 +1,15 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+// `skybridge dev` execs this file via tsx. tsx hooks Node's loader so the
+// dynamic import of the user's `src/server.ts` is transpiled on the fly.
+// We don't set the Vite manifest here — Vite middleware serves views in dev —
+// and only call run() when the export is still an McpServer instance, so
+// legacy templates that top-level-await run() themselves stay no-op here.
+const userServerPath = path.join(process.cwd(), "src", "server.ts");
+const mod = await import(pathToFileURL(userServerPath).href);
+const userExport = mod.default;
+
+if (userExport && typeof userExport.run === "function") {
+  await userExport.run();
+}

--- a/packages/core/src/cli/use-nodemon.ts
+++ b/packages/core/src/cli/use-nodemon.ts
@@ -1,11 +1,17 @@
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import nodemonOriginal from "nodemon";
 import { useEffect } from "react";
 import type { ExtendedNodemon } from "./nodemon.d.ts";
 import type { PushMessage } from "./use-messages.js";
 
 const nodemon = nodemonOriginal as ExtendedNodemon;
+
+// Absolute path to the shipped dev wrapper. tsx execs it; the wrapper then
+// dynamically imports `<cwd>/src/server.ts`. Keeping the wrapper inside the
+// skybridge package means no generated file lands in the user's repo.
+const devEntryPath = fileURLToPath(new URL("./dev-entry.js", import.meta.url));
 
 const SOURCEMAP_WARNING = /^Sourcemap for ".*" points to missing source files$/;
 
@@ -23,7 +29,7 @@ export function useNodemon(
       : {
           watch: ["src"],
           ext: "ts,json",
-          exec: "tsx src/server.ts",
+          exec: `tsx ${JSON.stringify(devEntryPath)}`,
         };
 
     nodemon({ ...config, env, stdout: false });

--- a/packages/core/src/commands/build.tsx
+++ b/packages/core/src/commands/build.tsx
@@ -1,8 +1,9 @@
-import { readFileSync, rmSync, writeFileSync } from "node:fs";
+import { rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { Command } from "@oclif/core";
 import { Box, render, Text } from "ink";
 import { useEffect } from "react";
+import { emitEntryWrapper, emitManifestModule } from "../cli/build-helpers.js";
 import { Header } from "../cli/header.js";
 import { resolveViewsDir } from "../cli/resolve-views-dir.js";
 import { type CommandStep, useExecuteSteps } from "../cli/use-execute-steps.js";
@@ -28,24 +29,25 @@ export const commandSteps: CommandStep[] = [
   },
   {
     label: "Emitting manifest module",
-    // Inline the Vite manifest as a JS module so the server can `import` it
+    // Inline the Vite manifest as a JS module so the wrapper can `import` it
     // instead of `readFileSync(process.cwd() + ...)` at runtime — required for
     // workerd, where neither cwd nor the assets directory is readable.
-    // The path mirrors `skybridge start`'s entry convention (dist/server.js)
-    // so the import in the user's entry resolves to a sibling file.
     run: () => {
       const root = process.cwd();
-      const manifest = readFileSync(
+      emitManifestModule(
         path.join(root, "dist", "assets", ".vite", "manifest.json"),
-        "utf-8",
-      );
-      writeFileSync(
         path.join(root, "dist", "vite-manifest.js"),
-        `export default ${manifest};\n`,
       );
     },
   },
-
+  {
+    label: "Emitting entry wrapper",
+    // dist/__entry.js wires manifest + run() so the user's src/server.ts only
+    // needs to export the McpServer instance. Deploy targets point here.
+    run: () => {
+      emitEntryWrapper(path.join(process.cwd(), "dist"));
+    },
+  },
   {
     label: "Emitting Cloudflare redirects",
     // Cloudflare's `assets.directory` maps URL → file literally — no

--- a/packages/core/src/commands/start.ts
+++ b/packages/core/src/commands/start.ts
@@ -24,7 +24,12 @@ export default class Start extends Command {
 
     console.clear();
 
-    const indexPath = resolve(process.cwd(), "dist/server.js");
+    // Prefer the wrapper (`dist/__entry.js`) when present, but fall back to
+    // `dist/server.js` so projects built with a previous skybridge version
+    // still start cleanly without a rebuild.
+    const entryPath = resolve(process.cwd(), "dist/__entry.js");
+    const legacyPath = resolve(process.cwd(), "dist/server.js");
+    const indexPath = existsSync(entryPath) ? entryPath : legacyPath;
 
     if (!existsSync(indexPath)) {
       console.error("❌ Error: No build output found");

--- a/packages/create-skybridge/templates/blank/Dockerfile
+++ b/packages/create-skybridge/templates/blank/Dockerfile
@@ -50,4 +50,4 @@ EXPOSE 3000
 # Run the built server directly rather than via `npm start` / `skybridge start`.
 # Each wrapper adds a process layer that can swallow SIGTERM, which makes
 # graceful shutdowns time out on platforms like Cloud Run, Fly, and k8s.
-CMD ["node", "dist/server.js"]
+CMD ["node", "dist/__entry.js"]

--- a/packages/create-skybridge/templates/blank/src/server.ts
+++ b/packages/create-skybridge/templates/blank/src/server.ts
@@ -11,11 +11,6 @@ const server = new McpServer(
 // Register tools with `server.registerTool(...)`.
 // Docs: https://docs.skybridge.tech/api-reference/register-tool
 
-if (process.env.NODE_ENV === "production") {
-  const { default: manifest } = await import("./vite-manifest.js");
-  server.setViteManifest(manifest);
-}
-
-export default await server.run();
+export default server;
 
 export type AppType = typeof server;

--- a/packages/create-skybridge/templates/blank/src/vite-manifest.d.ts
+++ b/packages/create-skybridge/templates/blank/src/vite-manifest.d.ts
@@ -1,4 +1,0 @@
-// Typed shim for the Vite manifest emitted by `skybridge build`. The actual
-// `vite-manifest.js` is generated alongside this file and gitignored.
-declare const manifest: Record<string, { file: string }>;
-export default manifest;

--- a/packages/create-skybridge/templates/demo/Dockerfile
+++ b/packages/create-skybridge/templates/demo/Dockerfile
@@ -50,4 +50,4 @@ EXPOSE 3000
 # Run the built server directly rather than via `npm start` / `skybridge start`.
 # Each wrapper adds a process layer that can swallow SIGTERM, which makes
 # graceful shutdowns time out on platforms like Cloud Run, Fly, and k8s.
-CMD ["node", "dist/server.js"]
+CMD ["node", "dist/__entry.js"]

--- a/packages/create-skybridge/templates/demo/src/server.ts
+++ b/packages/create-skybridge/templates/demo/src/server.ts
@@ -89,11 +89,6 @@ const server = new McpServer(
     },
   );
 
-if (process.env.NODE_ENV === "production") {
-  const { default: manifest } = await import("./vite-manifest.js");
-  server.setViteManifest(manifest);
-}
-
-export default await server.run();
+export default server;
 
 export type AppType = typeof server;

--- a/packages/create-skybridge/templates/demo/src/vite-manifest.d.ts
+++ b/packages/create-skybridge/templates/demo/src/vite-manifest.d.ts
@@ -1,4 +1,0 @@
-// Typed shim for the Vite manifest emitted by `skybridge build`. The actual
-// `vite-manifest.js` is generated alongside this file and gitignored.
-declare const manifest: Record<string, { file: string }>;
-export default manifest;


### PR DESCRIPTION
## Breaking change

**No.** All migration scenarios are covered:

- Legacy `src/server.ts` (`export default await server.run()`) still boots in dev — the user file's top-level `await` runs the server, and the dev wrapper's `typeof run === "function"` guard is then false, so no double-run.
- `skybridge build` still emits `dist/server.js`, so existing `wrangler.jsonc` / `Dockerfile` entries pointing at it keep working.
- `skybridge start` prefers `dist/__entry.js` but falls back to `dist/server.js` — upgrading skybridge without rebuilding still works.
- Public API (`McpServer.run`, `setViteManifest`) is unchanged.

No on-disk footprint in user repos: the dev wrapper is shipped inside `node_modules/skybridge/dist/cli/dev-entry.js`. `skybridge dev` execs it via tsx, and it dynamically imports `<cwd>/src/server.ts`.

---

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This refactor moves the server lifecycle wiring (`setViteManifest` + `run()`) out of user-authored `src/server.ts` into a generated `dist/__entry.js` wrapper emitted by `skybridge build`. User files now simply `export default server`, and the framework handles the rest.

- A new `dev-entry.ts` (shipped inside the skybridge package) is now exec'd by nodemon via tsx instead of the user's `src/server.ts` directly; it dynamically imports the user module and calls `run()` only when the export is a live McpServer instance, keeping legacy templates that top-level-await `server.run()` from double-running.
- `build-helpers.ts` extracts `emitManifestModule` and `emitEntryWrapper` (with a tested static content constant) so `build.tsx` gains a clean "Emitting entry wrapper" step and no longer manually inlines manifest logic.
- `start.ts` prefers `dist/__entry.js` with a fallback to `dist/server.js`, so projects built with an older skybridge version still boot without a rebuild.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The backward compatibility path for both dev and production is carefully handled, and no existing deploy targets break without a rebuild.

The refactor correctly handles all three lifecycle scenarios: new-style servers (export default server, run() called by wrapper), legacy servers (top-level await run(), detected by duck-typing in both dev-entry and __entry.js), and wrangler/Docker deploys (prefer __entry.js, fallback to server.js in skybridge start). The static ENTRY_WRAPPER_CONTENT is tested, the dev wrapper is scoped entirely inside the package with no user-repo footprint, and path quoting in nodemon exec handles spaces correctly.

No files require special attention.

<sub>Reviews (5): Last reviewed commit: ["refactor(examples): switch to export def..."](https://github.com/alpic-ai/skybridge/commit/45494a17d346aeeb98354e429cbc554d38f7eaef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34136615)</sub>

<!-- /greptile_comment -->