### PR TITLE
fix: replace outdated `chatgpt-app-builder` skill with `skybridge`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ Run `pnpm format` to auto-fix.
 ## Cross-cutting concerns
 
 When the public API of `packages/core/` changes (exports from `src/server/index.ts`, `src/web/index.ts`, and CLI commands in `src/commands/`):
-1. Update `skills/` references (chatgpt-app-builder)
+1. Update `skills/` references (skybridge)
 2. Update `docs/` — especially `api-reference/` and `guides/`
 
 PR reviewers must enforce these updates are included when a PR touches the public API.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ Every PR is reviewed by Greptile. If the check does not return 5/5, address each
 
 When your PR changes the public API of `packages/core` (exports from `src/server/index.ts`, `src/web/index.ts`, or the CLI commands in `src/commands/`), it must also update:
 
-1. `skills/` references (notably `chatgpt-app-builder`)
+1. `skills/` references (notably `skybridge`)
 2. `docs/`, especially `api-reference/` and `guides/`
 
 Reviewers will block PRs that touch the public API without these updates.

--- a/examples/investigation-game/AGENTS.md
+++ b/examples/investigation-game/AGENTS.md
@@ -1,1 +1,1 @@
-Before writing code, first explore the project structure, then invoke the chatgpt-app-builder skill for documentation.
+Before writing code, first explore the project structure, then invoke the skybridge skill for documentation.

--- a/packages/create-skybridge/src/index.ts
+++ b/packages/create-skybridge/src/index.ts
@@ -278,7 +278,7 @@ export async function init(args: string[] = process.argv.slice(2)) {
       "add",
       "alpic-ai/skybridge",
       "--skill",
-      "chatgpt-app-builder",
+      "skybridge",
       "--agent",
       "universal",
       "claude-code",

--- a/packages/create-skybridge/templates/blank/AGENTS.md
+++ b/packages/create-skybridge/templates/blank/AGENTS.md
@@ -1,1 +1,1 @@
-This is a ChatGPT/MCP app built with Skybridge. ALWAYS use the `chatgpt-app-builder` skill when planning or updating the codebase.
+This is a ChatGPT/MCP app built with Skybridge. ALWAYS use the `skybridge` skill when planning or updating the codebase.

--- a/packages/create-skybridge/templates/demo/AGENTS.md
+++ b/packages/create-skybridge/templates/demo/AGENTS.md
@@ -1,1 +1,1 @@
-This is a ChatGPT/MCP app built with Skybridge. ALWAYS use the `chatgpt-app-builder` skill when planning or updating the codebase.
+This is a ChatGPT/MCP app built with Skybridge. ALWAYS use the `skybridge` skill when planning or updating the codebase.


### PR DESCRIPTION
Fixes #843

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces all references to the outdated `chatgpt-app-builder` skill with `skybridge` across docs, templates, and the `create-skybridge` CLI initializer, bringing them in line with the already-existing `skills/skybridge/` skill directory.

- `AGENTS.md` and `CONTRIBUTING.md` are updated to instruct contributors to maintain the `skybridge` skill (instead of `chatgpt-app-builder`) when the public API changes.
- Template `AGENTS.md` files and the `create-skybridge` CLI `--skill` argument are updated to reference `skybridge`, which resolves to the existing `skills/skybridge/SKILL.md` at runtime.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are straightforward string replacements in docs, templates, and a single CLI argument, with the target skills/skybridge/ directory already present and well-formed.

Every changed line is a mechanical rename from chatgpt-app-builder to skybridge. The skills/skybridge/SKILL.md already exists and mirrors the content of the old skill, so the CLI --skill skybridge argument will resolve at runtime. The old skills/chatgpt-app-builder/ directory is left in place, which is a minor cleanup gap but carries no functional risk.

The orphaned skills/chatgpt-app-builder/ directory is worth a quick look — it wasn't removed and could cause confusion, though it doesn't block anything.

<sub>Reviews (1): Last reviewed commit: ["fix(create-skybridge): replace outdated ..."](https://github.com/alpic-ai/skybridge/commit/681b08783bfda49f55c4fa6d4a4578a0bb9352b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35074288)</sub>

<!-- /greptile_comment -->