### PR TITLE
feat(core): customProvider (SKY-446)

### DIFF
--- a/packages/core/src/server/auth/discovery.test.ts
+++ b/packages/core/src/server/auth/discovery.test.ts
@@ -6,21 +6,25 @@ import { discoverAuthorizationServer } from "./discovery.js";
 let server: http.Server | undefined;
 afterEach(() => server?.close());
 
-const DOC = {
-  issuer: "https://idp.test",
-  authorization_endpoint: "https://idp.test/authorize",
-  token_endpoint: "https://idp.test/token",
-  registration_endpoint: "https://idp.test/register",
-  response_types_supported: ["code"],
-  scopes_supported: ["openid", "email"],
-  jwks_uri: "https://idp.test/jwks",
-};
+function doc(origin: string, extra: Record<string, unknown> = {}) {
+  return {
+    issuer: origin,
+    authorization_endpoint: `${origin}/authorize`,
+    token_endpoint: `${origin}/token`,
+    registration_endpoint: `${origin}/register`,
+    response_types_supported: ["code"],
+    scopes_supported: ["openid", "email"],
+    jwks_uri: `${origin}/jwks`,
+    ...extra,
+  };
+}
 
-// Serves the given bodies at their well-known paths; returns the origin URL.
-// A string body is sent raw (text/html); anything else is JSON-encoded.
-async function serve(routes: Record<string, unknown>) {
+// Serves bodies built from the live origin at their well-known paths; returns
+// the origin. A string body is sent raw (text/html); anything else is JSON.
+async function serve(build: (origin: string) => Record<string, unknown>) {
+  let origin = "";
   const srv = http.createServer((req, res) => {
-    const body = routes[req.url ?? ""];
+    const body = build(origin)[req.url ?? ""];
     if (body === undefined) {
       res.writeHead(404).end();
       return;
@@ -34,49 +38,60 @@ async function serve(routes: Record<string, unknown>) {
   });
   await new Promise<void>((resolve) => srv.listen(0, resolve));
   server = srv;
-  const port = (srv.address() as { port: number }).port;
-  return `http://localhost:${port}`;
+  origin = `http://localhost:${(srv.address() as { port: number }).port}`;
+  return origin;
 }
 
 describe("discoverAuthorizationServer", () => {
   it("fetches and validates openid-configuration", async () => {
-    const base = await serve({ "/.well-known/openid-configuration": DOC });
+    const base = await serve((o) => ({
+      "/.well-known/openid-configuration": doc(o),
+    }));
     const meta = await discoverAuthorizationServer(base);
-    expect(meta.registration_endpoint).toBe("https://idp.test/register");
-    expect(meta.jwks_uri).toBe("https://idp.test/jwks");
+    expect(meta.registration_endpoint).toBe(`${base}/register`);
+    expect(meta.jwks_uri).toBe(`${base}/jwks`);
   });
 
   it("falls back to oauth-authorization-server when oidc is 404", async () => {
-    const base = await serve({
-      "/.well-known/oauth-authorization-server": DOC,
-    });
+    const base = await serve((o) => ({
+      "/.well-known/oauth-authorization-server": doc(o),
+    }));
     const meta = await discoverAuthorizationServer(base);
-    expect(meta.registration_endpoint).toBe("https://idp.test/register");
+    expect(meta.registration_endpoint).toBe(`${base}/register`);
   });
 
   it("throws when no well-known doc is reachable", async () => {
-    const base = await serve({});
+    const base = await serve(() => ({}));
     await expect(discoverAuthorizationServer(base)).rejects.toThrow(
       /discovery failed/i,
     );
   });
 
   it("falls through to oauth-authorization-server when oidc doc is schema-invalid", async () => {
-    const invalidDoc = { ...DOC };
-    delete (invalidDoc as Partial<typeof DOC>).response_types_supported;
-    const base = await serve({
-      "/.well-known/openid-configuration": invalidDoc,
-      "/.well-known/oauth-authorization-server": DOC,
-    });
+    const base = await serve((o) => ({
+      "/.well-known/openid-configuration": doc(o, {
+        response_types_supported: undefined,
+      }),
+      "/.well-known/oauth-authorization-server": doc(o),
+    }));
     const meta = await discoverAuthorizationServer(base);
-    expect(meta.registration_endpoint).toBe("https://idp.test/register");
+    expect(meta.registration_endpoint).toBe(`${base}/register`);
+  });
+
+  it("rejects a doc whose issuer does not match the fetch origin", async () => {
+    const base = await serve(() => ({
+      "/.well-known/openid-configuration": doc("https://evil.test"),
+    }));
+    await expect(discoverAuthorizationServer(base)).rejects.toThrow(
+      /discovery failed/i,
+    );
   });
 
   it("treats a 200 non-JSON body as unreachable and throws discovery failed", async () => {
-    const base = await serve({
+    const base = await serve(() => ({
       "/.well-known/openid-configuration": "<html>nope</html>",
       "/.well-known/oauth-authorization-server": "<html>nope</html>",
-    });
+    }));
     await expect(discoverAuthorizationServer(base)).rejects.toThrow(
       /discovery failed/i,
     );

--- a/packages/core/src/server/auth/discovery.test.ts
+++ b/packages/core/src/server/auth/discovery.test.ts
@@ -71,17 +71,6 @@ describe("discoverAuthorizationServer", () => {
     );
   });
 
-  it("falls through to oauth-authorization-server when oidc doc is schema-invalid", async () => {
-    const base = await serve((o) => ({
-      "/.well-known/openid-configuration": doc(o, {
-        response_types_supported: undefined,
-      }),
-      "/.well-known/oauth-authorization-server": doc(o),
-    }));
-    const meta = await discoverAuthorizationServer(base);
-    expect(meta.registration_endpoint).toBe(`${base}/register`);
-  });
-
   it("rejects a doc whose issuer does not match the fetch origin", async () => {
     const base = await serve(() => ({
       "/.well-known/openid-configuration": doc("https://evil.test"),

--- a/packages/core/src/server/auth/discovery.test.ts
+++ b/packages/core/src/server/auth/discovery.test.ts
@@ -48,6 +48,14 @@ describe("discoverAuthorizationServer", () => {
     expect(meta.jwks_uri).toBe(`${base}/jwks`);
   });
 
+  it("accepts a canonically slash-terminated issuer", async () => {
+    const base = await serve((o) => ({
+      "/.well-known/openid-configuration": doc(o, { issuer: `${o}/` }),
+    }));
+    const meta = await discoverAuthorizationServer(base);
+    expect(meta.registration_endpoint).toBe(`${base}/register`);
+  });
+
   it("falls back to oauth-authorization-server when oidc is 404", async () => {
     const base = await serve((o) => ({
       "/.well-known/oauth-authorization-server": doc(o),

--- a/packages/core/src/server/auth/discovery.test.ts
+++ b/packages/core/src/server/auth/discovery.test.ts
@@ -19,18 +19,14 @@ function doc(origin: string, extra: Record<string, unknown> = {}) {
   };
 }
 
-// Serves bodies built from the live origin at their well-known paths; returns
-// the origin. A string body is sent raw (text/html); anything else is JSON.
+// Serves JSON bodies built from the live origin at their well-known paths;
+// returns the origin URL.
 async function serve(build: (origin: string) => Record<string, unknown>) {
   let origin = "";
   const srv = http.createServer((req, res) => {
     const body = build(origin)[req.url ?? ""];
     if (body === undefined) {
       res.writeHead(404).end();
-      return;
-    }
-    if (typeof body === "string") {
-      res.writeHead(200, { "content-type": "text/html" }).end(body);
       return;
     }
     res.setHeader("content-type", "application/json");
@@ -81,16 +77,6 @@ describe("discoverAuthorizationServer", () => {
   it("rejects a doc whose issuer does not match the fetch origin", async () => {
     const base = await serve(() => ({
       "/.well-known/openid-configuration": doc("https://evil.test"),
-    }));
-    await expect(discoverAuthorizationServer(base)).rejects.toThrow(
-      /discovery failed/i,
-    );
-  });
-
-  it("treats a 200 non-JSON body as unreachable and throws discovery failed", async () => {
-    const base = await serve(() => ({
-      "/.well-known/openid-configuration": "<html>nope</html>",
-      "/.well-known/oauth-authorization-server": "<html>nope</html>",
     }));
     await expect(discoverAuthorizationServer(base)).rejects.toThrow(
       /discovery failed/i,

--- a/packages/core/src/server/auth/discovery.test.ts
+++ b/packages/core/src/server/auth/discovery.test.ts
@@ -56,6 +56,17 @@ describe("discoverAuthorizationServer", () => {
     );
   });
 
+  it("falls through to oauth-authorization-server when oidc doc is schema-invalid", async () => {
+    const invalidDoc = { ...DOC };
+    delete (invalidDoc as Partial<typeof DOC>).response_types_supported;
+    const base = await serve({
+      "/.well-known/openid-configuration": invalidDoc,
+      "/.well-known/oauth-authorization-server": DOC,
+    });
+    const meta = await discoverAuthorizationServer(base);
+    expect(meta.registration_endpoint).toBe("https://idp.test/register");
+  });
+
   it("treats a 200 non-JSON body as unreachable and throws discovery failed", async () => {
     const srv = http.createServer((_req, res) => {
       res.writeHead(200, { "content-type": "text/html" });

--- a/packages/core/src/server/auth/discovery.test.ts
+++ b/packages/core/src/server/auth/discovery.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment node
+import http from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { discoverAuthorizationServer } from "./discovery.js";
+
+let server: http.Server | undefined;
+afterEach(() => server?.close());
+
+const DOC = {
+  issuer: "https://idp.test",
+  authorization_endpoint: "https://idp.test/authorize",
+  token_endpoint: "https://idp.test/token",
+  registration_endpoint: "https://idp.test/register",
+  response_types_supported: ["code"],
+  scopes_supported: ["openid", "email"],
+  jwks_uri: "https://idp.test/jwks",
+};
+
+// Serves the given bodies at their well-known paths; returns the origin URL.
+async function serve(routes: Record<string, unknown>) {
+  const srv = http.createServer((req, res) => {
+    const body = routes[req.url ?? ""];
+    if (body === undefined) {
+      res.writeHead(404).end();
+      return;
+    }
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify(body));
+  });
+  await new Promise<void>((resolve) => srv.listen(0, resolve));
+  server = srv;
+  const port = (srv.address() as { port: number }).port;
+  return `http://localhost:${port}`;
+}
+
+describe("discoverAuthorizationServer", () => {
+  it("fetches and validates openid-configuration", async () => {
+    const base = await serve({ "/.well-known/openid-configuration": DOC });
+    const meta = await discoverAuthorizationServer(base);
+    expect(meta.registration_endpoint).toBe("https://idp.test/register");
+    expect(meta.jwks_uri).toBe("https://idp.test/jwks");
+  });
+
+  it("falls back to oauth-authorization-server when oidc is 404", async () => {
+    const base = await serve({
+      "/.well-known/oauth-authorization-server": DOC,
+    });
+    const meta = await discoverAuthorizationServer(base);
+    expect(meta.registration_endpoint).toBe("https://idp.test/register");
+  });
+
+  it("throws when no well-known doc is reachable", async () => {
+    const base = await serve({});
+    await expect(discoverAuthorizationServer(base)).rejects.toThrow(
+      /discovery failed/i,
+    );
+  });
+
+  it("treats a 200 non-JSON body as unreachable and throws discovery failed", async () => {
+    const srv = http.createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "text/html" });
+      res.end("<html>nope</html>");
+    });
+    await new Promise<void>((resolve) => srv.listen(0, resolve));
+    server = srv;
+    const port = (srv.address() as { port: number }).port;
+    const base = `http://localhost:${port}`;
+    await expect(discoverAuthorizationServer(base)).rejects.toThrow(
+      /discovery failed/i,
+    );
+  });
+});

--- a/packages/core/src/server/auth/discovery.test.ts
+++ b/packages/core/src/server/auth/discovery.test.ts
@@ -17,11 +17,16 @@ const DOC = {
 };
 
 // Serves the given bodies at their well-known paths; returns the origin URL.
+// A string body is sent raw (text/html); anything else is JSON-encoded.
 async function serve(routes: Record<string, unknown>) {
   const srv = http.createServer((req, res) => {
     const body = routes[req.url ?? ""];
     if (body === undefined) {
       res.writeHead(404).end();
+      return;
+    }
+    if (typeof body === "string") {
+      res.writeHead(200, { "content-type": "text/html" }).end(body);
       return;
     }
     res.setHeader("content-type", "application/json");
@@ -68,14 +73,10 @@ describe("discoverAuthorizationServer", () => {
   });
 
   it("treats a 200 non-JSON body as unreachable and throws discovery failed", async () => {
-    const srv = http.createServer((_req, res) => {
-      res.writeHead(200, { "content-type": "text/html" });
-      res.end("<html>nope</html>");
+    const base = await serve({
+      "/.well-known/openid-configuration": "<html>nope</html>",
+      "/.well-known/oauth-authorization-server": "<html>nope</html>",
     });
-    await new Promise<void>((resolve) => srv.listen(0, resolve));
-    server = srv;
-    const port = (srv.address() as { port: number }).port;
-    const base = `http://localhost:${port}`;
     await expect(discoverAuthorizationServer(base)).rejects.toThrow(
       /discovery failed/i,
     );

--- a/packages/core/src/server/auth/discovery.ts
+++ b/packages/core/src/server/auth/discovery.ts
@@ -3,7 +3,11 @@ import {
   OAuthMetadataSchema,
 } from "@modelcontextprotocol/sdk/shared/auth.js";
 
-/** Discovered metadata; `jwks_uri` is an RFC field the SDK type doesn't expose. */
+/**
+ * Discovered AS metadata + `jwks_uri` — the SDK's `OAuthMetadata` omits it (its
+ * OAuth client never verifies tokens), but we need it to verify token signatures
+ * via JWKS, so we re-type the field for typed access.
+ */
 export type DiscoveredMetadata = OAuthMetadata & { jwks_uri?: string };
 
 const WELL_KNOWN = [
@@ -22,43 +26,29 @@ export async function discoverAuthorizationServer(
 
   for (const path of WELL_KNOWN) {
     const url = `${base}${path}`;
-    let res: Response;
+    // Any failure (network/timeout, non-2xx, non-JSON, invalid metadata, issuer
+    // mismatch) records a per-URL reason and falls through to the next path.
     try {
-      res = await fetch(url, {
+      const res = await fetch(url, {
         signal: AbortSignal.timeout(DISCOVERY_TIMEOUT_MS),
       });
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const parsed = OAuthMetadataSchema.safeParse(await res.json());
+      if (!parsed.success) {
+        throw new Error(`invalid metadata (${parsed.error.message})`);
+      }
+      // RFC 8414 §3.3: issuer must match the fetch origin (slash-insensitive).
+      if (parsed.data.issuer.replace(/\/$/, "") !== base) {
+        throw new Error(`issuer mismatch: ${parsed.data.issuer}`);
+      }
+      return parsed.data as DiscoveredMetadata;
     } catch (err) {
       errors.push(
         `${url}: ${err instanceof Error ? err.message : String(err)}`,
       );
-      continue;
     }
-    if (!res.ok) {
-      errors.push(`${url}: HTTP ${res.status}`);
-      continue;
-    }
-    let json: unknown;
-    try {
-      json = await res.json();
-    } catch {
-      errors.push(`${url}: response is not valid JSON`);
-      continue;
-    }
-    const parsed = OAuthMetadataSchema.safeParse(json);
-    if (!parsed.success) {
-      errors.push(`${url}: invalid metadata (${parsed.error.message})`);
-      continue;
-    }
-    // RFC 8414 §3.3: the document's issuer must match the URL it came from.
-    // Compare slash-insensitively so a canonically slash-terminated issuer
-    // isn't rejected by the trailing-slash strip applied to `base`.
-    if (parsed.data.issuer.replace(/\/$/, "") !== base) {
-      errors.push(
-        `${url}: issuer mismatch (${parsed.data.issuer} !== ${base})`,
-      );
-      continue;
-    }
-    return parsed.data as DiscoveredMetadata;
   }
 
   throw new Error(`OAuth discovery failed for ${issuer}: ${errors.join("; ")}`);

--- a/packages/core/src/server/auth/discovery.ts
+++ b/packages/core/src/server/auth/discovery.ts
@@ -1,14 +1,15 @@
-import {
-  type OAuthMetadata,
-  OAuthMetadataSchema,
-} from "@modelcontextprotocol/sdk/shared/auth.js";
+import { OAuthMetadataSchema } from "@modelcontextprotocol/sdk/shared/auth.js";
+import { z } from "zod";
 
 /**
- * Discovered AS metadata + `jwks_uri` — the SDK's `OAuthMetadata` omits it (its
- * OAuth client never verifies tokens), but we need it to verify token signatures
- * via JWKS, so we re-type the field for typed access.
+ * Discovery doc validated as OAuth AS metadata + `jwks_uri`. The SDK's
+ * `OAuthMetadataSchema` omits `jwks_uri` (its client never verifies tokens), but
+ * we need it for JWKS token verification, so we extend the schema to keep it.
  */
-export type DiscoveredMetadata = OAuthMetadata & { jwks_uri?: string };
+const DiscoverySchema = OAuthMetadataSchema.extend({
+  jwks_uri: z.string().optional(),
+});
+export type DiscoveredMetadata = z.infer<typeof DiscoverySchema>;
 
 const WELL_KNOWN = [
   "/.well-known/openid-configuration",
@@ -35,15 +36,12 @@ export async function discoverAuthorizationServer(
       if (!res.ok) {
         throw new Error(`HTTP ${res.status}`);
       }
-      const parsed = OAuthMetadataSchema.safeParse(await res.json());
-      if (!parsed.success) {
-        throw new Error(`invalid metadata (${parsed.error.message})`);
-      }
+      const meta = DiscoverySchema.parse(await res.json());
       // RFC 8414 §3.3: issuer must match the fetch origin (slash-insensitive).
-      if (parsed.data.issuer.replace(/\/$/, "") !== base) {
-        throw new Error(`issuer mismatch: ${parsed.data.issuer}`);
+      if (meta.issuer.replace(/\/$/, "") !== base) {
+        throw new Error(`issuer mismatch: ${meta.issuer}`);
       }
-      return parsed.data as DiscoveredMetadata;
+      return meta;
     } catch (err) {
       errors.push(
         `${url}: ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/core/src/server/auth/discovery.ts
+++ b/packages/core/src/server/auth/discovery.ts
@@ -50,7 +50,9 @@ export async function discoverAuthorizationServer(
       continue;
     }
     // RFC 8414 §3.3: the document's issuer must match the URL it came from.
-    if (parsed.data.issuer !== base) {
+    // Compare slash-insensitively so a canonically slash-terminated issuer
+    // isn't rejected by the trailing-slash strip applied to `base`.
+    if (parsed.data.issuer.replace(/\/$/, "") !== base) {
       errors.push(
         `${url}: issuer mismatch (${parsed.data.issuer} !== ${base})`,
       );

--- a/packages/core/src/server/auth/discovery.ts
+++ b/packages/core/src/server/auth/discovery.ts
@@ -1,0 +1,53 @@
+import {
+  type OAuthMetadata,
+  OAuthMetadataSchema,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+
+/** Discovered metadata; `jwks_uri` is an RFC field the SDK type doesn't expose. */
+export type DiscoveredMetadata = OAuthMetadata & { jwks_uri?: string };
+
+const WELL_KNOWN = [
+  "/.well-known/openid-configuration",
+  "/.well-known/oauth-authorization-server",
+];
+
+/** Fetches and validates an authorization server's discovery document. */
+export async function discoverAuthorizationServer(
+  issuer: string,
+): Promise<DiscoveredMetadata> {
+  const base = issuer.replace(/\/$/, "");
+  const errors: string[] = [];
+
+  for (const path of WELL_KNOWN) {
+    const url = `${base}${path}`;
+    let res: Response;
+    try {
+      res = await fetch(url);
+    } catch (err) {
+      errors.push(
+        `${url}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      continue;
+    }
+    if (!res.ok) {
+      errors.push(`${url}: HTTP ${res.status}`);
+      continue;
+    }
+    let json: unknown;
+    try {
+      json = await res.json();
+    } catch {
+      errors.push(`${url}: response is not valid JSON`);
+      continue;
+    }
+    const parsed = OAuthMetadataSchema.safeParse(json);
+    if (!parsed.success) {
+      throw new Error(
+        `OAuth metadata at ${url} is invalid: ${parsed.error.message}`,
+      );
+    }
+    return parsed.data as DiscoveredMetadata;
+  }
+
+  throw new Error(`OAuth discovery failed for ${issuer}: ${errors.join("; ")}`);
+}

--- a/packages/core/src/server/auth/discovery.ts
+++ b/packages/core/src/server/auth/discovery.ts
@@ -42,9 +42,8 @@ export async function discoverAuthorizationServer(
     }
     const parsed = OAuthMetadataSchema.safeParse(json);
     if (!parsed.success) {
-      throw new Error(
-        `OAuth metadata at ${url} is invalid: ${parsed.error.message}`,
-      );
+      errors.push(`${url}: invalid metadata (${parsed.error.message})`);
+      continue;
     }
     return parsed.data as DiscoveredMetadata;
   }

--- a/packages/core/src/server/auth/discovery.ts
+++ b/packages/core/src/server/auth/discovery.ts
@@ -11,6 +11,8 @@ const WELL_KNOWN = [
   "/.well-known/oauth-authorization-server",
 ];
 
+const DISCOVERY_TIMEOUT_MS = 5000;
+
 /** Fetches and validates an authorization server's discovery document. */
 export async function discoverAuthorizationServer(
   issuer: string,
@@ -22,7 +24,9 @@ export async function discoverAuthorizationServer(
     const url = `${base}${path}`;
     let res: Response;
     try {
-      res = await fetch(url);
+      res = await fetch(url, {
+        signal: AbortSignal.timeout(DISCOVERY_TIMEOUT_MS),
+      });
     } catch (err) {
       errors.push(
         `${url}: ${err instanceof Error ? err.message : String(err)}`,
@@ -43,6 +47,13 @@ export async function discoverAuthorizationServer(
     const parsed = OAuthMetadataSchema.safeParse(json);
     if (!parsed.success) {
       errors.push(`${url}: invalid metadata (${parsed.error.message})`);
+      continue;
+    }
+    // RFC 8414 §3.3: the document's issuer must match the URL it came from.
+    if (parsed.data.issuer !== base) {
+      errors.push(
+        `${url}: issuer mismatch (${parsed.data.issuer} !== ${base})`,
+      );
       continue;
     }
     return parsed.data as DiscoveredMetadata;

--- a/packages/core/src/server/auth/providers/custom.test.ts
+++ b/packages/core/src/server/auth/providers/custom.test.ts
@@ -45,7 +45,6 @@ describe("customProvider", () => {
       audience: "my-api",
       baseUrl: "https://app.example.test",
       scopes: ["openid"],
-      enforcement: "optional",
     });
 
     expect(config.baseUrl).toBe("https://app.example.test");
@@ -55,7 +54,6 @@ describe("customProvider", () => {
       jwksUri: `${base}/jwks`,
     });
     expect(config.scopesSupported).toEqual(["openid"]);
-    expect(config.enforcement).toBe("optional");
     expect(config.oauthMetadata.registration_endpoint).toBe(`${base}/register`);
   });
 

--- a/packages/core/src/server/auth/providers/custom.test.ts
+++ b/packages/core/src/server/auth/providers/custom.test.ts
@@ -73,6 +73,17 @@ describe("customProvider", () => {
     expect(config.baseUrl).toBeUndefined();
   });
 
+  it("ignores a runtime issuer override (keeps the discovered trust anchor)", async () => {
+    const base = await serveDiscovery();
+    const config = await customProvider({
+      issuer: base,
+      audience: "a",
+      metadataOverrides: { issuer: "https://evil.test" } as never,
+    });
+    expect(config.verify.issuer).toBe(base);
+    expect(config.oauthMetadata.issuer).toBe(base);
+  });
+
   it("rejects a non-DCR IdP (no registration_endpoint)", async () => {
     const base = await serveDiscovery({ registration_endpoint: undefined });
     await expect(

--- a/packages/core/src/server/auth/providers/custom.test.ts
+++ b/packages/core/src/server/auth/providers/custom.test.ts
@@ -6,38 +6,39 @@ import { customProvider } from "./custom.js";
 let server: http.Server | undefined;
 afterEach(() => server?.close());
 
-async function serveDiscovery(doc: Record<string, unknown>) {
+function doc(origin: string, extra: Record<string, unknown> = {}) {
+  return {
+    issuer: origin,
+    authorization_endpoint: `${origin}/authorize`,
+    token_endpoint: `${origin}/token`,
+    registration_endpoint: `${origin}/register`,
+    response_types_supported: ["code"],
+    scopes_supported: ["openid", "email", "profile"],
+    jwks_uri: `${origin}/jwks`,
+    ...extra,
+  };
+}
+
+// Serves the discovery doc (built from the live origin) at the OIDC well-known path.
+async function serveDiscovery(extra: Record<string, unknown> = {}) {
+  let origin = "";
   const srv = http.createServer((req, res) => {
     if (req.url !== "/.well-known/openid-configuration") {
       res.writeHead(404).end();
       return;
     }
     res.setHeader("content-type", "application/json");
-    res.end(JSON.stringify(doc));
+    res.end(JSON.stringify(doc(origin, extra)));
   });
   await new Promise<void>((resolve) => srv.listen(0, resolve));
   server = srv;
-  const port = (srv.address() as { port: number }).port;
-  return `http://localhost:${port}`;
-}
-
-const ISSUER = "https://idp.test";
-function doc(extra: Record<string, unknown> = {}) {
-  return {
-    issuer: ISSUER,
-    authorization_endpoint: `${ISSUER}/authorize`,
-    token_endpoint: `${ISSUER}/token`,
-    registration_endpoint: `${ISSUER}/register`,
-    response_types_supported: ["code"],
-    scopes_supported: ["openid", "email", "profile"],
-    jwks_uri: `${ISSUER}/jwks`,
-    ...extra,
-  };
+  origin = `http://localhost:${(srv.address() as { port: number }).port}`;
+  return origin;
 }
 
 describe("customProvider", () => {
   it("builds an OAuthConfig from discovery", async () => {
-    const base = await serveDiscovery(doc());
+    const base = await serveDiscovery();
 
     const config = await customProvider({
       issuer: base,
@@ -49,19 +50,17 @@ describe("customProvider", () => {
 
     expect(config.baseUrl).toBe("https://app.example.test");
     expect(config.verify).toEqual({
-      issuer: ISSUER,
+      issuer: base,
       audience: "my-api",
-      jwksUri: `${ISSUER}/jwks`,
+      jwksUri: `${base}/jwks`,
     });
     expect(config.scopesSupported).toEqual(["openid"]);
     expect(config.enforcement).toBe("optional");
-    expect(config.oauthMetadata.registration_endpoint).toBe(
-      `${ISSUER}/register`,
-    );
+    expect(config.oauthMetadata.registration_endpoint).toBe(`${base}/register`);
   });
 
   it("defaults scopesSupported to the discovered scopes", async () => {
-    const base = await serveDiscovery(doc());
+    const base = await serveDiscovery();
     const config = await customProvider({
       issuer: base,
       audience: "a",
@@ -71,9 +70,7 @@ describe("customProvider", () => {
   });
 
   it("rejects a non-DCR IdP (no registration_endpoint)", async () => {
-    const base = await serveDiscovery(
-      doc({ registration_endpoint: undefined }),
-    );
+    const base = await serveDiscovery({ registration_endpoint: undefined });
     await expect(
       customProvider({
         issuer: base,
@@ -84,7 +81,7 @@ describe("customProvider", () => {
   });
 
   it("applies metadataOverrides over discovered values", async () => {
-    const base = await serveDiscovery(doc());
+    const base = await serveDiscovery();
     const config = await customProvider({
       issuer: base,
       audience: "a",

--- a/packages/core/src/server/auth/providers/custom.test.ts
+++ b/packages/core/src/server/auth/providers/custom.test.ts
@@ -49,7 +49,7 @@ describe("customProvider", () => {
 
     expect(config.baseUrl).toBe("https://app.example.test");
     expect(config.verify).toEqual({
-      issuer: base,
+      issuer: ISSUER,
       audience: "my-api",
       jwksUri: `${ISSUER}/jwks`,
     });

--- a/packages/core/src/server/auth/providers/custom.test.ts
+++ b/packages/core/src/server/auth/providers/custom.test.ts
@@ -84,6 +84,16 @@ describe("customProvider", () => {
     expect(config.oauthMetadata.issuer).toBe(base);
   });
 
+  it("ignores a runtime jwks_uri override (keeps the discovered signing keys)", async () => {
+    const base = await serveDiscovery();
+    const config = await customProvider({
+      issuer: base,
+      audience: "a",
+      metadataOverrides: { jwks_uri: "https://evil.test/keys" } as never,
+    });
+    expect(config.verify.jwksUri).toBe(`${base}/jwks`);
+  });
+
   it("rejects a non-DCR IdP (no registration_endpoint)", async () => {
     const base = await serveDiscovery({ registration_endpoint: undefined });
     await expect(
@@ -91,6 +101,17 @@ describe("customProvider", () => {
         issuer: base,
         audience: "a",
         baseUrl: "https://app.example.test",
+      }),
+    ).rejects.toThrow(/not DCR-compatible/);
+  });
+
+  it("rejects a non-DCR IdP even if an override supplies registration_endpoint", async () => {
+    const base = await serveDiscovery({ registration_endpoint: undefined });
+    await expect(
+      customProvider({
+        issuer: base,
+        audience: "a",
+        metadataOverrides: { registration_endpoint: `${base}/register` },
       }),
     ).rejects.toThrow(/not DCR-compatible/);
   });

--- a/packages/core/src/server/auth/providers/custom.test.ts
+++ b/packages/core/src/server/auth/providers/custom.test.ts
@@ -67,6 +67,12 @@ describe("customProvider", () => {
     expect(config.scopesSupported).toEqual(["openid", "email", "profile"]);
   });
 
+  it("allows omitting baseUrl (server infers it from headers)", async () => {
+    const base = await serveDiscovery();
+    const config = await customProvider({ issuer: base, audience: "a" });
+    expect(config.baseUrl).toBeUndefined();
+  });
+
   it("rejects a non-DCR IdP (no registration_endpoint)", async () => {
     const base = await serveDiscovery({ registration_endpoint: undefined });
     await expect(

--- a/packages/core/src/server/auth/providers/custom.test.ts
+++ b/packages/core/src/server/auth/providers/custom.test.ts
@@ -57,22 +57,6 @@ describe("customProvider", () => {
     expect(config.oauthMetadata.registration_endpoint).toBe(`${base}/register`);
   });
 
-  it("defaults scopesSupported to the discovered scopes", async () => {
-    const base = await serveDiscovery();
-    const config = await customProvider({
-      issuer: base,
-      audience: "a",
-      baseUrl: "https://app.example.test",
-    });
-    expect(config.scopesSupported).toEqual(["openid", "email", "profile"]);
-  });
-
-  it("allows omitting baseUrl (server infers it from headers)", async () => {
-    const base = await serveDiscovery();
-    const config = await customProvider({ issuer: base, audience: "a" });
-    expect(config.baseUrl).toBeUndefined();
-  });
-
   it("ignores a runtime issuer override (keeps the discovered trust anchor)", async () => {
     const base = await serveDiscovery();
     const config = await customProvider({
@@ -92,17 +76,6 @@ describe("customProvider", () => {
       metadataOverrides: { jwks_uri: "https://evil.test/keys" } as never,
     });
     expect(config.verify.jwksUri).toBe(`${base}/jwks`);
-  });
-
-  it("rejects a non-DCR IdP (no registration_endpoint)", async () => {
-    const base = await serveDiscovery({ registration_endpoint: undefined });
-    await expect(
-      customProvider({
-        issuer: base,
-        audience: "a",
-        baseUrl: "https://app.example.test",
-      }),
-    ).rejects.toThrow(/not DCR-compatible/);
   });
 
   it("rejects a non-DCR IdP even if an override supplies registration_endpoint", async () => {

--- a/packages/core/src/server/auth/providers/custom.test.ts
+++ b/packages/core/src/server/auth/providers/custom.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment node
+import http from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { customProvider } from "./custom.js";
+
+let server: http.Server | undefined;
+afterEach(() => server?.close());
+
+async function serveDiscovery(doc: Record<string, unknown>) {
+  const srv = http.createServer((req, res) => {
+    if (req.url !== "/.well-known/openid-configuration") {
+      res.writeHead(404).end();
+      return;
+    }
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify(doc));
+  });
+  await new Promise<void>((resolve) => srv.listen(0, resolve));
+  server = srv;
+  const port = (srv.address() as { port: number }).port;
+  return `http://localhost:${port}`;
+}
+
+const ISSUER = "https://idp.test";
+function doc(extra: Record<string, unknown> = {}) {
+  return {
+    issuer: ISSUER,
+    authorization_endpoint: `${ISSUER}/authorize`,
+    token_endpoint: `${ISSUER}/token`,
+    registration_endpoint: `${ISSUER}/register`,
+    response_types_supported: ["code"],
+    scopes_supported: ["openid", "email", "profile"],
+    jwks_uri: `${ISSUER}/jwks`,
+    ...extra,
+  };
+}
+
+describe("customProvider", () => {
+  it("builds an OAuthConfig from discovery", async () => {
+    const base = await serveDiscovery(doc());
+
+    const config = await customProvider({
+      issuer: base,
+      audience: "my-api",
+      baseUrl: "https://app.example.test",
+      scopes: ["openid"],
+      enforcement: "optional",
+    });
+
+    expect(config.baseUrl).toBe("https://app.example.test");
+    expect(config.verify).toEqual({
+      issuer: base,
+      audience: "my-api",
+      jwksUri: `${ISSUER}/jwks`,
+    });
+    expect(config.scopesSupported).toEqual(["openid"]);
+    expect(config.enforcement).toBe("optional");
+    expect(config.oauthMetadata.registration_endpoint).toBe(
+      `${ISSUER}/register`,
+    );
+  });
+
+  it("defaults scopesSupported to the discovered scopes", async () => {
+    const base = await serveDiscovery(doc());
+    const config = await customProvider({
+      issuer: base,
+      audience: "a",
+      baseUrl: "https://app.example.test",
+    });
+    expect(config.scopesSupported).toEqual(["openid", "email", "profile"]);
+  });
+
+  it("rejects a non-DCR IdP (no registration_endpoint)", async () => {
+    const base = await serveDiscovery(
+      doc({ registration_endpoint: undefined }),
+    );
+    await expect(
+      customProvider({
+        issuer: base,
+        audience: "a",
+        baseUrl: "https://app.example.test",
+      }),
+    ).rejects.toThrow(/not DCR-compatible/);
+  });
+
+  it("applies metadataOverrides over discovered values", async () => {
+    const base = await serveDiscovery(doc());
+    const config = await customProvider({
+      issuer: base,
+      audience: "a",
+      baseUrl: "https://app.example.test",
+      metadataOverrides: { token_endpoint: "https://override/token" },
+    });
+    expect(config.oauthMetadata.token_endpoint).toBe("https://override/token");
+  });
+});

--- a/packages/core/src/server/auth/providers/custom.ts
+++ b/packages/core/src/server/auth/providers/custom.ts
@@ -35,7 +35,7 @@ export async function customProvider(opts: {
     issuer: _issuer,
     jwks_uri: _jwks,
     ...overrides
-  } = (opts.metadataOverrides ?? {}) as Partial<DiscoveredMetadata>;
+  }: Partial<DiscoveredMetadata> = opts.metadataOverrides ?? {};
   const oauthMetadata: DiscoveredMetadata = { ...discovered, ...overrides };
 
   return {

--- a/packages/core/src/server/auth/providers/custom.ts
+++ b/packages/core/src/server/auth/providers/custom.ts
@@ -9,7 +9,8 @@ import type { OAuthConfig } from "../index.js";
 export async function customProvider(opts: {
   issuer: string;
   audience: string;
-  baseUrl: string;
+  /** Omit to let the server infer the resource origin from request headers. */
+  baseUrl?: string;
   scopes?: string[];
   requiredScopes?: string[];
   metadataOverrides?: Omit<Partial<OAuthMetadata>, "issuer">;

--- a/packages/core/src/server/auth/providers/custom.ts
+++ b/packages/core/src/server/auth/providers/custom.ts
@@ -16,10 +16,11 @@ export async function customProvider(opts: {
   metadataOverrides?: Omit<Partial<OAuthMetadata>, "issuer">;
 }): Promise<OAuthConfig> {
   const discovered = await discoverAuthorizationServer(opts.issuer);
-  const oauthMetadata: DiscoveredMetadata = {
-    ...discovered,
-    ...opts.metadataOverrides,
-  };
+  // Drop `issuer` from overrides at runtime (the type already forbids it) so it
+  // can't be swapped after discovery validated the original authorization server.
+  const { issuer: _ignoredIssuer, ...overrides } = (opts.metadataOverrides ??
+    {}) as Partial<OAuthMetadata>;
+  const oauthMetadata: DiscoveredMetadata = { ...discovered, ...overrides };
 
   if (!oauthMetadata.registration_endpoint) {
     throw new Error(
@@ -36,7 +37,7 @@ export async function customProvider(opts: {
     baseUrl: opts.baseUrl,
     oauthMetadata,
     verify: {
-      issuer: oauthMetadata.issuer,
+      issuer: discovered.issuer,
       audience: opts.audience,
       jwksUri: oauthMetadata.jwks_uri,
     },

--- a/packages/core/src/server/auth/providers/custom.ts
+++ b/packages/core/src/server/auth/providers/custom.ts
@@ -13,7 +13,7 @@ export async function customProvider(opts: {
   scopes?: string[];
   requiredScopes?: string[];
   enforcement?: "required" | "optional";
-  metadataOverrides?: Partial<OAuthMetadata>;
+  metadataOverrides?: Omit<Partial<OAuthMetadata>, "issuer">;
 }): Promise<OAuthConfig> {
   const discovered = await discoverAuthorizationServer(opts.issuer);
   const oauthMetadata: DiscoveredMetadata = {

--- a/packages/core/src/server/auth/providers/custom.ts
+++ b/packages/core/src/server/auth/providers/custom.ts
@@ -12,7 +12,6 @@ export async function customProvider(opts: {
   baseUrl: string;
   scopes?: string[];
   requiredScopes?: string[];
-  enforcement?: "required" | "optional";
   metadataOverrides?: Omit<Partial<OAuthMetadata>, "issuer">;
 }): Promise<OAuthConfig> {
   const discovered = await discoverAuthorizationServer(opts.issuer);
@@ -42,6 +41,5 @@ export async function customProvider(opts: {
     },
     scopesSupported: opts.scopes ?? oauthMetadata.scopes_supported,
     requiredScopes: opts.requiredScopes,
-    enforcement: opts.enforcement,
   };
 }

--- a/packages/core/src/server/auth/providers/custom.ts
+++ b/packages/core/src/server/auth/providers/custom.ts
@@ -36,7 +36,7 @@ export async function customProvider(opts: {
     baseUrl: opts.baseUrl,
     oauthMetadata,
     verify: {
-      issuer: opts.issuer,
+      issuer: oauthMetadata.issuer,
       audience: opts.audience,
       jwksUri: oauthMetadata.jwks_uri,
     },

--- a/packages/core/src/server/auth/providers/custom.ts
+++ b/packages/core/src/server/auth/providers/custom.ts
@@ -16,22 +16,27 @@ export async function customProvider(opts: {
   metadataOverrides?: Omit<Partial<OAuthMetadata>, "issuer">;
 }): Promise<OAuthConfig> {
   const discovered = await discoverAuthorizationServer(opts.issuer);
-  // Drop `issuer` from overrides at runtime (the type already forbids it) so it
-  // can't be swapped after discovery validated the original authorization server.
-  const { issuer: _ignoredIssuer, ...overrides } = (opts.metadataOverrides ??
-    {}) as Partial<OAuthMetadata>;
-  const oauthMetadata: DiscoveredMetadata = { ...discovered, ...overrides };
 
-  if (!oauthMetadata.registration_endpoint) {
+  // The IdP's own discovery must advertise DCR and a JWKS; overrides can't fake it.
+  if (!discovered.registration_endpoint) {
     throw new Error(
       `${opts.issuer} is not DCR-compatible (no registration_endpoint); customProvider only supports DCR IdPs.`,
     );
   }
-  if (!oauthMetadata.jwks_uri) {
+  if (!discovered.jwks_uri) {
     throw new Error(
       `${opts.issuer} discovery has no jwks_uri; JWKS verification requires it.`,
     );
   }
+
+  // Overrides adjust only advertised metadata (e.g. proxied endpoints). The
+  // trust anchor (issuer, jwks_uri) always comes from validated discovery.
+  const {
+    issuer: _issuer,
+    jwks_uri: _jwks,
+    ...overrides
+  } = (opts.metadataOverrides ?? {}) as Partial<DiscoveredMetadata>;
+  const oauthMetadata: DiscoveredMetadata = { ...discovered, ...overrides };
 
   return {
     baseUrl: opts.baseUrl,
@@ -39,7 +44,7 @@ export async function customProvider(opts: {
     verify: {
       issuer: discovered.issuer,
       audience: opts.audience,
-      jwksUri: oauthMetadata.jwks_uri,
+      jwksUri: discovered.jwks_uri,
     },
     scopesSupported: opts.scopes ?? oauthMetadata.scopes_supported,
     requiredScopes: opts.requiredScopes,

--- a/packages/core/src/server/auth/providers/custom.ts
+++ b/packages/core/src/server/auth/providers/custom.ts
@@ -1,0 +1,47 @@
+import type { OAuthMetadata } from "@modelcontextprotocol/sdk/shared/auth.js";
+import {
+  type DiscoveredMetadata,
+  discoverAuthorizationServer,
+} from "../discovery.js";
+import type { OAuthConfig } from "../index.js";
+
+/** Builds a complete {@link OAuthConfig} for a DCR-compatible IdP via discovery. */
+export async function customProvider(opts: {
+  issuer: string;
+  audience: string;
+  baseUrl: string;
+  scopes?: string[];
+  requiredScopes?: string[];
+  enforcement?: "required" | "optional";
+  metadataOverrides?: Partial<OAuthMetadata>;
+}): Promise<OAuthConfig> {
+  const discovered = await discoverAuthorizationServer(opts.issuer);
+  const oauthMetadata: DiscoveredMetadata = {
+    ...discovered,
+    ...opts.metadataOverrides,
+  };
+
+  if (!oauthMetadata.registration_endpoint) {
+    throw new Error(
+      `${opts.issuer} is not DCR-compatible (no registration_endpoint); customProvider only supports DCR IdPs.`,
+    );
+  }
+  if (!oauthMetadata.jwks_uri) {
+    throw new Error(
+      `${opts.issuer} discovery has no jwks_uri; JWKS verification requires it.`,
+    );
+  }
+
+  return {
+    baseUrl: opts.baseUrl,
+    oauthMetadata,
+    verify: {
+      issuer: opts.issuer,
+      audience: opts.audience,
+      jwksUri: oauthMetadata.jwks_uri,
+    },
+    scopesSupported: opts.scopes ?? oauthMetadata.scopes_supported,
+    requiredScopes: opts.requiredScopes,
+    enforcement: opts.enforcement,
+  };
+}

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -1,4 +1,5 @@
 export type { OAuthConfig } from "./auth/index.js";
+export { customProvider } from "./auth/providers/custom.js";
 export {
   type AuthInfo,
   type AuthMetadataOptions,


### PR DESCRIPTION
### Summary

- Add `customProvider(...)` — async factory that builds a complete `OAuthConfig` from a DCR-compatible IdP's discovery document.
- Replaces the hand-written `oauthMetadata` block: point it at the issuer, it discovers the rest.
- Refuses non-DCR IdPs (no `registration_endpoint`) with a clear error.

### Architecture Notes

- **Discovery is the reusable core** — internal `auth/discovery.ts` probes `openid-configuration`, falls back to `oauth-authorization-server`, then validates. SKY-447's branded providers build on it; `customProvider` is a thin layer over it.
  - *Why both endpoints:* there's no universal discovery URL. DCR-compatible IdPs split between OIDC discovery (`openid-configuration` — near-universal, and guarantees the `jwks_uri` we need to verify tokens) and OAuth-native discovery (RFC 8414 `oauth-authorization-server` — where `jwks_uri` is optional).
- **Verifies against the discovered issuer** — the AS's canonical metadata issuer, not the caller-supplied string, so token `iss` matching is exact.

> Base: `main` — SKY-445 (#873) merged.

### Usage

`customProvider` returns the `OAuthConfig` consumed by the `oauth` field from #873 — point it at a DCR-compatible IdP's issuer and it discovers the rest:

```ts
import { McpServer, customProvider } from "skybridge/server";

const server = new McpServer(
  { name: "my-app", version: "1.0.0" },
  { capabilities: {} },
  {
    oauth: await customProvider({
      issuer: "https://auth.example.com", // DCR-compatible IdP
      audience: "my-mcp-api",
      scopes: ["openid", "email"],
      // baseUrl omitted -> resource origin inferred from request headers
    }),
  },
);

// /mcp now requires a valid bearer token; handlers read the caller via extra.authInfo:
server.registerTool(
  { name: "whoami", description: "Return the signed-in user", inputSchema: {} },
  (_args, extra) => ({
    content: [{ type: "text", text: extra.authInfo?.clientId ?? "anonymous" }],
  }),
);
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `customProvider`, an async factory that builds a complete `OAuthConfig` by fetching and validating an IdP's discovery document. It tries OIDC `openid-configuration` first, falls back to RFC 8414 `oauth-authorization-server`, and refuses to proceed if the IdP doesn't advertise DCR or a `jwks_uri`.

- `discovery.ts` handles fetch-with-timeout, issuer-binding validation (RFC 8414 §3.3, slash-tolerant), and a structured two-endpoint fallback loop.
- `custom.ts` extracts `issuer` and `jwks_uri` from `metadataOverrides` at runtime before merging, so the token-verification trust anchor always comes from validated discovery — overrides only affect the advertised `oauthMetadata` returned to clients.
- Tests exercise the full set of security invariants: issuer-mismatch rejection, slash-terminated issuers, DCR enforcement, and blocked `issuer`/`jwks_uri` overrides.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the critical trust-anchor properties (issuer and JWKS URI used for token verification) are validated from discovery and cannot be overridden by callers; DCR enforcement is checked against the raw discovered metadata before any overrides are applied.

All previously raised security concerns have been resolved: the issuer-binding check is in place, fetch carries a 5-second timeout, `issuer` and `jwks_uri` are stripped from `metadataOverrides` at runtime before merging, and the DCR presence check runs on the pre-override `discovered` object. The test suite validates each of these invariants with a real HTTP server.

No files require special attention.

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **metadataOverrides can replace canonical issuer used for token verification**

   - **Bug**
     - The contract says `metadataOverrides` should be applied except for `issuer`, and `verify.issuer` should come from the canonical discovered issuer. In the executed head scenario, passing `metadataOverrides.issuer: "https://malicious-override.example"` caused both `oauthMetadata.issuer` and `verify.issuer` to become the override value instead of the localhost issuer from the discovery document. This makes token verification inconsistent with the discovered authorization server.
   - **Cause**
     - In `packages/core/src/server/auth/providers/custom.ts`, the factory constructs `oauthMetadata` with `{ ...discovered, ...opts.metadataOverrides }` and later sets `verify.issuer` from `oauthMetadata.issuer`, so an override-supplied `issuer` wins over the discovered canonical issuer despite the intended exclusion.
   - **Fix**
     - Ensure `issuer` cannot be applied from overrides at runtime, not just in the TypeScript type. For example, destructure and discard `issuer` from `opts.metadataOverrides` before spreading, or explicitly reset `oauthMetadata.issuer = discovered.issuer`; set `verify.issuer` directly from `discovered.issuer`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (10): Last reviewed commit: ["refactor(core): parse jwks\_uri via exten..."](https://github.com/alpic-ai/skybridge/commit/3ac429dacb1514cdf447e2b1c473ff1d7ed6b716) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38160478)</sub>

<!-- /greptile_comment -->