### PR TITLE
feat(devtools): truncate long tool param descriptions with see more/less.

### DIFF
--- a/packages/devtools/src/components/layout/tools-list/form/templates.tsx
+++ b/packages/devtools/src/components/layout/tools-list/form/templates.tsx
@@ -25,11 +25,12 @@ function TruncatedDescription({ id, text }: { id?: string; text: string }) {
   const spanRef = useRef<HTMLSpanElement>(null);
 
   useEffect(() => {
+    setExpanded(false);
     const el = spanRef.current;
     if (el) {
       setIsClamped(el.scrollHeight > el.clientHeight);
     }
-  }, []);
+  }, [text]);
 
   return (
     <p id={id} className={descriptionTextClass}>

--- a/packages/devtools/src/components/layout/tools-list/form/templates.tsx
+++ b/packages/devtools/src/components/layout/tools-list/form/templates.tsx
@@ -19,13 +19,7 @@ import {
   ghostButtonClass,
 } from "./styles.js";
 
-function TruncatedDescription({
-  id,
-  text,
-}: {
-  id?: string;
-  text: string;
-}) {
+function TruncatedDescription({ id, text }: { id?: string; text: string }) {
   const [expanded, setExpanded] = useState(false);
   const [isClamped, setIsClamped] = useState(false);
   const spanRef = useRef<HTMLSpanElement>(null);
@@ -35,7 +29,7 @@ function TruncatedDescription({
     if (el) {
       setIsClamped(el.scrollHeight > el.clientHeight);
     }
-  }, [text]);
+  }, []);
 
   return (
     <p id={id} className={descriptionTextClass}>
@@ -213,11 +207,13 @@ export function ObjectFieldTemplate(props: ObjectFieldTemplateProps) {
           {required && <span className="ml-1 text-destructive">*</span>}
         </div>
       )}
-      {!isRoot && description && (
-        typeof description === "string"
-          ? <TruncatedDescription text={description} />
-          : <p className={descriptionTextClass}>{description}</p>
-      )}
+      {!isRoot &&
+        description &&
+        (typeof description === "string" ? (
+          <TruncatedDescription text={description} />
+        ) : (
+          <p className={descriptionTextClass}>{description}</p>
+        ))}
       {properties
         .filter((p) => !p.hidden)
         .map((p) => (

--- a/packages/devtools/src/components/layout/tools-list/form/templates.tsx
+++ b/packages/devtools/src/components/layout/tools-list/form/templates.tsx
@@ -24,14 +24,18 @@ function TruncatedDescription({ id, text }: { id?: string; text: string }) {
   const [isClamped, setIsClamped] = useState(false);
   const spanRef = useRef<HTMLSpanElement>(null);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: text triggers re-measurement of clamping without being read inside the effect
   useEffect(() => {
     setExpanded(false);
-    const el = spanRef.current;
-    if (el) {
-      setIsClamped(el.scrollHeight > el.clientHeight);
-    }
   }, [text]);
+
+  useEffect(() => {
+    if (!expanded) {
+      const element = spanRef.current;
+      if (element) {
+        setIsClamped(element.scrollHeight > element.clientHeight);
+      }
+    }
+  }, [expanded, text]);
 
   return (
     <p id={id} className={descriptionTextClass}>
@@ -149,7 +153,7 @@ export function FieldTemplate(props: FieldTemplateProps) {
           {required && <span className="ml-1 text-destructive">*</span>}
         </label>
       )}
-      {showHint && <TruncatedDescription text={rawDescription as string} />}
+      {showHint && <TruncatedDescription text={rawDescription!} />}
       {children}
       {errors}
       {help}
@@ -213,13 +217,9 @@ export function ObjectFieldTemplate(props: ObjectFieldTemplateProps) {
           {required && <span className="ml-1 text-destructive">*</span>}
         </div>
       )}
-      {!isRoot &&
-        description &&
-        (typeof description === "string" ? (
-          <TruncatedDescription text={description} />
-        ) : (
-          <p className={descriptionTextClass}>{description}</p>
-        ))}
+      {!isRoot && description && (
+        <TruncatedDescription text={String(description)} />
+      )}
       {properties
         .filter((p) => !p.hidden)
         .map((p) => (

--- a/packages/devtools/src/components/layout/tools-list/form/templates.tsx
+++ b/packages/devtools/src/components/layout/tools-list/form/templates.tsx
@@ -11,12 +11,49 @@ import type {
 } from "@rjsf/utils";
 import { getInputProps } from "@rjsf/utils";
 import { Plus, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils.js";
 import {
   denseInputClass,
   descriptionTextClass,
   ghostButtonClass,
 } from "./styles.js";
+
+function TruncatedDescription({
+  id,
+  text,
+}: {
+  id?: string;
+  text: string;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [isClamped, setIsClamped] = useState(false);
+  const spanRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    const el = spanRef.current;
+    if (el) {
+      setIsClamped(el.scrollHeight > el.clientHeight);
+    }
+  }, [text]);
+
+  return (
+    <p id={id} className={descriptionTextClass}>
+      <span ref={spanRef} className={expanded ? undefined : "line-clamp-3"}>
+        {text}
+      </span>
+      {isClamped && (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="ml-1 text-[10px] text-muted-foreground underline"
+        >
+          {expanded ? "see less" : "see more"}
+        </button>
+      )}
+    </p>
+  );
+}
 
 export function BaseInputTemplate(props: BaseInputTemplateProps) {
   const {
@@ -116,7 +153,7 @@ export function FieldTemplate(props: FieldTemplateProps) {
           {required && <span className="ml-1 text-destructive">*</span>}
         </label>
       )}
-      {showHint && <p className={descriptionTextClass}>{rawDescription}</p>}
+      {showHint && <TruncatedDescription text={rawDescription as string} />}
       {children}
       {errors}
       {help}
@@ -140,9 +177,7 @@ export function DescriptionFieldTemplate(props: DescriptionFieldProps) {
     return null;
   }
   return (
-    <p id={props.id} className={descriptionTextClass}>
-      {props.description}
-    </p>
+    <TruncatedDescription id={props.id} text={String(props.description)} />
   );
 }
 
@@ -179,7 +214,9 @@ export function ObjectFieldTemplate(props: ObjectFieldTemplateProps) {
         </div>
       )}
       {!isRoot && description && (
-        <p className={descriptionTextClass}>{description}</p>
+        typeof description === "string"
+          ? <TruncatedDescription text={description} />
+          : <p className={descriptionTextClass}>{description}</p>
       )}
       {properties
         .filter((p) => !p.hidden)
@@ -212,7 +249,7 @@ export function ArrayFieldTemplate(props: ArrayFieldTemplateProps) {
           {required && <span className="ml-1 text-destructive">*</span>}
         </div>
       )}
-      {description && <p className={descriptionTextClass}>{description}</p>}
+      {description && <TruncatedDescription text={description} />}
       {/* rjsf v6: items is ReactElement[] (pre-rendered ArrayFieldItemTemplate). */}
       {items}
       {canAdd && (

--- a/packages/devtools/src/components/layout/tools-list/form/templates.tsx
+++ b/packages/devtools/src/components/layout/tools-list/form/templates.tsx
@@ -24,6 +24,7 @@ function TruncatedDescription({ id, text }: { id?: string; text: string }) {
   const [isClamped, setIsClamped] = useState(false);
   const spanRef = useRef<HTMLSpanElement>(null);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: text triggers re-measurement of clamping without being read inside the effect
   useEffect(() => {
     setExpanded(false);
     const el = spanRef.current;
@@ -171,8 +172,12 @@ export function DescriptionFieldTemplate(props: DescriptionFieldProps) {
   if (!props.description) {
     return null;
   }
-  return (
-    <TruncatedDescription id={props.id} text={String(props.description)} />
+  return typeof props.description === "string" ? (
+    <TruncatedDescription id={props.id} text={props.description} />
+  ) : (
+    <p id={props.id} className={descriptionTextClass}>
+      {props.description}
+    </p>
   );
 }
 

--- a/packages/devtools/src/components/layout/tools-list/form/templates.tsx
+++ b/packages/devtools/src/components/layout/tools-list/form/templates.tsx
@@ -219,13 +219,13 @@ export function ObjectFieldTemplate(props: ObjectFieldTemplateProps) {
           {required && <span className="ml-1 text-destructive">*</span>}
         </div>
       )}
-      {!isRoot && description && (
-        typeof description === "string" ? (
+      {!isRoot &&
+        description &&
+        (typeof description === "string" ? (
           <TruncatedDescription text={description} />
         ) : (
           <p className={descriptionTextClass}>{description}</p>
-        )
-      )}
+        ))}
       {properties
         .filter((p) => !p.hidden)
         .map((p) => (

--- a/packages/devtools/src/components/layout/tools-list/form/templates.tsx
+++ b/packages/devtools/src/components/layout/tools-list/form/templates.tsx
@@ -24,10 +24,12 @@ function TruncatedDescription({ id, text }: { id?: string; text: string }) {
   const [isClamped, setIsClamped] = useState(false);
   const spanRef = useRef<HTMLSpanElement>(null);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: text is a trigger — reset expanded whenever the prop changes
   useEffect(() => {
     setExpanded(false);
   }, [text]);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: text is a trigger — re-check clamping whenever the prop changes
   useEffect(() => {
     if (!expanded) {
       const element = spanRef.current;
@@ -153,7 +155,7 @@ export function FieldTemplate(props: FieldTemplateProps) {
           {required && <span className="ml-1 text-destructive">*</span>}
         </label>
       )}
-      {showHint && <TruncatedDescription text={rawDescription!} />}
+      {showHint && <TruncatedDescription text={rawDescription as string} />}
       {children}
       {errors}
       {help}

--- a/packages/devtools/src/components/layout/tools-list/form/templates.tsx
+++ b/packages/devtools/src/components/layout/tools-list/form/templates.tsx
@@ -220,7 +220,11 @@ export function ObjectFieldTemplate(props: ObjectFieldTemplateProps) {
         </div>
       )}
       {!isRoot && description && (
-        <TruncatedDescription text={String(description)} />
+        typeof description === "string" ? (
+          <TruncatedDescription text={description} />
+        ) : (
+          <p className={descriptionTextClass}>{description}</p>
+        )
       )}
       {properties
         .filter((p) => !p.hidden)

--- a/packages/devtools/src/components/layout/tools-list/index.tsx
+++ b/packages/devtools/src/components/layout/tools-list/index.tsx
@@ -57,7 +57,7 @@ function ToolsList() {
         type="single"
         value={openTool ?? ""}
         onValueChange={handleToolClick}
-        className="min-h-0 overflow-y-auto"
+        className="min-h-0 overflow-y-auto scrollbar-hide"
       >
         {tools.map((tool) => (
           <ToolItem key={tool.name} tool={tool} open={openTool === tool.name} />

--- a/packages/devtools/src/index.css
+++ b/packages/devtools/src/index.css
@@ -26,6 +26,13 @@
   --color-ring: #5eead4;
 }
 
+@utility scrollbar-hide {
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
 .preview-region {
   /* Figma “bg-secondary-subtle” / “border-tertiary” → @alpic-ai/ui @theme color tokens */
   --preview-region-bg: var(--color-light-gray);


### PR DESCRIPTION
Closes #831 

## Demo


https://github.com/user-attachments/assets/74756c3e-37ac-45fd-b1f4-b9e8efb5d6f2

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `TruncatedDescription` component that clamps long tool parameter descriptions to 3 lines with a "see more / see less" toggle, and hides the tools-list scrollbar with a new `scrollbar-hide` utility class.

- `TruncatedDescription` uses two `useEffect` hooks — one resets `expanded` when `text` changes, the other re-measures clamping — both with correct dependency arrays. `DescriptionFieldTemplate` and `ObjectFieldTemplate` apply a `typeof description === "string"` guard before delegating to the new component, matching the existing pattern in the codebase.
- `ArrayFieldTemplate` reads `description` from `schema.description`, which is always `string | undefined` in JSON Schema, so passing it directly to `TruncatedDescription` is safe without an additional guard.

<h3>Confidence Score: 5/5</h3>

The change is purely additive UI enhancement confined to the devtools package; no data paths, APIs, or shared logic are affected.

The TruncatedDescription component is self-contained, both useEffect hooks carry the correct dependency arrays, and every call site that could receive a ReactElement description applies a typeof guard before delegating to the new component.

No files require special attention.

<sub>Reviews (7): Last reviewed commit: ["fix(devtools): reformat ObjectFieldTempl..."](https://github.com/alpic-ai/skybridge/commit/f964e59ba74826966df9f29fd7c81d9f53a7ebd8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34536864)</sub>

<!-- /greptile_comment -->