### PR TITLE
Expose devtools interface as WebMCP tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         working-directory: packages/devtools
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -92,7 +92,7 @@ jobs:
 
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: packages/devtools/playwright-report/

--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Restore Next.js cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: landing/.next/cache
           key: ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('landing/**/*.[jt]s', 'landing/**/*.[jt]sx') }}

--- a/packages/devtools/e2e/tests/every-input-type.spec.ts
+++ b/packages/devtools/e2e/tests/every-input-type.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 
 test.describe("every-input-type tool", () => {
   test("returns each filled field as structuredContent", async ({ page }) => {
-    await page.goto("/?tool=every-input-type");
+    await page.goto("/");
 
     const tool = page.locator('[data-tool-name="every-input-type"]');
 

--- a/packages/devtools/e2e/tests/every-input-type.spec.ts
+++ b/packages/devtools/e2e/tests/every-input-type.spec.ts
@@ -4,29 +4,28 @@ test.describe("every-input-type tool", () => {
   test("returns each filled field as structuredContent", async ({ page }) => {
     await page.goto("/?tool=every-input-type");
 
-    await page.getByLabel("name").fill("Alice");
-    await page.getByLabel("age").fill("30");
-    await page.getByLabel("favoriteNumber").fill("7");
-    await page.getByLabel("isDeveloper").click();
-    await page.getByLabel("bio").fill("hello world");
+    const tool = page.locator('[data-tool-name="every-input-type"]');
 
-    await page.getByLabel("experienceLevel").click();
+    await tool.getByLabel("name").fill("Alice");
+    await tool.getByLabel("age").fill("30");
+    await tool.getByLabel("favoriteNumber").fill("7");
+    await tool.getByLabel("isDeveloper").click();
+    await tool.getByLabel("bio").fill("hello world");
+
+    await tool.getByLabel("experienceLevel").click();
     await page.getByRole("option", { name: "advanced" }).click();
 
-    await page.getByLabel("colors").click();
+    await tool.getByLabel("colors").click();
     await page.getByRole("option", { name: "red" }).click();
     await page.getByRole("option", { name: "blue" }).click();
     await page.keyboard.press("Escape");
 
-    await page.getByLabel("enableNotifications").click();
-    await page.getByLabel("maxExamples").fill("5");
-    await page.getByLabel("theme").click();
+    await tool.getByLabel("enableNotifications").click();
+    await tool.getByLabel("maxExamples").fill("5");
+    await tool.getByLabel("theme").click();
     await page.getByRole("option", { name: "dark" }).click();
 
-    await page
-      .locator('[data-tool-name="every-input-type"]')
-      .getByRole("button", { name: /^run$/i })
-      .click();
+    await tool.getByRole("button", { name: /^run$/i }).click();
 
     const main = page.getByRole("main");
     await expect(main).toContainText('"name": "Alice"');

--- a/packages/devtools/e2e/tests/smoke.spec.ts
+++ b/packages/devtools/e2e/tests/smoke.spec.ts
@@ -17,12 +17,9 @@ test.describe("devtools smoke", () => {
     await page.goto("/?tool=echo");
 
     const token = `ping-${crypto.randomUUID()}`;
-    await page.getByLabel("message").fill(token);
-    // Every tool header has its own Run button — scope to this tool.
-    await page
-      .locator('[data-tool-name="echo"]')
-      .getByRole("button", { name: /^run$/i })
-      .click();
+    const echo = page.locator('[data-tool-name="echo"]');
+    await echo.getByLabel("message").fill(token);
+    await echo.getByRole("button", { name: /^run$/i }).click();
 
     // Token appears in the rendered JSON response in the main panel.
     await expect(page.getByRole("main")).toContainText(token);
@@ -34,11 +31,9 @@ test.describe("devtools smoke", () => {
     await page.goto("/?tool=echo-card");
 
     const token = `card-${crypto.randomUUID()}`;
-    await page.getByLabel("message").fill(token);
-    await page
-      .locator('[data-tool-name="echo-card"]')
-      .getByRole("button", { name: /^run$/i })
-      .click();
+    const echoCard = page.locator('[data-tool-name="echo-card"]');
+    await echoCard.getByLabel("message").fill(token);
+    await echoCard.getByRole("button", { name: /^run$/i }).click();
 
     // First-time view compilation by Vite can take a few seconds.
     const widget = page.frameLocator('iframe[title="html-preview"]');
@@ -51,7 +46,9 @@ test.describe("visibility badge", () => {
     page,
   }) => {
     await page.goto("/?tool=dual-visibility-tool");
-    const badges = page.getByTestId("tool-visibility");
+    const badges = page
+      .locator('[data-tool-name="dual-visibility-tool"]')
+      .getByTestId("tool-visibility");
     await expect(badges).toBeVisible();
     await expect(badges.getByText("model", { exact: true })).toBeVisible();
     await expect(badges.getByText("app", { exact: true })).toBeVisible();
@@ -61,7 +58,9 @@ test.describe("visibility badge", () => {
     page,
   }) => {
     await page.goto("/?tool=model-only-tool");
-    const badges = page.getByTestId("tool-visibility");
+    const badges = page
+      .locator('[data-tool-name="model-only-tool"]')
+      .getByTestId("tool-visibility");
     await expect(badges).toBeVisible();
     await expect(badges.getByText("model", { exact: true })).toBeVisible();
     await expect(badges.getByText("app", { exact: true })).toHaveCount(0);
@@ -71,7 +70,9 @@ test.describe("visibility badge", () => {
     page,
   }) => {
     await page.goto("/?tool=app-only-tool");
-    const badges = page.getByTestId("tool-visibility");
+    const badges = page
+      .locator('[data-tool-name="app-only-tool"]')
+      .getByTestId("tool-visibility");
     await expect(badges).toBeVisible();
     await expect(badges.getByText("app", { exact: true })).toBeVisible();
     await expect(badges.getByText("model", { exact: true })).toHaveCount(0);
@@ -79,6 +80,8 @@ test.describe("visibility badge", () => {
 
   test("hides the badge area when visibility is not set", async ({ page }) => {
     await page.goto("/?tool=echo");
-    await expect(page.getByTestId("tool-visibility")).toHaveCount(0);
+    await expect(
+      page.locator('[data-tool-name="echo"]').getByTestId("tool-visibility"),
+    ).toHaveCount(0);
   });
 });

--- a/packages/devtools/e2e/tests/smoke.spec.ts
+++ b/packages/devtools/e2e/tests/smoke.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 
 test.describe("devtools smoke", () => {
   test("connects to the fixture and lists tools", async ({ page }) => {
-    await page.goto("/?tool=echo");
+    await page.goto("/");
 
     await expect(page.getByText("e2e-fixture")).toBeVisible();
     await expect(
@@ -14,7 +14,7 @@ test.describe("devtools smoke", () => {
   });
 
   test("calls a plain tool and renders the response", async ({ page }) => {
-    await page.goto("/?tool=echo");
+    await page.goto("/");
 
     const token = `ping-${crypto.randomUUID()}`;
     const echo = page.locator('[data-tool-name="echo"]');
@@ -28,7 +28,7 @@ test.describe("devtools smoke", () => {
   test("calls a widget tool and renders inside the iframe", async ({
     page,
   }) => {
-    await page.goto("/?tool=echo-card");
+    await page.goto("/");
 
     const token = `card-${crypto.randomUUID()}`;
     const echoCard = page.locator('[data-tool-name="echo-card"]');
@@ -45,7 +45,7 @@ test.describe("visibility badge", () => {
   test("renders both scopes when visibility is ['model', 'app']", async ({
     page,
   }) => {
-    await page.goto("/?tool=dual-visibility-tool");
+    await page.goto("/");
     const badges = page
       .locator('[data-tool-name="dual-visibility-tool"]')
       .getByTestId("tool-visibility");
@@ -57,7 +57,7 @@ test.describe("visibility badge", () => {
   test("renders only the model badge when visibility is ['model']", async ({
     page,
   }) => {
-    await page.goto("/?tool=model-only-tool");
+    await page.goto("/");
     const badges = page
       .locator('[data-tool-name="model-only-tool"]')
       .getByTestId("tool-visibility");
@@ -69,7 +69,7 @@ test.describe("visibility badge", () => {
   test("renders only the app badge when visibility is ['app']", async ({
     page,
   }) => {
-    await page.goto("/?tool=app-only-tool");
+    await page.goto("/");
     const badges = page
       .locator('[data-tool-name="app-only-tool"]')
       .getByTestId("tool-visibility");
@@ -79,7 +79,7 @@ test.describe("visibility badge", () => {
   });
 
   test("hides the badge area when visibility is not set", async ({ page }) => {
-    await page.goto("/?tool=echo");
+    await page.goto("/");
     await expect(
       page.locator('[data-tool-name="echo"]').getByTestId("tool-visibility"),
     ).toHaveCount(0);

--- a/packages/devtools/src/components/layout/tool-panel/tool-panel-toolbar.tsx
+++ b/packages/devtools/src/components/layout/tool-panel/tool-panel-toolbar.tsx
@@ -52,7 +52,12 @@ function applyViewOptions(data: FormData): string {
   const { userAgent, setPreference } = useInspectorPreferencesStore.getState();
 
   const mode = data.get("displayMode");
-  if (isOneOf(mode, ["inline", "pip", "fullscreen"] as const)) {
+  if (
+    isOneOf(
+      mode,
+      displayModes.map((d) => d.mode),
+    )
+  ) {
     setPreference("displayMode", mode);
   }
 

--- a/packages/devtools/src/components/layout/tool-panel/tool-panel-toolbar.tsx
+++ b/packages/devtools/src/components/layout/tool-panel/tool-panel-toolbar.tsx
@@ -327,6 +327,14 @@ export const ToolPanelToolbar = ({
           </Command>
         </PopoverContent>
       </Popover>
+      <div className="sr-only" aria-hidden>
+        <ViewOptionSelect
+          name="locale"
+          description="The BCP 47 locale code to preview the view in."
+          value={locale}
+          options={locales.map((l) => l.code)}
+        />
+      </div>
 
       <ToolbarToggle
         icon={isMobile ? Smartphone : Monitor}
@@ -344,15 +352,6 @@ export const ToolPanelToolbar = ({
           onClick={onOpenLogs}
         />
       )}
-
-      <div className="sr-only" aria-hidden>
-        <ViewOptionSelect
-          name="locale"
-          description="The BCP 47 locale code to preview the view in."
-          value={locale}
-          options={locales.map((l) => l.code)}
-        />
-      </div>
     </form>
   );
 };

--- a/packages/devtools/src/components/layout/tool-panel/tool-panel-toolbar.tsx
+++ b/packages/devtools/src/components/layout/tool-panel/tool-panel-toolbar.tsx
@@ -30,21 +30,13 @@ import type { RequestDisplayMode } from "skybridge/web";
 import { useInspectorPreferencesStore } from "@/lib/inspector-preferences-store.js";
 import { cn } from "@/lib/utils.js";
 import { locales } from "./locales.js";
+import { isOneOf } from "./utils.js";
 
 const displayModes: { mode: RequestDisplayMode; icon: LucideIcon }[] = [
   { mode: "fullscreen", icon: Maximize2 },
   { mode: "pip", icon: PictureInPicture2 },
   { mode: "inline", icon: SquareSplitVertical },
 ];
-
-function isOneOf<T extends string>(
-  value: unknown,
-  allowed: readonly T[],
-): value is T {
-  return (
-    typeof value === "string" && (allowed as readonly string[]).includes(value)
-  );
-}
 
 // Applies the form's current values to the preferences store and returns a
 // human-readable summary for the agent.
@@ -156,9 +148,6 @@ function ToolbarButton({
   );
 }
 
-// Native checkbox styled like a ToolbarButton, so binary preferences are real
-// form controls: the declarative WebMCP form derives a boolean property from
-// them, and toggling (by user click or agent fill) submits the form.
 function ToolbarToggle({
   icon: Icon,
   label,
@@ -212,9 +201,6 @@ export const ToolPanelToolbar = ({
   const formRef = useRef<HTMLFormElement>(null);
   const [localeOpen, setLocaleOpen] = useState(false);
 
-  // The locale picker is a custom popover (not a form control), so it writes
-  // the chosen code into its hidden mirror select and submits — keeping the
-  // form's submit handler the single place where preferences are applied.
   const submitLocale = (code: string) => {
     const form = formRef.current;
     const control = form?.elements.namedItem("locale");
@@ -359,8 +345,6 @@ export const ToolPanelToolbar = ({
         />
       )}
 
-      {/* Agent-facing mirror of the locale picker — the only control that
-          can't be a native form element (it's a searchable popover). */}
       <div className="sr-only" aria-hidden>
         <ViewOptionSelect
           name="locale"

--- a/packages/devtools/src/components/layout/tool-panel/tool-panel-toolbar.tsx
+++ b/packages/devtools/src/components/layout/tool-panel/tool-panel-toolbar.tsx
@@ -24,7 +24,7 @@ import {
   SquareSplitVertical,
   Sun,
 } from "lucide-react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import type { RequestDisplayMode } from "skybridge/web";
 
 import { useInspectorPreferencesStore } from "@/lib/inspector-preferences-store.js";
@@ -36,6 +36,83 @@ const displayModes: { mode: RequestDisplayMode; icon: LucideIcon }[] = [
   { mode: "pip", icon: PictureInPicture2 },
   { mode: "inline", icon: SquareSplitVertical },
 ];
+
+function isOneOf<T extends string>(
+  value: unknown,
+  allowed: readonly T[],
+): value is T {
+  return (
+    typeof value === "string" && (allowed as readonly string[]).includes(value)
+  );
+}
+
+// Applies the form's current values to the preferences store and returns a
+// human-readable summary for the agent.
+function applyViewOptions(data: FormData): string {
+  const { userAgent, setPreference } = useInspectorPreferencesStore.getState();
+
+  const mode = data.get("displayMode");
+  if (isOneOf(mode, ["inline", "pip", "fullscreen"] as const)) {
+    setPreference("displayMode", mode);
+  }
+
+  // Checkboxes are absent from FormData when unchecked, so absence is
+  // meaningful (false) — apply unconditionally.
+  setPreference("theme", data.has("darkTheme") ? "dark" : "light");
+  setPreference("userAgent", {
+    ...userAgent,
+    device: {
+      ...userAgent?.device,
+      type: data.has("mobileDevice") ? "mobile" : "desktop",
+    },
+  });
+
+  const locale = data.get("locale");
+  if (
+    isOneOf(
+      locale,
+      locales.map((l) => l.code),
+    )
+  ) {
+    setPreference("locale", locale);
+  }
+
+  const next = useInspectorPreferencesStore.getState();
+  return `View preview options: displayMode=${next.displayMode}, theme=${next.theme}, locale=${next.locale}, device=${next.userAgent?.device?.type ?? "desktop"}.`;
+}
+
+// Visually-hidden native select mirroring one preference, so the declarative
+// WebMCP form derives an enum input schema from it and agents can set it —
+// while the visible toolbar keeps its custom (non-form-control) buttons.
+// Changes (from agents or from the visible buttons writing into it) are
+// applied exclusively through the form's submit handler.
+function ViewOptionSelect({
+  name,
+  description,
+  value,
+  options,
+}: {
+  name: string;
+  description: string;
+  value: string;
+  options: readonly string[];
+}) {
+  return (
+    <select
+      name={name}
+      toolparamdescription={description}
+      value={value}
+      tabIndex={-1}
+      onChange={(e) => e.currentTarget.form?.requestSubmit()}
+    >
+      {options.map((option) => (
+        <option key={option} value={option}>
+          {option}
+        </option>
+      ))}
+    </select>
+  );
+}
 
 const buttonBaseClass =
   "inline-flex h-7 cursor-pointer items-center gap-1.5 rounded-md px-2.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
@@ -74,6 +151,45 @@ function ToolbarButton({
   );
 }
 
+// Native checkbox styled like a ToolbarButton, so binary preferences are real
+// form controls: the declarative WebMCP form derives a boolean property from
+// them, and toggling (by user click or agent fill) submits the form.
+function ToolbarToggle({
+  icon: Icon,
+  label,
+  name,
+  description,
+  checked,
+}: {
+  icon: LucideIcon;
+  label: string;
+  name: string;
+  description: string;
+  checked: boolean;
+}) {
+  return (
+    <label
+      className={cn(
+        buttonBaseClass,
+        "border border-border bg-background",
+        buttonIdleClass,
+        "has-focus-visible:ring-1 has-focus-visible:ring-ring",
+      )}
+    >
+      <input
+        type="checkbox"
+        name={name}
+        toolparamdescription={description}
+        checked={checked}
+        onChange={(e) => e.currentTarget.form?.requestSubmit()}
+        className="sr-only"
+      />
+      <Icon className="size-3.5" />
+      <span>{label}</span>
+    </label>
+  );
+}
+
 type ToolPanelToolbarProps = {
   logsOpen: boolean;
   onOpenLogs: () => void;
@@ -87,9 +203,21 @@ export const ToolPanelToolbar = ({
   const theme = useInspectorPreferencesStore((s) => s.theme);
   const locale = useInspectorPreferencesStore((s) => s.locale);
   const userAgent = useInspectorPreferencesStore((s) => s.userAgent);
-  const setPreference = useInspectorPreferencesStore((s) => s.setPreference);
 
+  const formRef = useRef<HTMLFormElement>(null);
   const [localeOpen, setLocaleOpen] = useState(false);
+
+  // The locale picker is a custom popover (not a form control), so it writes
+  // the chosen code into its hidden mirror select and submits — keeping the
+  // form's submit handler the single place where preferences are applied.
+  const submitLocale = (code: string) => {
+    const form = formRef.current;
+    const control = form?.elements.namedItem("locale");
+    if (control instanceof HTMLSelectElement) {
+      control.value = code;
+    }
+    form?.requestSubmit();
+  };
 
   const isDark = theme === "dark";
   const isMobile = (userAgent?.device?.type ?? "desktop") === "mobile";
@@ -97,32 +225,62 @@ export const ToolPanelToolbar = ({
     locales.find((l) => l.code === locale)?.englishName ?? locale;
 
   return (
-    <div className="mt-3 flex w-full shrink-0 items-center gap-1.5 px-3">
-      <div className="inline-flex h-7 items-center rounded-md border border-border bg-background p-0.5">
+    <form
+      ref={formRef}
+      toolname="devtools_set_view_options"
+      tooldescription="Set the Skybridge devtools view preview options. Any subset of fields can be changed: display mode, theme, locale, and device type."
+      toolautosubmit=""
+      onSubmit={(event) => {
+        event.preventDefault();
+        const summary = applyViewOptions(new FormData(event.currentTarget));
+        const native = event.nativeEvent;
+        if (
+          native instanceof SubmitEvent &&
+          native.agentInvoked &&
+          typeof native.respondWith === "function"
+        ) {
+          native.respondWith(
+            Promise.resolve({ content: [{ type: "text", text: summary }] }),
+          );
+        }
+      }}
+      className="mt-3 flex w-full shrink-0 items-center gap-1.5 px-3"
+    >
+      <fieldset className="inline-flex h-7 items-center rounded-md border border-border bg-background p-0.5">
+        <legend className="sr-only">Display mode</legend>
         {displayModes.map(({ mode, icon: Icon }) => {
           const selected = displayMode === mode;
           return (
-            <button
+            <label
               key={mode}
-              type="button"
-              aria-pressed={selected}
-              onClick={() => setPreference("displayMode", mode)}
               className={cn(
-                "inline-flex h-full cursor-pointer items-center gap-1.5 rounded px-2 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                "inline-flex h-full cursor-pointer items-center gap-1.5 rounded px-2 text-xs font-medium transition-colors",
+                "has-focus-visible:ring-1 has-focus-visible:ring-ring",
                 selected ? buttonSelectedClass : buttonIdleClass,
               )}
             >
+              <input
+                type="radio"
+                name="displayMode"
+                value={mode}
+                checked={selected}
+                onChange={(e) => e.currentTarget.form?.requestSubmit()}
+                toolparamdescription="How the host lays out the rendered view."
+                className="sr-only"
+              />
               <Icon className="size-3.5" />
               <span>{mode}</span>
-            </button>
+            </label>
           );
         })}
-      </div>
+      </fieldset>
 
-      <ToolbarButton
+      <ToolbarToggle
         icon={isDark ? Moon : Sun}
         label={isDark ? "dark" : "light"}
-        onClick={() => setPreference("theme", isDark ? "light" : "dark")}
+        name="darkTheme"
+        description="Preview the view in dark theme (true) or light theme (false)."
+        checked={isDark}
       />
 
       <Popover open={localeOpen} onOpenChange={setLocaleOpen}>
@@ -153,7 +311,7 @@ export const ToolPanelToolbar = ({
                     value={l.code}
                     keywords={[l.englishName, l.localeName]}
                     onSelect={(v) => {
-                      setPreference("locale", v);
+                      submitLocale(v);
                       setLocaleOpen(false);
                     }}
                   >
@@ -179,18 +337,12 @@ export const ToolPanelToolbar = ({
         </PopoverContent>
       </Popover>
 
-      <ToolbarButton
+      <ToolbarToggle
         icon={isMobile ? Smartphone : Monitor}
         label={isMobile ? "mobile" : "desktop"}
-        onClick={() =>
-          setPreference("userAgent", {
-            ...userAgent,
-            device: {
-              ...userAgent?.device,
-              type: isMobile ? "desktop" : "mobile",
-            },
-          })
-        }
+        name="mobileDevice"
+        description="Preview the view on a mobile device (true) or desktop (false)."
+        checked={isMobile}
       />
 
       {!logsOpen && displayMode !== "fullscreen" && (
@@ -201,6 +353,17 @@ export const ToolPanelToolbar = ({
           onClick={onOpenLogs}
         />
       )}
-    </div>
+
+      {/* Agent-facing mirror of the locale picker — the only control that
+          can't be a native form element (it's a searchable popover). */}
+      <div className="sr-only" aria-hidden>
+        <ViewOptionSelect
+          name="locale"
+          description="The BCP 47 locale code to preview the view in."
+          value={locale}
+          options={locales.map((l) => l.code)}
+        />
+      </div>
+    </form>
   );
 };

--- a/packages/devtools/src/components/layout/tool-panel/utils.ts
+++ b/packages/devtools/src/components/layout/tool-panel/utils.ts
@@ -1,0 +1,8 @@
+export function isOneOf<T extends string>(
+  value: unknown,
+  allowed: readonly T[],
+): value is T {
+  return (
+    typeof value === "string" && (allowed as readonly string[]).includes(value)
+  );
+}

--- a/packages/devtools/src/components/layout/tools-list/form/templates.tsx
+++ b/packages/devtools/src/components/layout/tools-list/form/templates.tsx
@@ -22,6 +22,7 @@ import {
 export function BaseInputTemplate(props: BaseInputTemplateProps) {
   const {
     id,
+    name,
     value,
     required,
     disabled,
@@ -57,6 +58,8 @@ export function BaseInputTemplate(props: BaseInputTemplateProps) {
   return (
     <input
       id={id}
+      name={name}
+      toolparamdescription={schema.description}
       className={denseInputClass}
       value={value ?? ""}
       required={required}

--- a/packages/devtools/src/components/layout/tools-list/form/tool-form-tag.tsx
+++ b/packages/devtools/src/components/layout/tools-list/form/tool-form-tag.tsx
@@ -1,0 +1,19 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types";
+import { useMemo } from "react";
+
+export function ToolFormTag({
+  name,
+  description,
+}: Pick<Tool, "name" | "description">) {
+  return useMemo(
+    () => (props: React.ComponentProps<"form">) => (
+      <form
+        toolname={name}
+        tooldescription={description}
+        toolautosubmit=""
+        {...props}
+      />
+    ),
+    [name, description],
+  );
+}

--- a/packages/devtools/src/components/layout/tools-list/form/widgets.tsx
+++ b/packages/devtools/src/components/layout/tools-list/form/widgets.tsx
@@ -28,12 +28,14 @@ import { denseSelectTriggerClass, denseTextareaClass } from "./styles.js";
 function TextareaWidget(props: WidgetProps) {
   const {
     id,
+    name,
     value,
     required,
     disabled,
     readonly,
     placeholder,
     options,
+    schema,
     onChange,
     onBlur,
     onFocus,
@@ -44,6 +46,8 @@ function TextareaWidget(props: WidgetProps) {
   return (
     <textarea
       id={id}
+      name={name}
+      toolparamdescription={schema.description}
       rows={rows}
       className={denseTextareaClass}
       value={value ?? ""}

--- a/packages/devtools/src/components/layout/tools-list/index.tsx
+++ b/packages/devtools/src/components/layout/tools-list/index.tsx
@@ -2,20 +2,16 @@ import { Accordion } from "@alpic-ai/ui/components/accordion";
 import { Button } from "@alpic-ai/ui/components/button";
 import { useTimeout } from "ahooks";
 import { RefreshCw } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useSuspenseTools } from "@/lib/mcp/index.js";
-import { useSelectedToolName } from "@/lib/nuqs.js";
 import { queryClient } from "@/lib/query-client.js";
 import { cn } from "@/lib/utils.js";
 import { ToolItem } from "./tool-item.js";
 
 function ToolsList() {
   const tools = useSuspenseTools();
-  // `selectedTool` (?tool=) drives the result view (right pane). Which tool
-  // accordions are expanded is separate local state — 0..N can be open at once.
-  const [selectedTool, setSelectedTool] = useSelectedToolName();
-  const [openTools, setOpenTools] = useState<string[]>(() =>
-    selectedTool ? [selectedTool] : [],
+  const [openTools, setOpenTools] = useState<string[]>(
+    tools.map((tool) => tool.name),
   );
   const [refreshing, setRefreshing] = useState(false);
   const [tailDelay, setTailDelay] = useState<number | undefined>(undefined);
@@ -24,14 +20,6 @@ function ToolsList() {
     setRefreshing(false);
     setTailDelay(undefined);
   }, tailDelay);
-
-  // On first load with nothing selected, focus + open the first tool.
-  useEffect(() => {
-    if (selectedTool == null && tools[0]) {
-      setSelectedTool(tools[0].name);
-      setOpenTools((prev) => (prev.length ? prev : [tools[0].name]));
-    }
-  }, [selectedTool, tools, setSelectedTool]);
 
   const refreshTools = async () => {
     setTailDelay(undefined);

--- a/packages/devtools/src/components/layout/tools-list/tool-item.tsx
+++ b/packages/devtools/src/components/layout/tools-list/tool-item.tsx
@@ -103,7 +103,7 @@ export function ToolItem({ tool }: { tool: Tool }) {
     // Focus this tool so the result view (right pane) shows its output — even
     // when Run was clicked from a collapsed header.
     setSelectedTool(tool.name);
-    await callTool({ toolName: tool.name, args: formData });
+    return await callTool({ toolName: tool.name, args: formData });
   };
 
   // Enter/⌘Enter run the tool whose input is focused. Scoped per tool so that
@@ -236,6 +236,7 @@ export function ToolItem({ tool }: { tool: Tool }) {
           setJsonError={setJsonError}
           saved={saved}
           inputInvalid={inputInvalid}
+          onRun={handleRun}
         />
       </AccordionContent>
     </AccordionItem>
@@ -400,6 +401,7 @@ function ToolBody({
   setJsonError,
   saved,
   inputInvalid,
+  onRun,
 }: {
   tool: Tool;
   formData: Record<string, unknown>;
@@ -411,6 +413,7 @@ function ToolBody({
   setJsonError: (value: boolean) => void;
   saved: SavedInputController;
   inputInvalid: boolean;
+  onRun: () => Promise<unknown>;
 }) {
   const hasInput =
     tool.inputSchema &&
@@ -527,10 +530,11 @@ function ToolBody({
           </div>
           <TabsContent value="form">
             <FormBody
-              schema={tool.inputSchema as RJSFSchema}
+              tool={tool}
               formData={formData}
               setFormData={setFormData}
               formRef={formRef}
+              onRun={onRun}
             />
           </TabsContent>
           {/* -mt-4 cancels the Tabs gap so the textarea's top merges into the
@@ -559,17 +563,34 @@ function ToolBody({
 }
 
 function FormBody({
-  schema,
+  tool,
   formData,
   setFormData,
   formRef,
+  onRun,
 }: {
-  schema: RJSFSchema;
+  tool: Tool;
   formData: Record<string, unknown>;
   setFormData: (data: Record<string, unknown> | null) => void;
   formRef: React.RefObject<Form<unknown, RJSFSchema> | null>;
+  onRun: () => Promise<unknown>;
 }) {
+  const schema = tool.inputSchema as RJSFSchema;
   const containerRef = useRef<HTMLDivElement>(null);
+
+  const ToolFormTag = useMemo(() => {
+    const { name, description } = tool;
+    return function ToolFormTag(props: React.ComponentProps<"form">) {
+      return (
+        <form
+          toolname={name}
+          tooldescription={description}
+          toolautosubmit=""
+          {...props}
+        />
+      );
+    };
+  }, [tool]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -590,11 +611,22 @@ function FormBody({
     <div ref={containerRef}>
       <FormComponent
         ref={formRef as React.RefObject<Form<unknown, RJSFSchema>>}
+        tagName={ToolFormTag}
         schema={schema}
         validator={validator}
         uiSchema={buildFormUiSchema(schema)}
         formData={formData}
         onChange={(data) => setFormData(data.formData)}
+        onSubmit={(_, event) => {
+          const native = event.nativeEvent;
+          const run = onRun();
+          if (
+            native instanceof SubmitEvent &&
+            typeof native.respondWith === "function"
+          ) {
+            native.respondWith(run);
+          }
+        }}
         showErrorList={false}
         widgets={formWidgets}
         templates={formTemplates}

--- a/packages/devtools/src/components/layout/tools-list/tool-item.tsx
+++ b/packages/devtools/src/components/layout/tools-list/tool-item.tsx
@@ -38,6 +38,7 @@ import { useCallToolResult, useStore } from "@/lib/store.js";
 import { cn } from "@/lib/utils.js";
 import { AccordionTrigger } from "./accordion-trigger.js";
 import { buildFormUiSchema, formTemplates, formWidgets } from "./form/index.js";
+import { ToolFormTag } from "./form/tool-form-tag.js";
 import { SavedInputsDropdown, SaveInputDialog } from "./saved-inputs.js";
 import { TruncatedDescription } from "./truncated-description.js";
 
@@ -421,8 +422,6 @@ function ToolBody({
     tool.inputSchema &&
     Object.keys(tool.inputSchema.properties ?? {}).length > 0;
 
-  // Tools without input render no form, so the declarative WebMCP path
-  // (`<form toolname …>`) never applies. Register them imperatively instead.
   useRegisterWebMcpTool({
     tool,
     enabled: !hasInput,
@@ -599,19 +598,6 @@ function FormBody({
   const schema = tool.inputSchema as RJSFSchema;
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const ToolFormTag = useMemo(() => {
-    return function ToolFormTag(props: React.ComponentProps<"form">) {
-      return (
-        <form
-          toolname={tool.name}
-          tooldescription={tool.description}
-          toolautosubmit=""
-          {...props}
-        />
-      );
-    };
-  }, [tool.name, tool.description]);
-
   useEffect(() => {
     const container = containerRef.current;
     if (!container) {
@@ -631,7 +617,7 @@ function FormBody({
     <div ref={containerRef}>
       <FormComponent
         ref={formRef as React.RefObject<Form<unknown, RJSFSchema>>}
-        tagName={ToolFormTag}
+        tagName={ToolFormTag(tool)}
         idPrefix={tool.name}
         schema={schema}
         validator={validator}

--- a/packages/devtools/src/components/layout/tools-list/tool-item.tsx
+++ b/packages/devtools/src/components/layout/tools-list/tool-item.tsx
@@ -633,6 +633,7 @@ function FormBody({
       <FormComponent
         ref={formRef as React.RefObject<Form<unknown, RJSFSchema>>}
         tagName={ToolFormTag}
+        idPrefix={tool.name}
         schema={schema}
         validator={validator}
         uiSchema={buildFormUiSchema(schema)}

--- a/packages/devtools/src/components/layout/tools-list/tool-item.tsx
+++ b/packages/devtools/src/components/layout/tools-list/tool-item.tsx
@@ -19,6 +19,7 @@ import validator from "@rjsf/validator-ajv8";
 import { useKeyPress } from "ahooks";
 import { Braces, ClipboardList, Loader2, Play, Save } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import type { CallToolResponse } from "skybridge/web";
 import { useAuthStore } from "@/lib/auth-store.js";
 import { CopyButton } from "@/lib/copy.js";
 import {
@@ -26,6 +27,7 @@ import {
   useCallTool,
   useServerInfo,
 } from "@/lib/mcp/index.js";
+import { useRegisterWebMcpTool } from "@/lib/mcp/webmcp.js";
 import { useSelectedToolName } from "@/lib/nuqs.js";
 import {
   type SavedInput,
@@ -418,6 +420,25 @@ function ToolBody({
   const hasInput =
     tool.inputSchema &&
     Object.keys(tool.inputSchema.properties ?? {}).length > 0;
+
+  // Tools without input render no form, so the declarative WebMCP path
+  // (`<form toolname …>`) never applies. Register them imperatively instead.
+  useRegisterWebMcpTool({
+    tool,
+    enabled: !hasInput,
+    execute: async () => {
+      const response = (await onRun()) as
+        | Pick<CallToolResponse, "content" | "isError">
+        | undefined;
+      return (
+        response ?? {
+          content: [{ type: "text", text: "The tool call was not executed." }],
+          isError: true,
+        }
+      );
+    },
+  });
+
   const visibility = getToolVisibility(tool);
   const [saveOpen, setSaveOpen] = useState(false);
   const { serverName, savedInputs, activeKey } = saved;

--- a/packages/devtools/src/components/layout/tools-list/tool-item.tsx
+++ b/packages/devtools/src/components/layout/tools-list/tool-item.tsx
@@ -600,18 +600,17 @@ function FormBody({
   const containerRef = useRef<HTMLDivElement>(null);
 
   const ToolFormTag = useMemo(() => {
-    const { name, description } = tool;
     return function ToolFormTag(props: React.ComponentProps<"form">) {
       return (
         <form
-          toolname={name}
-          tooldescription={description}
+          toolname={tool.name}
+          tooldescription={tool.description}
           toolautosubmit=""
           {...props}
         />
       );
     };
-  }, [tool]);
+  }, [tool.name, tool.description]);
 
   useEffect(() => {
     const container = containerRef.current;

--- a/packages/devtools/src/lib/mcp/webmcp.ts
+++ b/packages/devtools/src/lib/mcp/webmcp.ts
@@ -1,0 +1,74 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResponse } from "skybridge/web";
+
+// Minimal typings for the WebMCP proposal (https://github.com/webmachinelearning/webmcp).
+// Tools registered on `document.modelContext` are discoverable by browser
+// agents, which can invoke them against the connected MCP server.
+interface ModelContextToolDescriptor {
+  name: string;
+  description?: string;
+  inputSchema?: Tool["inputSchema"];
+  execute: (
+    args: Record<string, unknown>,
+  ) => Promise<Pick<CallToolResponse, "content" | "isError">>;
+}
+
+interface ModelContext {
+  registerTool: (
+    descriptor: ModelContextToolDescriptor,
+    options?: { signal?: AbortSignal },
+  ) => Promise<void>;
+}
+
+declare global {
+  /**
+   * To align with the fact that tools are effectively per-Document, the WebML CG agreed to move the modelContext getter from the Navigator interface to the Document interface. You can find the full technical details in Issue 173 and PR #184.
+   *
+   * navigator.modelContext is now deprecated as of Chrome 150.0.7861.0 and will be removed in a future Chrome release.
+   * Use document.modelContext instead.
+   */
+  interface Navigator {
+    modelContext?: ModelContext;
+  }
+  interface Document {
+    modelContext?: ModelContext;
+  }
+
+  /**
+   * Declarative WebMCP additions to `SubmitEvent`
+   * (https://github.com/webmachinelearning/webmcp/blob/main/declarative-api-explainer.md).
+   */
+  interface SubmitEvent {
+    /** True when the form submission was invoked by an agent. */
+    readonly agentInvoked?: boolean;
+    /**
+     * Overrides the default form action and pipes the resolved value back to
+     * the agent that invoked the form tool. `preventDefault()` must be called
+     * before this method.
+     */
+    respondWith?(agentResponse: Promise<unknown>): void;
+  }
+}
+
+/**
+ * Declarative WebMCP markers: `<form toolname tooldescription toolautosubmit>`
+ * exposes the form as a tool to browser agents, and `toolparamdescription` on
+ * form controls documents each input-schema property.
+ */
+declare module "react" {
+  interface FormHTMLAttributes<T> {
+    toolname?: string;
+    tooldescription?: string;
+    /** Boolean attribute — pass an empty string to enable. */
+    toolautosubmit?: string;
+  }
+  interface InputHTMLAttributes<T> {
+    toolparamdescription?: string;
+  }
+  interface TextareaHTMLAttributes<T> {
+    toolparamdescription?: string;
+  }
+  interface SelectHTMLAttributes<T> {
+    toolparamdescription?: string;
+  }
+}

--- a/packages/devtools/src/lib/mcp/webmcp.ts
+++ b/packages/devtools/src/lib/mcp/webmcp.ts
@@ -1,4 +1,5 @@
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { useEffect, useRef } from "react";
 import type { CallToolResponse } from "skybridge/web";
 
 // Minimal typings for the WebMCP proposal (https://github.com/webmachinelearning/webmcp).
@@ -71,4 +72,41 @@ declare module "react" {
   interface SelectHTMLAttributes<T> {
     toolparamdescription?: string;
   }
+}
+
+export function useRegisterWebMcpTool({
+  tool,
+  enabled,
+  execute,
+}: {
+  tool: Tool;
+  enabled: boolean;
+  execute: () => Promise<Pick<CallToolResponse, "content" | "isError">>;
+}) {
+  // Keep the latest handler without re-registering on every render.
+  const executeRef = useRef(execute);
+  useEffect(() => {
+    executeRef.current = execute;
+  });
+
+  const { name, description, inputSchema } = tool;
+  useEffect(() => {
+    const modelContext = document.modelContext ?? navigator.modelContext;
+    if (!enabled || !modelContext) {
+      return;
+    }
+    const controller = new AbortController();
+    void modelContext.registerTool(
+      {
+        name,
+        description,
+        inputSchema,
+        execute: () => executeRef.current(),
+      },
+      { signal: controller.signal },
+    );
+    return () => {
+      controller.abort();
+    };
+  }, [enabled, name, description, inputSchema]);
 }

--- a/skills/chatgpt-app-builder/references/run-locally.md
+++ b/skills/chatgpt-app-builder/references/run-locally.md
@@ -14,7 +14,21 @@ When started, output the local MCP server and devtools URL.
 
 Hot reload enabled (nodemon for server, HMR for views).
 
-## 2. Connect to AI Assistants (Optional)
+## 2. Test in DevTools via Chrome DevTools MCP (Optional)
+
+Use the devtools to render views locally. Use this method when iterating with the user on the rendered result of its app.
+
+The devtools page exposes WebMCP tools, powering faster interactions than with traditional click/fill/screenshot interactions. Requires the Chrome DevTools MCP server running with `--categoryExperimentalWebmcp=true`, which adds the `list_webmcp_tools` and `execute_webmcp_tool` tools.
+
+1. `navigate_page` to the devtools URL output by the dev server
+2. `list_webmcp_tools` to discover the page's tools:
+   - one tool per app tool — executes it on the local MCP server, returns its result, and renders its view in the preview pane
+   - `devtools_set_view_options` — sets any subset of `displayMode` (`inline`|`pip`|`fullscreen`), `darkTheme` (boolean), `mobileDevice` (boolean), `locale` (BCP 47 code)
+3. `execute_webmcp_tool` with `toolName` and JSON-stringified `input`
+
+Interactions inside the rendered view itself are not WebMCP tools, use regular DOM understanding and interactions. Use `take_screenshot` only to visually verify rendering — screenshot the preview iframe (accessible name `html-preview` in the page snapshot) rather than the full page.
+
+## 3. Connect to AI Assistants (Optional)
 
 Ask user if they want to test in ChatGPT/Claude or just use local devtools.
 

--- a/skills/skybridge/SKILL.md
+++ b/skills/skybridge/SKILL.md
@@ -21,7 +21,7 @@ SPEC.md keeps track of the app's requirements and design decisions. Keep it up t
 ## Setup
 
 1. **Copy template** → [copy-template.md](references/copy-template.md): when starting a new project with ready SPEC.md
-2. **Run locally** → [run-locally.md](references/run-locally.md): when ready to test, need dev server or ChatGPT/Claude connection
+2. **Run locally** → [run-locally.md](references/run-locally.md): when ready to test — dev server, agent-driven devtools, ChatGPT/Claude connection
 
 ## Architecture
 

--- a/skills/skybridge/SKILL.md
+++ b/skills/skybridge/SKILL.md
@@ -21,7 +21,7 @@ SPEC.md keeps track of the app's requirements and design decisions. Keep it up t
 ## Setup
 
 1. **Copy template** → [copy-template.md](references/copy-template.md): when starting a new project with ready SPEC.md
-2. **Run locally** → [run-locally.md](references/run-locally.md): when ready to test — dev server, agent-driven devtools, ChatGPT/Claude connection
+2. **Run locally** → [run-locally.md](references/run-locally.md): when ready to test, need dev server, use devtools to render views or connect to ChatGPT/Claude
 
 ## Architecture
 


### PR DESCRIPTION
# Objective

This PR aims at making Skybridge DevTools more agent-friendly.
It focus on exposing :
- localhost MCP server tools
- Skybridge DevTools interface controls (display mode, theme, local, device)

This PR is inspired by [server-sim](https://github.com/EvanBacon/serve-sim) project by [Evan Bacon](https://github.com/EvanBacon) that exposes Expo iOS simulator as a web interface controlled through by a coding agent through Chrome DevTools.

# Context

- Chrome DevTools supports WebMCP tools. It can list and invoke tools exposed by a web page. It can explore the history of calls made from a page (see [Chrome Devtools documentation](https://developer.chrome.com/docs/devtools/application/webmcp))
- Coding agents can use Chrome DevTools via MCP using [ChromeDevTools/chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp)
- WebMCP tools are available to Chrome DevTools MCP server using the experimental flag [categoryExperimentalWebmcp](https://github.com/ChromeDevTools/chrome-devtools-mcp/blob/main/docs/tool-reference.md#webmcp)

# Content

- For localhost MCP server tools: 
  - customize RJSF forms components to add support for [declarative WebMCP tools](https://github.com/webmachinelearning/webmcp/blob/main/declarative-api-explainer.md)
  - require to open all tools input by default as only forms in DOM are exposed as tools
  - tools without input don't render form, a WebMCP tool is rendered imperatively instead
- For Skybridge DevTools interface controls: also declarative WebMCP tools. Required changing the controls to a native form. Only the locale picker needed a shadow form input as no native element supports a searchable list.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR exposes the Skybridge DevTools interface as WebMCP tools so browser-based coding agents can invoke MCP server tools and control devtools UI options (display mode, theme, locale, device) without manual DOM interactions. It uses both the declarative WebMCP form-attribute API (`toolname`, `toolparamdescription`, `toolautosubmit`) and the imperative `document.modelContext.registerTool` API for tools without form inputs.

- RJSF form components are enhanced with `name` and `toolparamdescription` attributes; all tool accordions are opened by default so their forms are in the DOM for WebMCP discovery; tools with no input are registered imperatively via a new `useRegisterWebMcpTool` hook.
- The toolbar is converted from a `<div>` of imperative buttons to a native `<form>` with radio/checkbox controls; a visually-hidden `<select>` bridges the locale combobox to the form for WebMCP schema extraction; changes from both user and agent paths flow through a single `applyViewOptions` handler.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the rules-of-hooks violation in ToolFormTag, which will throw at runtime for every tool with input fields.

The toolbar refactor, the imperative WebMCP hook for no-input tools, and all test updates are implemented correctly. The one concrete issue is that `ToolFormTag` is both defined with a `useMemo` call and invoked as `ToolFormTag(tool)` (a plain function call) at the `tagName` prop site in `FormBody`. React enforces that hooks can only be called from function components or other hooks — calling `useMemo` inside a helper that is then invoked as a plain function will throw in development and behave unpredictably in production. This affects every tool that has at least one input field.

packages/devtools/src/components/layout/tools-list/form/tool-form-tag.tsx and its call site in packages/devtools/src/components/layout/tools-list/tool-item.tsx (line 620).

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/devtools/src/components/layout/tools-list/form/tool-form-tag.tsx:4-19
**`ToolFormTag` is called as a function in a render path, breaking the React rules of hooks**

`ToolFormTag` calls `useMemo` internally, but it's invoked as a plain function — `tagName={ToolFormTag(tool)}` — not rendered as a component. React hooks called outside a component or custom hook will throw "Invalid hook call" at runtime whenever `FormBody` renders. The return value of `useMemo` here is also a component constructor (a function), not a React element, which is what `tagName` expects as a tag factory.

The fix is to move the memoised component factory into `FormBody` itself (or into a dedicated custom hook called from `FormBody`), so `useMemo` runs inside a proper React function component.

`````

</details>

<sub>Reviews (8): Last reviewed commit: ["Move hidden form input replication close..."](https://github.com/alpic-ai/skybridge/commit/fd767e9cdad57c774ecbbad799892c4aaf3348a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36728418)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->