### PR TITLE
fix: change capitals source of data

### DIFF
--- a/examples/capitals/src/capitals.ts
+++ b/examples/capitals/src/capitals.ts
@@ -1,14 +1,9 @@
-// Minimal data for list (5 fields)
-type RestCountryMinimal = {
-  name: { common: string };
-  capital?: string[];
-  capitalInfo?: { latlng?: [number, number] };
-  cca2: string;
-  flags: { svg: string };
-};
+// The restcountries.com API was deprecated in 2026 (now requires an API key),
+// so we fetch the same dataset from the original open-source project instead.
+const COUNTRIES_DATA_URL =
+  "https://gitlab.com/restcountries/restcountries/-/raw/master/src/main/resources/countriesV3.1.json";
 
-// Full data for details (10 fields)
-type RestCountryFull = {
+type RestCountry = {
   name: { common: string };
   capital?: string[];
   capitalInfo?: { latlng?: [number, number] };
@@ -45,56 +40,44 @@ export type CapitalSummary = {
   coordinates: { lat: number; lng: number };
 };
 
-// Cache for minimal capitals list
-let listCache: RestCountryMinimal[] | null = null;
-let listCacheTime = 0;
-const CACHE_TTL = 1000 * 60 * 60; // 1 hour
+// Cache the dataset in memory to avoid re-downloading it on every tool call
+let countriesCache: RestCountry[] | null = null;
+let countriesCacheTime = 0;
+const CACHE_TTL = 1000 * 60 * 60;
 
-async function fetchAllCountriesMinimal(): Promise<RestCountryMinimal[]> {
+async function fetchAllCountries(): Promise<RestCountry[]> {
   const now = Date.now();
-  if (listCache && now - listCacheTime < CACHE_TTL) {
-    return listCache;
+  if (countriesCache && now - countriesCacheTime < CACHE_TTL) {
+    return countriesCache;
   }
 
-  const fields = ["name", "capital", "capitalInfo", "cca2", "flags"].join(",");
-  const response = await fetch(
-    `https://restcountries.com/v3.1/all?fields=${fields}`,
-  );
+  const response = await fetch(COUNTRIES_DATA_URL);
   if (!response.ok) {
-    throw new Error(`RestCountries API error: ${response.status}`);
+    throw new Error(`Countries dataset error: ${response.status}`);
   }
 
-  const data = (await response.json()) as RestCountryMinimal[];
-  listCache = data.filter(
+  const data = await response.json();
+  if (!Array.isArray(data)) {
+    throw new Error("Countries dataset error: expected an array of countries");
+  }
+
+  countriesCache = (data as RestCountry[]).filter(
     (c) => c.capital && c.capital.length > 0 && c.capitalInfo?.latlng,
   );
-  listCacheTime = now;
+  countriesCacheTime = now;
 
-  return listCache;
+  return countriesCache;
 }
 
-async function fetchCountryByCode(cca2: string): Promise<RestCountryFull> {
-  const fields = [
-    "name",
-    "capital",
-    "capitalInfo",
-    "cca2",
-    "cca3",
-    "flags",
-    "latlng",
-    "population",
-    "continents",
-    "currencies",
-  ].join(",");
-
-  const response = await fetch(
-    `https://restcountries.com/v3.1/alpha/${cca2}?fields=${fields}`,
+async function getCountryByCode(cca2: string): Promise<RestCountry> {
+  const countries = await fetchAllCountries();
+  const country = countries.find(
+    (c) => c.cca2.toLowerCase() === cca2.toLowerCase(),
   );
-  if (!response.ok) {
-    throw new Error(`RestCountries API error: ${response.status}`);
+  if (!country) {
+    throw new Error(`Country "${cca2}" not found`);
   }
-
-  return (await response.json()) as RestCountryFull;
+  return country;
 }
 
 async function fetchWikipediaSummary(title: string) {
@@ -120,7 +103,7 @@ async function fetchWikipediaSummary(title: string) {
 }
 
 export async function getAllCapitals(): Promise<CapitalSummary[]> {
-  const countries = await fetchAllCountriesMinimal();
+  const countries = await fetchAllCountries();
 
   return countries.map((c) => ({
     name: c.capital?.[0] ?? "",
@@ -134,7 +117,7 @@ export async function getAllCapitals(): Promise<CapitalSummary[]> {
 }
 
 export async function getCapitalByCountryCode(cca2: string): Promise<Capital> {
-  const country = await fetchCountryByCode(cca2);
+  const country = await getCountryByCode(cca2);
 
   if (!country.capital) {
     throw new Error(`No capital found for country ${cca2}`);

--- a/examples/capitals/src/server.ts
+++ b/examples/capitals/src/server.ts
@@ -4,22 +4,11 @@ import { McpServer } from "skybridge/server";
 import * as z from "zod";
 import {
   type Capital,
-  type CapitalSummary,
   getAllCapitals,
   getCapitalByCountryCode,
   getCapitalByName,
   getCapitalSlug,
 } from "./capitals.js";
-
-// Cache allCapitals to be mindful of country REST API
-let cachedAllCapitals: CapitalSummary[] | null = null;
-
-async function getCachedAllCapitals(): Promise<CapitalSummary[]> {
-  if (!cachedAllCapitals) {
-    cachedAllCapitals = await getAllCapitals();
-  }
-  return cachedAllCapitals;
-}
 
 const server = new McpServer(
   {
@@ -65,8 +54,7 @@ const server = new McpServer(
     },
     async ({ name }) => {
       try {
-        // Fetch list first (minimal data), then details for requested capital
-        const allCapitals = await getCachedAllCapitals();
+        const allCapitals = await getAllCapitals();
         const capital = await getCapitalByName(name);
 
         return {
@@ -88,7 +76,7 @@ const server = new McpServer(
       } catch (error) {
         const message =
           error instanceof Error ? error.message : "Unknown error";
-        const allCapitals = await getCachedAllCapitals().catch(() => []);
+        const allCapitals = await getAllCapitals().catch(() => []);
         return {
           _meta: { allCapitals },
           structuredContent: { error: message },


### PR DESCRIPTION
https://restcountries.com/ which was previously used switched to a paid plan to deliver the capitals information. The capitals example app was broken showing the following error due to the API change: 
<img width="813" height="551" alt="image" src="https://github.com/user-attachments/assets/0b228fd9-217f-438a-b278-8d53ba9b6369" />

I'm now hitting directly the source of truth of this API which is an open gitlab repository:  `https://gitlab.com/restcountries/restcountries/-/raw/master/src/main/resources/countriesV3.1.json`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the capitals example app by switching from `restcountries.com` (now paywalled) to the same upstream data served directly from the project's GitLab repository as a raw JSON file.

- **`capitals.ts`**: Consolidates the two previous type definitions (`RestCountryMinimal` / `RestCountryFull`) into a single `RestCountry` type and replaces the two-endpoint fetch pattern with one bulk download that is filtered and cached in memory. The `getCountryByCode` lookup now searches the cached array instead of making a per-country API call.
- **`server.ts`**: Removes the now-redundant `getCachedAllCapitals` wrapper (caching has moved entirely into `capitals.ts`) and cleans up the unused `CapitalSummary` import.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is a straightforward data-source swap that restores a broken example app, with no impact on production code paths.

The core logic is correct and the caching approach is sound. Two minor concerns exist: the URL targets the mutable `master` branch, so an upstream repo restructure could silently break the app after the next cache expiry; and the removal of the server-level `getCachedAllCapitals` guard means concurrent cold-start requests will each independently download the full dataset instead of sharing a single in-flight request. Neither issue blocks this example app in practice, but both are worth addressing before the pattern is copied elsewhere.

examples/capitals/src/capitals.ts — the URL pinning and in-flight deduplication points discussed in comments.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
examples/capitals/src/capitals.ts:3-4
The URL points to the mutable `master` branch of the upstream repo. If the maintainers ever rename, move, or restructure `countriesV3.1.json`, the app will start throwing errors on every request (the cache won't help once it expires). Pinning to a specific commit SHA makes the dependency explicit and reproducible.

```suggestion
// Pinned to a specific commit to avoid silent breakage if the upstream
// repo restructures its files. Update the SHA when a newer dataset is needed.
const COUNTRIES_DATA_URL =
  "https://gitlab.com/restcountries/restcountries/-/raw/b4f25e49118c65ffc9e65db3ea4f0e1c4611e4fd/src/main/resources/countriesV3.1.json";
```

### Issue 2 of 2
examples/capitals/src/capitals.ts:48-70
**Concurrent cold-start fetches not deduplicated**

`fetchAllCountries` has no in-flight deduplication. If multiple requests arrive simultaneously before `countriesCache` is populated (server startup or after a 1-hour TTL expiry), each will independently download the full ~6 MB JSON from GitLab. The old code mitigated this because the server-level `getCachedAllCapitals` acted as a process-lifetime gate; that guard was removed in this PR. For an example app the impact is minor, but a simple promise-based lock (`let inflightFetch: Promise<RestCountry[]> | null = null`) would prevent the redundant downloads.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: change capitals source of data"](https://github.com/alpic-ai/skybridge/commit/dd3250708297b001a7fcbfc94fc06bd6c1d090bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37010976)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->