### PR TITLE
feat(infrastructure): add chess.skybridge.tech DNS record

### DIFF
--- a/infrastructure/lib/constructs/SkybridgeRecords.ts
+++ b/infrastructure/lib/constructs/SkybridgeRecords.ts
@@ -51,6 +51,7 @@ export class SkybridgeRecords extends Construct {
     // Showcase apps pointing to alpic.ai
     for (const subdomain of [
       "capitals",
+      "chess",
       "ecommerce",
       "flight-booking",
       "generative-ui",


### PR DESCRIPTION
Adds a Route53 CNAME for `chess.skybridge.tech` → `cname.alpic.ai`, matching the other showcase example subdomains, so the `chess` example (added in #842) is reachable at its own domain.

## Changes
- `infrastructure/lib/constructs/SkybridgeRecords.ts`: add `"chess"` to the showcase apps subdomain list.

## Verification
- `tsc --noEmit` passes
- `cdk synth` produces `chess.skybridge.tech. CNAME cname.alpic.ai`

## Follow-up
- Requires `cdk deploy` and the chess app being mapped on the Alpic side for the domain to resolve.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `chess.skybridge.tech` as a Route53 CNAME record pointing to `cname.alpic.ai`, enabling the chess showcase example to be reachable at its own subdomain.

- The single-line addition inserts `"chess"` in alphabetical order into the existing showcase-app subdomain loop, following the same pattern as all other showcase entries.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a one-line addition to an existing list with no logic changes.

The change adds a single string to an existing array. It follows the established pattern exactly, is placed in alphabetical order, and produces the expected CNAME record. There is nothing here that could regress existing records or introduce incorrect behaviour.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["feat(infrastructure): add chess.skybridg..."](https://github.com/alpic-ai/skybridge/commit/becf06b5360c91067e8e78c5c1efc7c67f3336c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35238162)</sub>

<!-- /greptile_comment -->