### PR TITLE
feat: add oauth providers

### DIFF
--- a/docs/api-reference/auth0-provider.mdx
+++ b/docs/api-reference/auth0-provider.mdx
@@ -1,0 +1,61 @@
+---
+title: auth0Provider
+sidebarTitle: "Auth0"
+description: "Wire OAuth from an Auth0 tenant"
+---
+
+`auth0Provider` wires authentication through [Auth0](https://auth0.com/). Auth0 carries the audience in the authorize request rather than as a resource indicator, so it also requires this server's public URL as `serverUrl`.
+
+## Example
+
+```ts server.ts highlight={1,7-11}
+import { McpServer, auth0Provider } from "skybridge/server";
+
+const server = new McpServer(
+  { name: "personal-shopper", version: "0.0.1" },
+  { capabilities: {} },
+  {
+    oauth: await auth0Provider({
+      domain: process.env.AUTH0_DOMAIN,
+      audience: process.env.AUTH0_API_IDENTIFIER,
+      serverUrl: process.env.SERVER_URL,
+    }),
+  },
+);
+```
+
+## Signature
+
+```ts
+auth0Provider(opts: Auth0ProviderOptions): Promise<OAuthConfig>;
+```
+
+## Parameters
+
+### `opts`
+
+- **`domain`** is the tenant domain, for example `acme.us.auth0.com`.
+
+- **`audience`** is the API Identifier from the Auth0 dashboard, bound into the token's `aud` claim.
+
+- **`serverUrl`** is this server's public URL, required for Auth0.
+
+It also accepts the shared [`CustomProviderOptions`](/api-reference/custom-provider#parameters) options: `scopes`, `requiredScopes`, and `metadataOverrides`.
+
+Requires Dynamic Client Registration enabled on the tenant.
+
+## Returns
+
+A `Promise` for the [`OAuthConfig`](/api-reference/custom-provider#returns) you pass to the [`oauth`](/api-reference/mcp-server#constructor) constructor option.
+
+<CardGroup cols={3}>
+  <Card title="Connect an Identity Provider" icon="fingerprint" href="/guides/auth-providers">
+    Set up sign-in with a hosted provider
+  </Card>
+  <Card title="Authenticate Users" icon="key" href="/build/auth">
+    Add sign-in to your app end to end
+  </Card>
+  <Card title="customProvider" icon="key-round" href="/api-reference/custom-provider">
+    Wire OAuth from any IdP's discovery document
+  </Card>
+</CardGroup>

--- a/docs/api-reference/clerk-provider.mdx
+++ b/docs/api-reference/clerk-provider.mdx
@@ -1,0 +1,57 @@
+---
+title: clerkProvider
+sidebarTitle: "Clerk"
+description: "Wire OAuth from a Clerk instance"
+---
+
+`clerkProvider` wires authentication through [Clerk](https://clerk.com/). Clerk access tokens carry no `aud` claim, so there is no `audience` option.
+
+## Example
+
+```ts server.ts highlight={1,7-9}
+import { McpServer, clerkProvider } from "skybridge/server";
+
+const server = new McpServer(
+  { name: "personal-shopper", version: "0.0.1" },
+  { capabilities: {} },
+  {
+    oauth: await clerkProvider({
+      domain: process.env.CLERK_FRONTEND_API,
+    }),
+  },
+);
+```
+
+## Signature
+
+```ts
+clerkProvider(opts: ClerkProviderOptions): Promise<OAuthConfig>;
+```
+
+## Parameters
+
+### `opts`
+
+**`domain`** is the Clerk Frontend API URL, for example `acme.clerk.accounts.dev` or a production custom domain.
+
+There is no `audience` option: Clerk binds no audience to its tokens.
+
+It also accepts the shared [`CustomProviderOptions`](/api-reference/custom-provider#parameters) options: `baseUrl`, `serverUrl`, `scopes`, `requiredScopes`, and `metadataOverrides`.
+
+Requires Dynamic Client Registration enabled on the instance, and the OAuth application set to issue JWT access tokens (opaque tokens can't be verified).
+
+## Returns
+
+A `Promise` for the [`OAuthConfig`](/api-reference/custom-provider#returns) you pass to the [`oauth`](/api-reference/mcp-server#constructor) constructor option.
+
+<CardGroup cols={3}>
+  <Card title="Connect an Identity Provider" icon="fingerprint" href="/guides/auth-providers">
+    Set up sign-in with a hosted provider
+  </Card>
+  <Card title="Authenticate Users" icon="key" href="/build/auth">
+    Add sign-in to your app end to end
+  </Card>
+  <Card title="customProvider" icon="key-round" href="/api-reference/custom-provider">
+    Wire OAuth from any IdP's discovery document
+  </Card>
+</CardGroup>

--- a/docs/api-reference/custom-provider.mdx
+++ b/docs/api-reference/custom-provider.mdx
@@ -51,7 +51,7 @@ type CustomProviderOptions = {
 | --- | --- |
 | `issuer` | The only required option: the IdP base URL whose discovery document is fetched at boot. It must serve a `jwks_uri`, or the call throws. |
 | `audience` | Checked against each token's `aud` claim. Omit it only for an IdP that binds no audience (Clerk): the `aud` check is then skipped. |
-| `baseUrl` | This server's public URL. Set it and the resource URLs are baked once at boot; omit it and they resolve per request from the `x-forwarded-host` / `origin` / `host` headers. |
+| `baseUrl` | This server's public URL. Set it and the resource URLs are baked once at boot; omit it and they resolve per request from the `x-forwarded-host` / `x-forwarded-proto` / `host` headers. |
 | `serverUrl` | Advertises this server as the authorization server: the served AS metadata `issuer` and the PRM `authorization_servers` use this URL instead of the IdP's, while verification still trusts the IdP's real `iss`. Needed when this server must sit in the auth path, as [`auth0Provider`](/api-reference/auth0-provider) does, or behind the Alpic DCR proxy. |
 | `scopes` | Scopes advertised in the served metadata; defaults to the IdP's. |
 | `requiredScopes` | Server-wide scope floor enforced before any handler, layered under each tool's [`securitySchemes`](/api-reference/register-tool#securityschemes); a token missing one gets a 403. |

--- a/docs/api-reference/custom-provider.mdx
+++ b/docs/api-reference/custom-provider.mdx
@@ -1,0 +1,94 @@
+---
+title: customProvider
+sidebarTitle: "Custom"
+description: "Wire OAuth from any IdP's discovery document"
+---
+
+`customProvider` builds a complete [`OAuthConfig`](#returns) from an identity provider's OAuth discovery document: it reads the provider's metadata at boot and verifies access tokens against its JWKS. Reach for it when no [branded provider](/api-reference/workos-provider) fits, for any IdP that publishes [discovery metadata](https://datatracker.ietf.org/doc/html/rfc8414) and signs JWT access tokens.
+
+## Example
+
+```ts server.ts highlight={1,7-10}
+import { McpServer, customProvider } from "skybridge/server";
+
+const server = new McpServer(
+  { name: "personal-shopper", version: "0.0.1" },
+  { capabilities: {} },
+  {
+    oauth: await customProvider({
+      issuer: "https://auth.myshop.com",
+      audience: process.env.SERVER_URL,
+    }),
+  },
+);
+```
+
+`customProvider` fetches `https://auth.myshop.com`'s discovery document at boot, then the [`oauth`](/api-reference/mcp-server#constructor) option mounts the well-known metadata and JWKS bearer verification on `/mcp`. `audience` is the value the IdP binds into the token's `aud` claim, here this server's public URL.
+
+## Signature
+
+```ts
+customProvider(opts: CustomProviderOptions): Promise<OAuthConfig>;
+```
+
+## Parameters
+
+### `opts`
+
+```ts
+type CustomProviderOptions = {
+  issuer: string;
+  audience?: string;
+  baseUrl?: string;
+  serverUrl?: string;
+  scopes?: string[];
+  requiredScopes?: string[];
+  metadataOverrides?: Omit<Partial<OAuthMetadata>, "issuer">;
+};
+```
+
+| Field | Description |
+| --- | --- |
+| `issuer` | The only required option: the IdP base URL whose discovery document is fetched at boot. It must serve a `jwks_uri`, or the call throws. |
+| `audience` | Checked against each token's `aud` claim. Omit it only for an IdP that binds no audience (Clerk): the `aud` check is then skipped. |
+| `baseUrl` | This server's public URL. Set it and the resource URLs are baked once at boot; omit it and they resolve per request from the `x-forwarded-host` / `origin` / `host` headers. |
+| `serverUrl` | Advertises this server as the authorization server: the served AS metadata `issuer` and the PRM `authorization_servers` use this URL instead of the IdP's, while verification still trusts the IdP's real `iss`. Needed when this server must sit in the auth path, as [`auth0Provider`](/api-reference/auth0-provider) does, or behind the Alpic DCR proxy. |
+| `scopes` | Scopes advertised in the served metadata; defaults to the IdP's. |
+| `requiredScopes` | Server-wide scope floor enforced before any handler, layered under each tool's [`securitySchemes`](/api-reference/register-tool#securityschemes); a token missing one gets a 403. |
+| `metadataOverrides` | Adjusts advertised metadata only. |
+
+## Returns
+
+A `Promise` (discovery is a boot-time network call) for the `OAuthConfig` you pass to the [`oauth`](/api-reference/mcp-server#constructor) constructor option.
+
+```ts
+type OAuthConfig = {
+  baseUrl?: string;
+  oauthMetadata: OAuthMetadata;
+  verify: { issuer: string; audience?: string; jwksUri?: string };
+  scopesSupported?: string[];
+  requiredScopes?: string[];
+};
+```
+
+| Field | Description |
+| --- | --- |
+| `baseUrl` | Echoes the `baseUrl` option. |
+| `oauthMetadata` | AS metadata served at `/.well-known/oauth-authorization-server`. |
+| `verify` | JWKS token-verification config. |
+| `scopesSupported` | Scopes advertised in protected-resource metadata. |
+| `requiredScopes` | Server-wide required-scope floor. |
+
+Build this object by hand only to wire an IdP whose metadata `customProvider` can't discover: supply `verify.issuer` and `verify.jwksUri` yourself and the [`oauth`](/api-reference/mcp-server#constructor) option mounts the same endpoints.
+
+<CardGroup cols={3}>
+  <Card title="Connect an Identity Provider" icon="fingerprint" href="/guides/auth-providers">
+    Set up sign-in with a hosted provider
+  </Card>
+  <Card title="Authenticate Users" icon="key" href="/build/auth">
+    Add sign-in to your app end to end
+  </Card>
+  <Card title="McpServer" icon="server" href="/api-reference/mcp-server">
+    Pass the config to the oauth option
+  </Card>
+</CardGroup>

--- a/docs/api-reference/custom-provider.mdx
+++ b/docs/api-reference/custom-provider.mdx
@@ -8,7 +8,7 @@ description: "Wire OAuth from any IdP's discovery document"
 
 ## Example
 
-```ts server.ts highlight={1,7-10}
+```ts server.ts highlight={1,7-12}
 import { McpServer, customProvider } from "skybridge/server";
 
 const server = new McpServer(
@@ -18,6 +18,8 @@ const server = new McpServer(
     oauth: await customProvider({
       issuer: "https://auth.myshop.com",
       audience: process.env.SERVER_URL,
+      scopes: ["openid", "profile", "checkout"],
+      requiredScopes: ["openid"],
     }),
   },
 );

--- a/docs/api-reference/descope-provider.mdx
+++ b/docs/api-reference/descope-provider.mdx
@@ -1,0 +1,57 @@
+---
+title: descopeProvider
+sidebarTitle: "Descope"
+description: "Wire OAuth from a Descope MCP Server"
+---
+
+`descopeProvider` wires authentication through a [Descope](https://www.descope.com/) MCP Server, so your tools receive a signed-in Descope user.
+
+## Example
+
+```ts server.ts highlight={1,7-9}
+import { McpServer, descopeProvider } from "skybridge/server";
+
+const server = new McpServer(
+  { name: "personal-shopper", version: "0.0.1" },
+  { capabilities: {} },
+  {
+    oauth: await descopeProvider({
+      url: process.env.DESCOPE_DISCOVERY_URL,
+    }),
+  },
+);
+```
+
+## Signature
+
+```ts
+descopeProvider(opts: DescopeProviderOptions): Promise<OAuthConfig>;
+```
+
+## Parameters
+
+### `opts`
+
+- **`url`** is the MCP Server's Discovery URL (its Issuer) from the console's Connection Information, for example `https://api.descope.com/v1/apps/agentic/<projectId>/<mcpServerId>`, or your custom domain.
+
+- **`audience`** defaults to the Project ID derived from `url`: Descope binds the token's `aud` to `[DCR client id, project id]`. Pass it explicitly to override.
+
+It also accepts the shared [`CustomProviderOptions`](/api-reference/custom-provider#parameters) options: `baseUrl`, `serverUrl`, `scopes`, `requiredScopes`, and `metadataOverrides`.
+
+Requires Dynamic Client Registration enabled on the MCP Server. With DCR disabled and the Alpic DCR proxy, use [`customProvider`](/api-reference/custom-provider) with `serverUrl` instead.
+
+## Returns
+
+A `Promise` for the [`OAuthConfig`](/api-reference/custom-provider#returns) you pass to the [`oauth`](/api-reference/mcp-server#constructor) constructor option.
+
+<CardGroup cols={3}>
+  <Card title="Connect an Identity Provider" icon="fingerprint" href="/guides/auth-providers">
+    Set up sign-in with a hosted provider
+  </Card>
+  <Card title="Authenticate Users" icon="key" href="/build/auth">
+    Add sign-in to your app end to end
+  </Card>
+  <Card title="customProvider" icon="key-round" href="/api-reference/custom-provider">
+    Wire OAuth from any IdP's discovery document
+  </Card>
+</CardGroup>

--- a/docs/api-reference/descope-provider.mdx
+++ b/docs/api-reference/descope-provider.mdx
@@ -34,7 +34,7 @@ descopeProvider(opts: DescopeProviderOptions): Promise<OAuthConfig>;
 
 - **`url`** is the MCP Server's Discovery URL (its Issuer) from the console's Connection Information, for example `https://api.descope.com/v1/apps/agentic/<projectId>/<mcpServerId>`, or your custom domain.
 
-- **`audience`** defaults to the Project ID derived from `url`: Descope binds the token's `aud` to `[DCR client id, project id]`. Pass it explicitly to override.
+- **`audience`** defaults to the Project ID parsed from the `/agentic/<projectId>/<mcpServerId>` segment of `url` (Descope binds the token's `aud` to `[DCR client id, project id]`). If `url` lacks that segment, such as a custom domain, pass `audience` explicitly or the server throws at startup.
 
 It also accepts the shared [`CustomProviderOptions`](/api-reference/custom-provider#parameters) options: `baseUrl`, `serverUrl`, `scopes`, `requiredScopes`, and `metadataOverrides`.
 

--- a/docs/api-reference/mcp-server.mdx
+++ b/docs/api-reference/mcp-server.mdx
@@ -38,10 +38,13 @@ new McpServer(
 ```ts
 type SkybridgeServerOptions = {
   json?: JsonOptions;
+  oauth?: OAuthConfig;
 };
 ```
 
 `json` tunes the [`express.json()`](https://expressjs.com/en/5x/api/express/#expressjsonoptions) parser Skybridge pre-applies, for example to raise the default 100kb body-size limit.
+
+`oauth` is an [`OAuthConfig`](/api-reference/custom-provider#returns), usually from [`customProvider`](/api-reference/custom-provider) or a branded provider. When set, it mounts the well-known OAuth metadata and bearer-token verification on `/mcp`.
 
 ## Properties
 

--- a/docs/api-reference/stytch-provider.mdx
+++ b/docs/api-reference/stytch-provider.mdx
@@ -1,0 +1,58 @@
+---
+title: stytchProvider
+sidebarTitle: "Stytch"
+description: "Wire OAuth from Stytch Connected Apps"
+---
+
+`stytchProvider` wires authentication through [Stytch Connected Apps](https://stytch.com/), so your tools receive a signed-in Stytch user.
+
+## Example
+
+```ts server.ts highlight={1,7-10}
+import { McpServer, stytchProvider } from "skybridge/server";
+
+const server = new McpServer(
+  { name: "personal-shopper", version: "0.0.1" },
+  { capabilities: {} },
+  {
+    oauth: await stytchProvider({
+      domain: process.env.STYTCH_DOMAIN,
+      audience: process.env.STYTCH_PROJECT_ID,
+    }),
+  },
+);
+```
+
+## Signature
+
+```ts
+stytchProvider(opts: StytchProviderOptions): Promise<OAuthConfig>;
+```
+
+## Parameters
+
+### `opts`
+
+- **`domain`** is the project domain, for example `acme.customers.stytch.dev`, or a configured custom domain.
+
+- **`audience`** is the Stytch Project ID, the audience Stytch binds into the token's `aud` claim.
+
+It also accepts the shared [`CustomProviderOptions`](/api-reference/custom-provider#parameters) options: `baseUrl`, `serverUrl`, `scopes`, `requiredScopes`, and `metadataOverrides`.
+
+Requires Dynamic Client Registration enabled in the Stytch dashboard.
+
+## Returns
+
+A `Promise` for the [`OAuthConfig`](/api-reference/custom-provider#returns) you pass to the [`oauth`](/api-reference/mcp-server#constructor) constructor option.
+
+<CardGroup cols={3}>
+  <Card title="Connect an Identity Provider" icon="fingerprint" href="/guides/auth-providers">
+    Set up sign-in with a hosted provider
+  </Card>
+  <Card title="Authenticate Users" icon="key" href="/build/auth">
+    Add sign-in to your app end to end
+  </Card>
+  <Card title="customProvider" icon="key-round" href="/api-reference/custom-provider">
+    Wire OAuth from any IdP's discovery document
+  </Card>
+</CardGroup>

--- a/docs/api-reference/workos-provider.mdx
+++ b/docs/api-reference/workos-provider.mdx
@@ -1,0 +1,58 @@
+---
+title: workosProvider
+sidebarTitle: "WorkOS"
+description: "Wire OAuth from WorkOS AuthKit"
+---
+
+`workosProvider` wires authentication through [WorkOS AuthKit](https://www.workos.com/), so your tools receive a signed-in WorkOS user.
+
+## Example
+
+```ts server.ts highlight={1,7-10}
+import { McpServer, workosProvider } from "skybridge/server";
+
+const server = new McpServer(
+  { name: "personal-shopper", version: "0.0.1" },
+  { capabilities: {} },
+  {
+    oauth: await workosProvider({
+      domain: process.env.AUTHKIT_DOMAIN,
+      audience: process.env.SERVER_URL,
+    }),
+  },
+);
+```
+
+## Signature
+
+```ts
+workosProvider(opts: WorkosProviderOptions): Promise<OAuthConfig>;
+```
+
+## Parameters
+
+### `opts`
+
+- **`domain`** is the AuthKit domain, for example `acme.authkit.app`.
+
+- **`audience`** is the [Resource Indicator](https://datatracker.ietf.org/doc/html/rfc8707) configured in the WorkOS dashboard, typically this server's public URL. AuthKit binds it into the token's `aud` claim.
+
+It also accepts the shared [`CustomProviderOptions`](/api-reference/custom-provider#parameters) options: `baseUrl`, `serverUrl`, `scopes`, `requiredScopes`, and `metadataOverrides`.
+
+Requires Dynamic Client Registration enabled in the WorkOS dashboard (Connect → Configuration).
+
+## Returns
+
+A `Promise` for the [`OAuthConfig`](/api-reference/custom-provider#returns) you pass to the [`oauth`](/api-reference/mcp-server#constructor) constructor option.
+
+<CardGroup cols={3}>
+  <Card title="Connect an Identity Provider" icon="fingerprint" href="/guides/auth-providers">
+    Set up sign-in with a hosted provider
+  </Card>
+  <Card title="Authenticate Users" icon="key" href="/build/auth">
+    Add sign-in to your app end to end
+  </Card>
+  <Card title="customProvider" icon="key-round" href="/api-reference/custom-provider">
+    Wire OAuth from any IdP's discovery document
+  </Card>
+</CardGroup>

--- a/docs/build/auth.mdx
+++ b/docs/build/auth.mdx
@@ -4,11 +4,11 @@ description: "Know who's behind every tool call"
 icon: "key"
 ---
 
-import { Hero } from "/components/hero.jsx";
-
-<Hero src="/images/auth.png" alt="Auth Illustration" />
-
 [Tool](/build/tools) calls are anonymous by default: nothing in the protocol tells you who's asking. [OAuth](https://oauth.net/2/) closes that gap, and the host does most of the work: it discovers your authorization server, signs the user in, refreshes tokens, and attaches a Bearer token to every request. Your server keeps three jobs: publish the discovery metadata, verify the tokens, and read the user in your handlers.
+
+<Tip>
+Using [Auth0](/guides/auth-providers#auth0), [Clerk](/guides/auth-providers#clerk), [Descope](/guides/auth-providers#descope), [Stytch](/guides/auth-providers#stytch), [WorkOS](/guides/auth-providers#workos), or [any other OAuth provider](/guides/auth-providers#any-other-provider)? Connect it in one line instead of wiring this by hand. That path can't yet [mix public and authenticated tools](#mix-public-and-authenticated-tools).
+</Tip>
 
 Here's a complete server where every tool requires sign-in:
 
@@ -203,13 +203,13 @@ server.registerTool(
 
 ## Go Further
 <Columns cols={3}>
-    <Card title="Register Tools" img="/images/tools.png" href="/build/tools">
+    <Card title="Register Tools" icon="wrench" href="/build/tools">
         Define what humans and agents can do
     </Card>
-    <Card title="Create Views" img="/images/view.png" href="/build/view">
+    <Card title="Create Views" icon="palette" href="/build/view">
         Craft interactive UIs rendered in conversation
     </Card>
-    <Card title="Manage State" img="/images/state.png" href="/build/state">
+    <Card title="Manage State" icon="database" href="/build/state">
         Decide what the model sees
     </Card>
 </Columns>

--- a/docs/build/index.mdx
+++ b/docs/build/index.mdx
@@ -14,16 +14,16 @@ Building an MCP App means answering four questions: what the model can do, what 
 | Who is asking | [Authenticate Users](/build/auth) | [`requireBearerAuth`](/api-reference/require-bearer-auth), [`securitySchemes`](/api-reference/register-tool#securityschemes) |
 
 <Columns cols={2}>
-    <Card title="Register Tools" img="/images/tools.png" href="/build/tools">
+    <Card title="Register Tools" icon="wrench" href="/build/tools">
         Define what humans and agents can do
     </Card>
-    <Card title="Create Views" img="/images/view.png" href="/build/view">
+    <Card title="Create Views" icon="palette" href="/build/view">
         Craft interactive UIs rendered in conversation
     </Card>
-    <Card title="Manage State" img="/images/state.png" href="/build/state">
+    <Card title="Manage State" icon="database" href="/build/state">
         Decide what the model sees
     </Card>
-    <Card title="Authenticate Users" img="/images/auth.png" href="/build/auth">
+    <Card title="Authenticate Users" icon="key" href="/build/auth">
         Know who's behind every tool call
     </Card>
 </Columns>

--- a/docs/build/state.mdx
+++ b/docs/build/state.mdx
@@ -4,10 +4,6 @@ description: "Decide what the model sees"
 icon: "database"
 ---
 
-import { Hero } from "/components/hero.jsx";
-
-<Hero src="/images/state.png" alt="State Illustration" />
-
 Between [tool](/build/tools) calls, the model is blind: it doesn't watch the user's interactions with the UI. Yet, to answer the user's next message, the model often needs to know what's on screen. State is how the [view](/build/view) closes that gap, and the design decision is always the same: what should the model see, what shouldn't, and when.
 
 Here's a complete view, the `carousel` mounted by a tool call to `search-products`, holding shared state, hidden state, and a narration for the model:
@@ -137,13 +133,13 @@ This is what lets the user speak in references: "what do you think of this one?"
 
 ## Go Further
 <Columns cols={3}>
-    <Card title="Register Tools" img="/images/tools.png" href="/build/tools">
+    <Card title="Register Tools" icon="wrench" href="/build/tools">
         Define what humans and agents can do
     </Card>
-    <Card title="Create Views" img="/images/view.png" href="/build/view">
+    <Card title="Create Views" icon="palette" href="/build/view">
         Craft interactive UIs rendered in conversation
     </Card>
-    <Card title="Authenticate Users" img="/images/auth.png" href="/build/auth">
+    <Card title="Authenticate Users" icon="key" href="/build/auth">
         Know who's behind every tool call
     </Card>
 </Columns>

--- a/docs/build/tools.mdx
+++ b/docs/build/tools.mdx
@@ -4,10 +4,6 @@ description: "Define what humans and agents can do"
 icon: "wrench"
 ---
 
-import { Hero } from "/components/hero.jsx";
-
-<Hero src="/images/tools.png" alt="Tools Illustration" />
-
 Tools are the entry point of your app: the model reads their metadata and triggers them when they fit the conversation. Think of them as an API: each tool has one job, and jobs can complement each other. Bind a view to a tool, and the host [mounts](/get-started/architecture#app-lifecycle) it inline in the conversation. The model isn't the only caller: the user can trigger tools too, via the [view](/build/view).
 
 Here's a complete tool definition:
@@ -276,13 +272,13 @@ Each model call to the tool mounts a fresh view instance. Tools without `view` a
 
 ## Go Further
 <Columns cols={3}>
-    <Card title="Create Views" img="/images/view.png" href="/build/view">
+    <Card title="Create Views" icon="palette" href="/build/view">
         Craft interactive UIs rendered in conversation
     </Card>
-    <Card title="Manage State" img="/images/state.png" href="/build/state">
+    <Card title="Manage State" icon="database" href="/build/state">
         Decide what the model sees
     </Card>
-    <Card title="Authenticate Users" img="/images/auth.png" href="/build/auth">
+    <Card title="Authenticate Users" icon="key" href="/build/auth">
         Know who's behind every tool call
     </Card>
 </Columns>

--- a/docs/build/view.mdx
+++ b/docs/build/view.mdx
@@ -4,10 +4,6 @@ description: "Craft interactive UIs rendered in conversation"
 icon: "palette"
 ---
 
-import { Hero } from "/components/hero.jsx";
-
-<Hero src="/images/view.png" alt="View Illustration" />
-
 Views are the face of your app: UI components the host mounts inline when the [tool](/build/tools) they're bound to returns. A view reads what the tool produced, calls tools back when the user acts, and manages the [state](/build/state) shared with the model. It's plain [React](https://react.dev/), running in a sandboxed iframe inside the host.
 
 Here's a complete view, the `carousel` mounted by `search-products`, next to a minimal version of the tools it talks to:
@@ -206,13 +202,13 @@ server.registerTool(
 
 ## Go Further
 <Columns cols={3}>
-    <Card title="Register Tools" img="/images/tools.png" href="/build/tools">
+    <Card title="Register Tools" icon="wrench" href="/build/tools">
         Define what humans and agents can do
     </Card>
-    <Card title="Manage State" img="/images/state.png" href="/build/state">
+    <Card title="Manage State" icon="database" href="/build/state">
         Decide what the model sees
     </Card>
-    <Card title="Authenticate Users" img="/images/auth.png" href="/build/auth">
+    <Card title="Authenticate Users" icon="key" href="/build/auth">
         Know who's behind every tool call
     </Card>
 </Columns>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -69,6 +69,7 @@
               "guides/csp",
               "guides/ux",
               "guides/files",
+              "guides/auth-providers",
               "guides/migrate"
             ],
             "expanded": true
@@ -104,6 +105,18 @@
               "api-reference/optional-bearer-auth",
               "api-reference/require-bearer-auth",
               "api-reference/verifier"
+            ]
+          },
+          {
+            "group": "Identity Providers",
+            "icon": "fingerprint",
+            "pages": [
+              "api-reference/auth0-provider",
+              "api-reference/clerk-provider",
+              "api-reference/descope-provider",
+              "api-reference/stytch-provider",
+              "api-reference/workos-provider",
+              "api-reference/custom-provider"
             ]
           },
           {

--- a/docs/get-started/architecture.mdx
+++ b/docs/get-started/architecture.mdx
@@ -4,10 +4,6 @@ description: "Design conversational experiences leveraging model intelligence"
 icon: route
 ---
 
-import { Hero } from "/components/hero.jsx";
-
-<Hero src="/images/architecture.png" alt="Architecture Illustration" />
-
 MCP Apps have three actors involved: the app, the user, and the model. This creates context asymmetry: each actor holds a partial picture of the system. The model is blind to the UI: it can’t see visuals or user interactions unless you explicitly sync them back. The user can’t see the tool output flowing underneath. Building well means understanding these blind spots and designing the information flow between all three.
 
 The core design challenge isn’t layout or styling: it’s deciding who sees what, and when. What does the model need to know? What should stay hidden from it? Where should natural language replace traditional UI?
@@ -195,13 +191,13 @@ npx skills add alpic-ai/skybridge -s skybridge
 
 ## Go Further
 <Columns cols={3}>
-    <Card title="Build" img="/images/tools.png" href="/build">
+    <Card title="Build" icon="drafting-compass" href="/build">
         Learn everything that makes great MCP Apps
     </Card>
-    <Card title="Test" img="/images/devtools.png" href="/test">
+    <Card title="Test" icon="test-tube-diagonal" href="/test">
         Validate your app at every step
     </Card>
-    <Card title="Ship" img="/images/deploy.png" href="/ship">
+    <Card title="Ship" icon="cloud-upload" href="/ship">
         Deploy your app to a stable, public URL
     </Card>
 </Columns>

--- a/docs/get-started/introduction.mdx
+++ b/docs/get-started/introduction.mdx
@@ -5,10 +5,6 @@ sidebarTitle: "Introduction"
 icon: "house"
 ---
 
-import { Hero } from "/components/hero.jsx";
-
-<Hero src="/images/intro.png" alt="Introduction Illustration" />
-
 Skybridge is a fullstack TypeScript framework for building MCP Apps: interactive [views](/build/view) that render inside model hosts. Define [tools](/build/tools), write React components, and let Skybridge do the rest:
 
 <CodeGroup>
@@ -53,13 +49,13 @@ MCP Apps are the surface on which humans and agents use software collaboratively
 MCP Apps introduce a fundamental shift: unlike bidirectional web apps, they are three-way systems where data flows between your app, the user, and the model. It boils down to mastering these core concepts:
 
 <Columns cols={3}>
-    <Card title="Architecture" img="/images/architecture.png" href="/get-started/architecture">
+    <Card title="Architecture" icon="route" href="/get-started/architecture">
         Design experiences leveraging model intelligence.
     </Card>
-    <Card title="Tools" img="/images/tools.png" href="/build/tools">
+    <Card title="Tools" icon="wrench" href="/build/tools">
         Define what humans and agents can see and do.
     </Card>
-    <Card title="Views" img="/images/view.png" href="/build/view">
+    <Card title="Views" icon="palette" href="/build/view">
         Craft interactive UIs rendered in conversation.
     </Card>
 </Columns>
@@ -77,13 +73,13 @@ npx skills add alpic-ai/skybridge -s skybridge
 ```
 
 <Columns cols={3}>
-    <Card title="Quickstart" img="/images/quickstart.png" href="/get-started/quickstart">
+    <Card title="Quickstart" icon="zap" href="/get-started/quickstart">
         Build, test, and deploy your first MCP App
     </Card>
-    <Card title="Architecture" img="/images/architecture.png" href="/get-started/architecture">
+    <Card title="Architecture" icon="route" href="/get-started/architecture">
         Design conversational experiences leveraging model intelligence
     </Card>
-    <Card title="Build" img="/images/tools.png" href="/build">
+    <Card title="Build" icon="drafting-compass" href="/build">
         Learn everything that makes great MCP Apps
     </Card>
 </Columns>

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -4,10 +4,6 @@ description: "Build, test, and deploy your first MCP App"
 icon: "zap"
 ---
 
-import { Hero } from "/components/hero.jsx";
-
-<Hero src="/images/quickstart.png" alt="Quickstart Illustration" />
-
 To get a running codebase right away, you can scaffold a project from our templates. They come pre-configured with:
 - a working [MCP server](/api-reference/mcp-server)
 - a complete development environment with a [local emulator](/test/devtools), file watching, and hot module reload
@@ -120,13 +116,13 @@ See [Ship](/ship) for all deployment options.
 
 ## Go Further
 <Columns cols={3}>
-    <Card title="Architecture" img="/images/architecture.png" href="/get-started/architecture">
+    <Card title="Architecture" icon="route" href="/get-started/architecture">
         Design conversational experiences leveraging model intelligence
     </Card>
-    <Card title="Build" img="/images/tools.png" href="/build">
+    <Card title="Build" icon="drafting-compass" href="/build">
         Learn everything that makes great MCP Apps
     </Card>
-    <Card title="Test" img="/images/devtools.png" href="/test">
+    <Card title="Test" icon="test-tube-diagonal" href="/test">
         Validate your app at every step
     </Card>
 </Columns>

--- a/docs/guides/auth-providers.mdx
+++ b/docs/guides/auth-providers.mdx
@@ -5,15 +5,11 @@ sidebarTitle: "Identity Providers"
 icon: "fingerprint"
 ---
 
-[Authenticating users](/build/auth) adds a signed-in identity to every tool call. The host runs the sign-in flow and attaches a token to each request; your server verifies that token, and the verification is specific to each identity provider. A provider does that work for you: you connect one to your server, and your handlers read the signed-in user with no token-checking code to write.
+[Authenticating users](/build/auth) wires sign-in through a hosted identity provider in one constructor option, so your tools receive a signed-in user. ChatGPT and Claude drive the flow the same way; what varies is the provider. The sections below cover one each: [Auth0](#auth0), [Clerk](#clerk), [Descope](#descope), [Stytch](#stytch), and [WorkOS](#workos), plus a [custom provider](#any-other-provider) for any other.
 
-ChatGPT and Claude run this flow the same way, so the part that varies is which identity provider you connect. The sections below cover one each: [Auth0](#auth0), [Clerk](#clerk), [Descope](#descope), [Stytch](#stytch), and [WorkOS](#workos), plus a [custom provider](/api-reference/custom-provider) for any other.
-
-Every provider here shares three requirements:
-
-- **[Dynamic Client Registration (DCR)](https://datatracker.ietf.org/doc/html/rfc7591)** enabled, so hosts can register themselves without a hand-issued client ID.
-- **JWT access tokens** (not opaque ones), so the server can verify a token by its signature.
-- **An audience** the provider binds into the token's `aud` claim, matched at verification. Clerk is the exception: its tokens carry no `aud`.
+<Info>
+These providers enforce sign-in on every request. To [mix public and authenticated tools](/build/auth#mix-public-and-authenticated-tools) in one server, wire the middleware by hand instead.
+</Info>
 
 ## Auth0
 
@@ -128,7 +124,13 @@ See the runnable [`auth-workos`](https://github.com/alpic-ai/skybridge/tree/main
 
 ## Any Other Provider
 
-For an identity provider without a branded wrapper, [`customProvider`](/api-reference/custom-provider) wires any IdP that publishes a discovery document and signs JWT access tokens. Pass the issuer and the audience it binds:
+For an identity provider without a branded wrapper, [`customProvider`](/api-reference/custom-provider) wires any IdP that meets three requirements:
+
+- **[Dynamic Client Registration (DCR)](https://datatracker.ietf.org/doc/html/rfc7591)** enabled, so hosts can register themselves without a hand-issued client ID.
+- **JWT access tokens** (not opaque ones), so the server can verify a token by its signature.
+- **An audience** the provider binds into the token's `aud` claim.
+
+Pass the issuer and the audience it binds:
 
 ```ts server.ts highlight={2-5}
 const server = new McpServer(serverInfo, capabilities, {
@@ -141,16 +143,18 @@ const server = new McpServer(serverInfo, capabilities, {
 
 Omit `audience` for a provider that binds none, and set `serverUrl` when Skybridge must advertise itself as the authorization server, as Auth0 and the Alpic DCR proxy require.
 
+[Google](https://developers.google.com/identity/protocols/oauth2) and [GitHub](https://docs.github.com/en/apps/oauth-apps) don't support DCR, so `customProvider` can't wire them directly. To offer Google or GitHub sign-in, configure a branded provider (Auth0, Clerk, Stytch, or WorkOS) with them as an upstream social connection.
+
 After sign-in, [reading the user and scoping data to them](/build/auth) is the same across every provider: handlers read `extra.authInfo`, and a tool declaring [`securitySchemes`](/api-reference/register-tool#securityschemes) with scopes gates access to them.
 
 <Columns cols={3}>
-    <Card title="Authenticate Users" img="/images/auth.png" href="/build/auth">
+    <Card title="Authenticate Users" icon="key" href="/build/auth">
         Publish metadata, verify tokens, read the user
     </Card>
-    <Card title="Register Tools" img="/images/tools.png" href="/build/tools">
+    <Card title="Register Tools" icon="wrench" href="/build/tools">
         Declare which tools require sign-in
     </Card>
-    <Card title="Tunnel" img="/images/tunnel.png" href="/test/tunnel">
+    <Card title="Tunnel" icon="globe" href="/test/tunnel">
         Test the OAuth flow in a real host
     </Card>
 </Columns>

--- a/docs/guides/auth-providers.mdx
+++ b/docs/guides/auth-providers.mdx
@@ -1,0 +1,156 @@
+---
+title: "Connect an Identity Provider"
+description: "Wire sign-in through a hosted OAuth provider"
+sidebarTitle: "Identity Providers"
+icon: "fingerprint"
+---
+
+[Authenticating users](/build/auth) adds a signed-in identity to every tool call. The host runs the sign-in flow and attaches a token to each request; your server verifies that token, and the verification is specific to each identity provider. A provider does that work for you: you connect one to your server, and your handlers read the signed-in user with no token-checking code to write.
+
+ChatGPT and Claude run this flow the same way, so the part that varies is which identity provider you connect. The sections below cover one each: [Auth0](#auth0), [Clerk](#clerk), [Descope](#descope), [Stytch](#stytch), and [WorkOS](#workos), plus a [custom provider](/api-reference/custom-provider) for any other.
+
+Every provider here shares three requirements:
+
+- **[Dynamic Client Registration (DCR)](https://datatracker.ietf.org/doc/html/rfc7591)** enabled, so hosts can register themselves without a hand-issued client ID.
+- **JWT access tokens** (not opaque ones), so the server can verify a token by its signature.
+- **An audience** the provider binds into the token's `aud` claim, matched at verification. Clerk is the exception: its tokens carry no `aud`.
+
+## Auth0
+
+[Auth0](https://auth0.com/docs/) issues opaque tokens by default, so you register an API to get verifiable JWTs.
+
+1. In the [Auth0 dashboard](https://manage.auth0.com/), create a **Regular Web Application** and note its **Domain**.
+2. Create an **API** (**Applications → APIs**) with an **Identifier** (e.g. `https://your-mcp-server.com`); this identifier is your audience and need not be a real URL.
+3. Under **Settings → Tenant Settings → API Authorization Settings**, set **Default Audience** to that identifier and enable **Dynamic Client Registration**.
+4. Enable **Application Connections**, promote your login connection to domain level, and set the API's **user access policy** to **Allow**, so DCR-created clients can sign users in.
+
+Pass the tenant domain, the API Identifier as `audience`, and this server's public URL as `serverUrl` to [`auth0Provider`](/api-reference/auth0-provider):
+
+```ts server.ts highlight={1,7-11}
+import { McpServer, auth0Provider } from "skybridge/server";
+
+const server = new McpServer(
+  { name: "personal-shopper", version: "0.0.1" },
+  { capabilities: {} },
+  {
+    oauth: await auth0Provider({
+      domain: process.env.AUTH0_DOMAIN,
+      audience: process.env.AUTH0_API_IDENTIFIER,
+      serverUrl: process.env.SERVER_URL,
+    }),
+  },
+).registerTool(/* search-products, requires oauth2 */);
+```
+
+See the runnable [`auth-auth0`](https://github.com/alpic-ai/skybridge/tree/main/examples/auth-auth0) example.
+
+## Clerk
+
+[Clerk](https://clerk.com/) access tokens carry no `aud` claim, so there is no audience to configure.
+
+1. Sign up at [clerk.com](https://clerk.com/) and create an application.
+2. Create an OAuth application with **Dynamic client registration** enabled and **Generate access tokens as JWTs** turned on.
+3. Copy your **Frontend API URL** (**API keys**), e.g. `acme.clerk.accounts.dev`.
+
+Pass the domain alone to [`clerkProvider`](/api-reference/clerk-provider), no audience:
+
+```ts server.ts highlight={2-4}
+const server = new McpServer(serverInfo, capabilities, {
+  oauth: await clerkProvider({
+    domain: process.env.CLERK_FRONTEND_API,
+  }),
+}).registerTool(/* search-products, requires oauth2 */);
+```
+
+See the [`auth-clerk`](https://github.com/alpic-ai/skybridge/tree/main/examples/auth-clerk) example.
+
+## Descope
+
+A [Descope](https://docs.descope.com/mcp) MCP Server binds the token's `aud` to the project, so the provider derives the audience from the Discovery URL you pass.
+
+1. Sign up at [descope.com](https://www.descope.com/) and create a project.
+2. In the console's **MCP Servers** section, create an MCP Server and enable **Dynamic Client Registration** on it.
+3. Copy the MCP Server's **Discovery URL** from its Connection Information.
+
+Pass that URL to [`descopeProvider`](/api-reference/descope-provider); the audience defaults to the Project ID derived from it:
+
+```ts server.ts highlight={2-4}
+const server = new McpServer(serverInfo, capabilities, {
+  oauth: await descopeProvider({
+    url: process.env.DESCOPE_MCP_SERVER_URL,
+  }),
+}).registerTool(/* search-products, requires oauth2 */);
+```
+
+See the [`auth-descope`](https://github.com/alpic-ai/skybridge/tree/main/examples/auth-descope) example.
+
+## Stytch
+
+[Stytch Connected Apps](https://stytch.com/docs/connected-apps) ships its consent screen only as a React component, so the login, consent, and callback pages are served as static HTML from your server, and the Connected App points at them.
+
+1. Sign up at [stytch.com](https://stytch.com/) and create a **Consumer** project.
+2. Under **Connected Apps**, create a Connected App with Dynamic Client Registration enabled.
+3. Note your **Project ID**, **project domain** (e.g. `acme.customers.stytch.dev`), and **Public Token**.
+4. Set the Connected App's **Authorization URL** to your server's consent page and add its callback to the **Redirect URLs** allowlist. The [`auth-stytch`](https://github.com/alpic-ai/skybridge/tree/main/examples/auth-stytch) example ships those HTML pages.
+
+Pass the project domain and the Project ID as the audience to [`stytchProvider`](/api-reference/stytch-provider):
+
+```ts server.ts highlight={2-5}
+const server = new McpServer(serverInfo, capabilities, {
+  oauth: await stytchProvider({
+    domain: process.env.STYTCH_DOMAIN,
+    audience: process.env.STYTCH_PROJECT_ID,
+  }),
+}).registerTool(/* search-products, requires oauth2 */);
+```
+
+## WorkOS
+
+[WorkOS AuthKit](https://www.workos.com/docs/user-management/authkit) needs DCR enabled and your server registered as a Resource Indicator so issued tokens carry the right `aud`.
+
+1. Sign up at [workos.com](https://www.workos.com/) and enable AuthKit.
+2. Enable Dynamic Client Registration under **Connect → Configuration**.
+3. Register your server URL as a **Resource Indicator**, so AuthKit sets each token's `aud` to it.
+4. Copy your **AuthKit domain** (e.g. `acme.authkit.app`).
+
+Pass the domain and your server URL as the audience to [`workosProvider`](/api-reference/workos-provider):
+
+```ts server.ts highlight={2-5}
+const server = new McpServer(serverInfo, capabilities, {
+  oauth: await workosProvider({
+    domain: process.env.AUTHKIT_DOMAIN,
+    audience: process.env.SERVER_URL,
+  }),
+}).registerTool(/* search-products, requires oauth2 */);
+```
+
+See the runnable [`auth-workos`](https://github.com/alpic-ai/skybridge/tree/main/examples/auth-workos) example.
+
+## Any Other Provider
+
+For an identity provider without a branded wrapper, [`customProvider`](/api-reference/custom-provider) wires any IdP that publishes a discovery document and signs JWT access tokens. Pass the issuer and the audience it binds:
+
+```ts server.ts highlight={2-5}
+const server = new McpServer(serverInfo, capabilities, {
+  oauth: await customProvider({
+    issuer: "https://auth.example.com",
+    audience: process.env.SERVER_URL,
+  }),
+}).registerTool(/* search-products, requires oauth2 */);
+```
+
+Omit `audience` for a provider that binds none, and set `serverUrl` when Skybridge must advertise itself as the authorization server, as Auth0 and the Alpic DCR proxy require.
+
+After sign-in, [reading the user and scoping data to them](/build/auth) is the same across every provider: handlers read `extra.authInfo`, and a tool declaring [`securitySchemes`](/api-reference/register-tool#securityschemes) with scopes gates access to them.
+
+<Columns cols={3}>
+    <Card title="Authenticate Users" img="/images/auth.png" href="/build/auth">
+        Publish metadata, verify tokens, read the user
+    </Card>
+    <Card title="Register Tools" img="/images/tools.png" href="/build/tools">
+        Declare which tools require sign-in
+    </Card>
+    <Card title="Tunnel" img="/images/tunnel.png" href="/test/tunnel">
+        Test the OAuth flow in a real host
+    </Card>
+</Columns>

--- a/docs/guides/csp.mdx
+++ b/docs/guides/csp.mdx
@@ -5,10 +5,6 @@ sidebarTitle: "CSP"
 icon: "shield"
 ---
 
-import { Hero } from "/components/hero.jsx";
-
-<Hero src="/images/csp.png" alt="CSP Illustration" />
-
 Views render in a sandboxed iframe under a strict [Content Security Policy](https://developer.mozilla.org/fr/docs/Web/HTTP/Guides/CSP): it blocks every cross-origin request the view hasn't declared. Your server's own origin is allowed automatically, so a view that only talks to its server needs no configuration. For anything else, list the origin on the [tool's config `view.csp`](http://localhost:3000/api-reference/register-tool#csp).
 
 ```ts server.ts
@@ -162,13 +158,13 @@ For the full field reference, see [registerTool](/api-reference/register-tool#cs
 
 ## Go Further
 <Columns cols={3}>
-    <Card title="Create Views" img="/images/view.png" href="/build/view">
+    <Card title="Create Views" icon="palette" href="/build/view">
         Craft interactive UIs rendered in conversation
     </Card>
-    <Card title="UX Design" img="/images/ux.png" href="/guides/ux">
+    <Card title="UX Design" icon="sparkles" href="/guides/ux">
         Account for what makes an MCP App different
     </Card>
-    <Card title="Audit" img="/images/audit.png" href="/test/audit">
+    <Card title="Audit" icon="clipboard-check" href="/test/audit">
         Validate before submission
     </Card>
 </Columns>

--- a/docs/guides/files.mdx
+++ b/docs/guides/files.mdx
@@ -5,10 +5,6 @@ sidebarTitle: "Files"
 icon: "paperclip"
 ---
 
-import { Hero } from "/components/hero.jsx";
-
-<Hero src="/images/files.png" alt="Files Illustration" />
-
 [Views](/build/view) run in a sandboxed iframe, cut off from the conversation and the user's disk. Each host opens its own door for files, and the two work differently: ChatGPT keeps a file store your [tools](/build/tools) and views read and write; Claude only lets a view save a file to the user's device. What you can build depends on the host.
 
 ## Files in ChatGPT
@@ -235,13 +231,13 @@ export default function ReceiptSummary({ items }: { items: LineItem[] }) {
 
 ## Go Further
 <Columns cols={3}>
-    <Card title="Create Views" img="/images/view.png" href="/build/view">
+    <Card title="Create Views" icon="palette" href="/build/view">
         Craft interactive UIs rendered in conversation
     </Card>
-    <Card title="Register Tools" img="/images/tools.png" href="/build/tools">
+    <Card title="Register Tools" icon="wrench" href="/build/tools">
         Define what humans and agents can do
     </Card>
-    <Card title="UX Design" img="/images/ux.png" href="/guides/ux">
+    <Card title="UX Design" icon="sparkles" href="/guides/ux">
         Account for what makes an MCP App different
     </Card>
 </Columns>

--- a/docs/guides/index.mdx
+++ b/docs/guides/index.mdx
@@ -7,16 +7,16 @@ icon: "book-open"
 Each one is self-contained: it names the concern it solves, shows the [APIs](/api-reference) involved, and works a single example end to end. They don't build on each other, so read whichever fits the problem in front of you.
 
 <Columns cols={2}>
-    <Card title="Configure CSP" img="/images/csp.png" href="/guides/csp">
+    <Card title="Configure CSP" icon="shield" href="/guides/csp">
         Let your views reach the domains they need
     </Card>
-    <Card title="UX Design" img="/images/ux.png" href="/guides/ux">
+    <Card title="UX Design" icon="sparkles" href="/guides/ux">
         Account for what makes an MCP App different
     </Card>
-    <Card title="Handle Files" img="/images/files.png" href="/guides/files">
+    <Card title="Handle Files" icon="paperclip" href="/guides/files">
         Move files in and out of your app
     </Card>
-    <Card title="Migrate to Skybridge" img="/images/migrate.png" href="/guides/migrate">
+    <Card title="Migrate to Skybridge" icon="bird" href="/guides/migrate">
         Bring an existing MCP App over
     </Card>
 </Columns>

--- a/docs/guides/migrate.mdx
+++ b/docs/guides/migrate.mdx
@@ -5,10 +5,6 @@ sidebarTitle: "Migrate"
 icon: "bird"
 ---
 
-import { Hero } from "/components/hero.jsx";
-
-<Hero src="/images/migrate.png" alt="Migrate Illustration" />
-
 The Skybridge Skill migrates an existing MCP App for you, whatever framework or library it's built on. It teaches your coding agent Skybridge, then drives the rewrite.
 
 ## Install the Skill
@@ -45,13 +41,13 @@ If your app calls `window.openai` or the `ext-apps` protocol directly, the [feat
 
 ## Go Further
 <Columns cols={3}>
-    <Card title="Register Tools" img="/images/tools.png" href="/build/tools">
+    <Card title="Register Tools" icon="wrench" href="/build/tools">
         Define what humans and agents can do
     </Card>
-    <Card title="Create Views" img="/images/view.png" href="/build/view">
+    <Card title="Create Views" icon="palette" href="/build/view">
         Craft interactive UIs rendered in conversation
     </Card>
-    <Card title="Manage State" img="/images/state.png" href="/build/state">
+    <Card title="Manage State" icon="database" href="/build/state">
         Decide what the model sees
     </Card>
 </Columns>

--- a/docs/guides/ux.mdx
+++ b/docs/guides/ux.mdx
@@ -5,10 +5,6 @@ sidebarTitle: "UX"
 icon: "sparkles"
 ---
 
-import { Hero } from "/components/hero.jsx";
-
-<Hero src="/images/ux.png" alt="UX Illustration" />
-
 An MCP App is a new kind of surface with its own UX principles. The [view](/build/view) shares the screen with an ongoing conversation, in a frame the host controls. Skybridge surfaces that environment through [hooks](/api-reference/overview#hooks), so the view can read its context and adapt.
 
 ```tsx views/carousel.tsx
@@ -189,13 +185,13 @@ The [DevTools](/test/devtools) environment inspector flips theme, display mode, 
 
 ## Go Further
 <Columns cols={3}>
-    <Card title="Create Views" img="/images/view.png" href="/build/view">
+    <Card title="Create Views" icon="palette" href="/build/view">
         Craft interactive UIs rendered in conversation
     </Card>
-    <Card title="Handle Files" img="/images/files.png" href="/guides/files">
+    <Card title="Handle Files" icon="paperclip" href="/guides/files">
         Move files in and out of your app
     </Card>
-    <Card title="Configure CSP" img="/images/csp.png" href="/guides/csp">
+    <Card title="Configure CSP" icon="shield" href="/guides/csp">
         Let your views reach the domains they need
     </Card>
 </Columns>

--- a/docs/ship.mdx
+++ b/docs/ship.mdx
@@ -4,10 +4,6 @@ description: "Deploy your app to a stable, public URL"
 icon: "cloud-upload"
 ---
 
-import { Hero } from "/components/hero.jsx";
-
-<Hero src="/images/deploy.png" alt="Deploy Illustration" />
-
 A deployed MCP App is a server on a public URL: hosts connect to `https://your-domain.com/mcp` and the built [views](/build/view) are served from the same origin.
 
 Two commands take it there:

--- a/docs/test/audit.mdx
+++ b/docs/test/audit.mdx
@@ -4,10 +4,6 @@ description: "Catch spec and platform issues before submission"
 icon: "clipboard-check"
 ---
 
-import { Hero } from "/components/hero.jsx";
-
-<Hero src="/images/audit.png" alt="Audit Illustration" />
-
 Before a platform accepts your app, the server must conform to the MCP specs, and each platform layers its own requirements on top, which differ between [OpenAI](https://developers.openai.com/apps-sdk/app-submission-guidelines) and [Anthropic](https://claude.com/docs/connectors/building/submission). The Audit checks your app's conformance and performs end-to-end tests in real ChatGPT and Claude conversations, triggering [tools](/build/tools) and rendering [views](/build/view).
 
 ## Run the Audit
@@ -44,7 +40,7 @@ The Audit is powered by [Alpic Beacon](https://docs.alpic.ai/testing/beacon). It
 - **App behavior**: the app actually works, verified by triggering tools and rendering views in real ChatGPT and Claude conversations.
 
 <Frame caption="The Audit interface">
-<Hero src="/images/audit-screenshot.png" alt="Audit Illustration" />
+<img src="/images/audit-screenshot.png" alt="Audit Illustration" />
 </Frame>
 
 The report returns an overall score, a readiness status per platform, and the issues found, each with its severity (error, warning, info), the affected component, and the solution. **Improve your score** turns the report into a prompt for your coding agent to fix them all.
@@ -55,13 +51,13 @@ OAuth-protected servers aren't supported yet.
 
 ## Go Further
 <Columns cols={3}>
-    <Card title="DevTools" img="/images/devtools.png" href="/test/devtools">
+    <Card title="DevTools" icon="square-dashed-mouse-pointer" href="/test/devtools">
         Call tools and render views locally, without a host
     </Card>
-    <Card title="Tunnel" img="/images/tunnel.png" href="/test/tunnel">
+    <Card title="Tunnel" icon="globe" href="/test/tunnel">
         Expose your local server to real hosts
     </Card>
-    <Card title="Playground" img="/images/playground.png" href="/test/playground">
+    <Card title="Playground" icon="message-circle" href="/test/playground">
         Chat with a real model running your app
     </Card>
 </Columns>

--- a/docs/test/devtools.mdx
+++ b/docs/test/devtools.mdx
@@ -4,10 +4,6 @@ description: "Call tools and render views locally, without a host"
 icon: "square-dashed-mouse-pointer"
 ---
 
-import { Hero } from "/components/hero.jsx";
-
-<Hero src="/images/devtools.png" alt="DevTools Illustration" />
-
 Testing through a real host means exposing a public URL, registering a connector, starting a conversation, and prompting the model until it calls the right [tool](/build/tools). DevTools cuts that loop down to a file save: it runs locally, emulates the host runtime, and lets you call tools directly, no model or host involved.
 
 ## Start the Emulator
@@ -43,7 +39,7 @@ Every [tool](/build/tools) registered on the server appears in the sidebar autom
 Select a tool in the sidebar and DevTools gives you the full exchange:
 
 <Frame caption="The DevTools interface">
-<Hero src="/images/devtools-screenshot.png" alt="DevTools Illustration" />
+<img src="/images/devtools-screenshot.png" alt="DevTools Illustration" />
 </Frame>
 
 - **Tool controls**: generated from the tool's [input schema](/api-reference/register-tool#inputschema-outputschema). Inputs can be saved and re-run from the tool header.
@@ -72,13 +68,13 @@ To test your app against a real LLM, use the [playground](/test/playground) or c
 
 ## Go Further
 <Columns cols={3}>
-    <Card title="Tunnel" img="/images/tunnel.png" href="/test/tunnel">
+    <Card title="Tunnel" icon="globe" href="/test/tunnel">
         Expose your local server to real hosts
     </Card>
-    <Card title="Playground" img="/images/playground.png" href="/test/playground">
+    <Card title="Playground" icon="message-circle" href="/test/playground">
         Chat with a real model running your app
     </Card>
-    <Card title="Audit" img="/images/audit.png" href="/test/audit">
+    <Card title="Audit" icon="clipboard-check" href="/test/audit">
         Catch spec and platform issues before submission
     </Card>
 </Columns>

--- a/docs/test/index.mdx
+++ b/docs/test/index.mdx
@@ -14,16 +14,16 @@ Testing an MCP App means assessing how well it integrates with the host, interac
 | Validate before submission | [Audit](/test/audit) | <Icon icon="check" color="#22C55E" /> | <Icon icon="check" color="#22C55E" /> | <Icon icon="x" color="#EF4444" /> |
 
 <Columns cols={2}>
-    <Card title="DevTools" img="/images/devtools.png" href="/test/devtools">
+    <Card title="DevTools" icon="square-dashed-mouse-pointer" href="/test/devtools">
         Call tools and render views locally, without a host
     </Card>
-    <Card title="Tunnel" img="/images/tunnel.png" href="/test/tunnel">
+    <Card title="Tunnel" icon="globe" href="/test/tunnel">
         Expose your local server to real hosts
     </Card>
-    <Card title="Playground" img="/images/playground.png" href="/test/playground">
+    <Card title="Playground" icon="message-circle" href="/test/playground">
         Chat with a real model running your app
     </Card>
-    <Card title="Audit" img="/images/audit.png" href="/test/audit">
+    <Card title="Audit" icon="clipboard-check" href="/test/audit">
         Catch spec and platform issues before submission
     </Card>
 </Columns>

--- a/docs/test/playground.mdx
+++ b/docs/test/playground.mdx
@@ -4,10 +4,6 @@ description: "Chat with a real model running your app"
 icon: "message-circle"
 ---
 
-import { Hero } from "/components/hero.jsx";
-
-<Hero src="/images/playground.png" alt="Playground Illustration" />
-
 Putting a real model in the loop normally means registering your app in a host. The Playground skips that: a chat wired to your local server, where a real LLM uses your [tools](/build/tools) and the [views](/build/view) render inline.
 
 ## Start the Playground
@@ -54,13 +50,13 @@ With a model in the loop, the prompt surface and the state sync become testable:
 
 ## Go Further
 <Columns cols={3}>
-    <Card title="DevTools" img="/images/devtools.png" href="/test/devtools">
+    <Card title="DevTools" icon="square-dashed-mouse-pointer" href="/test/devtools">
         Call tools and render views locally, without a host
     </Card>
-    <Card title="Tunnel" img="/images/tunnel.png" href="/test/tunnel">
+    <Card title="Tunnel" icon="globe" href="/test/tunnel">
         Expose your local server to real hosts
     </Card>
-    <Card title="Audit" img="/images/audit.png" href="/test/audit">
+    <Card title="Audit" icon="clipboard-check" href="/test/audit">
         Catch spec and platform issues before submission
     </Card>
 </Columns>

--- a/docs/test/tunnel.mdx
+++ b/docs/test/tunnel.mdx
@@ -4,10 +4,6 @@ description: "Tunnel your local server to ChatGPT and Claude"
 icon: "globe"
 ---
 
-import { Hero } from "/components/hero.jsx";
-
-<Hero src="/images/tunnel.png" alt="Tunnel Illustration" />
-
 ChatGPT and Claude connect to MCP servers over the internet, and your dev server lives on localhost. The tunnel bridges the two: it exposes your local server on a public URL, so real hosts run your app while it keeps reloading on every file save.
 
 <Info>
@@ -66,13 +62,13 @@ ChatGPT and Claude cache your tool definitions at registration. When the server 
 
 ## Go Further
 <Columns cols={3}>
-    <Card title="DevTools" img="/images/devtools.png" href="/test/devtools">
+    <Card title="DevTools" icon="square-dashed-mouse-pointer" href="/test/devtools">
         Call tools and render views locally, without a host
     </Card>
-    <Card title="Playground" img="/images/playground.png" href="/test/playground">
+    <Card title="Playground" icon="message-circle" href="/test/playground">
         Chat with a real model running your app
     </Card>
-    <Card title="Audit" img="/images/audit.png" href="/test/audit">
+    <Card title="Audit" icon="clipboard-check" href="/test/audit">
         Catch spec and platform issues before submission
     </Card>
 </Columns>

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -4,10 +4,6 @@ description: "Fix the errors you're most likely to hit"
 icon: "cross"
 ---
 
-import { Hero } from "/components/hero.jsx";
-
-<Hero src="/images/troubleshooting.png" alt="Troubleshooting Illustration" />
-
 Common Skybridge errors, grouped by symptom, each with its cause and fix.
 
 ## Typed hooks report "Property does not exist on type"
@@ -62,10 +58,10 @@ Some hooks only work on one host. Skybridge picks the runtime at load, and calli
 
 ## Go Further
 <Columns cols={2}>
-    <Card title="Configure CSP" img="/images/csp.png" href="/guides/csp">
+    <Card title="Configure CSP" icon="shield" href="/guides/csp">
         Let your views reach the domains they need
     </Card>
-    <Card title="Audit" img="/images/audit.png" href="/test/audit">
+    <Card title="Audit" icon="clipboard-check" href="/test/audit">
         Validate before submission
     </Card>
 </Columns>


### PR DESCRIPTION
one guide + one api reference page per helper fn

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds OAuth provider documentation and updates the docs navigation.

- New API reference pages for Auth0, Clerk, Descope, Stytch, WorkOS, and custom providers.
- New identity-provider guide with setup examples.
- OAuth option documentation added to `McpServer`.
- Docs navigation updated for the new guide and provider reference pages.
- Several docs cards now use icons instead of image assets.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the changes are documentation-only and no code issues were identified.

The updated files are limited to docs content and navigation, with no runtime application code changes.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Baseline Mintlify docs preview was captured from the base commit to verify the initial state before adding OAuth provider docs, noting that the provider group was not present in docs.json and provider MDX files were absent.
- Head Mintlify docs preview was captured after adding OAuth provider docs/navigation, showing the OAuth provider content and provider API pages rendering, and runtime curl checks confirmed HTTP 200 with expected content markers for Auth0, Clerk, Descope, Stytch, WorkOS, auth0Provider, and customProvider; Mintlify broken-links check exited 0.

<a href="https://app.greptile.com/trex/runs/12629973/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: review, remove images"](https://github.com/alpic-ai/skybridge/commit/e9f6a8d1b5fe09f2ddd46f5532420874b1a7f618) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40492102)</sub>

<!-- /greptile_comment -->