### PR TITLE
fix(devtools): restore cached outputs

### DIFF
--- a/packages/devtools/e2e/tests/every-input-type.spec.ts
+++ b/packages/devtools/e2e/tests/every-input-type.spec.ts
@@ -5,6 +5,8 @@ test.describe("every-input-type tool", () => {
     await page.goto("/");
 
     const tool = page.locator('[data-tool-name="every-input-type"]');
+    // Only the first tool is expanded by default; open this one first.
+    await tool.locator('[data-slot="accordion-trigger"]').click();
 
     await tool.getByLabel("name").fill("Alice");
     await tool.getByLabel("age").fill("30");

--- a/packages/devtools/e2e/tests/smoke.spec.ts
+++ b/packages/devtools/e2e/tests/smoke.spec.ts
@@ -32,12 +32,15 @@ test.describe("devtools smoke", () => {
 
     const token = `card-${crypto.randomUUID()}`;
     const echoCard = page.locator('[data-tool-name="echo-card"]');
+    // Only the first tool is expanded by default; open this one first.
+    await echoCard.locator('[data-slot="accordion-trigger"]').click();
     await echoCard.getByLabel("message").fill(token);
     await echoCard.getByRole("button", { name: /^run$/i }).click();
 
-    // First-time view compilation by Vite can take a few seconds.
+    // First-time view compilation by Vite can take a while, especially under
+    // the full suite where several devtools servers compile views in parallel.
     const widget = page.frameLocator('iframe[title="html-preview"]');
-    await expect(widget.getByText(token)).toBeVisible({ timeout: 20_000 });
+    await expect(widget.getByText(token)).toBeVisible({ timeout: 45_000 });
   });
 });
 
@@ -46,9 +49,9 @@ test.describe("visibility badge", () => {
     page,
   }) => {
     await page.goto("/");
-    const badges = page
-      .locator('[data-tool-name="dual-visibility-tool"]')
-      .getByTestId("tool-visibility");
+    const tool = page.locator('[data-tool-name="dual-visibility-tool"]');
+    await tool.locator('[data-slot="accordion-trigger"]').click();
+    const badges = tool.getByTestId("tool-visibility");
     await expect(badges).toBeVisible();
     await expect(badges.getByText("model", { exact: true })).toBeVisible();
     await expect(badges.getByText("app", { exact: true })).toBeVisible();
@@ -58,9 +61,9 @@ test.describe("visibility badge", () => {
     page,
   }) => {
     await page.goto("/");
-    const badges = page
-      .locator('[data-tool-name="model-only-tool"]')
-      .getByTestId("tool-visibility");
+    const tool = page.locator('[data-tool-name="model-only-tool"]');
+    await tool.locator('[data-slot="accordion-trigger"]').click();
+    const badges = tool.getByTestId("tool-visibility");
     await expect(badges).toBeVisible();
     await expect(badges.getByText("model", { exact: true })).toBeVisible();
     await expect(badges.getByText("app", { exact: true })).toHaveCount(0);
@@ -70,9 +73,9 @@ test.describe("visibility badge", () => {
     page,
   }) => {
     await page.goto("/");
-    const badges = page
-      .locator('[data-tool-name="app-only-tool"]')
-      .getByTestId("tool-visibility");
+    const tool = page.locator('[data-tool-name="app-only-tool"]');
+    await tool.locator('[data-slot="accordion-trigger"]').click();
+    const badges = tool.getByTestId("tool-visibility");
     await expect(badges).toBeVisible();
     await expect(badges.getByText("app", { exact: true })).toBeVisible();
     await expect(badges.getByText("model", { exact: true })).toHaveCount(0);

--- a/packages/devtools/src/components/layout/tools-list/index.tsx
+++ b/packages/devtools/src/components/layout/tools-list/index.tsx
@@ -10,8 +10,10 @@ import { ToolItem } from "./tool-item.js";
 
 function ToolsList() {
   const tools = useSuspenseTools();
+  // Start with only the first tool open; its form's first input gets autofocus
+  // (handled in FormBody, which only mounts for open tools).
   const [openTools, setOpenTools] = useState<string[]>(
-    tools.map((tool) => tool.name),
+    tools.length > 0 ? [tools[0].name] : [],
   );
   const [refreshing, setRefreshing] = useState(false);
   const [tailDelay, setTailDelay] = useState<number | undefined>(undefined);

--- a/packages/devtools/src/components/layout/tools-list/tool-item.tsx
+++ b/packages/devtools/src/components/layout/tools-list/tool-item.tsx
@@ -52,6 +52,7 @@ export function ToolItem({ tool }: { tool: Tool }) {
   const requiresAuth = useAuthStore((s) => s.requiresAuth);
   const formRef = useRef<Form<unknown, RJSFSchema>>(null);
   const result = useCallToolResult(tool.name);
+  const hasCachedOutput = Boolean(result?.response);
   const { setToolData } = useStore();
   const formData = (result?.input ?? {}) as Record<string, unknown>;
   const setFormData = (data: Record<string, unknown> | null) => {
@@ -176,9 +177,17 @@ export function ToolItem({ tool }: { tool: Tool }) {
     <AccordionItem
       value={tool.name}
       data-tool-name={tool.name}
-      className="border-b border-border transition-colors last:border-b-0 data-[state=closed]:hover:bg-muted/40"
+      className={cn(
+        // 5px left border always reserved (light grey) so the row never shifts;
+        // turns cyan when selected.
+        "border-b border-l-[5px] border-border transition-colors last:border-b-0 data-[state=closed]:hover:bg-muted/40",
+        isSelected && "border-l-cyan-400",
+      )}
     >
+      {/* Clicking the header toggles the input panel (Radix) and, when the tool
+          has cached output, also selects it so that output shows on the right. */}
       <AccordionTrigger
+        onClick={hasCachedOutput ? () => setSelectedTool(tool.name) : undefined}
         className={cn(
           "font-mono text-xs font-normal text-foreground",
           "no-underline",
@@ -609,7 +618,9 @@ function FormBody({
       'input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="hidden"]):not([type="file"]):not([type="button"]):not([type="submit"]), textarea',
     );
     if (focusable && !focusable.value) {
-      focusable.focus();
+      // preventScroll: focusing must not yank the (tall) tool list down to the
+      // input on first render.
+      focusable.focus({ preventScroll: true });
     }
   }, []);
 

--- a/packages/devtools/src/components/layout/tools-list/tool-item.tsx
+++ b/packages/devtools/src/components/layout/tools-list/tool-item.tsx
@@ -184,8 +184,6 @@ export function ToolItem({ tool }: { tool: Tool }) {
         isSelected && "border-l-cyan-400",
       )}
     >
-      {/* Clicking the header toggles the input panel (Radix) and, when the tool
-          has cached output, also selects it so that output shows on the right. */}
       <AccordionTrigger
         onClick={hasCachedOutput ? () => setSelectedTool(tool.name) : undefined}
         className={cn(


### PR DESCRIPTION
'selecting' a tool means displaying the output. it can be achieved by
- running the tool
- clicking on the tool header, granted we have an previous output to display
selected tools are flagged with a cyan left border (on both tool header and body)

also fixed the auto-scroll on focused input: .focus() auto-scrolls the input into view, but it fires before the list layout has settled, so the browser scrolls against a half-built layout and overshoots to the bottom (where it then stays).

<img width="519" height="277" alt="Screenshot 2026-06-16 at 12 07 20" src="https://github.com/user-attachments/assets/547676ef-bdec-426f-8953-d1de2c4a6f23" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces "cached output selection" for the devtools tool list: clicking a tool's header now restores its previous output in the right pane (when a result exists), visualized via a 5 px cyan left border on the selected row. It also fixes an autofocus scroll overshoot caused by `.focus()` firing before the list layout settles, and changes the initial accordion state so only the first tool starts expanded (preventing all inputs from claiming autofocus simultaneously).

- `tool-item.tsx`: adds `hasCachedOutput` guard on the `AccordionTrigger` `onClick` to call `setSelectedTool`, adds left-border selection indicator, and switches to `focusable.focus({ preventScroll: true })`.
- `index.tsx`: narrows the initial `openTools` state to the first tool only.
- E2e tests: each test now explicitly opens the relevant accordion item before interacting, and the Vite iframe timeout is raised to 45 s for parallel runs.

<h3>Confidence Score: 5/5</h3>

The changes are narrowly scoped to UI interaction and autofocus behaviour with no data-layer or auth-path changes; safe to merge.

All three change areas (selection state, border styling, focus fix) are self-contained, the e2e tests are correctly updated to reflect the new default-open behaviour, and no store, network, or auth logic is touched.

No files require special attention.

<sub>Reviews (4): Last reviewed commit: ["fix: remove comment"](https://github.com/alpic-ai/skybridge/commit/3e6e08587d8a3838219ef21aa839f0d8ee4b24f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37873183)</sub>

<!-- /greptile_comment -->