### PR TITLE
feat(devtools): add saved queries

### DIFF
--- a/packages/devtools/src/components/layout/tools-list/saved-queries.tsx
+++ b/packages/devtools/src/components/layout/tools-list/saved-queries.tsx
@@ -1,0 +1,190 @@
+import { Button } from "@alpic-ai/ui/components/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@alpic-ai/ui/components/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@alpic-ai/ui/components/dropdown-menu";
+import { Input } from "@alpic-ai/ui/components/input";
+import { Label } from "@alpic-ai/ui/components/label";
+import { Check, ChevronDown, Trash2 } from "lucide-react";
+import { type FormEvent, useEffect, useId, useState } from "react";
+import type { SavedQuery } from "@/lib/saved-queries-store.js";
+import { cn } from "@/lib/utils.js";
+
+export function SavedQueriesDropdown({
+  queries,
+  activeKey,
+  onSelect,
+  onClear,
+  onDelete,
+}: {
+  queries: SavedQuery[];
+  activeKey: string | null;
+  onSelect: (query: SavedQuery) => void;
+  onClear: () => void;
+  onDelete: (key: string) => void;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex max-w-52 cursor-pointer items-center gap-1 rounded px-1 py-0.5 font-mono text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring aria-expanded:text-foreground"
+        >
+          <span className="truncate">{activeKey ?? "Input"}</span>
+          <ChevronDown className="size-3 shrink-0" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="min-w-48">
+        {queries.length === 0 ? (
+          <DropdownMenuItem
+            disabled
+            className="font-mono text-xs font-normal text-muted-foreground"
+          >
+            No saved queries yet
+          </DropdownMenuItem>
+        ) : (
+          <>
+            {/* "none" unselects the active query and clears the input. */}
+            <DropdownMenuItem
+              onSelect={onClear}
+              className="cursor-pointer font-mono text-xs font-normal"
+              disabled={queries.length < 0}
+            >
+              {queries.length > 0 && (
+                <Check
+                  className={cn(
+                    "size-3.5 shrink-0",
+                    activeKey === null ? "opacity-100" : "opacity-0",
+                  )}
+                />
+              )}
+
+              <span className="text-muted-foreground italic">
+                {queries.length > 0 ? "none" : "no saved input yet"}
+              </span>
+            </DropdownMenuItem>
+            {queries.map((query) => (
+              // The trash sits as a sibling overlay (not a child of the item)
+              // so its click never enters the item's selection path: clicking
+              // it deletes without also loading the query.
+              <div key={query.key} className="group/item relative">
+                <DropdownMenuItem
+                  // Clicking the already-selected query unselects it.
+                  onSelect={() =>
+                    query.key === activeKey ? onClear() : onSelect(query)
+                  }
+                  className="cursor-pointer pr-8 font-mono text-xs font-normal"
+                >
+                  <Check
+                    className={cn(
+                      "size-3.5 shrink-0",
+                      query.key === activeKey ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                  <span className="truncate">{query.key}</span>
+                </DropdownMenuItem>
+                <button
+                  type="button"
+                  aria-label={`Delete saved query ${query.key}`}
+                  onClick={() => onDelete(query.key)}
+                  className="absolute top-1/2 right-2.5 inline-flex -translate-y-1/2 cursor-pointer rounded p-1 text-light-gray-foreground opacity-0 transition-opacity hover:text-destructive focus-visible:opacity-100 group-hover/item:opacity-100"
+                >
+                  <Trash2 className="size-3.5" />
+                </button>
+              </div>
+            ))}
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export function SaveQueryDialog({
+  open,
+  onOpenChange,
+  defaultKey,
+  existingKeys,
+  onSave,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  defaultKey: string;
+  existingKeys: string[];
+  onSave: (key: string) => void;
+}) {
+  const inputId = useId();
+  const [key, setKey] = useState(defaultKey);
+  const trimmed = key.trim();
+  const isOverwrite = trimmed.length > 0 && existingKeys.includes(trimmed);
+
+  // Prefill the field each time the dialog (re)opens: with the active query's
+  // key, so saving over it is one click.
+  useEffect(() => {
+    if (open) {
+      setKey(defaultKey);
+    }
+  }, [open, defaultKey]);
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    if (!trimmed) {
+      return;
+    }
+    onSave(trimmed);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Save query</DialogTitle>
+          <DialogDescription>
+            Save the current input to reuse it later.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div className="space-y-1.5">
+            <Label htmlFor={inputId}>Name</Label>
+            <Input
+              id={inputId}
+              value={key}
+              onChange={(event) => setKey(event.target.value)}
+              placeholder="e.g. happy path"
+              autoFocus
+            />
+            {isOverwrite && (
+              <p className="text-xs text-muted-foreground">
+                A query named "{trimmed}" already exists: it will be
+                overwritten.
+              </p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" variant="primary" disabled={!trimmed}>
+              {isOverwrite ? "Overwrite" : "Save"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/devtools/src/components/layout/tools-list/saved-queries.tsx
+++ b/packages/devtools/src/components/layout/tools-list/saved-queries.tsx
@@ -58,7 +58,7 @@ export function SavedQueriesDropdown({
             <DropdownMenuItem
               onSelect={onClear}
               className="cursor-pointer font-mono text-xs font-normal"
-              disabled={queries.length < 0}
+              disabled={queries.length <= 0}
             >
               {queries.length > 0 && (
                 <Check

--- a/packages/devtools/src/components/layout/tools-list/saved-queries.tsx
+++ b/packages/devtools/src/components/layout/tools-list/saved-queries.tsx
@@ -50,7 +50,7 @@ export function SavedQueriesDropdown({
             disabled
             className="font-mono text-xs font-normal text-muted-foreground"
           >
-            No saved queries yet
+            No saved input yet
           </DropdownMenuItem>
         ) : (
           <>
@@ -74,12 +74,8 @@ export function SavedQueriesDropdown({
               </span>
             </DropdownMenuItem>
             {queries.map((query) => (
-              // The trash sits as a sibling overlay (not a child of the item)
-              // so its click never enters the item's selection path: clicking
-              // it deletes without also loading the query.
               <div key={query.key} className="group/item relative">
                 <DropdownMenuItem
-                  // Clicking the already-selected query unselects it.
                   onSelect={() =>
                     query.key === activeKey ? onClear() : onSelect(query)
                   }
@@ -149,9 +145,9 @@ export function SaveQueryDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Save query</DialogTitle>
+          <DialogTitle>Save input</DialogTitle>
           <DialogDescription>
-            Save the current input to reuse it later.
+            Save the current values to reuse it later.
           </DialogDescription>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-3">

--- a/packages/devtools/src/components/layout/tools-list/tool-item.tsx
+++ b/packages/devtools/src/components/layout/tools-list/tool-item.tsx
@@ -11,12 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@alpic-ai/ui/components/dialog";
-import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from "@alpic-ai/ui/components/tabs";
+import { Tabs, TabsContent } from "@alpic-ai/ui/components/tabs";
 import {
   Tooltip,
   TooltipContent,
@@ -29,7 +24,7 @@ import { Form as FormComponent } from "@rjsf/shadcn";
 import type { RJSFSchema } from "@rjsf/utils";
 import validator from "@rjsf/validator-ajv8";
 import { useKeyPress } from "ahooks";
-import { Loader2, Play } from "lucide-react";
+import { Braces, Loader2, PanelsTopLeft, Play } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useAuthStore } from "@/lib/auth-store.js";
 import { CopyButton } from "@/lib/copy.js";
@@ -295,15 +290,31 @@ function ToolBody({
       )}
       {hasInput && (
         <Tabs value={tab} onValueChange={(v) => setTab(v as TabValue)}>
-          <div className="flex items-center justify-between gap-2">
-            <TabsList variant="line">
-              <TabsTrigger value="form">form</TabsTrigger>
-              <TabsTrigger value="json">json</TabsTrigger>
-            </TabsList>
-            <CopyButton
-              value={JSON.stringify(formData, null, 2)}
-              label="Copy input"
-            />
+          <div className="flex items-end justify-between gap-2 border-b border-border">
+            <span className="pb-2 text-xs font-medium text-muted-foreground">
+              Input
+            </span>
+            <div className="inline-flex h-7 items-stretch overflow-hidden rounded-t-md border border-b-0 border-border bg-background text-light-gray-foreground">
+              <button
+                type="button"
+                title="Toggle between form and JSON input"
+                onClick={() => setTab(tab === "form" ? "json" : "form")}
+                className="inline-flex cursor-pointer items-center gap-1.5 px-2 text-xs font-medium transition-colors hover:bg-light-gray hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
+              >
+                {tab === "form" ? (
+                  <PanelsTopLeft className="size-3.5" />
+                ) : (
+                  <Braces className="size-3.5" />
+                )}
+                <span>{tab}</span>
+              </button>
+              <div className="w-px self-stretch bg-border" aria-hidden="true" />
+              <CopyButton
+                value={JSON.stringify(formData, null, 2)}
+                label="Copy input"
+                className="inline-flex items-center px-2 text-light-gray-foreground transition-colors hover:bg-light-gray hover:text-foreground"
+              />
+            </div>
           </div>
           <TabsContent value="form">
             <FormBody

--- a/packages/devtools/src/components/layout/tools-list/tool-item.tsx
+++ b/packages/devtools/src/components/layout/tools-list/tool-item.tsx
@@ -89,8 +89,6 @@ export function ToolItem({ tool, open }: { tool: Tool; open: boolean }) {
     await callTool({ toolName: tool.name, args: formData });
   };
 
-  // Enter/⌘Enter run the tool — but not while a dialog (e.g. the save-query
-  // modal) is open, so its own submit button handles Enter.
   const inDialog = (event: KeyboardEvent) =>
     (event.target as HTMLElement | null)?.closest("[role=dialog]") != null;
 

--- a/packages/devtools/src/components/layout/tools-list/tool-item.tsx
+++ b/packages/devtools/src/components/layout/tools-list/tool-item.tsx
@@ -24,15 +24,25 @@ import { Form as FormComponent } from "@rjsf/shadcn";
 import type { RJSFSchema } from "@rjsf/utils";
 import validator from "@rjsf/validator-ajv8";
 import { useKeyPress } from "ahooks";
-import { Braces, Loader2, PanelsTopLeft, Play } from "lucide-react";
+import { Braces, ClipboardList, Loader2, Play, Save } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useAuthStore } from "@/lib/auth-store.js";
 import { CopyButton } from "@/lib/copy.js";
-import { toolRequiresAuth, useCallTool } from "@/lib/mcp/index.js";
+import {
+  toolRequiresAuth,
+  useCallTool,
+  useServerInfo,
+} from "@/lib/mcp/index.js";
+import {
+  type SavedQuery,
+  useSavedQueries,
+  useSavedQueriesStore,
+} from "@/lib/saved-queries-store.js";
 import { useCallToolResult, useStore } from "@/lib/store.js";
 import { cn } from "@/lib/utils.js";
 import { AccordionTrigger } from "./accordion-trigger.js";
 import { buildFormUiSchema, formTemplates, formWidgets } from "./form/index.js";
+import { SavedQueriesDropdown, SaveQueryDialog } from "./saved-queries.js";
 
 type TabValue = "form" | "json";
 
@@ -79,8 +89,13 @@ export function ToolItem({ tool, open }: { tool: Tool; open: boolean }) {
     await callTool({ toolName: tool.name, args: formData });
   };
 
-  useKeyPress("meta.enter", () => {
-    if (!open) {
+  // Enter/⌘Enter run the tool — but not while a dialog (e.g. the save-query
+  // modal) is open, so its own submit button handles Enter.
+  const inDialog = (event: KeyboardEvent) =>
+    (event.target as HTMLElement | null)?.closest("[role=dialog]") != null;
+
+  useKeyPress("meta.enter", (event) => {
+    if (!open || inDialog(event)) {
       return;
     }
     handleRun();
@@ -89,7 +104,7 @@ export function ToolItem({ tool, open }: { tool: Tool; open: boolean }) {
   useKeyPress(
     "enter",
     (event) => {
-      if (!open) {
+      if (!open || inDialog(event)) {
         return;
       }
       const target = event.target as HTMLElement | null;
@@ -145,7 +160,9 @@ export function ToolItem({ tool, open }: { tool: Tool; open: boolean }) {
           ) : null
         }
       >
-        <div className="min-w-0 flex-1 truncate text-left">{tool.name}</div>
+        <div className="min-w-0 flex-1 truncate text-left text-sm font-medium">
+          {tool.name}
+        </div>
       </AccordionTrigger>
       {!open && tool.description ? (
         <div aria-hidden="true" className="px-3 pb-3 -mt-1 font-sans">
@@ -154,7 +171,7 @@ export function ToolItem({ tool, open }: { tool: Tool; open: boolean }) {
           </div>
         </div>
       ) : null}
-      <AccordionContent className="px-3 pt-1 pb-3 text-foreground">
+      <AccordionContent className="px-3 pt-0 pb-3 text-foreground">
         <ToolBody
           tool={tool}
           formData={formData}
@@ -201,6 +218,21 @@ function getToolVisibility(tool: Tool): Visibility[] | undefined {
   return values.length > 0 ? values : undefined;
 }
 
+// Keep only the fields the current schema still defines, so a query saved
+// against an older schema still applies cleanly.
+function intersectInputToSchema(
+  input: Record<string, unknown>,
+  tool: Tool,
+): Record<string, unknown> {
+  const properties = (tool.inputSchema?.properties ?? {}) as Record<
+    string,
+    unknown
+  >;
+  return Object.fromEntries(
+    Object.entries(input).filter(([name]) => name in properties),
+  );
+}
+
 function ToolBody({
   tool,
   formData,
@@ -225,6 +257,58 @@ function ToolBody({
     Object.keys(tool.inputSchema.properties ?? {}).length > 0;
   const visibility = getToolVisibility(tool);
   const [descriptionOpen, setDescriptionOpen] = useState(false);
+  const [saveOpen, setSaveOpen] = useState(false);
+  const serverName = useServerInfo()?.name;
+  const savedQueries = useSavedQueries(serverName, tool.name);
+  const saveQuery = useSavedQueriesStore((s) => s.saveQuery);
+  const updateQuery = useSavedQueriesStore((s) => s.updateQuery);
+  const deleteQuery = useSavedQueriesStore((s) => s.deleteQuery);
+  const setToolData = useStore((s) => s.setToolData);
+  const storedActiveKey =
+    useCallToolResult(tool.name)?.activeSavedQueryKey ?? null;
+
+  // The active query is the saved query the input was last loaded from/saved
+  // as. Ignore a stale key whose query was since deleted.
+  const activeQuery = storedActiveKey
+    ? savedQueries.find((q) => q.key === storedActiveKey)
+    : undefined;
+  const activeKey = activeQuery ? storedActiveKey : null;
+
+  const loadQuery = (query: SavedQuery) => {
+    // Both the form and JSON views read this shared input, so both update.
+    setToolData(tool.name, {
+      input: intersectInputToSchema(query.input, tool),
+      activeSavedQueryKey: query.key,
+    });
+  };
+
+  // Unselect the active query and clear the input.
+  const clearSelection = () => {
+    setToolData(tool.name, { input: {}, activeSavedQueryKey: null });
+  };
+
+  const saveFromModal = (key: string) => {
+    if (!serverName) {
+      return;
+    }
+    // An existing key overwrites that query; a new key creates one.
+    if (savedQueries.some((q) => q.key === key)) {
+      updateQuery(serverName, tool.name, key, formData);
+    } else {
+      saveQuery(serverName, tool.name, key, formData);
+    }
+    setToolData(tool.name, { activeSavedQueryKey: key });
+  };
+
+  const removeQuery = (key: string) => {
+    if (!serverName) {
+      return;
+    }
+    deleteQuery(serverName, tool.name, key);
+    if (key === storedActiveKey) {
+      setToolData(tool.name, { activeSavedQueryKey: null });
+    }
+  };
 
   return (
     <div className="space-y-3">
@@ -291,9 +375,21 @@ function ToolBody({
       {hasInput && (
         <Tabs value={tab} onValueChange={(v) => setTab(v as TabValue)}>
           <div className="flex items-end justify-between gap-2 border-b border-border">
-            <span className="pb-2 text-xs font-medium text-muted-foreground">
-              Input
-            </span>
+            {serverName ? (
+              <div className="min-w-0 pb-1.5">
+                <SavedQueriesDropdown
+                  queries={savedQueries}
+                  activeKey={activeKey}
+                  onSelect={loadQuery}
+                  onClear={clearSelection}
+                  onDelete={removeQuery}
+                />
+              </div>
+            ) : (
+              <span className="pb-2 text-xs font-medium text-muted-foreground">
+                Input
+              </span>
+            )}
             <div className="inline-flex h-7 items-stretch overflow-hidden rounded-t-md border border-b-0 border-border bg-background text-light-gray-foreground">
               <button
                 type="button"
@@ -302,18 +398,28 @@ function ToolBody({
                 className="inline-flex cursor-pointer items-center gap-1.5 px-2 text-xs font-medium transition-colors hover:bg-light-gray hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
               >
                 {tab === "form" ? (
-                  <PanelsTopLeft className="size-3.5" />
+                  <ClipboardList className="size-3.5" />
                 ) : (
                   <Braces className="size-3.5" />
                 )}
                 <span>{tab}</span>
               </button>
-              <div className="w-px self-stretch bg-border" aria-hidden="true" />
-              <CopyButton
-                value={JSON.stringify(formData, null, 2)}
-                label="Copy input"
-                className="inline-flex items-center px-2 text-light-gray-foreground transition-colors hover:bg-light-gray hover:text-foreground"
-              />
+              {serverName && (
+                <>
+                  <div
+                    className="w-px self-stretch bg-border"
+                    aria-hidden="true"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setSaveOpen(true)}
+                    className="inline-flex cursor-pointer items-center gap-1.5 px-2 text-xs font-medium text-light-gray-foreground transition-colors hover:bg-light-gray hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
+                  >
+                    <Save className="size-3.5" />
+                    <span>save</span>
+                  </button>
+                </>
+              )}
             </div>
           </div>
           <TabsContent value="form">
@@ -333,6 +439,15 @@ function ToolBody({
             />
           </TabsContent>
         </Tabs>
+      )}
+      {hasInput && serverName && (
+        <SaveQueryDialog
+          open={saveOpen}
+          onOpenChange={setSaveOpen}
+          defaultKey={activeKey ?? ""}
+          existingKeys={savedQueries.map((q) => q.key)}
+          onSave={saveFromModal}
+        />
       )}
     </div>
   );
@@ -419,15 +534,22 @@ function JsonBody({
 
   return (
     <div className="space-y-1.5">
-      <textarea
-        className={cn(
-          "max-h-80 min-h-20 w-full resize-none overflow-auto rounded-md border p-2 font-mono text-xs field-sizing-content",
-          error ? "border-destructive" : "border-border",
-        )}
-        spellCheck={false}
-        value={json}
-        onChange={(e) => handleChange(e.target.value)}
-      />
+      <div className="relative">
+        <textarea
+          className={cn(
+            "max-h-80 min-h-20 w-full resize-none overflow-auto rounded-md border p-2 pr-9 font-mono text-xs field-sizing-content",
+            error ? "border-destructive" : "border-border",
+          )}
+          spellCheck={false}
+          value={json}
+          onChange={(e) => handleChange(e.target.value)}
+        />
+        <CopyButton
+          value={json}
+          label="Copy input"
+          className="absolute top-2 right-2 z-10"
+        />
+      </div>
       {error && (
         <div className="text-xs text-destructive">
           The provided JSON is invalid

--- a/packages/devtools/src/components/layout/tools-list/tool-item.tsx
+++ b/packages/devtools/src/components/layout/tools-list/tool-item.tsx
@@ -421,7 +421,7 @@ function JsonBody({
     <div className="space-y-1.5">
       <textarea
         className={cn(
-          "h-80 w-full rounded-md border p-2 font-mono text-xs",
+          "max-h-80 min-h-20 w-full resize-none overflow-auto rounded-md border p-2 font-mono text-xs field-sizing-content",
           error ? "border-destructive" : "border-border",
         )}
         spellCheck={false}

--- a/packages/devtools/src/lib/saved-queries-store.ts
+++ b/packages/devtools/src/lib/saved-queries-store.ts
@@ -1,0 +1,104 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type SavedQuery = {
+  key: string;
+  input: Record<string, unknown>;
+  createdAt: number;
+};
+
+// serverName -> toolName -> queries
+type SavedQueriesByTool = Record<string, SavedQuery[]>;
+type SavedQueriesByServer = Record<string, SavedQueriesByTool>;
+
+type SavedQueriesState = {
+  queries: SavedQueriesByServer;
+  /** Persist the current input under a new key. */
+  saveQuery: (
+    serverName: string,
+    toolName: string,
+    key: string,
+    input: Record<string, unknown>,
+  ) => void;
+  /** Overwrite the input of an existing saved query (matched by key). */
+  updateQuery: (
+    serverName: string,
+    toolName: string,
+    key: string,
+    input: Record<string, unknown>,
+  ) => void;
+  deleteQuery: (serverName: string, toolName: string, key: string) => void;
+};
+
+const EMPTY: SavedQuery[] = [];
+
+export const useSavedQueriesStore = create<SavedQueriesState>()(
+  persist(
+    (set) => ({
+      queries: {},
+      saveQuery: (serverName, toolName, key, input) =>
+        set((state) => {
+          const forServer = state.queries[serverName] ?? {};
+          const forTool = forServer[toolName] ?? [];
+          const query: SavedQuery = { key, input, createdAt: Date.now() };
+          return {
+            queries: {
+              ...state.queries,
+              [serverName]: { ...forServer, [toolName]: [...forTool, query] },
+            },
+          };
+        }),
+      updateQuery: (serverName, toolName, key, input) =>
+        set((state) => {
+          const forServer = state.queries[serverName];
+          const forTool = forServer?.[toolName];
+          if (!forTool) {
+            return state;
+          }
+          const index = forTool.findIndex((q) => q.key === key);
+          if (index === -1) {
+            return state;
+          }
+          const next = [...forTool];
+          next[index] = { ...next[index], input };
+          return {
+            queries: {
+              ...state.queries,
+              [serverName]: { ...forServer, [toolName]: next },
+            },
+          };
+        }),
+      deleteQuery: (serverName, toolName, key) =>
+        set((state) => {
+          const forServer = state.queries[serverName];
+          const forTool = forServer?.[toolName];
+          if (!forTool) {
+            return state;
+          }
+          return {
+            queries: {
+              ...state.queries,
+              [serverName]: {
+                ...forServer,
+                [toolName]: forTool.filter((q) => q.key !== key),
+              },
+            },
+          };
+        }),
+    }),
+    {
+      name: "skybridge-devtools-saved-queries",
+      version: 1,
+      partialize: (state) => ({ queries: state.queries }),
+    },
+  ),
+);
+
+/** A tool's saved queries (stable empty array when none). */
+export const useSavedQueries = (
+  serverName: string | undefined,
+  toolName: string,
+): SavedQuery[] =>
+  useSavedQueriesStore((s) =>
+    serverName ? (s.queries[serverName]?.[toolName] ?? EMPTY) : EMPTY,
+  );

--- a/packages/devtools/src/lib/store.ts
+++ b/packages/devtools/src/lib/store.ts
@@ -23,6 +23,8 @@ type ToolData = {
   openaiLogs: OpenAiLog[];
   openaiObject: AppsSdkContext | null;
   openInAppUrl: string | null;
+  // Key of the saved query the current input was loaded from (session-only).
+  activeSavedQueryKey?: string | null;
 };
 
 export type Store = {


### PR DESCRIPTION
This adds saved queries so user can stash a tool's input under a name and pull it back in one click. 

How it works:
- The input header now has a selector where the "Input" label used to be. Pick a saved query to load it into both the form and JSON views; pick "none" to clear and start fresh.
- "save" stashes the current input under a name. Existing name → overwrites it, new name → creates one. The modal prefills with the current selection (so re-saving over it is one click), and Enter submits.
- Trash icon on hover deletes a query.
- Queries live in localStorage, scoped per server + tool, so they survive reloads and don't bleed across projects.
- If a tool's schema changed since you saved, loading keeps only the fields that still exist.

The input header got a small refresh while I was in there: form/json is now a single toggle, copy floats in the top-right of the JSON box, and the tool name is a touch bigger/bolder.

Implementation: a small zustand store persisted to localStorage (serverName → toolName → queries). The active selection is tracked per-tool on the existing in-memory tool store, and since the form and JSON views already share one input field, both stay in sync for free. New saved-queries.tsx holds the dropdown + save dialog; tool-item.tsx wires it into the header.

Coming next: run button + saved queries always in the tool header, regardless of the accordion state.

https://github.com/user-attachments/assets/083c22cc-9016-4258-8019-049e1f9f2799

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a saved-queries feature to the devtools panel: users can stash a tool's current input under a name, reload it in one click, and delete stale entries. Queries are scoped per server+tool and persisted to localStorage via a new zustand store.

- A new `SavedQueriesDropdown` and `SaveQueryDialog` are added in `saved-queries.tsx`; `tool-item.tsx` wires them into the existing `ToolBody` header, also fixing `meta+enter`/`enter` keyboard shortcuts to ignore keypresses inside any dialog.
- The input header is refreshed: the old tab list becomes a single form/JSON toggle button, and the copy button moves into the JSON textarea overlay.
- `intersectInputToSchema` defensively trims saved inputs to fields that still exist in the current schema, avoiding broken state after tool-schema changes.

<h3>Confidence Score: 5/5</h3>

The change is self-contained and additive — no existing behaviour is removed, only new optional UI is layered on top.

The store actions are immutable and guard against missing entries cleanly. The active-key derivation handles stale references without leaking into the UI. The `inDialog` keyboard guard correctly prevents the tool-run shortcut from firing inside the save dialog. No data-loss or incorrect-state paths were found.

No files require special attention.

<sub>Reviews (3): Last reviewed commit: ["fix: input instead of query"](https://github.com/alpic-ai/skybridge/commit/e871d34d3b0e4385af92496ae9e155ed204fbca7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36220931)</sub>

<!-- /greptile_comment -->