### PR TITLE
Update discord limit

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -136,7 +136,7 @@ jobs:
           RELEASE_URL: ${{ github.event.release.html_url }}
           RELEASE_BODY: ${{ github.event.release.body }}
         run: |
-          BODY=$(echo "$RELEASE_BODY" | cut -c 1-1500)
+          BODY=${RELEASE_BODY:0:4000}
           PAYLOAD=$(jq -n \
             --arg title "Skybridge $RELEASE_VERSION released" \
             --arg url "$RELEASE_URL" \


### PR DESCRIPTION
Updated to 4000 chars, leaving a small margin under Discord's 4096 embed description limit Use bash substring truncation, which actually limits the whole string and counts by character (so it won't split emoji into invalid UTF-8 the way a byte-based head -c could)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Discord notification step in the release workflow, increasing the embed description character limit from 1500 to 4000 and switching from `cut -c` to bash substring expansion (`${RELEASE_BODY:0:4000}`).

- The limit increase (1500 → 4000) gives more room under Discord's 4096 embed description cap, and the 96-character margin is a reasonable buffer.
- Bash substring expansion in a UTF-8 locale (which ubuntu-latest uses) correctly counts Unicode code points, so multi-byte characters like emoji will not be split mid-sequence; this is a safe replacement for `cut -c`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-line swap in a Discord notification step with no impact on the publish or release path itself.

The only file touched is a single line in the Discord notification job. The new bash substring expansion correctly truncates the release body before it is passed through `jq --arg`, which already handles JSON-escaping; there is no injection risk. The 4000-character limit leaves a comfortable buffer below Discord's 4096 embed description cap.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["Update discord limit"](https://github.com/alpic-ai/skybridge/commit/5f4d19c0e527b1dc3d39f7b37ca3be60201fc8c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36504783)</sub>

<!-- /greptile_comment -->