### PR TITLE
fix: add `tsx` to blank template `devDependencies`

### DIFF
--- a/packages/create-skybridge/templates/blank/package.json
+++ b/packages/create-skybridge/templates/blank/package.json
@@ -20,6 +20,7 @@
     "@skybridge/devtools": "^1.0.0",
     "@types/node": "^24.12.0",
     "alpic": "^1.104.1",
+    "tsx": "^4.21.0",
     "typescript": "^6.0.2"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1140,6 +1140,9 @@ importers:
       alpic:
         specifier: ^1.104.1
         version: 1.104.1(@opentelemetry/api@1.9.0)(arktype@2.1.27)(rxjs@7.8.2)(typescript@6.0.2)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
@@ -15351,7 +15354,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(@vitest/ui@4.1.4)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.4(@types/node@24.12.0)(typescript@6.0.2))(vite@8.0.3(@types/node@24.12.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(@vitest/ui@4.1.4)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.4(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
 
   '@vitest/utils@4.1.4':
     dependencies:


### PR DESCRIPTION
Closes #839 

## Working Demo
<img width="1920" height="1080" alt="Screenshot (431)" src="https://github.com/user-attachments/assets/6434aa33-2021-4b4a-a990-0771bf7f13e7" />
<img width="1920" height="1080" alt="Screenshot (432)" src="https://github.com/user-attachments/assets/71cf7ffc-6f04-4a68-bd89-626eaea170d7" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `tsx` to the `devDependencies` of the blank template, which was already present in the demo template. This fixes a missing runtime dependency that would cause TypeScript execution to fail when using the blank template out of the box.

- `packages/create-skybridge/templates/blank/package.json`: `tsx@^4.21.0` added to `devDependencies`, making it consistent with `templates/demo/package.json`.
- `pnpm-lock.yaml`: Lock file updated to reflect the new dependency; an incidental snapshot change updates `@types/node` from `24.12.0` to `25.5.0` in one resolved peer entry.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-line addition of a missing dev dependency that was already present in the sibling demo template.

The fix is narrow and well-scoped: it adds a single missing dev dependency (`tsx`) to the blank template's `package.json`. The demo template already declares the same dependency at the same version range, and the lock file update is mechanically generated. No logic, runtime behaviour, or public API is affected.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["chore: update lockfile for tsx in blank ..."](https://github.com/alpic-ai/skybridge/commit/1b2b6e9712cc92ec9e028c612722289d7847efe2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35078529)</sub>

<!-- /greptile_comment -->