### PR TITLE
feat: add security.md and minimumReleaseAge

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Skybridge, please report it privately
+by emailing **security@alpic.ai**. Do not open a public issue.
+
+Please include:
+
+- A description of the vulnerability and its impact
+- Steps to reproduce
+- Affected versions, if known
+
+We will acknowledge your report and keep you informed of the progress toward a fix.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,10 @@ packages:
   - "packages/create-skybridge/templates/blank"
   - "examples/*"
 
+# Delay installing newly published versions by 2 weeks to reduce exposure to
+# supply-chain attacks via compromised releases.
+minimumReleaseAge: 20160
+
 allowBuilds:
   esbuild: true
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `SECURITY.md` responsible-disclosure policy and enables pnpm's supply-chain protection by setting `minimumReleaseAge: 20160` in `pnpm-workspace.yaml`.

- `SECURITY.md` documents the private reporting process via `security@alpic.ai` and is well-structured. The only nit is a missing trailing newline.
- `minimumReleaseAge: 20160` is in **minutes** (per pnpm docs), which equals exactly 14 days — consistent with the \"2 weeks\" comment. This requires pnpm ≥ 10.16 and will block installs of packages published less than two weeks ago, including transitive dependencies.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both changes are additive and low-risk.

Adds a security disclosure document and a pnpm supply-chain guard. The numeric value (20160 minutes = 2 weeks) is correct, and the feature is well-supported in pnpm 10.16+. The only finding is a missing trailing newline in the Markdown file.

No files require special attention.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
SECURITY.md:14
The file is missing a trailing newline, which is a POSIX requirement for text files and can cause minor noise in some diff tools or linters.

```suggestion
We will acknowledge your report and keep you informed of the progress toward a fix.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add security.md and minimumRelease..."](https://github.com/alpic-ai/skybridge/commit/4c658fb5e076482c35527727b2366320415a33ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37825853)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->