### PR TITLE
Theo/sky 361 capitals of the world no map 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ cdk.out
 .claude/skills/
 .skybridge/
 packages/core/src/server/templates.generated.js
+.vercel

--- a/examples/capitals/package.json
+++ b/examples/capitals/package.json
@@ -33,7 +33,6 @@
     "@skybridge/devtools": "^1.0.0",
     "@tailwindcss/vite": "^4.1.14",
     "@types/express": "^5.0.3",
-    "@types/mapbox-gl": "^3.4.1",
     "@types/node": "^22.15.30",
     "@types/react": "^19.1.16",
     "@types/react-dom": "^19.1.9",

--- a/examples/capitals/package.json
+++ b/examples/capitals/package.json
@@ -19,7 +19,7 @@
     "dotenv": "^17.2.3",
     "express": "^5.1.0",
     "lucide-react": "^0.562.0",
-    "mapbox-gl": "^3.9.4",
+    "mapbox-gl": "^3.24.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-map-gl": "^7.1.8",

--- a/examples/capitals/src/views/components/MapView.tsx
+++ b/examples/capitals/src/views/components/MapView.tsx
@@ -1,8 +1,18 @@
+import mapboxgl from "mapbox-gl";
+import MapboxWorker from "mapbox-gl/dist/mapbox-gl-csp-worker?worker&inline";
 import { useEffect, useRef } from "react";
 import type { MapRef } from "react-map-gl";
 import { Map as MapboxMap, Marker, NavigationControl } from "react-map-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
 import { useLayout } from "skybridge/web";
+
+// By default mapbox-gl spawns its workers by stringifying its own bundled
+// code into a classic (non-module) blob worker. Vite's build rewrites the
+// dynamic import() calls in that code to a helper using import.meta, which
+// is a SyntaxError in a classic worker — the workers die and no layers
+// render. Loading the worker from the separate CSP build avoids this.
+(mapboxgl as unknown as { workerClass: new () => Worker }).workerClass =
+  MapboxWorker;
 
 type CapitalMarker = {
   name: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -325,8 +325,8 @@ importers:
         specifier: ^0.562.0
         version: 0.562.0(react@19.2.0)
       mapbox-gl:
-        specifier: ^3.9.4
-        version: 3.17.0
+        specifier: ^3.24.0
+        version: 3.24.0
       react:
         specifier: ^19.1.1
         version: 19.2.0
@@ -335,7 +335,7 @@ importers:
         version: 19.2.0(react@19.2.0)
       react-map-gl:
         specifier: ^7.1.8
-        version: 7.1.9(mapbox-gl@3.17.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 7.1.9(mapbox-gl@3.24.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-router-dom:
         specifier: ^7.12.0
         version: 7.13.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -2658,10 +2658,6 @@ packages:
 
   '@mapbox/vector-tile@2.0.4':
     resolution: {integrity: sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==}
-
-  '@mapbox/whoots-js@3.1.0':
-    resolution: {integrity: sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==}
-    engines: {node: '>=6.0.0'}
 
   '@maplibre/maplibre-gl-style-spec@19.3.3':
     resolution: {integrity: sha512-cOZZOVhDSulgK0meTsTkmNXb1ahVvmTmWmfx9gRBwc6hq98wS9JP35ESIoNq3xqEan+UN+gn8187Z6E4NKhLsw==}
@@ -5059,9 +5055,6 @@ packages:
   '@types/mapbox-gl@3.4.1':
     resolution: {integrity: sha512-NsGKKtgW93B+UaLPti6B7NwlxYlES5DpV5Gzj9F75rK5ALKsqSk15CiEHbOnTr09RGbr6ZYiCdI+59NNNcAImg==}
 
-  '@types/mapbox__point-geometry@0.1.4':
-    resolution: {integrity: sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA==}
-
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
@@ -6689,9 +6682,6 @@ packages:
     resolution: {integrity: sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
-  grid-index@1.1.0:
-    resolution: {integrity: sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA==}
-
   handlebars@4.7.9:
     resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
@@ -7724,8 +7714,8 @@ packages:
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
-  mapbox-gl@3.17.0:
-    resolution: {integrity: sha512-nCrDKRlr5di6xUksUDslNWwxroJ5yv1hT8pyVFtcpWJOOKsYQxF/wOFTMie8oxMnXeFkrz1Tl1TwA1XN1yX0KA==}
+  mapbox-gl@3.24.0:
+    resolution: {integrity: sha512-R+FdFUB3DnoE5FYASV7lGSiRyMkSblcZ2UEy7b2pt7s5ZbCxFIUPXd0E6iAFd8OdvdA2VtbvZZVylzAZNaurjA==}
 
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
@@ -7743,8 +7733,8 @@ packages:
       react:
         optional: true
 
-  martinez-polygon-clipping@0.7.4:
-    resolution: {integrity: sha512-jBEwrKtA0jTagUZj2bnmb4Yg2s4KnJGRePStgI7bAVjtcipKiF39R4LZ2V/UT61jMYWrTcBhPazexeqd6JAVtw==}
+  martinez-polygon-clipping@0.8.1:
+    resolution: {integrity: sha512-9PLLMzMPI6ihHox4Ns6LpVBLpRc7sbhULybZ/wyaY8sY3ECNe2+hxm1hA2/9bEEpRrdpjoeduBuZLg2aq1cSIQ==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -9591,9 +9581,6 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
-
-  tinyqueue@1.2.3:
-    resolution: {integrity: sha512-Qz9RgWuO9l8lT+Y9xvbzhPT2efIUIFd69N7eF7tJ9lnQl0iLj1M7peK7IoUGZL9DJHw9XftqLreccfxcQgYLxA==}
 
   tinyqueue@3.0.0:
     resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
@@ -11709,8 +11696,6 @@ snapshots:
       '@mapbox/point-geometry': 1.1.0
       '@types/geojson': 7946.0.16
       pbf: 4.0.1
-
-  '@mapbox/whoots-js@3.1.0': {}
 
   '@maplibre/maplibre-gl-style-spec@19.3.3':
     dependencies:
@@ -16009,8 +15994,6 @@ snapshots:
     dependencies:
       '@types/geojson': 7946.0.16
 
-  '@types/mapbox__point-geometry@0.1.4': {}
-
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -17944,8 +17927,6 @@ snapshots:
 
   graphql@16.12.0: {}
 
-  grid-index@1.1.0: {}
-
   handlebars@4.7.9:
     dependencies:
       minimist: 1.2.8
@@ -18995,18 +18976,15 @@ snapshots:
 
   make-error@1.3.6: {}
 
-  mapbox-gl@3.17.0:
+  mapbox-gl@3.24.0:
     dependencies:
-      '@mapbox/jsonlint-lines-primitives': 2.0.2
       '@mapbox/mapbox-gl-supported': 3.0.0
       '@mapbox/point-geometry': 1.1.0
       '@mapbox/tiny-sdf': 2.0.7
       '@mapbox/unitbezier': 0.0.1
       '@mapbox/vector-tile': 2.0.4
-      '@mapbox/whoots-js': 3.1.0
       '@types/geojson': 7946.0.16
       '@types/geojson-vt': 3.2.5
-      '@types/mapbox__point-geometry': 0.1.4
       '@types/pbf': 3.0.5
       '@types/supercluster': 7.1.3
       cheap-ruler: 4.0.0
@@ -19014,9 +18992,8 @@ snapshots:
       earcut: 3.0.2
       geojson-vt: 4.0.2
       gl-matrix: 3.4.4
-      grid-index: 1.1.0
       kdbush: 4.0.2
-      martinez-polygon-clipping: 0.7.4
+      martinez-polygon-clipping: 0.8.1
       murmurhash-js: 1.0.0
       pbf: 4.0.1
       potpack: 2.1.0
@@ -19032,11 +19009,11 @@ snapshots:
     optionalDependencies:
       react: 19.2.4
 
-  martinez-polygon-clipping@0.7.4:
+  martinez-polygon-clipping@0.8.1:
     dependencies:
       robust-predicates: 2.0.4
       splaytree: 0.1.4
-      tinyqueue: 1.2.3
+      tinyqueue: 3.0.0
 
   math-intrinsics@1.1.0: {}
 
@@ -20511,14 +20488,14 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-map-gl@7.1.9(mapbox-gl@3.17.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-map-gl@7.1.9(mapbox-gl@3.24.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       '@maplibre/maplibre-gl-style-spec': 19.3.3
       '@types/mapbox-gl': 3.4.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     optionalDependencies:
-      mapbox-gl: 3.17.0
+      mapbox-gl: 3.24.0
 
   react-markdown@9.1.0(@types/react@19.2.14)(react@19.2.4):
     dependencies:
@@ -21923,8 +21900,6 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
-
-  tinyqueue@1.2.3: {}
 
   tinyqueue@3.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -361,9 +361,6 @@ importers:
       '@types/express':
         specifier: ^5.0.3
         version: 5.0.6
-      '@types/mapbox-gl':
-        specifier: ^3.4.1
-        version: 3.4.1
       '@types/node':
         specifier: ^22.15.30
         version: 22.19.3
@@ -16660,7 +16657,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       http-errors: 2.0.0
       iconv-lite: 0.7.0
       on-finished: 2.4.1
@@ -17577,7 +17574,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -17700,7 +17697,7 @@ snapshots:
 
   finalhandler@2.1.0:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -17713,7 +17710,7 @@ snapshots:
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
 
   for-each@0.3.5:
     dependencies:
@@ -18709,7 +18706,7 @@ snapshots:
 
   koa-router@14.0.0:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       http-errors: 2.0.1
       koa-compose: 4.1.0
       path-to-regexp: 8.3.0
@@ -20075,7 +20072,7 @@ snapshots:
   pipenet@1.4.0:
     dependencies:
       axios: 1.13.6(debug@4.4.3)
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       human-readable-ids: 1.0.4
       koa: 3.1.2
       koa-router: 14.0.0
@@ -21118,7 +21115,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -21207,7 +21204,7 @@ snapshots:
 
   send@1.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1


### PR DESCRIPTION
<img width="862" height="585" alt="image" src="https://github.com/user-attachments/assets/bb989003-ed2a-4f84-997c-ac2b07963e76" />

Fixes mapbox tile rendering. 

Mapbox-gl's worker bootstrapping is inherently bundler-hostile. That has broken repeatedly over the years with different bundlers (Vue 3 + Vite, Angular 17, webpack 4). And it's now happening with Vite 8.

This PR fixes the issue but should we consider changing map provider ? Knowing there is similar issues with other map providers: https://github.com/vitejs/rolldown-vite/issues/585

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The review has been submitted. The PR fixes mapbox-gl tile rendering broken by Vite 8's bundler rewriting `import()` calls in classic blob workers. The fix imports the pre-built CSP worker and assigns it to `mapboxgl.workerClass`, which is the canonical workaround. One P2 observation: `?worker&inline` embeds the ~200 KB worker into the main bundle; `?worker` without `&inline` would produce a separate cacheable chunk for production use.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is a well-known one-line CSP worker workaround, and the mapbox-gl version bump is a straightforward minor-version update with no API changes in the components used here.

The fix is correct and the approach is widely recommended for this exact Vite/mapbox-gl incompatibility. The only observation is the use of `&inline` which bundles the worker into the main chunk rather than as a separate file, slightly inflating the initial load. This is a non-blocking trade-off, particularly for an example app.

No files require special attention. `MapView.tsx` contains the only logic change and it is straightforward.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
examples/capitals/src/views/components/MapView.tsx:2
**`&inline` inlines the entire worker into the main bundle**

The `?worker&inline` flag tells Vite to base64-encode the ~200 KB mapbox-gl CSP worker and embed it directly in the main JS chunk. This means every visitor downloading the page must pay the full worker cost upfront, even before the map is rendered. Using `?worker` (without `&inline`) would let Vite emit the worker as a separate chunk that the browser fetches lazily and can cache independently. For an example app this is fine, but it's worth being aware of if this pattern is adopted in production apps.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: update .gitignore to include temp..."](https://github.com/alpic-ai/skybridge/commit/e87d808b470bcf0df1a55f8a82ac920c6f0d55d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37192846)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->