### PR TITLE
docs: troubleshoot ViewName error before views.d.ts is generated

### DIFF
--- a/docs/concepts/type-safety.mdx
+++ b/docs/concepts/type-safety.mdx
@@ -252,6 +252,16 @@ Check that:
 2. Your `helpers.ts` imports this type correctly
 3. You're using method chaining
 
+### `Type '"foo"' is not assignable to type 'ViewName'`
+
+Skybridge generates `.skybridge/views.d.ts` from the files in `src/views/`. That file augments `ViewNameRegistry`, so `component` in `registerTool` only accepts registered view names. If you add a new view and run TypeScript before that file exists, you'll see this error even when the view file and tool name match.
+
+This is expected — not a runtime bug. During normal development, `pnpm dev` scans `src/views/` and regenerates `.skybridge/views.d.ts` automatically (the Vite plugin does the same on startup).
+
+**When you might hit this:** you create `src/views/foo.tsx`, register `component: "foo"` in `server.ts`, then run `tsc` or your editor's type checker before ever starting dev.
+
+**Fix:** run `pnpm dev` or `pnpm build` once — both scan views before compiling the server. After `.skybridge/views.d.ts` exists, the error should clear. If you already started `pnpm dev` but errors persist, restart dev so `tsc --watch` picks up the newly created `.skybridge/` directory.
+
 ## Related
 
 - [generateHelpers API](/api-reference/generate-helpers) - Full API documentation


### PR DESCRIPTION
## Summary

Adds documentation for a common DX issue that can occur when adding a new view before the first `pnpm dev` or `pnpm build run`.

The issue is already documented internally in `dev.tsx` , but not in the user-facing docs. 

This PR adds a troubleshooting note to the Type Safety section explaining how `.skybridge/views.d.ts` is generated and how to resolve the resulting TypeScript error.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a troubleshooting note for early `ViewName` type errors. The main changes are:

- Documents that `.skybridge/views.d.ts` is generated from view files.
- Explains why a new view can type-error before dev or build has run.
- Recommends running `pnpm dev` or `pnpm build` once, and restarting dev if the watcher missed `.skybridge/`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is limited to documentation and no code behavior is modified.

The update is narrowly scoped to a troubleshooting note in one docs file and matches the described developer experience issue.

<sub>Reviews (1): Last reviewed commit: ["docs: troubleshoot ViewName error before..."](https://github.com/alpic-ai/skybridge/commit/1b07553c0594cd7a91b58f3496ecba961906d8ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39292302)</sub>

<!-- /greptile_comment -->