### PR TITLE
Add product hunt badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@
   <a href="https://github.com/alpic-ai/skybridge/blob/main/LICENSE"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/github/license/alpic-ai/skybridge?color=D7FFC8&amp;labelColor=161B22&amp;style=for-the-badge"><img alt="License: MIT" src="https://img.shields.io/github/license/alpic-ai/skybridge?color=E8FBD9&amp;labelColor=F6F8FA&amp;style=for-the-badge"></picture></a>
 </p>
 
+<p align="center">
+  <a href="https://www.producthunt.com/products/skybridge?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-skybridge" target="_blank" rel="noopener noreferrer">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1162357&amp;theme=dark" />
+      <img alt="Skybridge - The full-stack open source React framework for MCP Apps | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1162357&amp;theme=light" />
+    </picture>
+  </a>
+</p>
+
 ## About Skybridge
 
 Skybridge helps developers build type-safe MCP apps for Claude, ChatGPT and other UI-enabled MCP clients, with a complete set of tooling designed for both humans and agents.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2,6 +2,10 @@
   "$schema": "https://mintlify.com/docs.json",
   "name": "Skybridge",
   "theme": "mint",
+  "banner": {
+    "content": "🚀 We're live on Product Hunt today, help us reach Product of the Day — [Upvote →](https://www.producthunt.com/products/skybridge?utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-skybridge)",
+    "dismissible": true
+  },
   "colors": {
     "primary": "#002FFF",
     "light": "#08F5F9",

--- a/landing/app/components/ph-banner.tsx
+++ b/landing/app/components/ph-banner.tsx
@@ -1,0 +1,17 @@
+// ponytail: single source for the PH link; swap when the launch post is live
+const PH_URL =
+  "https://www.producthunt.com/products/skybridge?utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-skybridge";
+
+export function ProductHuntBanner() {
+  return (
+    <a className="sb-ph-banner" href={PH_URL} target="_blank" rel="noreferrer">
+      <span className="sb-ph-emoji" aria-hidden="true">
+        🚀
+      </span>
+      <span>
+        We're live on Product Hunt today, help us reach Product of the Day
+      </span>
+      <span className="sb-ph-cta">Upvote →</span>
+    </a>
+  );
+}

--- a/landing/app/page.tsx
+++ b/landing/app/page.tsx
@@ -1,6 +1,7 @@
 import { CodeDemoSection } from "./components/demo";
 import { DevToolsSection } from "./components/devtools";
 import { Hero } from "./components/hero";
+import { ProductHuntBanner } from "./components/ph-banner";
 import { QuotesSection } from "./components/quotes";
 import { SiteNav } from "./components/site-nav";
 import { SocialProofSection } from "./components/social";
@@ -15,6 +16,7 @@ import { VideoSection } from "./components/video";
 export default function Home() {
   return (
     <div className="sb-root" data-theme="dark">
+      <ProductHuntBanner />
       <SiteNav />
       <Hero />
       <ValuesSection />

--- a/landing/app/skybridge.css
+++ b/landing/app/skybridge.css
@@ -107,6 +107,37 @@ body {
 
 /* ===== nav ===== */
 /* ===== nav (alpic.ai-style floating pill) ===== */
+.sb-ph-banner {
+  position: relative;
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 10px 20px;
+  font-size: 14px;
+  font-weight: 500;
+  text-align: center;
+  color: var(--sb-ice-ink);
+  background: linear-gradient(90deg, var(--sb-accent), var(--sb-lime));
+  text-decoration: none;
+}
+.sb-ph-banner:hover .sb-ph-cta {
+  text-decoration: underline;
+}
+.sb-ph-emoji {
+  font-size: 16px;
+}
+.sb-ph-cta {
+  font-weight: 700;
+}
+@media (max-width: 560px) {
+  .sb-ph-banner {
+    font-size: 12.5px;
+    gap: 6px;
+  }
+}
+
 .sb-nav {
   position: sticky;
   top: 16px;


### PR DESCRIPTION
<img width="1728" height="378" alt="image" src="https://github.com/user-attachments/assets/1e66cd08-8751-4448-b152-a44fee096730" />
<img width="3456" height="1274" alt="image" src="https://github.com/user-attachments/assets/463543b8-582e-4b0f-8102-c82f960fcdec" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Product Hunt launch-day promotional content across the repository: a featured badge in the README, a dismissible banner in the Mintlify docs, and a new full-width `ProductHuntBanner` component on the landing page.

- The README badge and docs banner are well-implemented; the docs banner correctly sets `dismissible: true`.
- The landing page banner renders unconditionally with no dismiss button and no expiry logic, while its copy (\"today\") is explicitly launch-day messaging — leaving it permanently visible after the launch has passed.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the launch day; the landing banner will show stale 'today' copy indefinitely without a follow-up removal.

The changes are purely presentational marketing content. The only concern is that the landing banner text ('We're live on Product Hunt today') will become stale messaging after launch day, and unlike the docs banner there is no dismiss option or any mechanism to retire it. This requires a manual follow-up PR to remove or replace the banner.

landing/app/components/ph-banner.tsx — the banner has no dismiss mechanism and will show time-sensitive copy after the launch day has passed.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
landing/app/components/ph-banner.tsx:5-17
**No dismiss mechanism for time-sensitive banner**

The banner copy ("We're live on Product Hunt today") is explicitly launch-day messaging, but the landing page banner is always rendered with no way for a visitor to dismiss it and no expiry logic. The docs banner in `docs.json` correctly sets `"dismissible": true` — the landing banner has no equivalent, so visitors who already upvoted (or who return days later) are stuck with stale "today" messaging on every page load.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add product hunt badges"](https://github.com/alpic-ai/skybridge/commit/8b3a8680ca171a03d0d65f1ba772d955d5f3b345) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38989907)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->