### PR TITLE
Escape backtick from release body to avoid backticks being see as command substitution

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,9 @@ jobs:
 
       - name: Set version
         id: version
+        env:
+          RELEASE_NAME: ${{ github.event.release.name }}
+          RELEASE_BODY: ${{ github.event.release.body }}
         run: |
           if [ "${{ github.event_name }}" = "release" ]; then
             # Remove 'v' prefix from release tag (e.g., v1.0.0 -> 1.0.0)
@@ -45,14 +48,14 @@ jobs:
               exit 1
             fi
 
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
-            echo "tag=latest" >> $GITHUB_OUTPUT
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
             echo "✅ Release version: $VERSION"
-            echo "Release name: ${{ github.event.release.name }}"
-            echo "Release body: ${{ github.event.release.body }}"
+            printf 'Release name: %s\n' "$RELEASE_NAME"
+            printf 'Release body:\n%s\n' "$RELEASE_BODY"
           else
-            echo "version=0.0.0-dev.${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
-            echo "tag=dev" >> $GITHUB_OUTPUT
+            echo "version=0.0.0-dev.${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+            echo "tag=dev" >> "$GITHUB_OUTPUT"
             echo "✅ Dev version: 0.0.0-dev.${GITHUB_SHA::7}"
           fi
 


### PR DESCRIPTION
Reference release metadata via env vars so markdown content (backticks, ${...}, etc.) is treated as data, not shell code

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a shell-injection / command-substitution risk in the `Set version` step by routing `github.event.release.name` and `github.event.release.body` through step-level `env:` variables rather than interpolating them directly into the shell script with `${{ }}`. The `notify-discord` job was already safe (it used `env:` vars fed into `jq --arg`).

- `RELEASE_NAME` and `RELEASE_BODY` are now declared as step `env:` entries so their values are treated as plain data by the shell, preventing backticks, `$()`, or `${}` in a release body from being evaluated as shell code.
- `printf 'Release body:\n%s\n' "$RELEASE_BODY"` replaces the former `echo "${{ github.event.release.body }}"`, which is the correct idiom for safely printing potentially multi-line/special-character strings.
- `$GITHUB_OUTPUT` redirect targets are now double-quoted — a minor but correct hardening improvement.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted, correct hardening of how user-controlled release metadata is passed into the shell step.

The fix is narrowly scoped: it moves two GitHub context values into env vars so the shell never sees them as interpolated text, and switches to printf for safe logging. The critical output path (VERSION computation and GITHUB_OUTPUT writes) is unaffected. The notify-discord job was already handling RELEASE_BODY safely via jq --arg. No regressions are introduced.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["Escape backtick from release body to avo..."](https://github.com/alpic-ai/skybridge/commit/0169cdbf61babb028bc78b124a165643a1ccf234) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36497115)</sub>

<!-- /greptile_comment -->