### PR TITLE
fix: serve view resource no matter the ?v= cache key

### DIFF
--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -385,6 +385,16 @@ type ErrorMiddlewareConfig = {
 };
 
 /**
+ * Drop the query string from a `ui://` view URI, leaving the bare path. The
+ * `?v=` cache key is the only query we append, so a plain split is enough and
+ * sidesteps `URL` normalization quirks on the non-special `ui:` scheme.
+ */
+function stripQuery(uri: string): string {
+  const queryIndex = uri.indexOf("?");
+  return queryIndex === -1 ? uri : uri.slice(0, queryIndex);
+}
+
+/**
  * Coerce a tool handler's return value into an MCP `content` array. Strings
  * become a single `TextContent`; a single block is wrapped in an array;
  * `undefined` produces `[]`. Mostly used internally — exported so consumers
@@ -490,6 +500,13 @@ export class McpServer<
     string,
     (extra: McpExtra | undefined) => ResourceMeta
   >();
+  /**
+   * Maps a view resource's query-less path to its canonical registered URI
+   * (the one carrying the `?v=` cache key). Lets `resources/read` resolve the
+   * underlying view no matter which version param the consumer sends, since
+   * the param is only a cache key, not part of the resource's identity.
+   */
+  private viewUriByPath = new Map<string, string>();
   private viteManifest: Record<string, ViteManifestEntry> | null = null;
   private readonly serverInfo: Implementation;
   private readonly serverOptions?: ServerOptions;
@@ -675,10 +692,45 @@ export class McpServer<
       },
     };
 
+    // Resolve a view's `resources/read` by its query-less path so the
+    // underlying asset is served no matter the `?v=` value (stale cache key,
+    // no param, etc.). The version param is a cache-busting hint for external
+    // consumers; it must not gate resolution. We rewrite the lookup URI to the
+    // canonical registered one, then restore the requested URI on the response
+    // so the consumer-facing URI is never rewritten.
+    const viewReadResolveEntry: McpMiddlewareEntry = {
+      filter: "resources/read",
+      handler: async (req, _extra, next) => {
+        const requested = req.params.uri;
+        if (typeof requested !== "string") {
+          return next();
+        }
+        const path = stripQuery(requested);
+        const canonical = this.viewUriByPath.get(path);
+        if (!canonical) {
+          return next();
+        }
+        req.params.uri = canonical;
+        const result = (await next()) as {
+          contents?: Array<{ uri?: string } & Record<string, unknown>>;
+        };
+        for (const content of result.contents ?? []) {
+          if (
+            typeof content.uri === "string" &&
+            stripQuery(content.uri) === path
+          ) {
+            content.uri = requested;
+          }
+        }
+        return result;
+      },
+    };
+
     const monitoringEntry = createMiddlewareEntry();
     const entries = [
       ...(monitoringEntry ? [monitoringEntry] : []),
       viewListMetaEntry,
+      viewReadResolveEntry,
       ...this.mcpMiddlewareEntries,
     ];
 
@@ -1065,6 +1117,7 @@ export class McpServer<
       );
     };
     this.viewMetaBuilders.set(viewUri, buildMeta);
+    this.viewUriByPath.set(stripQuery(viewUri), viewUri);
 
     this.registerResource(
       name,

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -711,18 +711,24 @@ export class McpServer<
           return next();
         }
         req.params.uri = canonical;
-        const result = (await next()) as {
-          contents?: Array<{ uri?: string } & Record<string, unknown>>;
-        };
-        for (const content of result.contents ?? []) {
-          if (
-            typeof content.uri === "string" &&
-            stripQuery(content.uri) === path
-          ) {
-            content.uri = requested;
+        try {
+          const result = (await next()) as {
+            contents?: Array<{ uri?: string } & Record<string, unknown>>;
+          };
+          for (const content of result.contents ?? []) {
+            if (
+              typeof content.uri === "string" &&
+              stripQuery(content.uri) === path
+            ) {
+              content.uri = requested;
+            }
           }
+          return result;
+        } finally {
+          // Restore the shared request params so middleware outer to us never
+          // observes the rewritten lookup URI after next() unwinds.
+          req.params.uri = requested;
         }
-        return result;
       },
     };
 

--- a/packages/core/src/server/view-resource-resolution.test.ts
+++ b/packages/core/src/server/view-resource-resolution.test.ts
@@ -1,0 +1,127 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { afterEach, describe, expect, it } from "vitest";
+import { __setBuildManifest, McpServer } from "./index.js";
+
+// Mirror what the Skybridge Vite plugin generates in `.skybridge/views.d.ts`:
+// narrow `ViewName` so `component: "widget"` typechecks against the registry.
+declare module "./server.js" {
+  interface ViewNameRegistry {
+    widget: true;
+  }
+}
+
+// SKY-435: a view resource must resolve no matter the `?v=` query param value.
+// The version param is a content-derived cache key for external consumers
+// (it busts host/CDN caches when the bundle changes); it is not part of the
+// resource's identity, so a stale, absent, or arbitrary param must still serve
+// the underlying asset.
+
+async function connect(register: (server: McpServer) => void) {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  register(server);
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  return {
+    client,
+    teardown: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+function registerWidget(server: McpServer) {
+  server.registerTool(
+    { name: "show", description: "show", view: { component: "widget" } },
+    () => ({ content: [{ type: "text" as const, text: "ok" }] }),
+  );
+}
+
+/** Narrow a read-resource content entry to its text variant. */
+function textContent(contents: Array<{ uri: string }>): {
+  uri: string;
+  text: string;
+} {
+  return contents[0] as { uri: string; text: string };
+}
+
+describe("view resource resolution (cache key)", () => {
+  afterEach(() => {
+    delete process.env.NODE_ENV;
+  });
+
+  it("resolves regardless of the ?v= param and echoes the requested URI", async () => {
+    const { client, teardown } = await connect(registerWidget);
+
+    const { resources } = await client.listResources();
+    const listed = resources.find((r) =>
+      r.uri.startsWith("ui://views/apps-sdk/widget.html"),
+    );
+    // Dev build advertises no cache key.
+    expect(listed?.uri).toBe("ui://views/apps-sdk/widget.html");
+
+    // A stale/arbitrary/absent param all resolve the same underlying asset,
+    // and the response echoes the URI the consumer asked for (never rewritten).
+    for (const uri of [
+      "ui://views/apps-sdk/widget.html?v=stale123",
+      "ui://views/apps-sdk/widget.html?v=whatever-else",
+      "ui://views/apps-sdk/widget.html",
+    ]) {
+      const { contents } = await client.readResource({ uri });
+      expect(contents).toHaveLength(1);
+      const content = textContent(contents);
+      expect(typeof content.text).toBe("string");
+      expect(content.text.length).toBeGreaterThan(0);
+      expect(content.uri).toBe(uri);
+    }
+
+    await teardown();
+  });
+
+  it("resolves a stale cache key when the canonical URI carries ?v= (prod)", async () => {
+    process.env.NODE_ENV = "production";
+    __setBuildManifest({
+      "src/views/widget.tsx": {
+        isEntry: true,
+        name: "widget",
+        file: "assets/widget-ABC123.js",
+      },
+      "style.css": { file: "assets/style-XYZ.css" },
+    } as unknown as Record<string, { file: string }>);
+
+    const { client, teardown } = await connect(registerWidget);
+
+    const { resources } = await client.listResources();
+    const listed = resources.find((r) =>
+      r.uri.startsWith("ui://views/apps-sdk/widget.html"),
+    );
+    // Production advertises a content-derived cache key.
+    expect(listed?.uri).toMatch(
+      /^ui:\/\/views\/apps-sdk\/widget\.html\?v=[0-9a-f]{8}$/,
+    );
+
+    // A consumer holding a stale key still resolves the current asset.
+    const staleUri = "ui://views/apps-sdk/widget.html?v=00000000";
+    const { contents } = await client.readResource({ uri: staleUri });
+    expect(contents).toHaveLength(1);
+    const content = textContent(contents);
+    expect(typeof content.text).toBe("string");
+    expect(content.uri).toBe(staleUri);
+
+    await teardown();
+  });
+
+  it("still throws for an unknown view path", async () => {
+    const { client, teardown } = await connect(registerWidget);
+
+    await expect(
+      client.readResource({ uri: "ui://views/apps-sdk/nope.html?v=1" }),
+    ).rejects.toThrow();
+
+    await teardown();
+  });
+});


### PR DESCRIPTION
external consumers might cache the view URI from tools/list, but we bake the version param into the resource URI and the SDK resolves reads by exact match. so as soon as the bundle changes (new hash) or a client sends a stale/empty param, resources/read 404s even though we can render the current bundle just fine.

now reads resolve a view by its query-less path: rewrite to the registered URI before lookup, then restore the requested URI on the response. the ?v= goes back to being purely a cache-buster in the advertised URIs and never gates resolution.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds path-based view resource resolution so `resources/read` succeeds regardless of the `?v=` cache-busting param a consumer sends. A new `viewUriByPath` map (path → canonical URI with `?v=`) is populated at registration time, and a `viewReadResolveEntry` middleware rewrites the incoming URI to the canonical one before lookup, then restores the originally-requested URI on the response and in `req.params.uri` (via `finally`).

- `stripQuery` helper strips the `?v=` cache key for map key storage and comparison, avoiding `URL` normalization quirks on the non-standard `ui:` scheme.
- The `viewReadResolveEntry` middleware passes through cleanly for non-view resources (no entry in `viewUriByPath`) and for resources whose path is entirely unknown.
- New integration tests cover the dev (no cache key), production (content-derived hash), stale-param, and unknown-path cases end-to-end with a real in-memory MCP transport.

<h3>Confidence Score: 5/5</h3>

The change is narrowly scoped to view resource reads, passes through cleanly for non-view URIs, and restores all shared mutable state in a `finally` block.

The middleware logic is simple and correct: it rewrites only registered view paths, restores `req.params.uri` unconditionally via `finally`, and the new integration tests exercise every meaningful variant (dev, prod, stale key, unknown path). No regressions are visible on the read or list paths.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["fix: restore req.params.uri after view r..."](https://github.com/alpic-ai/skybridge/commit/df4090c4dd12afec7b769b30f12c56d352c084b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37903385)</sub>

<!-- /greptile_comment -->