### PR TITLE
feat(devtools): remove outer frame

### DIFF
--- a/packages/devtools/src/components/layout/app-layout.tsx
+++ b/packages/devtools/src/components/layout/app-layout.tsx
@@ -29,68 +29,62 @@ function AppLayout() {
   });
 
   return (
-    <div className="grid h-screen grid-rows-1 overflow-hidden bg-muted p-3 text-foreground">
-      <div className="grid min-h-0 grid-rows-[auto_1fr] overflow-hidden rounded-2xl border border-border bg-background shadow-sm">
-        <Header />
-        {isConnected ? (
-          <div
-            id="devtools-card-body"
-            className="relative flex min-h-0 min-w-0 flex-1"
+    <div className="grid h-screen grid-rows-[auto_1fr] overflow-hidden bg-background text-foreground">
+      <Header />
+      {isConnected ? (
+        <div
+          id="devtools-card-body"
+          className="relative flex min-h-0 min-w-0 flex-1"
+        >
+          <Group
+            orientation="horizontal"
+            id={TOOLS_SPLIT_GROUP_ID}
+            className="flex min-h-0 min-w-0 flex-1"
+            defaultLayout={defaultLayout}
+            onLayoutChanged={onLayoutChanged}
           >
-            <Group
-              orientation="horizontal"
-              id={TOOLS_SPLIT_GROUP_ID}
-              className="flex min-h-0 min-w-0 flex-1"
-              defaultLayout={defaultLayout}
-              onLayoutChanged={onLayoutChanged}
+            <Panel
+              id={TOOLS_LIST_PANEL_ID}
+              defaultSize={380}
+              minSize={250}
+              maxSize={510}
+              className="min-h-0 min-w-0"
             >
-              <Panel
-                id={TOOLS_LIST_PANEL_ID}
-                defaultSize={380}
-                minSize={250}
-                maxSize={510}
-                className="min-h-0 min-w-0"
-              >
-                <aside className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
-                  <Suspense fallback={null}>
-                    <ToolsList />
-                  </Suspense>
-                </aside>
-              </Panel>
-              <Separator className="w-px shrink-0 bg-border transition-colors hover:bg-ring data-separator-active:bg-ring" />
-              <Panel
-                id={TOOL_PANEL_ID}
-                minSize={320}
-                className="min-h-0 min-w-0"
-              >
-                <main className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
-                  <Suspense fallback={null}>
-                    <ToolPanel />
-                  </Suspense>
-                </main>
-              </Panel>
-            </Group>
+              <aside className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
+                <Suspense fallback={null}>
+                  <ToolsList />
+                </Suspense>
+              </aside>
+            </Panel>
+            <Separator className="w-px shrink-0 bg-border transition-colors hover:bg-ring data-separator-active:bg-ring" />
+            <Panel id={TOOL_PANEL_ID} minSize={320} className="min-h-0 min-w-0">
+              <main className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
+                <Suspense fallback={null}>
+                  <ToolPanel />
+                </Suspense>
+              </main>
+            </Panel>
+          </Group>
+        </div>
+      ) : (
+        <div className="flex items-center justify-center">
+          <div className="space-y-4 text-center">
+            <p className="text-sm text-muted-foreground">
+              {status === "connecting"
+                ? "Connecting to server..."
+                : requiresAuth
+                  ? "Authentication required to access this server."
+                  : "Not connected to a server."}
+            </p>
+            {status !== "connecting" && (
+              <Button variant="secondary" onClick={connectToServer}>
+                <PlugZap className="size-3.5" />
+                Connect
+              </Button>
+            )}
           </div>
-        ) : (
-          <div className="flex items-center justify-center">
-            <div className="space-y-4 text-center">
-              <p className="text-sm text-muted-foreground">
-                {status === "connecting"
-                  ? "Connecting to server..."
-                  : requiresAuth
-                    ? "Authentication required to access this server."
-                    : "Not connected to a server."}
-              </p>
-              {status !== "connecting" && (
-                <Button variant="secondary" onClick={connectToServer}>
-                  <PlugZap className="size-3.5" />
-                  Connect
-                </Button>
-              )}
-            </div>
-          </div>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/devtools/src/components/layout/tools-list/accordion-trigger.tsx
+++ b/packages/devtools/src/components/layout/tools-list/accordion-trigger.tsx
@@ -23,7 +23,7 @@ export function AccordionTrigger({
       <AccordionPrimitive.Trigger
         data-slot="accordion-trigger"
         className={cn(
-          "flex min-h-0 min-w-0 flex-1 items-center gap-2 pl-3 pr-2 py-2.5 h-12",
+          "flex min-h-0 min-w-0 flex-1 items-center gap-2 pl-4 pr-2 py-2.5 h-12",
           "type-text-md font-semibold text-foreground text-left",
           "outline-none focus-visible:outline-none rounded-sm",
           "disabled:pointer-events-none disabled:opacity-50",
@@ -37,7 +37,7 @@ export function AccordionTrigger({
         {children}
       </AccordionPrimitive.Trigger>
       {action != null ? (
-        <div className="flex shrink-0 items-center pr-3">{action}</div>
+        <div className="flex shrink-0 items-center pr-4">{action}</div>
       ) : null}
     </AccordionPrimitive.Header>
   );

--- a/packages/devtools/src/components/layout/tools-list/index.tsx
+++ b/packages/devtools/src/components/layout/tools-list/index.tsx
@@ -45,7 +45,7 @@ function ToolsList() {
 
   return (
     <div className="grid h-full min-h-0 grid-rows-[auto_1fr]">
-      <header className="flex h-9 items-center justify-between border-b border-border  px-3 pr-0">
+      <header className="flex h-9 items-center justify-between border-b border-border pl-4 pr-0">
         <span className="text-sm font-medium">Tools</span>
         <Button
           onClick={refreshTools}

--- a/packages/devtools/src/components/layout/tools-list/tool-item.tsx
+++ b/packages/devtools/src/components/layout/tools-list/tool-item.tsx
@@ -215,12 +215,12 @@ export function ToolItem({ tool }: { tool: Tool }) {
         </div>
       </AccordionTrigger>
       {tool.description ? (
-        <div className="px-3 pb-3 font-sans">
+        <div className="px-4 pb-3 font-sans">
           <ToolDescription name={tool.name} description={tool.description} />
         </div>
       ) : null}
       <AccordionContent
-        className="px-3 pt-0 pb-3 text-foreground"
+        className="px-4 pt-0 pb-3 text-foreground"
         // Open/close instantly — disable the accordion slide animation (which
         // the ui component hardcodes on the Content root).
         style={{ animation: "none" }}


### PR DESCRIPTION
so smaller screens have more space. before/after on typical 13 inch viewport:

<img width="1402" height="810" alt="Screenshot 2026-06-09 at 15 54 26" src="https://github.com/user-attachments/assets/ed99e81d-63f5-4d43-9e6f-a54c3be1745e" />
<img width="1398" height="805" alt="Screenshot 2026-06-09 at 15 54 16" src="https://github.com/user-attachments/assets/87dc83e5-a358-44ea-802f-c4540fc3b97f" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the outer card frame (border, rounded corners, padding, shadow) from the devtools layout to reclaim screen space on smaller viewports, and bumps the horizontal padding in the tools-list sidebar components from `pl-3`/`px-3`/`pr-3` to `pl-4`/`px-4`/`pr-4` to maintain visual balance without the frame.

- `app-layout.tsx`: strips the outer wrapper div and its `bg-muted p-3` / `rounded-2xl border shadow-sm` styles; the root grid changes from `grid-rows-1` to `grid-rows-[auto_1fr]` so `Header` and the content panel continue to fill the viewport correctly.
- `accordion-trigger.tsx`, `index.tsx`, `tool-item.tsx`: uniform +1 step padding increase on the left/right edges of the sidebar to keep content visually aligned after the frame is gone.

<h3>Confidence Score: 5/5</h3>

Pure layout/styling change with no logic, data, or state mutations — safe to merge.

The change touches only Tailwind class strings and removes one wrapper div. The grid row template fix (grid-rows-[auto_1fr]) correctly replaces grid-rows-1 so the header and content panel still fill the screen, and the padding bumps in the sidebar files are consistent across all three affected components. No conditional logic, API calls, or shared state is touched.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["feat: make sure tool pane content and ap..."](https://github.com/alpic-ai/skybridge/commit/f2d6084bec3e76ff05daaee71f9e209e442111fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36451407)</sub>

<!-- /greptile_comment -->