### PR TITLE
fix: use color-picking to display chess board in PiP mode

### DIFF
--- a/examples/chess/README.md
+++ b/examples/chess/README.md
@@ -1,7 +1,11 @@
 # Skybridge Chess
 
-Play chess against the assistant inside the conversation. You play **White** and
-move first by dragging pieces; the assistant plays **Black**.
+Play chess against the assistant inside the conversation. The board opens on a
+**pick-a-side lobby**: choose **White** or **Black** to start. Picking a color
+is the user gesture that lets the view pop the board into **picture-in-picture**
+(via `useDisplayMode`), so you can keep chatting while you play. You drag your
+pieces; the assistant plays the other color (and opens the game if you take
+Black).
 
 This example is a Skybridge port of [MCPJam/chess-mcp](https://github.com/MCPJam/chess-mcp),
 and its purpose is to showcase **MCP Apps view-provided tools** — the
@@ -19,7 +23,7 @@ the model actually uses to play, with `useRegisterViewTool`:
 | `start_game` | server | Opens the board |
 | `chess_get_board_state` | **view** | Read FEN, turn, check, result, history |
 | `chess_get_legal_moves` | **view** | List legal moves (optionally from a square) |
-| `chess_make_move` | **view** | Play a move as Black |
+| `chess_make_move` | **view** | Play a move as the assistant's color |
 | `chess_reset_game` | **view** | Reset to the starting position |
 
 The host discovers the view tools via `tools/list` and invokes them via
@@ -30,11 +34,20 @@ move played, so the full game is pushed into the model's context on every change
 and survives a view remount. The chess logic is a thin, stateless wrapper
 (`src/lib/engine.ts`) — every helper rebuilds the engine from a FEN on demand.
 
+### Pick a side & picture-in-picture
+
+The view starts on a lobby with two buttons (White / Black). Picking a color
+calls the match store's `start` action and immediately requests
+`setDisplayMode("pip")` — most hosts only grant picture-in-picture in response
+to a user gesture, so the color choice doubles as that gesture. If you pick
+Black, the view fires a `sendFollowUpMessage` asking the assistant (White) to
+make the opening move.
+
 ### The turn loop
 
-1. The user drags a White piece. chess.js validates the move.
+1. You drag one of your pieces. chess.js validates the move.
 2. The view calls `sendFollowUpMessage`, asking the assistant (as the user) to
-   reply with its Black move.
+   reply with its move on the other color.
 3. The assistant calls the `chess_make_move` **view tool**, which updates the
    board in place.
 

--- a/examples/chess/src/index.css
+++ b/examples/chess/src/index.css
@@ -143,6 +143,82 @@
   box-shadow: var(--chess-board-shadow);
 }
 
+/* Pre-game lobby: pick a side to start. */
+.chess-lobby {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.chess-lobby-text {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.45;
+  color: var(--chess-muted);
+}
+
+.chess-lobby-choices {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+}
+
+.chess-side {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 1.25rem 0.75rem;
+  text-align: center;
+  color: var(--chess-fg);
+  background: var(--chess-panel);
+  border: 1px solid var(--chess-border);
+  border-radius: 0.875rem;
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    transform 0.1s ease,
+    box-shadow 0.15s ease;
+}
+
+.chess-side:hover {
+  border-color: var(--chess-accent);
+  box-shadow: var(--chess-board-shadow);
+}
+
+.chess-side:active {
+  transform: scale(0.97);
+}
+
+.chess-side-piece {
+  font-size: 2.5rem;
+  line-height: 1;
+}
+
+.chess-side--white .chess-side-piece {
+  color: #f5f8ff;
+  text-shadow: 0 1px 2px rgba(11, 21, 48, 0.45);
+}
+
+.chess-side--black .chess-side-piece {
+  color: #0b1530;
+}
+
+[data-theme="dark"] .chess-side--black .chess-side-piece {
+  color: #1a2a3a;
+  text-shadow: 0 0 1px rgba(234, 246, 255, 0.6);
+}
+
+.chess-side-label {
+  font-size: 0.9375rem;
+  font-weight: 700;
+}
+
+.chess-side-note {
+  font-size: 0.75rem;
+  color: var(--chess-muted);
+}
+
 .chess-status {
   display: flex;
   flex-wrap: wrap;

--- a/examples/chess/src/lib/match.ts
+++ b/examples/chess/src/lib/match.ts
@@ -16,11 +16,17 @@ import {
 // them: the engine is rebuilt from a bare FEN on each call, which carries the
 // position but not the line that led to it. Tracking them in the store is the
 // single source of truth for both the UI and the model.
+type Side = "w" | "b";
+
 type Match = Position & {
-  human: "w";
-  assistant: "b";
+  // Whether the player has picked a side yet. While `false` the view shows the
+  // pre-game lobby; picking a color flips it to `true` and opens the board.
+  started: boolean;
+  human: Side;
+  assistant: Side;
   log: string[];
   lastMove: PlayedMove | null;
+  start: (human: Side) => void;
   play: (request: MoveRequest) => MoveResult;
   restart: () => void;
 };
@@ -35,8 +41,16 @@ function freshMatch() {
 
 export const useMatch = createStore<Match>((set, get) => ({
   ...freshMatch(),
+  started: false,
   human: "w",
   assistant: "b",
+  start: (human) =>
+    set({
+      ...freshMatch(),
+      started: true,
+      human,
+      assistant: human === "w" ? "b" : "w",
+    }),
   play: (request) => {
     const result = tryMove(get().fen, request);
     if (result.ok) {
@@ -48,5 +62,7 @@ export const useMatch = createStore<Match>((set, get) => ({
     }
     return result;
   },
-  restart: () => set(freshMatch()),
+  // Back to the lobby so the player can pick a side again.
+  restart: () =>
+    set({ ...freshMatch(), started: false, human: "w", assistant: "b" }),
 }));

--- a/examples/chess/src/server.ts
+++ b/examples/chess/src/server.ts
@@ -4,7 +4,9 @@ import { readPosition, STARTING_FEN } from "./lib/engine.js";
 // Deliberately tiny server. The only thing it does is open the board — all of
 // the gameplay tools are registered by the view itself (see
 // src/views/chess.tsx) through `useRegisterViewTool`, so they run inside the
-// widget. The human is White and moves first; the assistant answers as Black.
+// widget. The view opens on a pick-a-side lobby; once the user chooses a color
+// (which also pops the board into picture-in-picture), the assistant plays the
+// other side.
 const server = new McpServer(
   {
     name: "skybridge-chess",
@@ -15,7 +17,7 @@ const server = new McpServer(
   {
     name: "start_game",
     description:
-      "Open an interactive chess board. The user plays White and moves first; you play Black. After the board is open, drive your side with the tools the view exposes — `chess_get_board_state`, `chess_get_legal_moves`, `chess_make_move`, and `chess_reset_game` — to inspect the position and answer with Black's moves.",
+      "Open an interactive chess board. The user first picks a side (White or Black) in the view; you play the other color. If they pick Black, you are White and move first. Drive your side with the tools the view exposes — `chess_get_board_state`, `chess_get_legal_moves`, `chess_make_move`, and `chess_reset_game` — to inspect the position and answer with your moves.",
     annotations: {
       title: "Start a chess game",
       readOnlyHint: false,
@@ -39,9 +41,9 @@ const server = new McpServer(
         {
           type: "text",
           text: [
-            "A fresh chess game is on the board.",
-            "White belongs to the user and moves first; you are Black.",
-            'Hold until the user has moved, then reply with Black\'s move by calling the `chess_make_move` view tool (for example `{ "san": "e5" }`).',
+            "A fresh chess board is open on the pick-a-side lobby.",
+            "Wait for the user to choose White or Black — you play the other color, and choosing also opens the board in picture-in-picture.",
+            'If they pick White, hold until they move, then reply with your Black move via the `chess_make_move` view tool (for example `{ "san": "e5" }`). If they pick Black, the view will prompt you to open as White.',
             "Lean on `chess_get_board_state` and `chess_get_legal_moves` to study the position first.",
           ].join(" "),
         },

--- a/examples/chess/src/views/chess.tsx
+++ b/examples/chess/src/views/chess.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import type { PieceDropHandlerArgs } from "react-chessboard";
 import { Chessboard } from "react-chessboard";
 import {
+  useDisplayMode,
   useLayout,
   useRegisterViewTool,
   useSendFollowUpMessage,
@@ -103,7 +104,7 @@ function useChessViewTools() {
     {
       name: TOOL.makeMove,
       description:
-        "Make a move as Black. Pass either `san` (e.g. 'e5', 'Nf6', 'O-O') or both `from` and `to`. The move has to be legal and it must be Black's turn.",
+        "Make a move as your color — the side the user did not pick (Black if they chose White, White if they chose Black). Pass either `san` (e.g. 'e5', 'Nf6', 'O-O') or both `from` and `to`. The move has to be legal and it must be your turn.",
       inputSchema: {
         san: z
           .string()
@@ -215,8 +216,13 @@ export default function ChessView() {
   const theme: Theme = themeOverride ?? hostTheme;
 
   const sendFollowUpMessage = useSendFollowUpMessage();
+  const [, setDisplayMode] = useDisplayMode();
   useChessViewTools();
 
+  const started = useMatch((store) => store.started);
+  const human = useMatch((store) => store.human);
+  const assistant = useMatch((store) => store.assistant);
+  const start = useMatch((store) => store.start);
   const fen = useMatch((store) => store.fen);
   const toMove = useMatch((store) => store.toMove);
   const over = useMatch((store) => store.over);
@@ -225,8 +231,81 @@ export default function ChessView() {
   const play = useMatch((store) => store.play);
   const restart = useMatch((store) => store.restart);
 
+  const humanName = human === "w" ? "White" : "Black";
+  const assistantName = assistant === "w" ? "White" : "Black";
+
+  // Picking a side is the user gesture hosts require before granting
+  // picture-in-picture — so we request it straight off the click.
+  const beginGame = (side: "w" | "b") => {
+    start(side);
+    setDisplayMode("pip");
+    if (side === "b") {
+      // The user took Black, so the assistant (White) opens the game.
+      sendFollowUpMessage(
+        `I'll play Black this game. You're White and move first — make the opening move by calling the ${TOOL.makeMove} view tool (for example \`{ "san": "e4" }\`).`,
+      );
+    }
+  };
+
+  if (!started) {
+    return (
+      <div className="chess-app chess-app--lobby" data-theme={theme}>
+        <header className="chess-header">
+          <div className="chess-brand">
+            <span className="chess-mark" aria-hidden="true" />
+            <div>
+              <h1 className="chess-title">Skybridge Chess</h1>
+              <p className="chess-subtitle">Pick a side to start playing</p>
+            </div>
+          </div>
+          <button
+            type="button"
+            className="chess-icon-button"
+            aria-label={
+              theme === "dark" ? "Switch to light mode" : "Switch to dark mode"
+            }
+            onClick={() => setThemeOverride(theme === "dark" ? "light" : "dark")}
+          >
+            {theme === "dark" ? "☀" : "☾"}
+          </button>
+        </header>
+
+        <div className="chess-lobby">
+          <p className="chess-lobby-text">
+            Choose your color. The game opens in a picture-in-picture window so
+            you can keep chatting while you play.
+          </p>
+          <div className="chess-lobby-choices">
+            <button
+              type="button"
+              className="chess-side chess-side--white"
+              onClick={() => beginGame("w")}
+            >
+              <span className="chess-side-piece" aria-hidden="true">
+                ♔
+              </span>
+              <span className="chess-side-label">Play as White</span>
+              <span className="chess-side-note">You move first</span>
+            </button>
+            <button
+              type="button"
+              className="chess-side chess-side--black"
+              onClick={() => beginGame("b")}
+            >
+              <span className="chess-side-piece" aria-hidden="true">
+                ♚
+              </span>
+              <span className="chess-side-label">Play as Black</span>
+              <span className="chess-side-note">Assistant moves first</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   const position = readPosition(fen);
-  const playerToMove = toMove === "w" && !over;
+  const playerToMove = toMove === human && !over;
   const palette = BOARD[theme];
 
   const squareStyles: Record<string, CSSProperties> = {};
@@ -259,7 +338,7 @@ export default function ChessView() {
     }
     if (!result.position.over) {
       sendFollowUpMessage(
-        `I played ${result.move.san} as White. Your turn — answer as Black with the ${TOOL.makeMove} tool.`,
+        `I played ${result.move.san} as ${humanName}. Your turn — answer as ${assistantName} with the ${TOOL.makeMove} tool.`,
       );
     }
     return true;
@@ -273,7 +352,7 @@ export default function ChessView() {
           <div>
             <h1 className="chess-title">Skybridge Chess</h1>
             <p className="chess-subtitle">
-              You play White · the assistant plays Black
+              You play {humanName} · the assistant plays {assistantName}
             </p>
           </div>
         </div>
@@ -305,7 +384,7 @@ export default function ChessView() {
           options={{
             position: fen,
             onPieceDrop,
-            boardOrientation: "white",
+            boardOrientation: human === "w" ? "white" : "black",
             allowDragging: playerToMove,
             id: "skybridge-chess",
             animationDurationInMs: 200,
@@ -327,7 +406,7 @@ export default function ChessView() {
         {log.length > 0 && (
           <span className="chess-moves">{formatLog(log)}</span>
         )}
-        {!over && toMove === "b" && (
+        {!over && toMove === assistant && (
           <span className="chess-hint">Waiting for the assistant…</span>
         )}
       </footer>


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a pick-a-side lobby to the chess example so players can choose White or Black before the game begins, using the color-pick click as the user gesture required to activate picture-in-picture mode via `useDisplayMode`.

- `match.ts` gains a `started` flag and a `start(side)` action; `restart()` now returns to lobby state instead of directly resuming as White.
- `chess.tsx` renders the lobby when `!started`, calls `setDisplayMode("pip")` on color selection, and fixes board orientation, move validation, and status text to use the dynamic `human`/`assistant` sides.
- `server.ts` and the README are updated to describe the new lobby and dynamic color assignment.

<h3>Confidence Score: 3/5</h3>

The core lobby and PiP logic is solid, but the chess_reset_game tool sends misleading information to the model after a reset.

After restart() is called, the game returns to the lobby (started: false), but the chess_reset_game tool still tells the model 'White (the player) moves first.' The model will act on that stale instruction instead of waiting for the user to pick a side in the lobby — an observable behavioral regression on the reset path.

examples/chess/src/views/chess.tsx — specifically the chess_reset_game tool handler around lines 168-187

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `examples/chess/src/views/chess.tsx`, line 169-183 ([link](https://github.com/alpic-ai/skybridge/blob/84e1cce8391cdc4cf4bd3130ddbaf8234dda50ab/examples/chess/src/views/chess.tsx#L169-L183)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> The `chess_reset_game` tool description and response text are now stale after `restart()` was changed to return to the lobby. `restart()` sets `started: false`, so the board is not immediately back in play — the user has to pick a side again. The model will see "White (the player) moves first" and either wait for White to move or try to respond as Black, when in reality nobody has a side yet. The description also still hardcodes "White to move" even though the user's color is no longer fixed.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: examples/chess/src/views/chess.tsx
   Line: 169-183

   Comment:
   The `chess_reset_game` tool description and response text are now stale after `restart()` was changed to return to the lobby. `restart()` sets `started: false`, so the board is not immediately back in play — the user has to pick a side again. The model will see "White (the player) moves first" and either wait for White to move or try to respond as Black, when in reality nobody has a side yet. The description also still hardcodes "White to move" even though the user's color is no longer fixed.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
examples/chess/src/views/chess.tsx:169-183
The `chess_reset_game` tool description and response text are now stale after `restart()` was changed to return to the lobby. `restart()` sets `started: false`, so the board is not immediately back in play — the user has to pick a side again. The model will see "White (the player) moves first" and either wait for White to move or try to respond as Black, when in reality nobody has a side yet. The description also still hardcodes "White to move" even though the user's color is no longer fixed.

```suggestion
    {
      name: TOOL.reset,
      description:
        "Clear the board back to the opening position. The view returns to the pick-a-side lobby; wait for the user to choose a color before making any moves.",
      annotations: { readOnlyHint: false, destructiveHint: true },
    },
    () => {
      useMatch.getState().restart();
      return {
        content: [
          {
            type: "text",
            text: "Board cleared. The view has returned to the pick-a-side lobby — wait for the user to choose White or Black before making any moves.",
          },
        ],
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use color-picking to display chess ..."](https://github.com/alpic-ai/skybridge/commit/84e1cce8391cdc4cf4bd3130ddbaf8234dda50ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36276473)</sub>

<!-- /greptile_comment -->