### PR TITLE
docs: add optional monitoring guidance to skybridge skill

### DIFF
--- a/skills/chatgpt-app-builder/SKILL.md
+++ b/skills/chatgpt-app-builder/SKILL.md
@@ -40,6 +40,7 @@ Design or evolve UX flows and API shape → [architecture.md](references/archite
 - **External links** → [open-external-links.md](references/open-external-links.md): when redirecting to external URLs or setting "open in app" target
 - **OAuth** → [oauth.md](references/oauth.md): when tools need user authentication to access user-specific data
 - **CSP** → [csp.md](references/csp.md): when declaring allowed domains for fetch, assets, redirects, or iframes
+- **Monitoring** → [monitoring.md](references/monitoring.md): when the user asks to capture user intents, collect user feedback, or instrument product-learning loops
 
 ## Deploy
 

--- a/skills/chatgpt-app-builder/references/monitoring.md
+++ b/skills/chatgpt-app-builder/references/monitoring.md
@@ -1,0 +1,73 @@
+# Monitoring
+
+Monitoring is optional. Do not add it by default just because a project uses Skybridge.
+
+Use this reference only when the user explicitly asks for:
+- user insights or user intents
+- user feedback collection
+- analytics for what users are asking for
+- product-learning or monitoring loops
+
+## User Insights
+
+To capture user intents in a Skybridge server, wire Alpic's insights middleware into the server before tool/widget registration.
+
+- Docs: <https://docs.alpic.ai/monitoring/user-intents>
+- Package: `@alpic-ai/insights`
+- Middleware: `intentMiddleware()`
+
+```ts
+import { intentMiddleware } from "@alpic-ai/insights";
+import { McpServer } from "skybridge/server";
+
+const server = new McpServer(
+  { name: "my-mcp-server", version: "1.0.0" },
+  { capabilities: {} },
+)
+  .mcpMiddleware(intentMiddleware())
+  .registerTool(/* ... */);
+```
+
+Useful options called out in the docs:
+- `tools`: restrict capture to specific tools
+- `argumentNameOverride`: reuse an existing field such as `query` or `question` instead of injecting `user_intent`
+
+## User Feedback
+
+To collect feedback from users or the LLM in a Skybridge server, wire Alpic's feedback middleware into the server before tool/widget registration.
+
+- Docs: <https://docs.alpic.ai/monitoring/user-feedbacks>
+- Package: `@alpic-ai/feedback`
+- Middleware: `feedbackMiddleware()`
+
+```ts
+import { feedbackMiddleware } from "@alpic-ai/feedback";
+import { McpServer } from "skybridge/server";
+
+const server = new McpServer(
+  { name: "my-mcp-server", version: "1.0.0" },
+  { capabilities: {} },
+)
+  .mcpMiddleware(feedbackMiddleware())
+  .registerTool(/* ... */);
+```
+
+## Combining Both
+
+If the user asks for both, register both middlewares before tool/widget registration.
+
+```ts
+import { feedbackMiddleware } from "@alpic-ai/feedback";
+import { intentMiddleware } from "@alpic-ai/insights";
+import { McpServer } from "skybridge/server";
+
+const server = new McpServer(
+  { name: "my-mcp-server", version: "1.0.0" },
+  { capabilities: {} },
+)
+  .mcpMiddleware(feedbackMiddleware())
+  .mcpMiddleware(intentMiddleware())
+  .registerTool(/* ... */);
+```
+
+Keep this section light in app planning. Monitoring is an add-on, not a required architecture step.

--- a/skills/chatgpt-app-builder/references/monitoring.md
+++ b/skills/chatgpt-app-builder/references/monitoring.md
@@ -8,16 +8,10 @@ Use this reference only when the user explicitly asks for:
 - analytics for what users are asking for
 - product-learning or monitoring loops
 
-## User Insights
-
-To capture user intents in a Skybridge server, wire Alpic's insights middleware into the server before tool/widget registration.
-
-- Docs: <https://docs.alpic.ai/monitoring/user-intents>
-- Package: `@alpic-ai/insights`
-- Middleware: `intentMiddleware()`
+Both middlewares ship in the same package, `@alpic-ai/insights`. Register them with `mcpMiddleware()` any time before `run()` (registering after `run()` or `connect()` throws). Their relative order does not matter.
 
 ```ts
-import { intentMiddleware } from "@alpic-ai/insights";
+import { feedbackMiddleware, intentMiddleware } from "@alpic-ai/insights";
 import { McpServer } from "skybridge/server";
 
 const server = new McpServer(
@@ -25,49 +19,25 @@ const server = new McpServer(
   { capabilities: {} },
 )
   .mcpMiddleware(intentMiddleware())
+  .mcpMiddleware(feedbackMiddleware())
   .registerTool(/* ... */);
 ```
 
-Useful options called out in the docs:
-- `tools`: restrict capture to specific tools
-- `argumentNameOverride`: reuse an existing field such as `query` or `question` instead of injecting `user_intent`
+Register only the middleware the user asked for.
+
+## User Insights
+
+`intentMiddleware()` injects a `user_intent` argument into the listed tools, which the LLM fills in from the user's own message.
+
+- Docs: <https://docs.alpic.ai/monitoring/user-intents>
+- Options:
+  - `tools`: array of tool names to restrict capture to; all other tools are left untouched
+  - `argumentNameOverride`: maps a tool name to one of its existing arguments (e.g. `{ "search-products": "query" }`) captured as the intent, so no synthetic `user_intent` is injected for that tool
 
 ## User Feedback
 
-To collect feedback from users or the LLM in a Skybridge server, wire Alpic's feedback middleware into the server before tool/widget registration.
+`feedbackMiddleware()` adds a `send_feedback` tool that the user or the LLM can call. It has no server-side handler: the middleware answers the call itself.
 
 - Docs: <https://docs.alpic.ai/monitoring/user-feedbacks>
-- Package: `@alpic-ai/feedback`
-- Middleware: `feedbackMiddleware()`
-
-```ts
-import { feedbackMiddleware } from "@alpic-ai/feedback";
-import { McpServer } from "skybridge/server";
-
-const server = new McpServer(
-  { name: "my-mcp-server", version: "1.0.0" },
-  { capabilities: {} },
-)
-  .mcpMiddleware(feedbackMiddleware())
-  .registerTool(/* ... */);
-```
-
-## Combining Both
-
-If the user asks for both, register both middlewares before tool/widget registration.
-
-```ts
-import { feedbackMiddleware } from "@alpic-ai/feedback";
-import { intentMiddleware } from "@alpic-ai/insights";
-import { McpServer } from "skybridge/server";
-
-const server = new McpServer(
-  { name: "my-mcp-server", version: "1.0.0" },
-  { capabilities: {} },
-)
-  .mcpMiddleware(feedbackMiddleware())
-  .mcpMiddleware(intentMiddleware())
-  .registerTool(/* ... */);
-```
 
 Keep this section light in app planning. Monitoring is an add-on, not a required architecture step.

--- a/skills/mcp-app-builder/SKILL.md
+++ b/skills/mcp-app-builder/SKILL.md
@@ -41,6 +41,7 @@ Design or evolve UX flows and API shape → [architecture.md](references/archite
 - **Download file** → [download-file.md](references/download-file.md): when saving content to the user's filesystem
 - **OAuth** → [oauth.md](references/oauth.md): when tools need user authentication to access user-specific data
 - **CSP** → [csp.md](references/csp.md): when declaring allowed domains for fetch, assets, redirects, or iframes
+- **Monitoring** → [monitoring.md](references/monitoring.md): when the user asks to capture user intents, collect user feedback, or instrument product-learning loops
 
 ## Deploy
 

--- a/skills/skybridge/SKILL.md
+++ b/skills/skybridge/SKILL.md
@@ -41,6 +41,7 @@ Design or evolve UX flows and API shape → [architecture.md](references/archite
 - **Download file** → [download-file.md](references/download-file.md): when saving content to the user's filesystem
 - **OAuth** → [oauth.md](references/oauth.md): when tools need user authentication to access user-specific data
 - **CSP** → [csp.md](references/csp.md): when declaring allowed domains for fetch, assets, redirects, or iframes
+- **Monitoring** → [monitoring.md](references/monitoring.md): when the user asks to capture user intents, collect user feedback, or instrument product-learning loops
 
 ## Deploy
 


### PR DESCRIPTION
## Summary
- add an optional monitoring reference to the Skybridge skill
- document how to wire User Insights via `intentMiddleware()`
- document how to wire User Feedback via `feedbackMiddleware()`

## Notes
- monitoring is explicitly optional and should not be added by default
- links point to the current Alpic docs pages for insights and feedback

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an optional monitoring reference document to the Skybridge skill, documenting how to wire `intentMiddleware()` (User Insights) and `feedbackMiddleware()` (User Feedback) into an MCP server. The new file is correctly placed in `skills/chatgpt-app-builder/references/` — the canonical home for shared reference docs — which the `skybridge` skill accesses via a pre-existing symlink (`skills/skybridge/references → ../chatgpt-app-builder/references`).

- `skills/chatgpt-app-builder/references/monitoring.md` is a new guide covering User Insights, User Feedback, and a combined setup example; it is explicitly scoped to on-demand use only.
- `skills/skybridge/SKILL.md` receives one new Implementation entry pointing to the new file, consistent with other entries in that section.

<h3>Confidence Score: 5/5</h3>

Docs-only change; no runtime code is modified and the file resolves correctly through the existing symlink.

Both changed files are documentation. The new reference file is well-structured and placed in the right directory given the existing symlink. The SKILL.md entry follows the same pattern as all other Implementation references. The only note is a cosmetic ordering inconsistency in the 'Combining Both' example.

No files require special attention.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
skills/chatgpt-app-builder/references/monitoring.md:56-71
**Middleware order inconsistency in "Combining Both"**

The individual sections present insights first and feedback second, but the "Combining Both" example reverses this — registering `feedbackMiddleware()` before `intentMiddleware()`. If the order is arbitrary, swapping to match the document's own top-to-bottom presentation (insights → feedback) would avoid confusion. If the order is significant (e.g., one middleware depends on context injected by the other), a brief note explaining the required ordering would help.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add optional monitoring guidance t..."](https://github.com/alpic-ai/skybridge/commit/df461063301465185cf6e3755f4276268417f321) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34378536)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->