### PR TITLE
fix: serve view resource no matter the ?v= cache key (#872)

### DIFF
--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -265,6 +265,16 @@ type ErrorMiddlewareConfig = {
   handlers: ErrorRequestHandler[];
 };
 
+/**
+ * Drop the query string from a `ui://` view URI, leaving the bare path. The
+ * `?v=` cache key is the only query we append, so a plain split is enough and
+ * sidesteps `URL` normalization quirks on the non-special `ui:` scheme.
+ */
+function stripQuery(uri: string): string {
+  const queryIndex = uri.indexOf("?");
+  return queryIndex === -1 ? uri : uri.slice(0, queryIndex);
+}
+
 export function normalizeContent(
   content: HandlerContent | undefined,
 ): ContentBlock[] {
@@ -310,6 +320,13 @@ export class McpServer<
   private mcpMiddlewareEntries: McpMiddlewareEntry[] = [];
   private mcpMiddlewareApplied = false;
   private claimedViews = new Map<string, string>();
+  /**
+   * Maps a view resource's query-less path to its canonical registered URI
+   * (the one carrying the `?v=` cache key). Lets `resources/read` resolve the
+   * underlying view no matter which version param the consumer sends, since
+   * the param is only a cache key, not part of the resource's identity.
+   */
+  private viewUriByPath = new Map<string, string>();
   private viteManifest: Record<string, ViteManifestEntry> | null = null;
   private readonly serverInfo: Implementation;
   private readonly serverOptions?: ServerOptions;
@@ -438,10 +455,52 @@ export class McpServer<
     }
     this.mcpMiddlewareApplied = true;
 
+    // Resolve a view's `resources/read` by its query-less path so the
+    // underlying asset is served no matter the `?v=` value (stale cache key,
+    // no param, etc.). The version param is a cache-busting hint for external
+    // consumers; it must not gate resolution. We rewrite the lookup URI to the
+    // canonical registered one, then restore the requested URI on the response
+    // so the consumer-facing URI is never rewritten.
+    const viewReadResolveEntry: McpMiddlewareEntry = {
+      filter: "resources/read",
+      handler: async (req, _extra, next) => {
+        const requested = req.params.uri;
+        if (typeof requested !== "string") {
+          return next();
+        }
+        const path = stripQuery(requested);
+        const canonical = this.viewUriByPath.get(path);
+        if (!canonical) {
+          return next();
+        }
+        req.params.uri = canonical;
+        try {
+          const result = (await next()) as {
+            contents?: Array<{ uri?: string } & Record<string, unknown>>;
+          };
+          for (const content of result.contents ?? []) {
+            if (
+              typeof content.uri === "string" &&
+              stripQuery(content.uri) === path
+            ) {
+              content.uri = requested;
+            }
+          }
+          return result;
+        } finally {
+          // Restore the shared request params so middleware outer to us never
+          // observes the rewritten lookup URI after next() unwinds.
+          req.params.uri = requested;
+        }
+      },
+    };
+
     const monitoringEntry = createMiddlewareEntry();
-    const entries = monitoringEntry
-      ? [monitoringEntry, ...this.mcpMiddlewareEntries]
-      : this.mcpMiddlewareEntries;
+    const entries = [
+      ...(monitoringEntry ? [monitoringEntry] : []),
+      viewReadResolveEntry,
+      ...this.mcpMiddlewareEntries,
+    ];
 
     if (entries.length === 0) {
       return;
@@ -715,6 +774,8 @@ export class McpServer<
     view: ViewConfig;
   }): void {
     const { hostType, uri: viewUri, mimeType, buildContentMeta } = viewResource;
+
+    this.viewUriByPath.set(stripQuery(viewUri), viewUri);
 
     this.registerResource(
       name,

--- a/packages/core/src/server/view-resource-resolution.test.ts
+++ b/packages/core/src/server/view-resource-resolution.test.ts
@@ -1,0 +1,129 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { afterEach, describe, expect, it } from "vitest";
+import { McpServer } from "./index.js";
+
+// Mirror what the Skybridge Vite plugin generates in `.skybridge/views.d.ts`:
+// narrow `ViewName` so `component: "widget"` typechecks against the registry.
+declare module "./server.js" {
+  interface ViewNameRegistry {
+    widget: true;
+  }
+}
+
+// SKY-435: a view resource must resolve no matter the `?v=` query param value.
+// The version param is a content-derived cache key for external consumers
+// (it busts host/CDN caches when the bundle changes); it is not part of the
+// resource's identity, so a stale, absent, or arbitrary param must still serve
+// the underlying asset.
+
+async function connect(register: (server: McpServer) => void) {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  register(server);
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  return {
+    client,
+    teardown: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+function registerWidget(server: McpServer) {
+  server.registerTool(
+    { name: "show", description: "show", view: { component: "widget" } },
+    () => ({ content: [{ type: "text" as const, text: "ok" }] }),
+  );
+}
+
+/** Narrow a read-resource content entry to its text variant. */
+function textContent(contents: Array<{ uri: string }>): {
+  uri: string;
+  text: string;
+} {
+  return contents[0] as { uri: string; text: string };
+}
+
+describe("view resource resolution (cache key)", () => {
+  afterEach(() => {
+    delete process.env.NODE_ENV;
+  });
+
+  it("resolves regardless of the ?v= param and echoes the requested URI", async () => {
+    const { client, teardown } = await connect(registerWidget);
+
+    const { resources } = await client.listResources();
+    const listed = resources.find((r) =>
+      r.uri.startsWith("ui://views/apps-sdk/widget.html"),
+    );
+    // Dev build advertises no cache key.
+    expect(listed?.uri).toBe("ui://views/apps-sdk/widget.html");
+
+    // A stale/arbitrary/absent param all resolve the same underlying asset,
+    // and the response echoes the URI the consumer asked for (never rewritten).
+    for (const uri of [
+      "ui://views/apps-sdk/widget.html?v=stale123",
+      "ui://views/apps-sdk/widget.html?v=whatever-else",
+      "ui://views/apps-sdk/widget.html",
+    ]) {
+      const { contents } = await client.readResource({ uri });
+      expect(contents).toHaveLength(1);
+      const content = textContent(contents);
+      expect(typeof content.text).toBe("string");
+      expect(content.text.length).toBeGreaterThan(0);
+      expect(content.uri).toBe(uri);
+    }
+
+    await teardown();
+  });
+
+  it("resolves a stale cache key when the canonical URI carries ?v= (prod)", async () => {
+    process.env.NODE_ENV = "production";
+
+    const { client, teardown } = await connect((server) => {
+      server.setViteManifest({
+        "src/views/widget.tsx": {
+          isEntry: true,
+          name: "widget",
+          file: "assets/widget-ABC123.js",
+        },
+        "style.css": { file: "assets/style-XYZ.css" },
+      } as unknown as Record<string, { file: string }>);
+      registerWidget(server);
+    });
+
+    const { resources } = await client.listResources();
+    const listed = resources.find((r) =>
+      r.uri.startsWith("ui://views/apps-sdk/widget.html"),
+    );
+    // Production advertises a content-derived cache key.
+    expect(listed?.uri).toMatch(
+      /^ui:\/\/views\/apps-sdk\/widget\.html\?v=[0-9a-f]{8}$/,
+    );
+
+    // A consumer holding a stale key still resolves the current asset.
+    const staleUri = "ui://views/apps-sdk/widget.html?v=00000000";
+    const { contents } = await client.readResource({ uri: staleUri });
+    expect(contents).toHaveLength(1);
+    const content = textContent(contents);
+    expect(typeof content.text).toBe("string");
+    expect(content.uri).toBe(staleUri);
+
+    await teardown();
+  });
+
+  it("still throws for an unknown view path", async () => {
+    const { client, teardown } = await connect(registerWidget);
+
+    await expect(
+      client.readResource({ uri: "ui://views/apps-sdk/nope.html?v=1" }),
+    ).rejects.toThrow();
+
+    await teardown();
+  });
+});

--- a/packages/core/src/server/view-resource-resolution.test.ts
+++ b/packages/core/src/server/view-resource-resolution.test.ts
@@ -11,7 +11,7 @@ declare module "./server.js" {
   }
 }
 
-- a view resource must resolve no matter the `?v=` query param value.
+// - a view resource must resolve no matter the `?v=` query param value.
 // The version param is a content-derived cache key for external consumers
 // (it busts host/CDN caches when the bundle changes); it is not part of the
 // resource's identity, so a stale, absent, or arbitrary param must still serve

--- a/packages/core/src/server/view-resource-resolution.test.ts
+++ b/packages/core/src/server/view-resource-resolution.test.ts
@@ -11,7 +11,7 @@ declare module "./server.js" {
   }
 }
 
-// SKY-435: a view resource must resolve no matter the `?v=` query param value.
+- a view resource must resolve no matter the `?v=` query param value.
 // The version param is a content-derived cache key for external consumers
 // (it busts host/CDN caches when the bundle changes); it is not part of the
 // resource's identity, so a stale, absent, or arbitrary param must still serve


### PR DESCRIPTION
Ports the #872 fix (`711743f`) onto this branch by hand instead of cherry-picking, to avoid conflicts from the 74-commit divergence.

## Differences vs `711743f`

- **`server.ts`** — additions are byte-identical (`stripQuery` helper, `viewUriByPath` map, the `resources/read` middleware that resolves any `?v=` to the canonical URI and echoes back the requested URI, and the map population in `registerViewResource`).
- **`view-resource-resolution.test.ts`** — only real difference: this branch predates the refactor that introduced the module-level `__setBuildManifest` helper, so the prod test sets the manifest via the `server.setViteManifest(...)` instance method inside the `connect` callback instead.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ports the `?v=` cache-key fix from `711743f` onto the `v0` branch by hand. It adds a `stripQuery` helper and a `viewUriByPath` map (path → canonical URI) populated at tool registration time, plus a `resources/read` middleware that rewrites any incoming URI to its canonical form, delegates to the underlying handler, then restores the original URI on both the response contents and the shared request params.

- **`server.ts`**: `viewReadResolveEntry` is unconditionally inserted into the middleware chain, so the dead-code guard at lines 505-507 (flagged in a prior review) is now unreachable.
- **`view-resource-resolution.test.ts`**: Three integration scenarios — dev (no version param), prod (stale key resolves against manifest-derived canonical), and unknown path (must throw) — with `setViteManifest` correctly called before `registerWidget` inside the `connect` callback.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the middleware logic is correct and the tests cover the key resolution scenarios.

The rewrite logic is sound: unknown paths pass through unmodified, the `finally` block restores request state on both success and error paths, and response content URIs are echoed back to the consumer as originally requested. No new functional defects were found beyond the pre-existing dead-code guard noted in a previous review cycle.

No files require special attention.

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/core/src/server/server.ts`, line 505-507 ([link](https://github.com/alpic-ai/skybridge/blob/180fd9832f3a6e209524d0dc1eb304a318c1c171/packages/core/src/server/server.ts#L505-L507)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Dead code guard — `entries.length === 0` can never be true now. `viewReadResolveEntry` is unconditionally included in the array, so the array always has at least one element and this early return is unreachable. The guard was meaningful before this PR (when the array was conditionally empty), but it's now misleading since it implies there is still a code path where no middleware is applied.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/core/src/server/server.ts
   Line: 505-507

   Comment:
   Dead code guard — `entries.length === 0` can never be true now. `viewReadResolveEntry` is unconditionally included in the array, so the array always has at least one element and this early return is unreachable. The guard was meaningful before this PR (when the array was conditionally empty), but it's now misleading since it implies there is still a code path where no middleware is applied.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["Update packages/core/src/server/view-res..."](https://github.com/alpic-ai/skybridge/commit/7410adc730211b5a29fa438df540b8a70eed3a40) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38107558)</sub>

<!-- /greptile_comment -->