### PR TITLE
feat(core): oauth field on McpServer + SDK wiring (SKY-445)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -70,6 +70,7 @@
     "express": "^5.2.1",
     "handlebars": "^4.7.9",
     "ink": "^7.0.0",
+    "jose": "^6.1.3",
     "open": "^11.0.0",
     "posthog-node": "^5.28.9",
     "superjson": "^2.2.6",

--- a/packages/core/src/server/auth/index.ts
+++ b/packages/core/src/server/auth/index.ts
@@ -1,42 +1,17 @@
 import type { OAuthMetadata } from "@modelcontextprotocol/sdk/shared/auth.js";
 import type { JwksVerifyConfig } from "./verify.js";
 
-/**
- * Resource-server OAuth configuration passed to `McpServer` via
- * `SkybridgeServerOptions.oauth`. Accepts a raw object or a branded provider
- * (SKY-447) that returns one. Remote-auth only: the MCP client runs the OAuth
- * flow directly against the upstream IdP; this server only advertises the
- * well-known metadata and verifies bearer tokens.
- */
+/** Resource-server OAuth config for `SkybridgeServerOptions.oauth`. */
 export type OAuthConfig = {
-  /**
-   * Public base URL of this resource server (e.g. `https://app.example.com`).
-   * Used for the served `resourceServerUrl` and the `resource_metadata` URL
-   * advertised in 401 `WWW-Authenticate` headers.
-   */
+  /** Public URL of this server; sets `resourceServerUrl` and the `resource_metadata` URL. */
   baseUrl: string;
-
-  /**
-   * Authorization-server metadata served verbatim at
-   * `/.well-known/oauth-authorization-server`. Its endpoints point at the
-   * upstream IdP.
-   */
+  /** AS metadata served at `/.well-known/oauth-authorization-server`. */
   oauthMetadata: OAuthMetadata;
-
-  /** JWKS-based token verification. */
   verify: JwksVerifyConfig;
-
-  /** Scopes advertised in the protected-resource metadata. */
+  /** Scopes advertised in protected-resource metadata. */
   scopesSupported?: string[];
-
-  /** Server-wide required-scope floor enforced by `requireBearerAuth`. */
+  /** Server-wide required-scope floor. */
   requiredScopes?: string[];
-
-  /**
-   * Transport-level enforcement on `/mcp`. `"required"` (default) gates every
-   * request — no valid token, no access. `"optional"` lets anonymous requests
-   * through for per-tool `securitySchemes` to decide (mixed-auth); a token, if
-   * present, must still verify and meet `requiredScopes`.
-   */
+  /** `required` (default) gates `/mcp`; `optional` allows anonymous for per-tool checks. */
   enforcement?: "required" | "optional";
 };

--- a/packages/core/src/server/auth/index.ts
+++ b/packages/core/src/server/auth/index.ts
@@ -3,8 +3,12 @@ import type { JwksVerifyConfig } from "./verify.js";
 
 /** Resource-server OAuth config for `SkybridgeServerOptions.oauth`. */
 export type OAuthConfig = {
-  /** Public URL of this server; sets `resourceServerUrl` and the `resource_metadata` URL. */
-  baseUrl: string;
+  /**
+   * Public URL of this server; sets `resourceServerUrl` and the
+   * `resource_metadata` URL. When omitted, it is inferred per request from
+   * `x-forwarded-host`/`origin`/`host` headers.
+   */
+  baseUrl?: string;
   /** AS metadata served at `/.well-known/oauth-authorization-server`. */
   oauthMetadata: OAuthMetadata;
   verify: JwksVerifyConfig;

--- a/packages/core/src/server/auth/index.ts
+++ b/packages/core/src/server/auth/index.ts
@@ -1,0 +1,35 @@
+import type { OAuthMetadata } from "@modelcontextprotocol/sdk/shared/auth.js";
+import type { JwksVerifyConfig } from "./verify.js";
+
+/**
+ * Resource-server OAuth configuration passed to `McpServer` via
+ * `SkybridgeServerOptions.oauth`. Accepts a raw object or a branded provider
+ * (SKY-447) that returns one. Remote-auth only: the MCP client runs the OAuth
+ * flow directly against the upstream IdP; this server only advertises the
+ * well-known metadata and verifies bearer tokens.
+ */
+export type OAuthConfig = {
+  /**
+   * Public base URL of this resource server (e.g. `https://app.example.com`).
+   * Used for the served `resourceServerUrl` and the `resource_metadata` URL
+   * advertised in 401 `WWW-Authenticate` headers. Developer-supplied — the
+   * framework never reads `process.env` for it.
+   */
+  baseUrl: string;
+
+  /**
+   * Authorization-server metadata served verbatim at
+   * `/.well-known/oauth-authorization-server`. Its endpoints point at the
+   * upstream IdP. Branded providers (SKY-447) fill this in.
+   */
+  oauthMetadata: OAuthMetadata;
+
+  /** JWKS-based token verification (`jose`). */
+  verify: JwksVerifyConfig;
+
+  /** Scopes advertised in the protected-resource metadata. */
+  scopesSupported?: string[];
+
+  /** Server-wide required-scope floor enforced by `requireBearerAuth`. */
+  requiredScopes?: string[];
+};

--- a/packages/core/src/server/auth/index.ts
+++ b/packages/core/src/server/auth/index.ts
@@ -12,19 +12,18 @@ export type OAuthConfig = {
   /**
    * Public base URL of this resource server (e.g. `https://app.example.com`).
    * Used for the served `resourceServerUrl` and the `resource_metadata` URL
-   * advertised in 401 `WWW-Authenticate` headers. Developer-supplied — the
-   * framework never reads `process.env` for it.
+   * advertised in 401 `WWW-Authenticate` headers.
    */
   baseUrl: string;
 
   /**
    * Authorization-server metadata served verbatim at
    * `/.well-known/oauth-authorization-server`. Its endpoints point at the
-   * upstream IdP. Branded providers (SKY-447) fill this in.
+   * upstream IdP.
    */
   oauthMetadata: OAuthMetadata;
 
-  /** JWKS-based token verification (`jose`). */
+  /** JWKS-based token verification. */
   verify: JwksVerifyConfig;
 
   /** Scopes advertised in the protected-resource metadata. */
@@ -32,4 +31,12 @@ export type OAuthConfig = {
 
   /** Server-wide required-scope floor enforced by `requireBearerAuth`. */
   requiredScopes?: string[];
+
+  /**
+   * Transport-level enforcement on `/mcp`. `"required"` (default) gates every
+   * request — no valid token, no access. `"optional"` lets anonymous requests
+   * through for per-tool `securitySchemes` to decide (mixed-auth); a token, if
+   * present, must still verify and meet `requiredScopes`.
+   */
+  enforcement?: "required" | "optional";
 };

--- a/packages/core/src/server/auth/index.ts
+++ b/packages/core/src/server/auth/index.ts
@@ -16,6 +16,4 @@ export type OAuthConfig = {
   scopesSupported?: string[];
   /** Server-wide required-scope floor. */
   requiredScopes?: string[];
-  /** `required` (default) gates `/mcp`; `optional` allows anonymous for per-tool checks. */
-  enforcement?: "required" | "optional";
 };

--- a/packages/core/src/server/auth/setup.test.ts
+++ b/packages/core/src/server/auth/setup.test.ts
@@ -167,3 +167,39 @@ describe("setupOAuth wiring", () => {
     await client.close();
   });
 });
+
+describe("oauth config validation", () => {
+  const validMetadata = {
+    issuer: ISSUER,
+    authorization_endpoint: `${ISSUER}/authorize`,
+    token_endpoint: `${ISSUER}/token`,
+    response_types_supported: ["code"],
+  };
+
+  it("throws on a non-absolute baseUrl", () => {
+    expect(
+      () =>
+        new McpServer({ name: "t", version: "0" }, undefined, {
+          oauth: {
+            baseUrl: "not-a-url",
+            oauthMetadata: validMetadata,
+            verify: { issuer: ISSUER, audience: AUDIENCE },
+          },
+        }),
+    ).toThrow(/baseUrl must be a valid absolute URL/);
+  });
+
+  it("throws when verify.audience is missing", () => {
+    expect(
+      () =>
+        new McpServer({ name: "t", version: "0" }, undefined, {
+          oauth: {
+            baseUrl: "https://app.example.test",
+            oauthMetadata: validMetadata,
+            // @ts-expect-error intentionally missing audience
+            verify: { issuer: ISSUER },
+          },
+        }),
+    ).toThrow(/verify requires both `issuer` and `audience`/);
+  });
+});

--- a/packages/core/src/server/auth/setup.test.ts
+++ b/packages/core/src/server/auth/setup.test.ts
@@ -191,6 +191,18 @@ describe("baseUrl inferred from headers", () => {
     expect(body.resource).toBe("https://public.example/");
   });
 
+  it("falls back to Host when Origin is opaque (null)", async () => {
+    const { jwksUri } = await startJwks();
+    const base = await bootServer(jwksUri, { baseUrl: null });
+
+    const res = await fetch(`${base}/.well-known/oauth-protected-resource`, {
+      headers: { origin: "null" },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { resource: string };
+    expect(body.resource).toMatch(/^http:\/\/(localhost|127\.0\.0\.1):/);
+  });
+
   it("points the 401 WWW-Authenticate at the inferred host", async () => {
     const { jwksUri } = await startJwks();
     const base = await bootServer(jwksUri, { baseUrl: null });

--- a/packages/core/src/server/auth/setup.test.ts
+++ b/packages/core/src/server/auth/setup.test.ts
@@ -1,0 +1,169 @@
+// @vitest-environment node
+import http from "node:http";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { RequestHandler } from "express";
+import * as jose from "jose";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { McpServer } from "../server.js";
+
+vi.mock("@skybridge/devtools", () => ({
+  devtoolsStaticServer: () =>
+    ((_req: unknown, _res: unknown, next: () => void) =>
+      next()) as RequestHandler,
+}));
+vi.mock("../viewsDevServer.js", () => ({
+  viewsDevServer: (_httpServer: unknown) =>
+    ((_req: unknown, _res: unknown, next: () => void) =>
+      next()) as RequestHandler,
+}));
+
+const ISSUER = "https://issuer.test";
+const AUDIENCE = "api://default";
+
+let jwksServer: http.Server | undefined;
+let appServer: http.Server | undefined;
+afterEach(() => {
+  jwksServer?.close();
+  appServer?.close();
+});
+
+async function startJwks() {
+  const { publicKey, privateKey } = await jose.generateKeyPair("RS256");
+  const jwk = {
+    ...(await jose.exportJWK(publicKey)),
+    kid: "test-key",
+    alg: "RS256",
+    use: "sig",
+  };
+  const server = http.createServer((_req, res) => {
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({ keys: [jwk] }));
+  });
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  jwksServer = server;
+  const port = (server.address() as { port: number }).port;
+  return { privateKey, jwksUri: `http://localhost:${port}/jwks` };
+}
+
+function signToken(key: CryptoKey) {
+  return new jose.SignJWT({
+    client_id: "client-1",
+    scope: "openid email",
+    sub: "user-1",
+  })
+    .setProtectedHeader({ alg: "RS256", kid: "test-key" })
+    .setIssuer(ISSUER)
+    .setAudience(AUDIENCE)
+    .setExpirationTime("1h")
+    .sign(key);
+}
+
+// Builds an oauth-configured server with an echo tool that returns authInfo,
+// boots it on a random port, and returns the base URL.
+async function bootServer(
+  jwksUri: string,
+  baseUrl = "https://app.example.test",
+) {
+  const { createApp } = await import("../express.js");
+  const server = new McpServer(
+    { name: "auth-test", version: "0.0.0" },
+    { capabilities: {} },
+    {
+      oauth: {
+        baseUrl,
+        oauthMetadata: {
+          issuer: ISSUER,
+          authorization_endpoint: `${ISSUER}/authorize`,
+          token_endpoint: `${ISSUER}/token`,
+          response_types_supported: ["code"],
+        },
+        verify: { issuer: ISSUER, audience: AUDIENCE, jwksUri },
+        scopesSupported: ["openid", "email"],
+        requiredScopes: ["openid"],
+      },
+    },
+  ).registerTool(
+    {
+      name: "whoami",
+      description: "Returns the caller identity.",
+      inputSchema: {},
+    },
+    (_args, extra) => ({
+      structuredContent: { clientId: extra.authInfo?.clientId ?? null },
+      content: [{ type: "text", text: extra.authInfo?.clientId ?? "anon" }],
+    }),
+  );
+
+  const httpServer = http.createServer();
+  await createApp({ mcpServer: server, httpServer });
+  const listening = http.createServer(server.express);
+  await new Promise<void>((resolve) => listening.listen(0, resolve));
+  appServer = listening;
+  const port = (listening.address() as { port: number }).port;
+  return `http://localhost:${port}`;
+}
+
+describe("setupOAuth wiring", () => {
+  it("serves protected-resource metadata", async () => {
+    const { jwksUri } = await startJwks();
+    const base = await bootServer(jwksUri);
+
+    const res = await fetch(`${base}/.well-known/oauth-protected-resource`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      resource: string;
+      authorization_servers: string[];
+      scopes_supported: string[];
+    };
+    expect(body.resource).toBe("https://app.example.test/");
+    expect(body.authorization_servers).toContain(ISSUER);
+    expect(body.scopes_supported).toEqual(["openid", "email"]);
+  });
+
+  it("serves authorization-server metadata", async () => {
+    const { jwksUri } = await startJwks();
+    const base = await bootServer(jwksUri);
+
+    const res = await fetch(`${base}/.well-known/oauth-authorization-server`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { issuer: string };
+    expect(body.issuer).toBe(ISSUER);
+  });
+
+  it("rejects /mcp without a token (401 + WWW-Authenticate)", async () => {
+    const { jwksUri } = await startJwks();
+    const base = await bootServer(jwksUri);
+
+    const res = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 1 }),
+    });
+    expect(res.status).toBe(401);
+    expect(res.headers.get("www-authenticate")).toMatch(/resource_metadata=/);
+  });
+
+  it("threads authInfo into the tool handler for a valid token", async () => {
+    const { privateKey, jwksUri } = await startJwks();
+    const base = await bootServer(jwksUri);
+    const token = await signToken(privateKey);
+
+    const client = new Client({ name: "test-client", version: "0.0.0" });
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`${base}/mcp`),
+      { requestInit: { headers: { Authorization: `Bearer ${token}` } } },
+    );
+    await client.connect(transport);
+
+    const result = (await client.callTool({
+      name: "whoami",
+      arguments: {},
+    })) as unknown as {
+      content: { type: string; text: string }[];
+    };
+    expect(result.content[0]?.text).toBe("client-1");
+
+    await client.close();
+  });
+});

--- a/packages/core/src/server/auth/setup.test.ts
+++ b/packages/core/src/server/auth/setup.test.ts
@@ -64,7 +64,10 @@ async function bootServer(
   {
     baseUrl = "https://app.example.test",
     enforcement = "required",
-  }: { baseUrl?: string; enforcement?: "required" | "optional" } = {},
+  }: {
+    baseUrl?: string | null;
+    enforcement?: "required" | "optional";
+  } = {},
 ) {
   const { createApp } = await import("../express.js");
   const server = new McpServer(
@@ -72,7 +75,7 @@ async function bootServer(
     { capabilities: {} },
     {
       oauth: {
-        baseUrl,
+        ...(baseUrl === null ? {} : { baseUrl }),
         oauthMetadata: {
           issuer: ISSUER,
           authorization_endpoint: `${ISSUER}/authorize`,
@@ -157,6 +160,38 @@ describe("setupOAuth wiring", () => {
     expect(result.content[0]?.text).toBe("client-1");
 
     await client.close();
+  });
+});
+
+describe("baseUrl inferred from headers", () => {
+  it("derives the resource origin from x-forwarded-host", async () => {
+    const { jwksUri } = await startJwks();
+    const base = await bootServer(jwksUri, { baseUrl: null });
+
+    const res = await fetch(`${base}/.well-known/oauth-protected-resource`, {
+      headers: { "x-forwarded-host": "infer.example.test" },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { resource: string };
+    expect(body.resource).toBe("https://infer.example.test/");
+  });
+
+  it("points the 401 WWW-Authenticate at the inferred host", async () => {
+    const { jwksUri } = await startJwks();
+    const base = await bootServer(jwksUri, { baseUrl: null });
+
+    const res = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-forwarded-host": "infer.example.test",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 1 }),
+    });
+    expect(res.status).toBe(401);
+    expect(res.headers.get("www-authenticate")).toMatch(
+      /resource_metadata="https:\/\/infer\.example\.test\//,
+    );
   });
 });
 

--- a/packages/core/src/server/auth/setup.test.ts
+++ b/packages/core/src/server/auth/setup.test.ts
@@ -191,12 +191,12 @@ describe("baseUrl inferred from headers", () => {
     expect(body.resource).toBe("https://public.example/");
   });
 
-  it("falls back to Host when Origin is opaque (null)", async () => {
+  it("ignores the client Origin header, using Host instead", async () => {
     const { jwksUri } = await startJwks();
     const base = await bootServer(jwksUri, { baseUrl: null });
 
     const res = await fetch(`${base}/.well-known/oauth-protected-resource`, {
-      headers: { origin: "null" },
+      headers: { origin: "https://chatgpt.com" },
     });
     expect(res.status).toBe(200);
     const body = (await res.json()) as { resource: string };

--- a/packages/core/src/server/auth/setup.test.ts
+++ b/packages/core/src/server/auth/setup.test.ts
@@ -61,13 +61,7 @@ function signToken(key: CryptoKey) {
 
 async function bootServer(
   jwksUri: string,
-  {
-    baseUrl = "https://app.example.test",
-    enforcement = "required",
-  }: {
-    baseUrl?: string | null;
-    enforcement?: "required" | "optional";
-  } = {},
+  { baseUrl = "https://app.example.test" }: { baseUrl?: string | null } = {},
 ) {
   const { createApp } = await import("../express.js");
   const server = new McpServer(
@@ -85,7 +79,6 @@ async function bootServer(
         verify: { issuer: ISSUER, audience: AUDIENCE, jwksUri },
         scopesSupported: ["openid", "email"],
         requiredScopes: ["openid"],
-        enforcement,
       },
     },
   ).registerTool(
@@ -219,32 +212,6 @@ describe("baseUrl inferred from headers", () => {
     expect(res.headers.get("www-authenticate")).toMatch(
       /resource_metadata="https:\/\/infer\.example\.test\//,
     );
-  });
-});
-
-describe("enforcement: optional", () => {
-  it("lets an anonymous /mcp request through", async () => {
-    const { jwksUri } = await startJwks();
-    const base = await bootServer(jwksUri, { enforcement: "optional" });
-
-    const res = await fetch(`${base}/mcp`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json, text/event-stream",
-      },
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        method: "initialize",
-        id: 1,
-        params: {
-          protocolVersion: "2025-06-18",
-          capabilities: {},
-          clientInfo: { name: "anon", version: "0.0.0" },
-        },
-      }),
-    });
-    expect(res.status).toBe(200);
   });
 });
 

--- a/packages/core/src/server/auth/setup.test.ts
+++ b/packages/core/src/server/auth/setup.test.ts
@@ -59,8 +59,6 @@ function signToken(key: CryptoKey) {
     .sign(key);
 }
 
-// Builds an oauth-configured server with an echo tool that returns authInfo,
-// boots it on a random port, and returns the base URL.
 async function bootServer(
   jwksUri: string,
   {

--- a/packages/core/src/server/auth/setup.test.ts
+++ b/packages/core/src/server/auth/setup.test.ts
@@ -176,6 +176,21 @@ describe("baseUrl inferred from headers", () => {
     expect(body.resource).toBe("https://infer.example.test/");
   });
 
+  it("uses the first hop of a forwarded-host chain", async () => {
+    const { jwksUri } = await startJwks();
+    const base = await bootServer(jwksUri, { baseUrl: null });
+
+    const res = await fetch(`${base}/.well-known/oauth-protected-resource`, {
+      headers: {
+        "x-forwarded-host": "public.example, internal.local",
+        "x-forwarded-proto": "https, http",
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { resource: string };
+    expect(body.resource).toBe("https://public.example/");
+  });
+
   it("points the 401 WWW-Authenticate at the inferred host", async () => {
     const { jwksUri } = await startJwks();
     const base = await bootServer(jwksUri, { baseUrl: null });

--- a/packages/core/src/server/auth/setup.test.ts
+++ b/packages/core/src/server/auth/setup.test.ts
@@ -63,7 +63,10 @@ function signToken(key: CryptoKey) {
 // boots it on a random port, and returns the base URL.
 async function bootServer(
   jwksUri: string,
-  baseUrl = "https://app.example.test",
+  {
+    baseUrl = "https://app.example.test",
+    enforcement = "required",
+  }: { baseUrl?: string; enforcement?: "required" | "optional" } = {},
 ) {
   const { createApp } = await import("../express.js");
   const server = new McpServer(
@@ -81,6 +84,7 @@ async function bootServer(
         verify: { issuer: ISSUER, audience: AUDIENCE, jwksUri },
         scopesSupported: ["openid", "email"],
         requiredScopes: ["openid"],
+        enforcement,
       },
     },
   ).registerTool(
@@ -165,6 +169,47 @@ describe("setupOAuth wiring", () => {
     expect(result.content[0]?.text).toBe("client-1");
 
     await client.close();
+  });
+});
+
+describe("enforcement: optional", () => {
+  it("lets an anonymous /mcp request through", async () => {
+    const { jwksUri } = await startJwks();
+    const base = await bootServer(jwksUri, { enforcement: "optional" });
+
+    const res = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "initialize",
+        id: 1,
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "anon", version: "0.0.0" },
+        },
+      }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("still rejects a malformed token", async () => {
+    const { jwksUri } = await startJwks();
+    const base = await bootServer(jwksUri, { enforcement: "optional" });
+
+    const res = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer not-a-real-token",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 1 }),
+    });
+    expect(res.status).toBe(401);
   });
 });
 

--- a/packages/core/src/server/auth/setup.test.ts
+++ b/packages/core/src/server/auth/setup.test.ts
@@ -123,16 +123,6 @@ describe("setupOAuth wiring", () => {
     expect(body.scopes_supported).toEqual(["openid", "email"]);
   });
 
-  it("serves authorization-server metadata", async () => {
-    const { jwksUri } = await startJwks();
-    const base = await bootServer(jwksUri);
-
-    const res = await fetch(`${base}/.well-known/oauth-authorization-server`);
-    expect(res.status).toBe(200);
-    const body = (await res.json()) as { issuer: string };
-    expect(body.issuer).toBe(ISSUER);
-  });
-
   it("rejects /mcp without a token (401 + WWW-Authenticate)", async () => {
     const { jwksUri } = await startJwks();
     const base = await bootServer(jwksUri);
@@ -194,21 +184,6 @@ describe("enforcement: optional", () => {
     });
     expect(res.status).toBe(200);
   });
-
-  it("still rejects a malformed token", async () => {
-    const { jwksUri } = await startJwks();
-    const base = await bootServer(jwksUri, { enforcement: "optional" });
-
-    const res = await fetch(`${base}/mcp`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: "Bearer not-a-real-token",
-      },
-      body: JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 1 }),
-    });
-    expect(res.status).toBe(401);
-  });
 });
 
 describe("oauth config validation", () => {
@@ -230,19 +205,5 @@ describe("oauth config validation", () => {
           },
         }),
     ).toThrow(/baseUrl must be a valid absolute URL/);
-  });
-
-  it("throws when verify.audience is missing", () => {
-    expect(
-      () =>
-        new McpServer({ name: "t", version: "0" }, undefined, {
-          oauth: {
-            baseUrl: "https://app.example.test",
-            oauthMetadata: validMetadata,
-            // @ts-expect-error intentionally missing audience
-            verify: { issuer: ISSUER },
-          },
-        }),
-    ).toThrow(/verify requires both `issuer` and `audience`/);
   });
 });

--- a/packages/core/src/server/auth/setup.ts
+++ b/packages/core/src/server/auth/setup.ts
@@ -1,0 +1,46 @@
+import { requireBearerAuth } from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js";
+import {
+  getOAuthProtectedResourceMetadataUrl,
+  mcpAuthMetadataRouter,
+} from "@modelcontextprotocol/sdk/server/auth/router.js";
+import type { Express } from "express";
+import type { OAuthConfig } from "./index.js";
+import { createJwksVerifier } from "./verify.js";
+
+/**
+ * Wires resource-server OAuth into the embedded Express app: serves the
+ * well-known metadata and enforces bearer auth on `/mcp`. Called from the
+ * `McpServer` constructor before any user middleware and the `/mcp` route.
+ */
+export function setupOAuth(app: Express, config: OAuthConfig): void {
+  let baseUrl: URL;
+  try {
+    baseUrl = new URL(config.baseUrl);
+  } catch {
+    throw new Error(
+      `oauth.baseUrl must be a valid absolute URL, got: ${JSON.stringify(
+        config.baseUrl,
+      )}`,
+    );
+  }
+  if (!config.verify?.issuer || !config.verify?.audience) {
+    throw new Error("oauth.verify requires both `issuer` and `audience`");
+  }
+
+  app.use(
+    mcpAuthMetadataRouter({
+      oauthMetadata: config.oauthMetadata,
+      resourceServerUrl: baseUrl,
+      scopesSupported: config.scopesSupported,
+    }),
+  );
+
+  app.use(
+    "/mcp",
+    requireBearerAuth({
+      verifier: createJwksVerifier(config.verify),
+      requiredScopes: config.requiredScopes,
+      resourceMetadataUrl: getOAuthProtectedResourceMetadataUrl(baseUrl),
+    }),
+  );
+}

--- a/packages/core/src/server/auth/setup.ts
+++ b/packages/core/src/server/auth/setup.ts
@@ -2,43 +2,78 @@ import {
   getOAuthProtectedResourceMetadataUrl,
   mcpAuthMetadataRouter,
 } from "@modelcontextprotocol/sdk/server/auth/router.js";
-import type { Express } from "express";
+import cors from "cors";
+import type { Express, Request } from "express";
 import { optionalBearerAuth, requireBearerAuth } from "../auth.js";
+import { resolveServerOrigin } from "../requestOrigin.js";
 import type { OAuthConfig } from "./index.js";
 import { createJwksVerifier } from "./verify.js";
 
 /** Mounts the well-known OAuth metadata and bearer auth on `/mcp`. */
 export function setupOAuth(app: Express, config: OAuthConfig): void {
-  let baseUrl: URL;
-  try {
-    baseUrl = new URL(config.baseUrl);
-  } catch {
-    throw new Error(
-      `oauth.baseUrl must be a valid absolute URL, got: ${JSON.stringify(
-        config.baseUrl,
-      )}`,
-    );
-  }
   if (!config.verify?.issuer || !config.verify?.audience) {
     throw new Error("oauth.verify requires both `issuer` and `audience`");
   }
 
-  app.use(
-    mcpAuthMetadataRouter({
-      oauthMetadata: config.oauthMetadata,
-      resourceServerUrl: baseUrl,
-      scopesSupported: config.scopesSupported,
-    }),
-  );
-
+  const verifier = createJwksVerifier(config.verify);
   const bearer =
     config.enforcement === "optional" ? optionalBearerAuth : requireBearerAuth;
+
+  // baseUrl known at boot: bake the resource URLs once, no Host-header trust.
+  if (config.baseUrl !== undefined) {
+    let baseUrl: URL;
+    try {
+      baseUrl = new URL(config.baseUrl);
+    } catch {
+      throw new Error(
+        `oauth.baseUrl must be a valid absolute URL, got: ${JSON.stringify(
+          config.baseUrl,
+        )}`,
+      );
+    }
+    app.use(
+      mcpAuthMetadataRouter({
+        oauthMetadata: config.oauthMetadata,
+        resourceServerUrl: baseUrl,
+        scopesSupported: config.scopesSupported,
+      }),
+    );
+    app.use(
+      "/mcp",
+      bearer({
+        verifier,
+        requiredScopes: config.requiredScopes,
+        resourceMetadataUrl: getOAuthProtectedResourceMetadataUrl(baseUrl),
+      }),
+    );
+    return;
+  }
+
+  // No baseUrl: resolve the resource origin per request from forwarded headers
+  // (same precedence the framework uses for view serverUrl). Origin headers are
+  // pathless, so the PRM path stays at root, matching the SDK's static layout.
+  const resolveOrigin = (req: Request) =>
+    new URL(resolveServerOrigin((key) => req.get(key)));
+
   app.use(
-    "/mcp",
+    "/.well-known/oauth-authorization-server",
+    cors(),
+    (_req, res) => void res.json(config.oauthMetadata),
+  );
+  app.use("/.well-known/oauth-protected-resource", cors(), (req, res) => {
+    res.json({
+      resource: resolveOrigin(req).href,
+      authorization_servers: [config.oauthMetadata.issuer],
+      scopes_supported: config.scopesSupported,
+    });
+  });
+  app.use("/mcp", (req, res, next) =>
     bearer({
-      verifier: createJwksVerifier(config.verify),
+      verifier,
       requiredScopes: config.requiredScopes,
-      resourceMetadataUrl: getOAuthProtectedResourceMetadataUrl(baseUrl),
-    }),
+      resourceMetadataUrl: getOAuthProtectedResourceMetadataUrl(
+        resolveOrigin(req),
+      ),
+    })(req, res, next),
   );
 }

--- a/packages/core/src/server/auth/setup.ts
+++ b/packages/core/src/server/auth/setup.ts
@@ -1,9 +1,9 @@
-import { requireBearerAuth } from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js";
 import {
   getOAuthProtectedResourceMetadataUrl,
   mcpAuthMetadataRouter,
 } from "@modelcontextprotocol/sdk/server/auth/router.js";
 import type { Express } from "express";
+import { optionalBearerAuth, requireBearerAuth } from "../auth.js";
 import type { OAuthConfig } from "./index.js";
 import { createJwksVerifier } from "./verify.js";
 
@@ -35,9 +35,11 @@ export function setupOAuth(app: Express, config: OAuthConfig): void {
     }),
   );
 
+  const bearer =
+    config.enforcement === "optional" ? optionalBearerAuth : requireBearerAuth;
   app.use(
     "/mcp",
-    requireBearerAuth({
+    bearer({
       verifier: createJwksVerifier(config.verify),
       requiredScopes: config.requiredScopes,
       resourceMetadataUrl: getOAuthProtectedResourceMetadataUrl(baseUrl),

--- a/packages/core/src/server/auth/setup.ts
+++ b/packages/core/src/server/auth/setup.ts
@@ -4,7 +4,7 @@ import {
 } from "@modelcontextprotocol/sdk/server/auth/router.js";
 import cors from "cors";
 import type { Express, Request } from "express";
-import { optionalBearerAuth, requireBearerAuth } from "../auth.js";
+import { requireBearerAuth } from "../auth.js";
 import { resolveServerOrigin } from "../requestOrigin.js";
 import type { OAuthConfig } from "./index.js";
 import { createJwksVerifier } from "./verify.js";
@@ -16,8 +16,6 @@ export function setupOAuth(app: Express, config: OAuthConfig): void {
   }
 
   const verifier = createJwksVerifier(config.verify);
-  const bearer =
-    config.enforcement === "optional" ? optionalBearerAuth : requireBearerAuth;
 
   // baseUrl known at boot: bake the resource URLs once, no Host-header trust.
   if (config.baseUrl !== undefined) {
@@ -40,7 +38,7 @@ export function setupOAuth(app: Express, config: OAuthConfig): void {
     );
     app.use(
       "/mcp",
-      bearer({
+      requireBearerAuth({
         verifier,
         requiredScopes: config.requiredScopes,
         resourceMetadataUrl: getOAuthProtectedResourceMetadataUrl(baseUrl),
@@ -68,7 +66,7 @@ export function setupOAuth(app: Express, config: OAuthConfig): void {
     });
   });
   app.use("/mcp", (req, res, next) =>
-    bearer({
+    requireBearerAuth({
       verifier,
       requiredScopes: config.requiredScopes,
       resourceMetadataUrl: getOAuthProtectedResourceMetadataUrl(

--- a/packages/core/src/server/auth/setup.ts
+++ b/packages/core/src/server/auth/setup.ts
@@ -7,11 +7,7 @@ import { optionalBearerAuth, requireBearerAuth } from "../auth.js";
 import type { OAuthConfig } from "./index.js";
 import { createJwksVerifier } from "./verify.js";
 
-/**
- * Wires resource-server OAuth into the embedded Express app: serves the
- * well-known metadata and enforces bearer auth on `/mcp`. Called from the
- * `McpServer` constructor before any user middleware and the `/mcp` route.
- */
+/** Mounts the well-known OAuth metadata and bearer auth on `/mcp`. */
 export function setupOAuth(app: Express, config: OAuthConfig): void {
   let baseUrl: URL;
   try {

--- a/packages/core/src/server/auth/verify.test.ts
+++ b/packages/core/src/server/auth/verify.test.ts
@@ -105,18 +105,4 @@ describe("createJwksVerifier", () => {
       "email",
     ]);
   });
-
-  it("defaults missing scope to an empty array", async () => {
-    const { privateKey, jwksUri } = await startJwks();
-    const verifier = createJwksVerifier({
-      issuer: ISSUER,
-      audience: AUDIENCE,
-      jwksUri,
-    });
-    const token = await sign(privateKey, { client_id: "c" });
-
-    const auth = await verifier.verifyAccessToken(token);
-    expect(auth.scopes).toEqual([]);
-    expect(auth.clientId).toBe("c");
-  });
 });

--- a/packages/core/src/server/auth/verify.test.ts
+++ b/packages/core/src/server/auth/verify.test.ts
@@ -10,7 +10,6 @@ const AUDIENCE = "api://default";
 let jwksServer: http.Server | undefined;
 afterEach(() => jwksServer?.close());
 
-// Spins a local JWKS endpoint and returns a signer bound to its key.
 async function startJwks() {
   const { publicKey, privateKey } = await jose.generateKeyPair("RS256");
   const jwk = {

--- a/packages/core/src/server/auth/verify.test.ts
+++ b/packages/core/src/server/auth/verify.test.ts
@@ -83,6 +83,29 @@ describe("createJwksVerifier", () => {
     );
   });
 
+  it("parses array scope claims and trims extra whitespace", async () => {
+    const { privateKey, jwksUri } = await startJwks();
+    const verifier = createJwksVerifier({
+      issuer: ISSUER,
+      audience: AUDIENCE,
+      jwksUri,
+    });
+
+    const arrayToken = await sign(privateKey, {
+      scope: ["openid", "email"],
+    });
+    expect((await verifier.verifyAccessToken(arrayToken)).scopes).toEqual([
+      "openid",
+      "email",
+    ]);
+
+    const messyToken = await sign(privateKey, { scope: " openid  email " });
+    expect((await verifier.verifyAccessToken(messyToken)).scopes).toEqual([
+      "openid",
+      "email",
+    ]);
+  });
+
   it("defaults missing scope to an empty array", async () => {
     const { privateKey, jwksUri } = await startJwks();
     const verifier = createJwksVerifier({

--- a/packages/core/src/server/auth/verify.test.ts
+++ b/packages/core/src/server/auth/verify.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+import http from "node:http";
+import * as jose from "jose";
+import { afterEach, describe, expect, it } from "vitest";
+import { createJwksVerifier } from "./verify.js";
+
+const ISSUER = "https://issuer.test";
+const AUDIENCE = "api://default";
+
+let jwksServer: http.Server | undefined;
+afterEach(() => jwksServer?.close());
+
+// Spins a local JWKS endpoint and returns a signer bound to its key.
+async function startJwks() {
+  const { publicKey, privateKey } = await jose.generateKeyPair("RS256");
+  const jwk = {
+    ...(await jose.exportJWK(publicKey)),
+    kid: "test-key",
+    alg: "RS256",
+    use: "sig",
+  };
+  const server = http.createServer((_req, res) => {
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({ keys: [jwk] }));
+  });
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  jwksServer = server;
+  const port = (server.address() as { port: number }).port;
+  return { privateKey, jwksUri: `http://localhost:${port}/jwks` };
+}
+
+function sign(
+  key: CryptoKey,
+  claims: Record<string, unknown>,
+  opts: { issuer?: string; audience?: string; expiresAt?: string } = {},
+) {
+  return new jose.SignJWT(claims)
+    .setProtectedHeader({ alg: "RS256", kid: "test-key" })
+    .setIssuer(opts.issuer ?? ISSUER)
+    .setAudience(opts.audience ?? AUDIENCE)
+    .setExpirationTime(opts.expiresAt ?? "1h")
+    .sign(key);
+}
+
+describe("createJwksVerifier", () => {
+  it("verifies a valid token and maps claims to AuthInfo", async () => {
+    const { privateKey, jwksUri } = await startJwks();
+    const verifier = createJwksVerifier({
+      issuer: ISSUER,
+      audience: AUDIENCE,
+      jwksUri,
+    });
+    const token = await sign(privateKey, {
+      client_id: "client-1",
+      scope: "openid email",
+      sub: "user-1",
+      email: "a@b.test",
+    });
+
+    const auth = await verifier.verifyAccessToken(token);
+
+    expect(auth.token).toBe(token);
+    expect(auth.clientId).toBe("client-1");
+    expect(auth.scopes).toEqual(["openid", "email"]);
+    expect(auth.extra?.subject).toBe("user-1");
+    expect(auth.extra?.email).toBe("a@b.test");
+  });
+
+  it("rejects a token with the wrong audience", async () => {
+    const { privateKey, jwksUri } = await startJwks();
+    const verifier = createJwksVerifier({
+      issuer: ISSUER,
+      audience: AUDIENCE,
+      jwksUri,
+    });
+    const token = await sign(
+      privateKey,
+      { client_id: "c" },
+      { audience: "api://other" },
+    );
+
+    await expect(verifier.verifyAccessToken(token)).rejects.toThrow(
+      /Token verification failed/,
+    );
+  });
+
+  it("defaults missing scope to an empty array", async () => {
+    const { privateKey, jwksUri } = await startJwks();
+    const verifier = createJwksVerifier({
+      issuer: ISSUER,
+      audience: AUDIENCE,
+      jwksUri,
+    });
+    const token = await sign(privateKey, { client_id: "c" });
+
+    const auth = await verifier.verifyAccessToken(token);
+    expect(auth.scopes).toEqual([]);
+    expect(auth.clientId).toBe("c");
+  });
+});

--- a/packages/core/src/server/auth/verify.ts
+++ b/packages/core/src/server/auth/verify.ts
@@ -37,12 +37,23 @@ export function createJwksVerifier(
       const { client_id, scope, exp, sub, ...rest } = payload as Record<
         string,
         unknown
-      > & { client_id?: string; scope?: string; exp?: number; sub?: string };
+      > & {
+        client_id?: string;
+        scope?: string | string[];
+        exp?: number;
+        sub?: string;
+      };
+
+      const scopes = Array.isArray(scope)
+        ? scope.map(String)
+        : typeof scope === "string"
+          ? scope.split(/\s+/).filter(Boolean)
+          : [];
 
       return {
         token,
         clientId: client_id ?? "",
-        scopes: typeof scope === "string" ? scope.split(" ") : [],
+        scopes,
         expiresAt: exp,
         extra: { subject: sub, ...rest },
       } satisfies AuthInfo;

--- a/packages/core/src/server/auth/verify.ts
+++ b/packages/core/src/server/auth/verify.ts
@@ -3,21 +3,16 @@ import type { OAuthTokenVerifier } from "@modelcontextprotocol/sdk/server/auth/p
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import * as jose from "jose";
 
-/** JWKS-based access-token verification settings. */
 export type JwksVerifyConfig = {
   /** Expected `iss` claim. */
   issuer: string;
   /** Expected `aud` claim. */
   audience: string;
-  /** JWKS URL. Defaults to `${issuer}/.well-known/jwks.json`. */
+  /** Defaults to `${issuer}/.well-known/jwks.json`. */
   jwksUri?: string;
 };
 
-/**
- * Builds an SDK `OAuthTokenVerifier` that validates JWT access tokens against a
- * remote JWKS using `jose`. Internal to the package — branded providers
- * (SKY-447) reuse it; it is never exported from `skybridge/server`.
- */
+/** Builds an `OAuthTokenVerifier` validating JWTs against a remote JWKS. Internal, not exported. */
 export function createJwksVerifier(
   config: JwksVerifyConfig,
 ): OAuthTokenVerifier {

--- a/packages/core/src/server/auth/verify.ts
+++ b/packages/core/src/server/auth/verify.ts
@@ -1,0 +1,56 @@
+import { InvalidTokenError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
+import type { OAuthTokenVerifier } from "@modelcontextprotocol/sdk/server/auth/provider.js";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import * as jose from "jose";
+
+/** JWKS-based access-token verification settings. */
+export type JwksVerifyConfig = {
+  /** Expected `iss` claim. */
+  issuer: string;
+  /** Expected `aud` claim. */
+  audience: string;
+  /** JWKS URL. Defaults to `${issuer}/.well-known/jwks.json`. */
+  jwksUri?: string;
+};
+
+/**
+ * Builds an SDK `OAuthTokenVerifier` that validates JWT access tokens against a
+ * remote JWKS using `jose`. Internal to the package — branded providers
+ * (SKY-447) reuse it; it is never exported from `skybridge/server`.
+ */
+export function createJwksVerifier(
+  config: JwksVerifyConfig,
+): OAuthTokenVerifier {
+  const jwksUri =
+    config.jwksUri ??
+    `${config.issuer.replace(/\/$/, "")}/.well-known/jwks.json`;
+  const jwks = jose.createRemoteJWKSet(new URL(jwksUri));
+
+  return {
+    async verifyAccessToken(token: string): Promise<AuthInfo> {
+      let payload: jose.JWTPayload;
+      try {
+        ({ payload } = await jose.jwtVerify(token, jwks, {
+          issuer: config.issuer,
+          audience: config.audience,
+        }));
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new InvalidTokenError(`Token verification failed: ${message}`);
+      }
+
+      const { client_id, scope, exp, sub, ...rest } = payload as Record<
+        string,
+        unknown
+      > & { client_id?: string; scope?: string; exp?: number; sub?: string };
+
+      return {
+        token,
+        clientId: client_id ?? "",
+        scopes: typeof scope === "string" ? scope.split(" ") : [],
+        expiresAt: exp,
+        extra: { subject: sub, ...rest },
+      } satisfies AuthInfo;
+    },
+  };
+}

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -1,3 +1,4 @@
+export type { OAuthConfig } from "./auth/index.js";
 export {
   type AuthInfo,
   type AuthMetadataOptions,

--- a/packages/core/src/server/requestOrigin.ts
+++ b/packages/core/src/server/requestOrigin.ts
@@ -1,7 +1,8 @@
 /**
  * Resolves this server's public origin from request headers, in precedence
- * `x-forwarded-host` → `origin` → `host` → localhost dev fallback. Shared by
- * view serving and OAuth metadata so the two can't drift.
+ * `x-forwarded-host` → `host` → localhost dev fallback. Shared by view serving
+ * and OAuth metadata so the two can't drift. `Origin` is deliberately ignored:
+ * it carries the *caller's* site, not this server's.
  */
 export function resolveServerOrigin(
   header: (key: string) => string | undefined,
@@ -13,12 +14,6 @@ export function resolveServerOrigin(
   if (forwardedHost) {
     const proto = firstHop(header("x-forwarded-proto")) || "https";
     return `${proto}://${forwardedHost}`;
-  }
-  // Skip opaque origins (browsers send the literal "null") and other
-  // non-URL values, falling through to the Host header.
-  const origin = header("origin");
-  if (origin && URL.canParse(origin)) {
-    return origin;
   }
   const host = header("host");
   if (host) {

--- a/packages/core/src/server/requestOrigin.ts
+++ b/packages/core/src/server/requestOrigin.ts
@@ -14,8 +14,10 @@ export function resolveServerOrigin(
     const proto = firstHop(header("x-forwarded-proto")) || "https";
     return `${proto}://${forwardedHost}`;
   }
+  // Skip opaque origins (browsers send the literal "null") and other
+  // non-URL values, falling through to the Host header.
   const origin = header("origin");
-  if (origin) {
+  if (origin && URL.canParse(origin)) {
     return origin;
   }
   const host = header("host");

--- a/packages/core/src/server/requestOrigin.ts
+++ b/packages/core/src/server/requestOrigin.ts
@@ -1,0 +1,26 @@
+/**
+ * Resolves this server's public origin from request headers, in precedence
+ * `x-forwarded-host` → `origin` → `host` → localhost dev fallback. Shared by
+ * view serving and OAuth metadata so the two can't drift.
+ */
+export function resolveServerOrigin(
+  header: (key: string) => string | undefined,
+): string {
+  const forwardedHost = header("x-forwarded-host");
+  if (forwardedHost) {
+    const proto = header("x-forwarded-proto") || "https";
+    return `${proto}://${forwardedHost}`;
+  }
+  const origin = header("origin");
+  if (origin) {
+    return origin;
+  }
+  const host = header("host");
+  if (host) {
+    const proto = ["127.0.0.1:", "localhost:"].some((p) => host.startsWith(p))
+      ? "http"
+      : "https";
+    return `${proto}://${host}`;
+  }
+  return `http://localhost:${process.env.__PORT || "3000"}`;
+}

--- a/packages/core/src/server/requestOrigin.ts
+++ b/packages/core/src/server/requestOrigin.ts
@@ -6,9 +6,12 @@
 export function resolveServerOrigin(
   header: (key: string) => string | undefined,
 ): string {
-  const forwardedHost = header("x-forwarded-host");
+  // Proxies may send X-Forwarded-* as a comma-separated chain; the client-facing
+  // hop is the first entry.
+  const firstHop = (value: string | undefined) => value?.split(",")[0]?.trim();
+  const forwardedHost = firstHop(header("x-forwarded-host"));
   if (forwardedHost) {
-    const proto = header("x-forwarded-proto") || "https";
+    const proto = firstHop(header("x-forwarded-proto")) || "https";
     return `${proto}://${forwardedHost}`;
   }
   const origin = header("origin");

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -32,6 +32,8 @@ import express, {
   type Express,
   type RequestHandler,
 } from "express";
+import type { OAuthConfig } from "./auth/index.js";
+import { setupOAuth } from "./auth/setup.js";
 import { createApp } from "./express.js";
 import { createMiddlewareEntry } from "./metric.js";
 import type {
@@ -146,6 +148,8 @@ export type JsonOptions = NonNullable<Parameters<typeof express.json>[0]>;
 export interface SkybridgeServerOptions {
   /** Options for the built-in `express.json()` middleware, e.g. `{ limit: "10mb" }`. */
   json?: JsonOptions;
+  /** Resource-server OAuth config. When set, mounts well-known metadata and bearer auth on `/mcp`. */
+  oauth?: OAuthConfig;
 }
 
 /**
@@ -521,6 +525,9 @@ export class McpServer<
     this.serverOptions = options;
     this.express = express();
     this.express.use(express.json(skybridgeOptions?.json));
+    if (skybridgeOptions?.oauth) {
+      setupOAuth(this.express, skybridgeOptions.oauth);
+    }
     // Pick up the manifest if `dist/__entry.js` primed it before importing
     // user code. Consume-once: clear after the first construction so a
     // subsequent test that doesn't prime can't inherit stale state.

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -48,6 +48,7 @@ import type {
   McpWildcard,
 } from "./middleware.js";
 import { buildMiddlewareChain, getHandlerMaps } from "./middleware.js";
+import { resolveServerOrigin } from "./requestOrigin.js";
 import { templateHelper } from "./templateHelper.js";
 
 const mergeWithUnion = <T extends object, S extends object>(
@@ -924,25 +925,7 @@ export class McpServer<
     };
     const isClaude = header("user-agent") === "Claude-User";
 
-    let serverUrl: string;
-    const forwardedHost = header("x-forwarded-host");
-    const origin = header("origin");
-    const host = header("host");
-
-    if (forwardedHost) {
-      const proto = header("x-forwarded-proto") || "https";
-      serverUrl = `${proto}://${forwardedHost}`;
-    } else if (origin) {
-      serverUrl = origin;
-    } else if (host) {
-      const proto = ["127.0.0.1:", "localhost:"].some((p) => host.startsWith(p))
-        ? "http"
-        : "https";
-      serverUrl = `${proto}://${host}`;
-    } else {
-      const devPort = process.env.__PORT || "3000";
-      serverUrl = `http://localhost:${devPort}`;
-    }
+    const serverUrl = resolveServerOrigin(header);
 
     const connectDomains = [serverUrl];
     if (!isProduction) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1090,6 +1090,9 @@ importers:
       ink:
         specifier: ^7.0.0
         version: 7.0.0(@types/react@19.2.14)(react@19.2.4)
+      jose:
+        specifier: ^6.1.3
+        version: 6.2.3
       nodemon:
         specifier: '>=3.0.0'
         version: 3.1.11
@@ -10742,7 +10745,7 @@ snapshots:
 
   '@auth0/auth0-auth-js@1.6.0':
     dependencies:
-      jose: 6.2.1
+      jose: 6.2.3
       openid-client: 6.8.2
 
   '@aws-cdk/asset-awscli-v1@2.2.263': {}
@@ -20228,7 +20231,7 @@ snapshots:
 
   openid-client@6.8.2:
     dependencies:
-      jose: 6.2.1
+      jose: 6.2.3
       oauth4webapi: 3.8.5
 
   openid-client@6.8.4:


### PR DESCRIPTION
### Summary

- Add an `oauth` field on the `McpServer` constructor for resource-server OAuth.
- Auto-mounts the well-known OAuth metadata and bearer auth on `/mcp`.
- `enforcement: "required" | "optional"` chooses full-gate vs anonymous-allowed (mixed-auth).
- Adds an internal `jose` JWKS verifier and exports the `OAuthConfig` type.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Adds an `oauth` option and exported `OAuthConfig` type for MCP server resource-server OAuth configuration.
- Wires OAuth protected-resource metadata and bearer authentication onto `/mcp`.
- Adds JWKS-backed JWT verification with `jose`, including tests for metadata, token verification, scope parsing, and inferred request origins.

<h3>Confidence Score: 5/5</h3>

The OAuth configuration, metadata wiring, bearer authentication, and JWT verification changes appear merge-safe.

The changes are focused, include targeted tests for setup and verification behavior, and no blocking code issues were identified.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Performed baseline OAuth mounting test to verify unauthenticated behavior, observing 404 Not Found for authorization-server and protected-resource, and 406 Not Acceptable for /mcp without auth.
- Re-ran the OAuth mounting test after changes and observed post-change behavior, with 200 OK for authorization-server and protected-resource, and 401 Unauthorized for /mcp with a Bearer WWW-Authenticate header.
- Evaluated OAuth enforcement baseline, where both required and optional anonymous probes returned 401 Unauthorized with the Bearer WWW-Authenticate header.
- Evaluated OAuth enforcement after; the after-state still returned 401 Unauthorized for both modes, so optional anonymous-allowed mixed auth was not demonstrated.
- Observed JWKS verifier flow after changes, where the after run reported IMPORT\_OK, local JWKS GET, VERIFY\_VALID\_STATUS 200 OK, mapped AuthInfo, and 401 Invalid Token for an invalid audience; the repository was restored to head after the before/after runs.
- Observed TypeScript compilation behavior related to OAuth configuration; before run showed missing OAuthConfig, after run accepted the OAuthConfig import but still failed with a TypeScript error indicating 'oauth' does not exist in type 'ServerOptions', with an unrelated templateHelper.ts error present but not blocking observation of the ServerOptions.oauth failure.

<a href="https://app.greptile.com/trex/runs/11517881/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **OAuth enforcement optional mode is not implemented**

   - **Bug**
     - The PR contract says `oauth.enforcement: 'required' | 'optional'` should choose full-gate auth vs anonymous-allowed mixed auth. On head, the same anonymous `/mcp` request configured with `enforcement: 'required'` and `enforcement: 'optional'` returned identical `401 Unauthorized` responses with the same Bearer `WWW-Authenticate` challenge and body, so optional mode does not allow anonymous access or otherwise differ from required mode.
   - **Cause**
     - `packages/core/src/server/auth/index.ts` does not define an `enforcement` property on `OAuthConfig`, and `packages/core/src/server/auth/setup.ts` unconditionally mounts `requireBearerAuth` for `/mcp` at the OAuth setup lines instead of branching on an enforcement mode.
   - **Fix**
     - Add `enforcement?: 'required' | 'optional'` to the OAuth config contract, default it as intended, and in `setupOAuth` only mount hard `requireBearerAuth` for required mode. For optional mode, use middleware that verifies a bearer token when present but calls through anonymously when absent, then add tests proving anonymous `/mcp` succeeds in optional mode and fails in required mode.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **McpServer constructor does not accept oauth in the second options argument**

   - **Bug**
     - The PR contract says SDK consumers should be able to instantiate `new McpServer(serverInfo, { oauth })`. On head, the identical consumer compile still fails with `TS2353: Object literal may only specify known properties, and 'oauth' does not exist in type 'ServerOptions'`.
   - **Cause**
     - `packages/core/src/server/server.ts` defines the constructor as `(serverInfo, options?: ServerOptions, skybridgeOptions?: SkybridgeServerOptions)` and `SkybridgeServerOptions.oauth` is only read from the third argument (`skybridgeOptions?.oauth`) around lines 519-530. The second argument remains the MCP SDK `ServerOptions` type and does not include `oauth`.
   - **Fix**
     - Either update the public contract/docs to require `new McpServer(serverInfo, options, { oauth })`, or change the constructor/options typing and wiring so the second options object can include `oauth` as claimed, while preserving compatibility with `ServerOptions`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (11): Last reviewed commit: ["feat(core): drop oauth enforcement param..."](https://github.com/alpic-ai/skybridge/commit/fa76c027dbc8caa99b4ae724544ca3e16b864d3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38090988)</sub>

<!-- /greptile_comment -->