### PR TITLE
fix(chess): notify model on UI-triggered game restart

### DIFF
--- a/examples/chess/src/views/chess.tsx
+++ b/examples/chess/src/views/chess.tsx
@@ -372,7 +372,12 @@ export default function ChessView() {
           <button
             type="button"
             className="chess-reset"
-            onClick={() => restart()}
+            onClick={() => {
+              restart();
+              sendFollowUpMessage(
+                "The player has restarted the game. The board is back to the starting position. Please wait for them to pick a side in the view before making any moves.",
+              );
+            }}
           >
             New game
           </button>


### PR DESCRIPTION
## Summary

- Clicking "New game" previously only reset the view/store state — the model still saw the old game in its conversation history and refused to start a new one ("a game is already ongoing")
- Fix sends a follow-up message on restart so the model knows the board was cleared and waits for the player to pick a side again (mirrors the pattern used in `beginGame`)

## Test plan

- [ ] Start a chess game, play a few moves
- [ ] Click "New game" — verify the model acknowledges the reset and shows the lobby without complaining about an ongoing game

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a UX bug where clicking "New game" only reset the local view/store state but left the model's conversation history intact, causing it to refuse a fresh game with "a game is already ongoing." The fix appends a follow-up message after `restart()`, mirroring the `beginGame` pattern, so the model learns the board was cleared and waits for the player to pick a side.

- Adds a `sendFollowUpMessage` call in the "New game" `onClick` handler alongside the existing `restart()` call, consistent with how `beginGame` and `onPieceDrop` already communicate game events to the model.
- The message wording correctly describes the reset state and instructs the model to hold off on moves until a side is chosen in the lobby.

<h3>Confidence Score: 4/5</h3>

Safe to merge — one-line behavior fix with no new state, no new dependencies, and no changes to game logic.

The change is small and well-scoped. `restart()` is called first (synchronously updating the store), then `sendFollowUpMessage` queues the notification — the same call order used in `beginGame` and `onPieceDrop`. The only subtle gap is that after restart the player might pick White and not trigger another follow-up until they physically drop a piece, leaving the model idle in the interim; but that same gap already exists in the original `beginGame("w")` path and is out of scope for this fix.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix(chess): notify model on UI-triggered..."](https://github.com/alpic-ai/skybridge/commit/e3dc6b1968fd592b626830d6fe6d99d813730cbb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36393505)</sub>

<!-- /greptile_comment -->