### PR TITLE
examples/chess

### DIFF
--- a/docs/api-reference/use-register-view-tool.mdx
+++ b/docs/api-reference/use-register-view-tool.mdx
@@ -1,0 +1,147 @@
+---
+title: useRegisterViewTool
+description: "React hook for exposing app-provided (view) tools that the host and model can call directly against the running view."
+---
+
+`useRegisterViewTool` registers a **view-provided tool** — a tool whose handler
+runs _inside the view_ rather than on the MCP server. The host discovers it via
+`tools/list` and invokes it via `tools/call`, and your handler executes against
+the view's live state. This is the MCP Apps ["app-provided
+tools"](https://github.com/modelcontextprotocol/ext-apps/pull/72) feature.
+
+It is the mirror image of [`useCallTool`](/api-reference/use-call-tool): with
+`useCallTool` the view _calls_ a server tool; with `useRegisterViewTool` the
+view _exposes_ a tool for the model to call.
+
+<Note>
+  View tools are an **MCP Apps** feature. The ChatGPT Apps SDK
+  (`window.openai`) runtime has no equivalent, so on that runtime
+  `useRegisterViewTool` is a no-op (a warning is logged). Use it when targeting
+  MCP Apps hosts.
+</Note>
+
+## Basic usage
+
+```tsx
+import { useRegisterViewTool } from "skybridge/web";
+import * as z from "zod";
+
+function Counter() {
+  const [count, setCount] = useState(0);
+
+  useRegisterViewTool(
+    {
+      name: "counter_increment",
+      description: "Increment the on-screen counter by an amount.",
+      inputSchema: { by: z.number().int().default(1) },
+      annotations: { readOnlyHint: false },
+    },
+    ({ by }) => {
+      setCount((current) => current + by);
+      return {
+        content: [{ type: "text", text: `Counter is now ${count + by}.` }],
+        structuredContent: { count: count + by },
+      };
+    },
+  );
+
+  return <span>{count}</span>;
+}
+```
+
+The tool is registered when the component mounts and removed when it unmounts.
+Arguments are validated against `inputSchema` before the handler runs, and the
+handler receives them fully typed.
+
+## Parameters
+
+```tsx
+useRegisterViewTool(config, handler);
+```
+
+### `config`
+
+```tsx
+type ViewToolConfig = {
+  name: string;
+  title?: string;
+  description?: string;
+  inputSchema?: ZodRawShape;
+  annotations?: ToolAnnotations;
+};
+```
+
+**Required.** Describes the tool. Mirrors the server-side
+[`registerTool`](/api-reference/register-tool) config.
+
+- `name` — Unique tool name. Prefer namespacing (e.g. `chess_make_move`) so it
+  never collides with a server tool.
+- `description` — Written for the model, which decides when to call the tool.
+- `inputSchema` — A Zod raw shape describing the arguments. Validated before the
+  handler runs; surfaced to the host as JSON Schema.
+- `annotations` — MCP tool annotations such as `readOnlyHint` and
+  `destructiveHint`.
+
+### `handler`
+
+```tsx
+type ViewToolHandler = (args) => ViewToolResult | Promise<ViewToolResult>;
+
+// ViewToolResult is the standard MCP `CallToolResult`:
+type ViewToolResult = {
+  content: ContentBlock[];
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+  _meta?: Record<string, unknown>;
+};
+```
+
+**Required.** Runs when the host calls the tool. `args` is typed from
+`config.inputSchema`. Return a standard MCP `CallToolResult` — `content`
+blocks plus optional `structuredContent`. Set `isError: true` to report a
+failure to the model.
+
+The handler is always read from the latest render, so it sees current state
+without forcing a re-registration.
+
+## Behavior
+
+- The tool is (re)registered when `config.name` changes. Keep the name stable
+  and the schema fixed for the tool's lifetime.
+- Arguments are validated against `inputSchema` before your handler runs;
+  invalid input is rejected by the runtime and the handler is not called.
+- Each registration / removal notifies the host via
+  `notifications/tools/list_changed`.
+
+## Example: a chess move tool
+
+```tsx
+import { useRegisterViewTool } from "skybridge/web";
+import * as z from "zod";
+
+useRegisterViewTool(
+  {
+    name: "chess_make_move",
+    description: "Play a move as Black, in SAN (e.g. 'Nf6') or from/to squares.",
+    inputSchema: {
+      san: z.string().optional(),
+      from: z.string().length(2).optional(),
+      to: z.string().length(2).optional(),
+    },
+    annotations: { readOnlyHint: false },
+  },
+  ({ san, from, to }) => {
+    const result = game.move(san ? { san } : { from, to });
+    if (!result.ok) {
+      return { content: [{ type: "text", text: result.error }], isError: true };
+    }
+    return {
+      content: [{ type: "text", text: `Played ${result.san}.` }],
+      structuredContent: { fen: result.fen },
+    };
+  },
+);
+```
+
+See the [`chess` example](https://github.com/alpic-ai/skybridge/tree/main/examples/chess)
+for a full app built around view tools.

--- a/docs/api-reference/use-register-view-tool.mdx
+++ b/docs/api-reference/use-register-view-tool.mdx
@@ -98,7 +98,8 @@ type ViewToolResult = {
 
 **Required.** Runs when the host calls the tool. `args` is typed from
 `config.inputSchema`. Return a standard MCP `CallToolResult` — `content`
-blocks plus optional `structuredContent`. Set `isError: true` to report a
+blocks plus optional `structuredContent` and `_meta` (forwarded to the host
+verbatim, same as a server tool result). Set `isError: true` to report a
 failure to the model.
 
 The handler is always read from the latest render, so it sees current state

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -111,6 +111,7 @@
             "pages": [
               "api-reference/use-tool-info",
               "api-reference/use-call-tool",
+              "api-reference/use-register-view-tool",
               "api-reference/use-layout",
               "api-reference/use-user",
               "api-reference/use-display-mode",

--- a/examples/chess/.gitignore
+++ b/examples/chess/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.env
+.DS_store
+.vercel

--- a/examples/chess/README.md
+++ b/examples/chess/README.md
@@ -1,0 +1,62 @@
+# Skybridge Chess
+
+Play chess against the assistant inside the conversation. You play **White** and
+move first by dragging pieces; the assistant plays **Black**.
+
+This example is a Skybridge port of [MCPJam/chess-mcp](https://github.com/MCPJam/chess-mcp),
+and its purpose is to showcase **MCP Apps view-provided tools** — the
+[`ext-apps` "app-provided tools"](https://github.com/modelcontextprotocol/ext-apps/pull/72)
+feature.
+
+## What it demonstrates
+
+Most of the game logic is **not** on the server. The server exposes a single
+`start_game` tool that opens the board. The **view** then registers the tools
+the model actually uses to play, with `useRegisterViewTool`:
+
+| Tool | Runs in | Purpose |
+| --- | --- | --- |
+| `start_game` | server | Opens the board |
+| `chess_get_board_state` | **view** | Read FEN, turn, check, result, history |
+| `chess_get_legal_moves` | **view** | List legal moves (optionally from a square) |
+| `chess_make_move` | **view** | Play a move as Black |
+| `chess_reset_game` | **view** | Reset to the starting position |
+
+The host discovers the view tools via `tools/list` and invokes them via
+`tools/call`, executing the handlers **inside the running widget** against a
+[chess.js](https://github.com/jhlywa/chess.js) engine. The match lives in a
+Skybridge synced store (`createStore`) that also keeps the move log and the last
+move played, so the full game is pushed into the model's context on every change
+and survives a view remount. The chess logic is a thin, stateless wrapper
+(`src/lib/engine.ts`) — every helper rebuilds the engine from a FEN on demand.
+
+### The turn loop
+
+1. The user drags a White piece. chess.js validates the move.
+2. The view calls `sendFollowUpMessage`, asking the assistant (as the user) to
+   reply with its Black move.
+3. The assistant calls the `chess_make_move` **view tool**, which updates the
+   board in place.
+
+### Look & feel
+
+The board is themed with the Skybridge palette (blue `#002FFF` → cyan
+`#08F5F9`), highlights the last move and any king in check, and ships a dark
+mode that follows the host theme with a manual toggle in the header.
+
+## Runtime support
+
+> View-provided tools are an **MCP Apps** feature. In the ChatGPT Apps SDK
+> runtime (`window.openai`) there is no equivalent, so `useRegisterViewTool` is
+> a no-op there — the human can still drag pieces, but the assistant cannot
+> call the view tools. Run this in an MCP Apps host (e.g. Claude) to see the
+> full loop.
+
+## Develop
+
+```bash
+pnpm install
+pnpm dev
+```
+
+Then open the devtools URL printed in the terminal.

--- a/examples/chess/alpic.json
+++ b/examples/chess/alpic.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://assets.alpic.ai/alpic.json",
+  "installCommand": "npm install",
+  "startCommand": "npm run --silent start"
+}

--- a/examples/chess/package.json
+++ b/examples/chess/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "skybridge-chess-example",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Skybridge Chess Example — showcases MCP Apps view-provided tools",
+  "type": "module",
+  "scripts": {
+    "dev": "skybridge dev",
+    "dev:tunnel": "skybridge dev --tunnel",
+    "build": "skybridge build",
+    "start": "skybridge start",
+    "deploy": "alpic deploy"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "chess.js": "^1.4.0",
+    "react": "^19.2.3",
+    "react-chessboard": "^5.10.0",
+    "react-dom": "^19.2.3",
+    "skybridge": "^1.0.0",
+    "tailwindcss": "^4.1.14",
+    "tw-animate-css": "^1.4.0",
+    "vite": "^7.3.1",
+    "zod": "^4.3.5"
+  },
+  "devDependencies": {
+    "@skybridge/devtools": "^1.0.0",
+    "@tailwindcss/vite": "^4.1.14",
+    "@types/node": "^24.0.0",
+    "@types/react": "^19.2.8",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.1.2",
+    "alpic": "^1.104.1",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3"
+  },
+  "engines": {
+    "node": ">=24.13.0"
+  }
+}

--- a/examples/chess/src/helpers.ts
+++ b/examples/chess/src/helpers.ts
@@ -1,0 +1,4 @@
+import { generateHelpers } from "skybridge/web";
+import type { AppType } from "./server.js";
+
+export const { useToolInfo, useCallTool } = generateHelpers<AppType>();

--- a/examples/chess/src/index.css
+++ b/examples/chess/src/index.css
@@ -1,0 +1,179 @@
+@import "tailwindcss";
+
+/* Skybridge brand
+ *   blue     #002FFF   (primary)
+ *   cyan     #08F5F9   (accent / highlight)
+ *   midnight #051413   (dark surface)
+ */
+:root {
+  --sky-blue: #002fff;
+  --sky-cyan: #08f5f9;
+  --sky-gradient: linear-gradient(135deg, #002fff 0%, #08f5f9 100%);
+
+  --chess-bg: #ffffff;
+  --chess-panel: #f5f8ff;
+  --chess-fg: #0b1530;
+  --chess-muted: #5a6b8c;
+  --chess-border: #dbe4f5;
+  --chess-accent: var(--sky-blue);
+  --chess-accent-fg: #ffffff;
+  --chess-board-shadow: 0 10px 30px -12px rgba(0, 47, 255, 0.35);
+}
+
+[data-theme="dark"] {
+  --chess-bg: #051413;
+  --chess-panel: #0a1f2b;
+  --chess-fg: #eaf6ff;
+  --chess-muted: #7e97b3;
+  --chess-border: #142c3a;
+  --chess-accent: var(--sky-cyan);
+  --chess-accent-fg: #051413;
+  --chess-board-shadow: 0 10px 32px -10px rgba(8, 245, 249, 0.3);
+}
+
+.chess-app {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  max-width: 28rem;
+  margin: 0 auto;
+  padding: 1.25rem;
+  color: var(--chess-fg);
+  background: var(--chess-bg);
+  border-radius: 1rem;
+  font-family:
+    ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+
+.chess-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.chess-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+}
+
+/* A small gradient tile that echoes the Skybridge logo mark. */
+.chess-mark {
+  flex-shrink: 0;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 0.5rem;
+  background: var(--sky-gradient);
+  box-shadow: 0 4px 12px -4px rgba(0, 47, 255, 0.5);
+}
+
+.chess-title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.chess-subtitle {
+  margin: 0.125rem 0 0;
+  font-size: 0.8125rem;
+  color: var(--chess-muted);
+}
+
+.chess-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.chess-icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  font-size: 0.9375rem;
+  line-height: 1;
+  color: var(--chess-fg);
+  background: var(--chess-panel);
+  border: 1px solid var(--chess-border);
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    transform 0.1s ease;
+}
+
+.chess-icon-button:hover {
+  border-color: var(--chess-accent);
+}
+
+.chess-icon-button:active {
+  transform: scale(0.94);
+}
+
+.chess-reset {
+  padding: 0.5rem 0.875rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--chess-accent-fg);
+  background: var(--sky-gradient);
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition:
+    opacity 0.15s ease,
+    transform 0.1s ease;
+}
+
+.chess-reset:hover {
+  opacity: 0.92;
+}
+
+.chess-reset:active {
+  transform: scale(0.97);
+}
+
+.chess-board {
+  width: 100%;
+  border-radius: 0.75rem;
+  box-shadow: var(--chess-board-shadow);
+}
+
+.chess-status {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.75rem;
+  padding: 0.625rem 0.75rem;
+  font-size: 0.8125rem;
+  background: var(--chess-panel);
+  border: 1px solid var(--chess-border);
+  border-radius: 0.625rem;
+}
+
+.chess-status-badge {
+  font-weight: 700;
+  padding: 0.125rem 0.5rem;
+  border-radius: 999px;
+  color: var(--sky-blue);
+  background: color-mix(in srgb, var(--sky-cyan) 22%, transparent);
+}
+
+[data-theme="dark"] .chess-status-badge {
+  color: var(--sky-cyan);
+}
+
+.chess-moves {
+  color: var(--chess-muted);
+  font-variant-numeric: tabular-nums;
+  word-break: break-word;
+}
+
+.chess-hint {
+  color: var(--chess-muted);
+  font-style: italic;
+}

--- a/examples/chess/src/lib/engine.ts
+++ b/examples/chess/src/lib/engine.ts
@@ -1,0 +1,119 @@
+import { Chess, type Square } from "chess.js";
+
+// A thin, stateless wrapper around chess.js. Every helper takes a FEN and
+// rebuilds the engine on demand, so nothing here holds mutable game state — the
+// running match lives in the synced store (see match.ts). White is always the
+// human, Black is always the assistant.
+
+export type Side = "w" | "b";
+export type Promotion = "q" | "r" | "b" | "n";
+
+/** How the game stands right now. `"ongoing"` means nobody has won yet. */
+export type Outcome = "ongoing" | "white" | "black" | "draw";
+
+export type MoveRequest =
+  | { san: string }
+  | { from: string; to: string; promotion?: Promotion };
+
+/** A serialisable read of the board, derived purely from a FEN string. */
+export type Position = {
+  fen: string;
+  toMove: Side;
+  check: boolean;
+  over: boolean;
+  outcome: Outcome;
+};
+
+export const STARTING_FEN = new Chess().fen();
+
+function decideOutcome(engine: Chess): Outcome {
+  if (engine.isCheckmate()) {
+    // Whoever is on the move has been mated, so the other side takes it.
+    return engine.turn() === "w" ? "black" : "white";
+  }
+  if (engine.isStalemate() || engine.isDraw()) {
+    return "draw";
+  }
+  return "ongoing";
+}
+
+export function readPosition(fen: string): Position {
+  const engine = new Chess(fen);
+  return {
+    fen: engine.fen(),
+    toMove: engine.turn(),
+    check: engine.inCheck(),
+    over: engine.isGameOver(),
+    outcome: decideOutcome(engine),
+  };
+}
+
+export type PlayedMove = { san: string; from: Square; to: Square };
+
+export type MoveResult =
+  | { ok: true; move: PlayedMove; position: Position }
+  | { ok: false; reason: string };
+
+export function tryMove(fen: string, request: MoveRequest): MoveResult {
+  const engine = new Chess(fen);
+  try {
+    const played = engine.move("san" in request ? request.san : request);
+    return {
+      ok: true,
+      move: { san: played.san, from: played.from, to: played.to },
+      position: readPosition(engine.fen()),
+    };
+  } catch {
+    const label =
+      "san" in request ? request.san : `${request.from}→${request.to}`;
+    return {
+      ok: false,
+      reason: `${label} is not a legal move in this position.`,
+    };
+  }
+}
+
+export function movesFor(fen: string, square?: string) {
+  const engine = new Chess(fen);
+  const verbose = square
+    ? engine.moves({ square: square as Square, verbose: true })
+    : engine.moves({ verbose: true });
+  return verbose.map((entry) => ({
+    san: entry.san,
+    from: entry.from,
+    to: entry.to,
+    promotion: entry.promotion,
+  }));
+}
+
+/** The square of the king that is currently in check, if any. */
+export function checkedKingSquare(fen: string): Square | null {
+  const engine = new Chess(fen);
+  if (!engine.inCheck()) {
+    return null;
+  }
+  const inDanger = engine.turn();
+  for (const rank of engine.board()) {
+    for (const cell of rank) {
+      if (cell && cell.type === "k" && cell.color === inDanger) {
+        return cell.square;
+      }
+    }
+  }
+  return null;
+}
+
+/** A one-line position summary written for the assistant to read back. */
+export function summarize(position: Position): string {
+  if (position.over) {
+    if (position.outcome === "draw") {
+      return "The game is drawn — no further moves.";
+    }
+    const winner =
+      position.outcome === "white" ? "White (the player)" : "Black (you)";
+    return `Checkmate. ${winner} has won.`;
+  }
+  const onMove = position.toMove === "w" ? "White (the player)" : "Black (you)";
+  const flag = position.check ? " — currently in check" : "";
+  return `${onMove} to move${flag}. FEN: ${position.fen}`;
+}

--- a/examples/chess/src/lib/match.ts
+++ b/examples/chess/src/lib/match.ts
@@ -1,0 +1,52 @@
+import { createStore } from "skybridge/web";
+import {
+  type MoveRequest,
+  type MoveResult,
+  type PlayedMove,
+  type Position,
+  readPosition,
+  STARTING_FEN,
+  tryMove,
+} from "./engine.js";
+
+// The live match, mirrored into the host's view state. Because it is synced,
+// the model sees every position change and the board survives a remount.
+//
+// We keep the move log and the last move here rather than asking chess.js for
+// them: the engine is rebuilt from a bare FEN on each call, which carries the
+// position but not the line that led to it. Tracking them in the store is the
+// single source of truth for both the UI and the model.
+type Match = Position & {
+  human: "w";
+  assistant: "b";
+  log: string[];
+  lastMove: PlayedMove | null;
+  play: (request: MoveRequest) => MoveResult;
+  restart: () => void;
+};
+
+function freshMatch() {
+  return {
+    ...readPosition(STARTING_FEN),
+    log: [] as string[],
+    lastMove: null as PlayedMove | null,
+  };
+}
+
+export const useMatch = createStore<Match>((set, get) => ({
+  ...freshMatch(),
+  human: "w",
+  assistant: "b",
+  play: (request) => {
+    const result = tryMove(get().fen, request);
+    if (result.ok) {
+      set({
+        ...result.position,
+        lastMove: result.move,
+        log: [...get().log, result.move.san],
+      });
+    }
+    return result;
+  },
+  restart: () => set(freshMatch()),
+}));

--- a/examples/chess/src/server.ts
+++ b/examples/chess/src/server.ts
@@ -1,0 +1,56 @@
+import { McpServer } from "skybridge/server";
+import { readPosition, STARTING_FEN } from "./lib/engine.js";
+
+// Deliberately tiny server. The only thing it does is open the board — all of
+// the gameplay tools are registered by the view itself (see
+// src/views/chess.tsx) through `useRegisterViewTool`, so they run inside the
+// widget. The human is White and moves first; the assistant answers as Black.
+const server = new McpServer(
+  {
+    name: "skybridge-chess",
+    version: "0.0.1",
+  },
+  { capabilities: {} },
+).registerTool(
+  {
+    name: "start_game",
+    description:
+      "Open an interactive chess board. The user plays White and moves first; you play Black. After the board is open, drive your side with the tools the view exposes — `chess_get_board_state`, `chess_get_legal_moves`, `chess_make_move`, and `chess_reset_game` — to inspect the position and answer with Black's moves.",
+    annotations: {
+      title: "Start a chess game",
+      readOnlyHint: false,
+      destructiveHint: true,
+      openWorldHint: false,
+    },
+    _meta: {
+      "openai/toolInvocation/invoking": "Setting up the board…",
+      "openai/toolInvocation/invoked": "Your move — you play White.",
+    },
+    view: {
+      component: "chess",
+      description: "Interactive chess board with view-provided tools",
+    },
+  },
+  async () => {
+    const position = readPosition(STARTING_FEN);
+    return {
+      structuredContent: position,
+      content: [
+        {
+          type: "text",
+          text: [
+            "A fresh chess game is on the board.",
+            "White belongs to the user and moves first; you are Black.",
+            'Hold until the user has moved, then reply with Black\'s move by calling the `chess_make_move` view tool (for example `{ "san": "e5" }`).',
+            "Lean on `chess_get_board_state` and `chess_get_legal_moves` to study the position first.",
+          ].join(" "),
+        },
+      ],
+      isError: false,
+    };
+  },
+);
+
+export default await server.run();
+
+export type AppType = typeof server;

--- a/examples/chess/src/views/chess.tsx
+++ b/examples/chess/src/views/chess.tsx
@@ -1,0 +1,336 @@
+import type { CSSProperties } from "react";
+import { useState } from "react";
+import type { PieceDropHandlerArgs } from "react-chessboard";
+import { Chessboard } from "react-chessboard";
+import {
+  useLayout,
+  useRegisterViewTool,
+  useSendFollowUpMessage,
+} from "skybridge/web";
+import * as z from "zod";
+import {
+  checkedKingSquare,
+  movesFor,
+  type Position,
+  readPosition,
+  summarize,
+} from "@/lib/engine.js";
+import { useMatch } from "@/lib/match.js";
+
+import "@/index.css";
+
+type Theme = "light" | "dark";
+
+const TOOL = {
+  boardState: "chess_get_board_state",
+  legalMoves: "chess_get_legal_moves",
+  makeMove: "chess_make_move",
+  reset: "chess_reset_game",
+} as const;
+
+// Skybridge brand palette, dialed down to a calm blue-slate so the pieces stay
+// readable. The vivid blue/cyan is reserved for accents (highlights, buttons),
+// not the 64 squares. Dark mode drops into the midnight range.
+const BOARD = {
+  light: {
+    lightSquare: "#eef2fb",
+    darkSquare: "#7e97c8",
+    notationOnLight: "#7e97c8",
+    notationOnDark: "#eef2fb",
+  },
+  dark: {
+    lightSquare: "#3a4a63",
+    darkSquare: "#243349",
+    notationOnLight: "#94a8c6",
+    notationOnDark: "#3a4a63",
+  },
+} satisfies Record<Theme, Record<string, string>>;
+
+const LAST_MOVE_RING = "inset 0 0 0 3px rgba(8, 245, 249, 0.9)";
+const CHECK_RING = "inset 0 0 0 3px rgba(244, 63, 94, 0.95)";
+
+function useChessViewTools() {
+  useRegisterViewTool(
+    {
+      name: TOOL.boardState,
+      description:
+        "Read where the game stands: FEN, the side to move, whether that side is in check, whether the game is finished, the outcome, and the moves played so far (SAN).",
+      annotations: { readOnlyHint: true },
+    },
+    () => {
+      const { fen, log } = useMatch.getState();
+      const position = readPosition(fen);
+      return {
+        content: [{ type: "text", text: summarize(position) }],
+        structuredContent: { ...position, moves: log },
+      };
+    },
+  );
+
+  useRegisterViewTool(
+    {
+      name: TOOL.legalMoves,
+      description:
+        "List every legal move for the side to move. Pass `from` to keep only the moves leaving a single square (e.g. `from: 'e7'`).",
+      inputSchema: {
+        from: z
+          .string()
+          .length(2)
+          .optional()
+          .describe("Origin square to filter on, e.g. 'e7'."),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    ({ from }) => {
+      const { fen } = useMatch.getState();
+      const { toMove } = readPosition(fen);
+      const moves = movesFor(fen, from);
+      return {
+        content: [
+          {
+            type: "text",
+            text: moves.length
+              ? `Legal moves: ${moves.map((entry) => entry.san).join(", ")}`
+              : "No legal moves available.",
+          },
+        ],
+        structuredContent: { toMove, moves },
+      };
+    },
+  );
+
+  useRegisterViewTool(
+    {
+      name: TOOL.makeMove,
+      description:
+        "Make a move as Black. Pass either `san` (e.g. 'e5', 'Nf6', 'O-O') or both `from` and `to`. The move has to be legal and it must be Black's turn.",
+      inputSchema: {
+        san: z
+          .string()
+          .optional()
+          .describe("Move in Standard Algebraic Notation, e.g. 'Nf6'."),
+        from: z
+          .string()
+          .length(2)
+          .optional()
+          .describe("Origin square, e.g. 'e7'."),
+        to: z
+          .string()
+          .length(2)
+          .optional()
+          .describe("Destination square, e.g. 'e5'."),
+        promotion: z
+          .enum(["q", "r", "b", "n"])
+          .optional()
+          .describe("Promotion piece when a pawn reaches the last rank."),
+      },
+      annotations: { readOnlyHint: false },
+    },
+    ({ san, from, to, promotion }) => {
+      const request = san
+        ? { san }
+        : from && to
+          ? { from, to, promotion }
+          : null;
+      if (!request) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "Pass either `san`, or both `from` and `to`.",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const result = useMatch.getState().play(request);
+      if (!result.ok) {
+        return {
+          content: [{ type: "text", text: result.reason }],
+          isError: true,
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Played ${result.move.san}. ${summarize(result.position)}`,
+          },
+        ],
+        structuredContent: result.position,
+      };
+    },
+  );
+
+  useRegisterViewTool(
+    {
+      name: TOOL.reset,
+      description:
+        "Clear the board back to the opening position (White to move).",
+      annotations: { readOnlyHint: false, destructiveHint: true },
+    },
+    () => {
+      useMatch.getState().restart();
+      return {
+        content: [
+          {
+            type: "text",
+            text: "Board cleared. White (the player) moves first.",
+          },
+        ],
+        structuredContent: readPosition(useMatch.getState().fen),
+      };
+    },
+  );
+}
+
+function statusText(position: Position): string {
+  if (position.over) {
+    if (position.outcome === "draw") {
+      return "Draw";
+    }
+    return position.outcome === "white" ? "White wins" : "Black wins";
+  }
+  const side = position.toMove === "w" ? "White" : "Black";
+  return `${side} to move${position.check ? " · check" : ""}`;
+}
+
+// Render the SAN log as numbered pairs: "1. e4 e5  2. Nf3 …".
+function formatLog(log: string[]): string {
+  const pairs: string[] = [];
+  for (let ply = 0; ply < log.length; ply += 2) {
+    const number = ply / 2 + 1;
+    const white = log[ply];
+    const black = log[ply + 1];
+    pairs.push(black ? `${number}. ${white} ${black}` : `${number}. ${white}`);
+  }
+  return pairs.join("  ");
+}
+
+export default function ChessView() {
+  const { theme: hostTheme } = useLayout();
+  const [themeOverride, setThemeOverride] = useState<Theme | null>(null);
+  const theme: Theme = themeOverride ?? hostTheme;
+
+  const sendFollowUpMessage = useSendFollowUpMessage();
+  useChessViewTools();
+
+  const fen = useMatch((store) => store.fen);
+  const toMove = useMatch((store) => store.toMove);
+  const over = useMatch((store) => store.over);
+  const log = useMatch((store) => store.log);
+  const lastMove = useMatch((store) => store.lastMove);
+  const play = useMatch((store) => store.play);
+  const restart = useMatch((store) => store.restart);
+
+  const position = readPosition(fen);
+  const playerToMove = toMove === "w" && !over;
+  const palette = BOARD[theme];
+
+  const squareStyles: Record<string, CSSProperties> = {};
+  if (lastMove) {
+    squareStyles[lastMove.from] = { boxShadow: LAST_MOVE_RING };
+    squareStyles[lastMove.to] = { boxShadow: LAST_MOVE_RING };
+  }
+  const kingInCheck = checkedKingSquare(fen);
+  if (kingInCheck) {
+    squareStyles[kingInCheck] = {
+      boxShadow: CHECK_RING,
+      background: "rgba(244, 63, 94, 0.35)",
+    };
+  }
+
+  const onPieceDrop = ({
+    sourceSquare,
+    targetSquare,
+  }: PieceDropHandlerArgs) => {
+    if (!targetSquare || !playerToMove) {
+      return false;
+    }
+    const result = play({
+      from: sourceSquare,
+      to: targetSquare,
+      promotion: "q",
+    });
+    if (!result.ok) {
+      return false;
+    }
+    if (!result.position.over) {
+      sendFollowUpMessage(
+        `I played ${result.move.san} as White. Your turn — answer as Black with the ${TOOL.makeMove} tool.`,
+      );
+    }
+    return true;
+  };
+
+  return (
+    <div className="chess-app" data-theme={theme}>
+      <header className="chess-header">
+        <div className="chess-brand">
+          <span className="chess-mark" aria-hidden="true" />
+          <div>
+            <h1 className="chess-title">Skybridge Chess</h1>
+            <p className="chess-subtitle">
+              You play White · the assistant plays Black
+            </p>
+          </div>
+        </div>
+        <div className="chess-actions">
+          <button
+            type="button"
+            className="chess-icon-button"
+            aria-label={
+              theme === "dark" ? "Switch to light mode" : "Switch to dark mode"
+            }
+            onClick={() =>
+              setThemeOverride(theme === "dark" ? "light" : "dark")
+            }
+          >
+            {theme === "dark" ? "☀" : "☾"}
+          </button>
+          <button
+            type="button"
+            className="chess-reset"
+            onClick={() => restart()}
+          >
+            New game
+          </button>
+        </div>
+      </header>
+
+      <div className="chess-board">
+        <Chessboard
+          options={{
+            position: fen,
+            onPieceDrop,
+            boardOrientation: "white",
+            allowDragging: playerToMove,
+            id: "skybridge-chess",
+            animationDurationInMs: 200,
+            boardStyle: {
+              borderRadius: "12px",
+              overflow: "hidden",
+            },
+            lightSquareStyle: { backgroundColor: palette.lightSquare },
+            darkSquareStyle: { backgroundColor: palette.darkSquare },
+            lightSquareNotationStyle: { color: palette.notationOnLight },
+            darkSquareNotationStyle: { color: palette.notationOnDark },
+            squareStyles,
+          }}
+        />
+      </div>
+
+      <footer className="chess-status">
+        <span className="chess-status-badge">{statusText(position)}</span>
+        {log.length > 0 && (
+          <span className="chess-moves">{formatLog(log)}</span>
+        )}
+        {!over && toMove === "b" && (
+          <span className="chess-hint">Waiting for the assistant…</span>
+        )}
+      </footer>
+    </div>
+  );
+}

--- a/examples/chess/tsconfig.json
+++ b/examples/chess/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "skybridge/tsconfig",
+
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+
+  "include": ["src", ".skybridge/**/*.d.ts"]
+}

--- a/examples/chess/vite.config.ts
+++ b/examples/chess/vite.config.ts
@@ -1,0 +1,14 @@
+import path from "node:path";
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { skybridge } from "skybridge/vite";
+import { defineConfig, type PluginOption } from "vite";
+
+export default defineConfig({
+  plugins: [skybridge() as PluginOption, react(), tailwindcss()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.29.0",
-    "@modelcontextprotocol/ext-apps": "^1.3.2",
+    "@modelcontextprotocol/ext-apps": "^1.7.3",
     "@oclif/core": "^4.10.3",
     "ci-info": "^4.4.0",
     "cors": "^2.8.6",

--- a/packages/core/src/web/bridges/apps-sdk/adaptor.ts
+++ b/packages/core/src/web/bridges/apps-sdk/adaptor.ts
@@ -171,4 +171,11 @@ export class AppsSdkAdaptor implements Adaptor {
 
     return window.openai.setOpenInAppUrl({ href });
   }
+
+  public registerViewTool = (): (() => void) => {
+    console.warn(
+      "[skybridge] registerViewTool: view tools are not supported on the Apps SDK runtime",
+    );
+    return () => {};
+  };
 }

--- a/packages/core/src/web/bridges/mcp-app/adaptor.ts
+++ b/packages/core/src/web/bridges/mcp-app/adaptor.ts
@@ -1,6 +1,7 @@
 import { dequal } from "dequal/lite";
 import type {
   Adaptor,
+  AnyViewToolHandler,
   CallToolResponse,
   DownloadParams,
   DownloadResult,
@@ -12,6 +13,7 @@ import type {
   RequestSizeOptions,
   SendFollowUpMessageOptions,
   SetViewStateAction,
+  ViewToolConfig,
 } from "../types.js";
 import { McpAppBridge } from "./bridge.js";
 import type { McpAppContext, McpAppContextKey } from "./types.js";
@@ -294,6 +296,13 @@ export class McpAppAdaptor implements Adaptor {
   public setOpenInAppUrl(_href: string): Promise<void> {
     throw new Error("setOpenInAppUrl is not implemented in MCP App.");
   }
+
+  public registerViewTool = (
+    config: ViewToolConfig,
+    handler: AnyViewToolHandler,
+  ): (() => void) => {
+    return McpAppBridge.getInstance().registerViewTool(config, handler);
+  };
 
   private subscribeToViewUUID(): void {
     const bridge = McpAppBridge.getInstance();

--- a/packages/core/src/web/bridges/mcp-app/bridge.ts
+++ b/packages/core/src/web/bridges/mcp-app/bridge.ts
@@ -1,6 +1,15 @@
 import { App } from "@modelcontextprotocol/ext-apps";
-import type { Implementation } from "@modelcontextprotocol/sdk/types.js";
-import type { Bridge, Subscribe } from "../types.js";
+import {
+  type Implementation,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import * as z from "zod";
+import type {
+  AnyViewToolHandler,
+  Bridge,
+  Subscribe,
+  ViewToolConfig,
+} from "../types.js";
 import type { McpAppContext, McpAppContextKey } from "./types.js";
 
 /** @internal Singleton bridge over the `ext-apps` JSON-RPC App connection. Used by {@link McpAppAdaptor}. */
@@ -16,7 +25,11 @@ export class McpAppBridge implements Bridge<McpAppContext> {
   private connectPromise: Promise<void>;
 
   constructor(options: { appInfo: Implementation }) {
-    this.app = new App(options.appInfo);
+    this.app = new App(options.appInfo, { tools: { listChanged: true } });
+
+    this.app.setRequestHandler(ListToolsRequestSchema, async () => ({
+      tools: [],
+    }));
 
     this.app.ontoolinput = (params) => {
       this.updateContext({ toolInput: params.arguments ?? {} });
@@ -56,6 +69,32 @@ export class McpAppBridge implements Bridge<McpAppContext> {
   public async getApp(): Promise<App> {
     await this.connectPromise;
     return this.app;
+  }
+
+  public registerViewTool(
+    config: ViewToolConfig,
+    handler: AnyViewToolHandler,
+  ): () => void {
+    const inputSchema = config.inputSchema
+      ? z.object(config.inputSchema)
+      : z.object({});
+
+    const registered = this.app.registerTool(
+      config.name,
+      {
+        ...(config.title !== undefined ? { title: config.title } : {}),
+        ...(config.description !== undefined
+          ? { description: config.description }
+          : {}),
+        inputSchema,
+        ...(config.annotations ? { annotations: config.annotations } : {}),
+      },
+      handler,
+    );
+
+    return () => {
+      registered.remove();
+    };
   }
 
   public static getInstance(

--- a/packages/core/src/web/bridges/mcp-app/view-tools.test.ts
+++ b/packages/core/src/web/bridges/mcp-app/view-tools.test.ts
@@ -1,0 +1,200 @@
+import { waitFor } from "@testing-library/react";
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as z from "zod";
+import { MockResizeObserver } from "../../hooks/test/utils.js";
+import { McpAppAdaptor } from "./adaptor.js";
+import { McpAppBridge } from "./bridge.js";
+
+type JsonRpcMessage = {
+  jsonrpc: "2.0";
+  id?: number;
+  method?: string;
+  params?: Record<string, unknown>;
+  result?: Record<string, unknown>;
+  error?: { message: string };
+};
+
+const outgoing: JsonRpcMessage[] = [];
+
+/**
+ * Stand-in MCP Apps host: replies to `ui/initialize` and records every message
+ * the app posts so tests can assert on responses and notifications.
+ */
+function installHostMock() {
+  outgoing.length = 0;
+  const postMessage = vi.fn((message: JsonRpcMessage) => {
+    outgoing.push(message);
+    if (message.method === "ui/initialize" && message.id !== undefined) {
+      act(() => {
+        window.dispatchEvent(
+          new MessageEvent("message", {
+            source: window.parent,
+            data: {
+              jsonrpc: "2.0",
+              id: message.id,
+              result: {
+                protocolVersion: "2025-06-18",
+                hostInfo: { name: "test-host", version: "1.0.0" },
+                hostCapabilities: {},
+                hostContext: {},
+              },
+            },
+          }),
+        );
+      });
+    }
+  });
+  vi.stubGlobal("parent", { postMessage });
+}
+
+let nextId = 1000;
+
+/** Send a host → app JSON-RPC request and resolve with the full response (result or error). */
+async function callHost(method: string, params: Record<string, unknown> = {}) {
+  const id = ++nextId;
+  act(() => {
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        source: window.parent,
+        data: { jsonrpc: "2.0", id, method, params },
+      }),
+    );
+  });
+  await waitFor(() => {
+    expect(outgoing.some((m) => m.id === id)).toBe(true);
+  });
+  return outgoing.find((m) => m.id === id);
+}
+
+describe("McpApp view tools", () => {
+  beforeEach(() => {
+    vi.stubGlobal("skybridge", { hostType: "mcp-app" });
+    vi.stubGlobal("ResizeObserver", MockResizeObserver);
+    McpAppBridge.resetInstance();
+    McpAppAdaptor.resetInstance();
+    installHostMock();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("advertises the tools capability during ui/initialize", async () => {
+    await McpAppBridge.getInstance().getApp();
+    const init = outgoing.find((m) => m.method === "ui/initialize");
+    expect(init?.params?.appCapabilities).toMatchObject({
+      tools: { listChanged: true },
+    });
+  });
+
+  it("lists a registered view tool with its input schema", async () => {
+    const adaptor = McpAppAdaptor.getInstance();
+    await McpAppBridge.getInstance().getApp();
+
+    adaptor.registerViewTool(
+      {
+        name: "chess_make_move",
+        description: "Play a move",
+        inputSchema: { san: z.string() },
+        annotations: { readOnlyHint: false },
+      },
+      () => ({ content: [{ type: "text", text: "ok" }] }),
+    );
+
+    const response = await callHost("tools/list");
+    const tools = response?.result?.tools as Array<{
+      name: string;
+      description?: string;
+      inputSchema: { properties?: Record<string, unknown> };
+      annotations?: { readOnlyHint?: boolean };
+    }>;
+    expect(tools).toHaveLength(1);
+    const [tool] = tools;
+    expect(tool?.name).toBe("chess_make_move");
+    expect(tool?.description).toBe("Play a move");
+    expect(tool?.inputSchema.properties).toHaveProperty("san");
+    expect(tool?.annotations?.readOnlyHint).toBe(false);
+  });
+
+  it("invokes the handler with validated args and returns its result", async () => {
+    const adaptor = McpAppAdaptor.getInstance();
+    await McpAppBridge.getInstance().getApp();
+
+    const handler = vi.fn(({ san }: { san: string }) => ({
+      content: [{ type: "text" as const, text: `played ${san}` }],
+      structuredContent: { lastMove: san },
+    }));
+
+    adaptor.registerViewTool(
+      { name: "chess_make_move", inputSchema: { san: z.string() } },
+      handler as never,
+    );
+
+    const response = await callHost("tools/call", {
+      name: "chess_make_move",
+      arguments: { san: "e4" },
+    });
+    const result = response?.result;
+
+    // ext-apps invokes the callback as `(args, extra)`; assert on the args only.
+    expect(handler.mock.calls[0]?.[0]).toEqual({ san: "e4" });
+    expect(result?.structuredContent).toEqual({ lastMove: "e4" });
+    expect(result?.isError).toBeFalsy();
+    expect(result?.content).toEqual([{ type: "text", text: "played e4" }]);
+  });
+
+  it("rejects the call without invoking the handler when args are invalid", async () => {
+    const adaptor = McpAppAdaptor.getInstance();
+    await McpAppBridge.getInstance().getApp();
+
+    const handler = vi.fn(() => ({ content: [] }));
+    adaptor.registerViewTool(
+      { name: "chess_make_move", inputSchema: { san: z.string() } },
+      handler as never,
+    );
+
+    // ext-apps validates input against the schema and rejects with a JSON-RPC
+    // error before the handler runs.
+    const response = await callHost("tools/call", {
+      name: "chess_make_move",
+      arguments: { san: 42 },
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(response?.error).toBeDefined();
+  });
+
+  it("rejects a call to an unknown tool", async () => {
+    await McpAppBridge.getInstance().getApp();
+    const response = await callHost("tools/call", {
+      name: "nope",
+      arguments: {},
+    });
+    expect(response?.error).toBeDefined();
+  });
+
+  it("removes the tool and notifies the host when unregistered", async () => {
+    const adaptor = McpAppAdaptor.getInstance();
+    await McpAppBridge.getInstance().getApp();
+
+    const unregister = adaptor.registerViewTool(
+      { name: "chess_reset" },
+      () => ({ content: [{ type: "text", text: "reset" }] }),
+    );
+
+    await waitFor(() => {
+      expect(
+        outgoing.some((m) => m.method === "notifications/tools/list_changed"),
+      ).toBe(true);
+    });
+
+    let listed = await callHost("tools/list");
+    expect(listed?.result?.tools).toHaveLength(1);
+
+    unregister();
+    listed = await callHost("tools/list");
+    expect(listed?.result?.tools).toHaveLength(0);
+  });
+});

--- a/packages/core/src/web/bridges/types.ts
+++ b/packages/core/src/web/bridges/types.ts
@@ -1,7 +1,12 @@
 import type {
+  SchemaOutput,
+  ZodRawShapeCompat,
+} from "@modelcontextprotocol/sdk/server/zod-compat.js";
+import type {
   CallToolResult,
   EmbeddedResource,
   ResourceLink,
+  ToolAnnotations,
 } from "@modelcontextprotocol/sdk/types.js";
 import type { useSyncExternalStore } from "react";
 import type { ViewHostType } from "../../server/index.js";
@@ -166,6 +171,54 @@ export type DownloadResult = {
 };
 
 /**
+ * Args passed to a {@link ViewToolHandler}, inferred from the tool's
+ * `inputSchema` (optionality preserved). Mirrors the server's `registerTool`.
+ */
+export type InferViewToolArgs<Shape extends ZodRawShapeCompat> = {
+  [K in keyof Shape as undefined extends SchemaOutput<Shape[K]>
+    ? never
+    : K]: SchemaOutput<Shape[K]>;
+} & {
+  [K in keyof Shape as undefined extends SchemaOutput<Shape[K]>
+    ? K
+    : never]?: SchemaOutput<Shape[K]>;
+};
+
+/**
+ * Declares a tool the view exposes to the host/model (the MCP Apps
+ * "app-provided tools" feature). Mirrors the server-side `registerTool` config.
+ * Namespace `name` (e.g. `chess_make_move`) to avoid clashing with server tools.
+ */
+export type ViewToolConfig<
+  TInput extends ZodRawShapeCompat = ZodRawShapeCompat,
+> = {
+  name: string;
+  title?: string;
+  description?: string;
+  inputSchema?: TInput;
+  annotations?: ToolAnnotations;
+};
+
+/**
+ * Value a {@link ViewToolHandler} returns — a standard MCP `CallToolResult`
+ * (`content` blocks plus optional `structuredContent` / `isError` / `_meta`),
+ * exactly as `ext-apps`' app tool callbacks return it.
+ */
+export type ViewToolResult = CallToolResult;
+
+/** Handler run when the host calls a view tool. Receives validated, typed args. */
+export type ViewToolHandler<
+  TInput extends ZodRawShapeCompat = ZodRawShapeCompat,
+> = (
+  args: InferViewToolArgs<TInput>,
+) => ViewToolResult | Promise<ViewToolResult>;
+
+/** @internal Untyped handler signature stored by the adaptor/bridge after type erasure. */
+export type AnyViewToolHandler = (
+  args: Record<string, unknown>,
+) => ViewToolResult | Promise<ViewToolResult>;
+
+/**
  * @internal
  * Low-level interface every host bridge implements. End-user code should use
  * the React hooks (`useCallTool`, `useViewState`, `useFiles`, …) rather than
@@ -194,4 +247,8 @@ export interface Adaptor {
   selectFiles(): Promise<FileMetadata[]>;
   openModal(options: RequestModalOptions): void;
   setOpenInAppUrl(href: string): Promise<void>;
+  registerViewTool(
+    config: ViewToolConfig,
+    handler: AnyViewToolHandler,
+  ): () => void;
 }

--- a/packages/core/src/web/hooks/index.ts
+++ b/packages/core/src/web/hooks/index.ts
@@ -10,6 +10,7 @@ export { type DownloadFn, useDownload } from "./use-download.js";
 export { useFiles } from "./use-files.js";
 export { type LayoutState, useLayout } from "./use-layout.js";
 export { type OpenExternalFn, useOpenExternal } from "./use-open-external.js";
+export { useRegisterViewTool } from "./use-register-view-tool.js";
 export { type RequestCloseFn, useRequestClose } from "./use-request-close.js";
 export { useRequestModal } from "./use-request-modal.js";
 export { type RequestSizeFn, useRequestSize } from "./use-request-size.js";

--- a/packages/core/src/web/hooks/use-register-view-tool.ts
+++ b/packages/core/src/web/hooks/use-register-view-tool.ts
@@ -1,0 +1,67 @@
+import type { ZodRawShapeCompat } from "@modelcontextprotocol/sdk/server/zod-compat.js";
+import { useEffect, useRef } from "react";
+import { getAdaptor } from "../bridges/index.js";
+import type {
+  AnyViewToolHandler,
+  ViewToolConfig,
+  ViewToolHandler,
+} from "../bridges/types.js";
+
+/**
+ * Register a tool the view exposes to the host and model — the MCP Apps
+ * "app-provided tools" feature. A view tool runs *inside the view*: the host
+ * discovers it via `tools/list` and invokes it via `tools/call`, and the
+ * handler executes against the view's live state. It is the inverse of
+ * {@link useCallTool} (which calls a server tool). Registered on mount, removed
+ * on unmount; re-registered when `config.name` changes.
+ *
+ * MCP Apps only — on the Apps SDK (`window.openai`) runtime it is a no-op.
+ *
+ * @example
+ * ```tsx
+ * import * as z from "zod";
+ * import { useRegisterViewTool } from "skybridge/web";
+ *
+ * useRegisterViewTool(
+ *   {
+ *     name: "chess_make_move",
+ *     description: "Play a move in algebraic notation, e.g. 'e4' or 'Nf3'.",
+ *     inputSchema: { san: z.string() },
+ *     annotations: { readOnlyHint: false },
+ *   },
+ *   ({ san }) => {
+ *     const move = game.move(san);
+ *     return {
+ *       content: [{ type: "text", text: move ? `Played ${move.san}` : "Illegal move" }],
+ *       structuredContent: { fen: game.fen() },
+ *       isError: !move,
+ *     };
+ *   },
+ * );
+ * ```
+ *
+ * @see https://docs.skybridge.tech/api-reference/use-register-view-tool
+ */
+export const useRegisterViewTool = <
+  TInput extends ZodRawShapeCompat = ZodRawShapeCompat,
+>(
+  config: ViewToolConfig<TInput>,
+  handler: ViewToolHandler<TInput>,
+) => {
+  const { name } = config;
+  const configRef = useRef(config);
+  configRef.current = config;
+  const handlerRef = useRef(handler);
+  handlerRef.current = handler;
+
+  useEffect(() => {
+    const adaptor = getAdaptor();
+    const wrappedHandler: AnyViewToolHandler = (args) =>
+      handlerRef.current(args as Parameters<ViewToolHandler<TInput>>[0]);
+
+    return adaptor.registerViewTool(
+      { ...configRef.current, name },
+      wrappedHandler,
+    );
+  }, [name]);
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -392,6 +392,67 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
+  examples/chess:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.3.6)
+      chess.js:
+        specifier: ^1.4.0
+        version: 1.4.0
+      react:
+        specifier: ^19.2.3
+        version: 19.2.4
+      react-chessboard:
+        specifier: ^5.10.0
+        version: 5.10.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react-dom:
+        specifier: ^19.2.3
+        version: 19.2.4(react@19.2.4)
+      skybridge:
+        specifier: workspace:*
+        version: link:../../packages/core
+      tailwindcss:
+        specifier: ^4.1.14
+        version: 4.2.4
+      tw-animate-css:
+        specifier: ^1.4.0
+        version: 1.4.0
+      vite:
+        specifier: ^7.3.1
+        version: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      zod:
+        specifier: ^4.3.5
+        version: 4.3.6
+    devDependencies:
+      '@skybridge/devtools':
+        specifier: ^1.0.0
+        version: 1.0.2(arktype@2.1.27)(typescript@5.9.3)
+      '@tailwindcss/vite':
+        specifier: ^4.1.14
+        version: 4.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.12.0
+      '@types/react':
+        specifier: ^19.2.8
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^5.1.2
+        version: 5.1.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      alpic:
+        specifier: ^1.104.1
+        version: 1.104.1(@opentelemetry/api@1.9.0)(arktype@2.1.27)(rxjs@7.8.2)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   examples/ecom-carousel:
     dependencies:
       '@alpic-ai/insights':
@@ -979,8 +1040,8 @@ importers:
         specifier: ^7.29.0
         version: 7.29.0
       '@modelcontextprotocol/ext-apps':
-        specifier: ^1.3.2
-        version: 1.3.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+        specifier: ^1.7.3
+        version: 1.7.3(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       '@oclif/core':
         specifier: ^4.10.3
         version: 4.10.3
@@ -1825,6 +1886,28 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/modifiers@9.0.0':
+    resolution: {integrity: sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
+
   '@dotenvx/dotenvx@1.51.2':
     resolution: {integrity: sha512-+693mNflujDZxudSEqSNGpn92QgFhJlBn9q2mDQ9yGWyHuz3hZ8B5g3EXCwdAz4DMJAI+OFCIbfEFZS+YRdrEA==}
     hasBin: true
@@ -2618,11 +2701,11 @@ packages:
   '@mintlify/validation@0.1.646':
     resolution: {integrity: sha512-SBahXEvIQHj3gZycgooe7Cs4sHPA35vrtvm8+xjlXnU85WuNJYFeV/n45h5xkYW2yem4+WhuMn6ladxuoUZDDw==}
 
-  '@modelcontextprotocol/ext-apps@1.3.2':
-    resolution: {integrity: sha512-DGG1FxN3s8g4KV+BF64dxph8j2mtxgU56Lu/WgBjylomqRIPshW0ut47OtBN4+V8r+Qp8kKUvCOBBzPY9+GurA==}
+  '@modelcontextprotocol/ext-apps@1.7.3':
+    resolution: {integrity: sha512-IRBaqDtBZyiwv046FNbyFCIERPT5npu2lDSTCsiRL4se9+s7zcLjRxXlQ7dyD0IZnyS2VjturHftY8GAiDvldA==}
     engines: {node: '>=20'}
     peerDependencies:
-      '@modelcontextprotocol/sdk': ^1.24.0
+      '@modelcontextprotocol/sdk': ^1.29.0
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
       zod: ^3.25.0 || ^4.0.0
@@ -5493,6 +5576,9 @@ packages:
 
   cheap-ruler@4.0.0:
     resolution: {integrity: sha512-0BJa8f4t141BYKQyn9NSQt1PguFQXMXwZiA5shfoaBYHAb2fFk2RAX+tiWMoQU+Agtzt3mdt0JtuyshAXqZ+Vw==}
+
+  chess.js@1.4.0:
+    resolution: {integrity: sha512-BBJgrrtKQOzFLonR0l+k64A98NLemPwNsCskwb+29bRwobUa4iTm51E1kwGPbWXAcfdDa18nad6vpPPKPWarqw==}
 
   chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
@@ -8442,6 +8528,13 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
+  react-chessboard@5.10.0:
+    resolution: {integrity: sha512-Y3PgaCVhnDG3IaQfu86OzTSEIEAUtuU5XwmHWnx3tcFOX7lSoAq81ZFX3MBj6y5a6FzDMTczMVmkkrV2CzTrIw==}
+    engines: {node: '>=20.11.0', pnpm: '>=9.4.0'}
+    peerDependencies:
+      react: ^19.0.0
+      react-dom: ^19.0.0
+
   react-dom@19.2.0:
     resolution: {integrity: sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==}
     peerDependencies:
@@ -10801,6 +10894,31 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
+  '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/modifiers@9.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
   '@dotenvx/dotenvx@1.51.2':
     dependencies:
       commander: 11.1.0
@@ -11870,9 +11988,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@modelcontextprotocol/ext-apps@1.3.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)':
+  '@modelcontextprotocol/ext-apps@1.7.3(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
+      '@standard-schema/spec': 1.1.0
       zod: 4.3.6
     optionalDependencies:
       react: 19.2.4
@@ -14845,6 +14964,13 @@ snapshots:
       tailwindcss: 4.2.2
       vite: 8.0.3(@types/node@25.5.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
+  '@tailwindcss/vite@4.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@tailwindcss/node': 4.2.4
+      '@tailwindcss/oxide': 4.2.4
+      tailwindcss: 4.2.4
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+
   '@tailwindcss/vite@4.2.4(vite@8.0.3(@types/node@24.12.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@tailwindcss/node': 4.2.4
@@ -15864,6 +15990,8 @@ snapshots:
   chardet@2.1.1: {}
 
   cheap-ruler@4.0.0: {}
+
+  chess.js@1.4.0: {}
 
   chokidar@3.5.3:
     dependencies:
@@ -19491,6 +19619,13 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.1
       unpipe: 1.0.0
+
+  react-chessboard@5.10.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/modifiers': 9.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   react-dom@19.2.0(react@19.2.0):
     dependencies:


### PR DESCRIPTION
- **feat(core): add view-provided tools (useRegisterViewTool)**
- **feat(examples): add chess app showcasing view-provided tools**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `useRegisterViewTool`, a React hook that lets a view register tools the host and model can call directly against the running widget (the MCP Apps "app-provided tools" feature), and adds a chess example built entirely around it.

- **Core hook (`use-register-view-tool.ts`)**: Clean ref-based design keeps the handler always in sync with current state while re-registering only when the tool `name` changes. Both adaptors implement `registerViewTool`; the Apps SDK no-ops with a warning as documented.
- **Bridge upgrade**: `ext-apps` is bumped to v1.7.3 to gain `app.registerTool`. Test coverage spans capability advertisement, tool listing, arg validation, handler invocation, and unregister/notify.
- **Chess example**: The `chess_make_move` handler doesn't guard against it being White's turn — chess.js validates legality for the *current mover*, so a valid White move passed on White's turn succeeds, letting the model advance the board without any user drag.

<h3>Confidence Score: 4/5</h3>

Safe to merge after adding a Black-turn guard in the chess_make_move handler; the core hook and bridge are solid.

The `useRegisterViewTool` hook and bridge implementation are well-tested and architecturally sound. The one real defect is in the chess example: `chess_make_move` never checks that it is actually Black's turn before forwarding the request to chess.js, which validates only legality for the current mover. A White move supplied on White's turn succeeds, letting the model advance the board on the player's behalf without any user drag gesture.

examples/chess/src/views/chess.tsx — the chess_make_move handler needs a turn guard

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
examples/chess/src/views/chess.tsx:129-147
The `chess_make_move` handler says "it must be Black's turn" in its description but never enforces it. Chess.js validates legality against the *current side to move*, not against a fixed color — so if the model (or host) calls the tool when it's White's turn and passes a valid White move (`{ san: "e4" }` at the start position, for example), the move succeeds and the assistant effectively plays White's pieces. The game state advances on White's behalf without any user drag, leaving the player with no turn to take.

Add an explicit turn guard before delegating to `play`.

```suggestion
    ({ san, from, to, promotion }) => {
      const { fen } = useMatch.getState();
      const position = readPosition(fen);
      if (position.toMove !== "b") {
        return {
          content: [
            {
              type: "text",
              text: "It is not Black's turn — wait for White (the player) to move first.",
            },
          ],
          isError: true,
        };
      }

      const request = san
        ? { san }
        : from && to
          ? { from, to, promotion }
          : null;
      if (!request) {
        return {
          content: [
            {
              type: "text",
              text: "Pass either `san`, or both `from` and `to`.",
            },
          ],
          isError: true,
        };
      }

      const result = useMatch.getState().play(request);
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["feat(examples): add chess app showcasing..."](https://github.com/alpic-ai/skybridge/commit/3151cd9014cd3b6d22743b98722585c464a3b861) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34966338)</sub>

<!-- /greptile_comment -->