### PR TITLE
fix(cli): increment port instead of random when default is taken

### DIFF
--- a/packages/core/src/cli/detect-port.ts
+++ b/packages/core/src/cli/detect-port.ts
@@ -1,6 +1,7 @@
 import net from "node:net";
 
 const DEFAULT_PORT = 3000;
+const MAX_PORT_INCREMENT = 100;
 
 export async function resolvePort(flagPort?: number) {
   if (flagPort && flagPort > 1) {
@@ -25,8 +26,8 @@ export async function resolvePort(flagPort?: number) {
 }
 
 /**
- * Returns the given port if available, otherwise lets the OS
- * pick a free port via `listen(0)`.
+ * Returns the first available port at or after `startPort`, incrementing
+ * by one until a free port is found or `MAX_PORT_INCREMENT` is reached.
  *
  * @param host - Bind address for the check. Pass `"localhost"` for
  *   services that bind to 127.0.0.1 (e.g. Vite HMR). Omit for
@@ -36,29 +37,14 @@ export async function detectAvailablePort(
   startPort: number,
   host?: string,
 ): Promise<number> {
-  const available = await isPortAvailable(startPort, host);
-  if (available) {
-    return startPort;
+  for (let port = startPort; port < startPort + MAX_PORT_INCREMENT; port++) {
+    if (await isPortAvailable(port, host)) {
+      return port;
+    }
   }
-
-  return new Promise((resolve, reject) => {
-    const server = net.createServer();
-
-    server.once("error", reject);
-    server.once("listening", () => {
-      const addr = server.address();
-      if (addr && typeof addr === "object") {
-        const { port } = addr;
-        server.close(() => resolve(port));
-      } else {
-        server.close(() =>
-          reject(new Error("Failed to detect available port")),
-        );
-      }
-    });
-
-    server.listen(0, host);
-  });
+  throw new Error(
+    `No available port found between ${startPort} and ${startPort + MAX_PORT_INCREMENT - 1}`,
+  );
 }
 
 function isPortAvailable(port: number, host?: string): Promise<boolean> {

--- a/packages/core/src/cli/detect-port.ts
+++ b/packages/core/src/cli/detect-port.ts
@@ -41,6 +41,7 @@ export async function detectAvailablePort(
     if (await isPortAvailable(port, host)) {
       return port;
     }
+    console.log(`Port ${port} is in use, trying another one...`);
   }
   throw new Error(
     `No available port found between ${startPort} and ${startPort + MAX_PORT_INCREMENT - 1}`,


### PR DESCRIPTION
## Summary
- When port 3000 is in use, `skybridge dev` now tries 3001, 3002, … up to 100 ports instead of letting the OS assign a random free port via `listen(0)`.
- Predictable URLs across restarts.

Closes SKY-419.

## Test plan
- [ ] `skybridge dev` with 3000 free → runs on 3000
- [ ] `skybridge dev` with 3000 occupied → runs on 3001
- [ ] `skybridge dev -p 4000` still honors the flag
- [ ] `PORT=5000 skybridge dev` still honors the env var

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the `listen(0)` OS-random-port fallback with a deterministic sequential scan of up to 100 ports starting from `startPort`, giving predictable URLs across restarts when the default port is busy.

- `detectAvailablePort` now iterates `startPort` through `startPort + 99`, returning the first free port or throwing a descriptive error if all are occupied. This is a behavior change at the call sites (`dev.tsx`, `start.ts`) which don't catch the new error, but the oclif framework catches unhandled errors from `run()` and displays them cleanly.
- The "port in use" diagnostic (`console.log`) writes to stdout; `console.warn` (stderr) is the conventional choice for advisory messages in CLI tools.

<h3>Confidence Score: 4/5</h3>

The change is safe to merge; the new sequential scan is correct and the error message is accurate.

The logic is straightforward and well-scoped. The only thing worth a second glance is that `detectAvailablePort` can now throw when all 100 ports are exhausted, and neither `dev.tsx` nor `start.ts` has a try/catch around `resolvePort` — but oclif catches errors from `run()` at the framework level, so users will see the descriptive error message rather than an unhandled rejection. The `console.log` writing to stdout instead of stderr is a minor style point.

Only `packages/core/src/cli/detect-port.ts` changed; the call sites in `dev.tsx` and `start.ts` are worth a quick glance to confirm the new throw path is handled acceptably in context.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/core/src/cli/detect-port.ts:44
`console.log` writes to stdout. In a CLI that may be piped or whose output is parsed by scripts, these diagnostic messages should go to stderr instead — `console.warn` routes there automatically.

```suggestion
    console.warn(`Port ${port} is in use, trying another one...`);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(cli): log port-in-use attempts when..."](https://github.com/alpic-ai/skybridge/commit/60820d01b74a6ddf36b359cd37d8f8e4158f359e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34899393)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->