### PR TITLE
Make chess go fullscreen instead of pip

### DIFF
--- a/examples/chess/README.md
+++ b/examples/chess/README.md
@@ -2,7 +2,7 @@
 
 Play chess against the assistant inside the conversation. The board opens on a
 **pick-a-side lobby**: choose **White** or **Black** to start. Picking a color
-is the user gesture that lets the view pop the board into **picture-in-picture**
+is the user gesture that lets the view pop the board into **fullscreen**
 (via `useDisplayMode`), so you can keep chatting while you play. You drag your
 pieces; the assistant plays the other color (and opens the game if you take
 Black).
@@ -34,11 +34,11 @@ move played, so the full game is pushed into the model's context on every change
 and survives a view remount. The chess logic is a thin, stateless wrapper
 (`src/lib/engine.ts`) — every helper rebuilds the engine from a FEN on demand.
 
-### Pick a side & picture-in-picture
+### Pick a side & fullscreen
 
 The view starts on a lobby with two buttons (White / Black). Picking a color
 calls the match store's `start` action and immediately requests
-`setDisplayMode("pip")` — most hosts only grant picture-in-picture in response
+`setDisplayMode("fullscreen")` — most hosts only grant fullscreen in response
 to a user gesture, so the color choice doubles as that gesture. If you pick
 Black, the view fires a `sendFollowUpMessage` asking the assistant (White) to
 make the opening move.

--- a/examples/chess/src/server.ts
+++ b/examples/chess/src/server.ts
@@ -5,7 +5,7 @@ import { readPosition, STARTING_FEN } from "./lib/engine.js";
 // the gameplay tools are registered by the view itself (see
 // src/views/chess.tsx) through `useRegisterViewTool`, so they run inside the
 // widget. The view opens on a pick-a-side lobby; once the user chooses a color
-// (which also pops the board into picture-in-picture), the assistant plays the
+// (which also pops the board into fullscreen), the assistant plays the
 // other side.
 const server = new McpServer(
   {
@@ -42,7 +42,7 @@ const server = new McpServer(
           type: "text",
           text: [
             "A fresh chess board is open on the pick-a-side lobby.",
-            "Wait for the user to choose White or Black — you play the other color, and choosing also opens the board in picture-in-picture.",
+            "Wait for the user to choose White or Black — you play the other color, and choosing also opens the board in fullscreen.",
             'If they pick White, hold until they move, then reply with your Black move via the `chess_make_move` view tool (for example `{ "san": "e5" }`). If they pick Black, the view will prompt you to open as White.',
             "Lean on `chess_get_board_state` and `chess_get_legal_moves` to study the position first.",
           ].join(" "),

--- a/examples/chess/src/views/chess.tsx
+++ b/examples/chess/src/views/chess.tsx
@@ -272,8 +272,8 @@ export default function ChessView() {
 
         <div className="chess-lobby">
           <p className="chess-lobby-text">
-            Choose your color. The game opens in a fullscreen window so you can
-            keep chatting while you play.
+            Choose your color. The game opens fullscreen so you can focus on
+            the board.
           </p>
           <div className="chess-lobby-choices">
             <button

--- a/examples/chess/src/views/chess.tsx
+++ b/examples/chess/src/views/chess.tsx
@@ -235,10 +235,10 @@ export default function ChessView() {
   const assistantName = assistant === "w" ? "White" : "Black";
 
   // Picking a side is the user gesture hosts require before granting
-  // picture-in-picture — so we request it straight off the click.
+  // fullscreen — so we request it straight off the click.
   const beginGame = (side: "w" | "b") => {
     start(side);
-    setDisplayMode("pip");
+    setDisplayMode("fullscreen");
     if (side === "b") {
       // The user took Black, so the assistant (White) opens the game.
       sendFollowUpMessage(
@@ -272,8 +272,8 @@ export default function ChessView() {
 
         <div className="chess-lobby">
           <p className="chess-lobby-text">
-            Choose your color. The game opens in a picture-in-picture window so
-            you can keep chatting while you play.
+            Choose your color. The game opens in a fullscreen window so you can
+            keep chatting while you play.
           </p>
           <div className="chess-lobby-choices">
             <button


### PR DESCRIPTION
In order to avoid chess board clip

<img width="1696" height="1502" alt="image" src="https://github.com/user-attachments/assets/c67f9948-9a83-41ed-b0a4-5835a72e670e" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Switches the chess view's display mode from picture-in-picture (`"pip"`) to fullscreen (`"fullscreen"`) to prevent the board from being clipped.

- `chess.tsx`: Changes `setDisplayMode(\"pip\")` to `setDisplayMode(\"fullscreen\")` and updates the lobby copy to \"The game opens fullscreen so you can focus on the board.\"
- `server.ts` and `README.md`: Updates all inline comments and prose references from \"picture-in-picture\" to \"fullscreen\" to match the new behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-line functional switch between two well-typed, supported display modes, with consistent comment and doc updates throughout.

The core change is a single call site switching from `pip` to `fullscreen`, both of which are valid values of `RequestDisplayMode`. The surrounding text and comments were updated consistently across all three files, and the lobby copy now accurately describes fullscreen rather than PiP behavior.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["Fix wording"](https://github.com/alpic-ai/skybridge/commit/c6c2bebb3c4482418ee1e24eda8818d15fa19f6e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36958426)</sub>

<!-- /greptile_comment -->