### PR TITLE
docs(skill): update skills for authentication

### DIFF
--- a/docs/api-reference/register-tool.mdx
+++ b/docs/api-reference/register-tool.mdx
@@ -32,7 +32,7 @@ const server = new McpServer({ name: "shop", version: "1.0" }).registerTool(
     },
   },
   async ({ query, maxPrice }, { authInfo }) => {
-    const userId = authInfo.extra?.sub as string;
+    const userId = authInfo.extra?.subject as string;
     const products = await search(query, { maxPrice, userId });
     return {
       content: `Found ${products.length} products for "${query}".`,

--- a/docs/api-reference/verifier.mdx
+++ b/docs/api-reference/verifier.mdx
@@ -20,7 +20,7 @@ async function verifyAccessToken(token: string): Promise<AuthInfo> {
       clientId: payload.client_id,
       scopes: payload.scope.split(" "),
       expiresAt: payload.exp,
-      extra: { sub: payload.sub },
+      extra: { subject: payload.sub },
     };
   } catch (err) {
     throw new InvalidTokenError(

--- a/docs/build/auth.mdx
+++ b/docs/build/auth.mdx
@@ -120,7 +120,7 @@ export async function verifyAccessToken(token: string): Promise<AuthInfo> {
       clientId: payload.clientId,
       scopes: payload.scopes,
       expiresAt: payload.expiresAt,
-      extra: { sub: payload.sub },
+      extra: { subject: payload.sub },
     };
   } catch (err) {
     throw new InvalidTokenError(
@@ -191,7 +191,9 @@ server.registerTool(
 
 With unauthenticated requests reaching [handlers](/api-reference/register-tool#handler), the scope check is no longer a formality: it's the only gate on protected tools.
 
-```ts server.ts highlight={8-10}
+Reject with a `mcp/www_authenticate` challenge rather than a plain error result. The handler runs after the transport, so it can't answer with a 401, and an error result carrying no challenge reaches the host as an opaque tool failure that never starts the sign-in flow.
+
+```ts server.ts highlight={8-19}
 server.registerTool(
   {
     name: "create-checkout",
@@ -200,7 +202,17 @@ server.registerTool(
   },
   async ({ productIds }, extra) => {
     if (!extra.authInfo?.scopes.includes("checkout")) {
-      return { content: "Sign in to check out.", isError: true };
+      const error = extra.authInfo ? "insufficient_scope" : "invalid_token";
+      return {
+        isError: true,
+        content: [{ type: "text", text: "Sign in to check out." }],
+        _meta: {
+          "mcp/www_authenticate": [
+            `Bearer error="${error}", error_description="Sign in to check out.", ` +
+              `scope="checkout", resource_metadata="${process.env.SERVER_URL}/.well-known/oauth-protected-resource"`,
+          ],
+        },
+      };
     }
     return {
       structuredContent: { url: await checkout(productIds, extra.authInfo) },
@@ -208,6 +220,8 @@ server.registerTool(
   },
 );
 ```
+
+This is the shape the [`oauth`](/api-reference/mcp-server#constructor) provider option emits for you; on the manual path you build it yourself.
 
 <Card title="All done!" type="tip" href="/test" horizontal icon="check">
     You now know how to authenticate users. Learn how to test your MCP App in the next chapter.

--- a/docs/build/auth.mdx
+++ b/docs/build/auth.mdx
@@ -191,9 +191,7 @@ server.registerTool(
 
 With unauthenticated requests reaching [handlers](/api-reference/register-tool#handler), the scope check is no longer a formality: it's the only gate on protected tools.
 
-Reject with a `mcp/www_authenticate` challenge rather than a plain error result. The handler runs after the transport, so it can't answer with a 401, and an error result carrying no challenge reaches the host as an opaque tool failure that never starts the sign-in flow.
-
-```ts server.ts highlight={8-19}
+```ts server.ts highlight={8-10}
 server.registerTool(
   {
     name: "create-checkout",
@@ -202,17 +200,7 @@ server.registerTool(
   },
   async ({ productIds }, extra) => {
     if (!extra.authInfo?.scopes.includes("checkout")) {
-      const error = extra.authInfo ? "insufficient_scope" : "invalid_token";
-      return {
-        isError: true,
-        content: [{ type: "text", text: "Sign in to check out." }],
-        _meta: {
-          "mcp/www_authenticate": [
-            `Bearer error="${error}", error_description="Sign in to check out.", ` +
-              `scope="checkout", resource_metadata="${process.env.SERVER_URL}/.well-known/oauth-protected-resource"`,
-          ],
-        },
-      };
+      return { content: "Sign in to check out.", isError: true };
     }
     return {
       structuredContent: { url: await checkout(productIds, extra.authInfo) },
@@ -220,8 +208,6 @@ server.registerTool(
   },
 );
 ```
-
-This is the shape the [`oauth`](/api-reference/mcp-server#constructor) provider option emits for you; on the manual path you build it yourself.
 
 <Card title="All done!" type="tip" href="/test" horizontal icon="check">
     You now know how to authenticate users. Learn how to test your MCP App in the next chapter.

--- a/skills/chatgpt-app-builder/evals/skill.json
+++ b/skills/chatgpt-app-builder/evals/skill.json
@@ -12,8 +12,12 @@
     "expected_behavior": "Must read state-and-context.md and answer: Zustand. createStore is a thin wrapper around Zustand."
   },
   {
-    "query": "How do I return an auth error that prompts the user to sign in?",
-    "expected_behavior": "Must read oauth.md. Answer: return isError: true with _meta containing 'mcp/www_authenticate' key pointing to oauth-protected-resource endpoint."
+    "query": "Add WorkOS sign-in to my MCP server so tools require auth.",
+    "expected_behavior": "Must read oauth.md. Answer: pass oauth: await workosProvider({ domain, audience }) as the third McpServer arg. Must NOT hand-mount requireBearerAuth / mcpAuthMetadataRouter or hand-write a JWKS verifier."
+  },
+  {
+    "query": "How does an authenticated server prompt the user to sign in when they haven't yet?",
+    "expected_behavior": "Must read oauth.md. Answer: the oauth field auto-mounts discovery + Bearer verification; unauthenticated requests to /mcp get HTTP 401 before any handler runs and the host walks the user through OAuth. Handlers do NOT return a custom auth error for this."
   },
   {
     "query": "What CSP property triggers stricter review during publishing?",

--- a/skills/chatgpt-app-builder/evals/skill.json
+++ b/skills/chatgpt-app-builder/evals/skill.json
@@ -20,6 +20,10 @@
     "expected_behavior": "Must read oauth.md. Answer: the oauth field auto-mounts discovery + Bearer verification; unauthenticated requests to /mcp get HTTP 401 before any handler runs and the host walks the user through OAuth. Handlers do NOT return a custom auth error for this."
   },
   {
+    "query": "My server has an OAuth provider but I want one tool to stay usable without signing in.",
+    "expected_behavior": "Must read oauth.md. Answer: keep the oauth provider and set auth: { allowsAnonymous: true } on that tool (auth: { scopes: [...] } for gated ones); skybridge enforces it before the handler. Must NOT say mixed auth requires manual wiring with optionalBearerAuth, nor that handlers must check authInfo themselves."
+  },
+  {
     "query": "What CSP property triggers stricter review during publishing?",
     "expected_behavior": "Must read csp.md. Answer: frameDomains (for iframe embeds) triggers stricter review."
   },

--- a/skills/chatgpt-app-builder/evals/skill.json
+++ b/skills/chatgpt-app-builder/evals/skill.json
@@ -24,6 +24,10 @@
     "expected_behavior": "Must read oauth.md. Answer: keep the oauth provider and set auth: { allowsAnonymous: true } on that tool (auth: { scopes: [...] } for gated ones); skybridge enforces it before the handler. Must NOT say mixed auth requires manual wiring with optionalBearerAuth, nor that handlers must check authInfo themselves."
   },
   {
+    "query": "I'm on the manual wiring path with optionalBearerAuth. What do I return from a gated tool handler when there's no token?",
+    "expected_behavior": "Must read oauth.md. Answer: return isError: true with a _meta['mcp/www_authenticate'] array holding a Bearer challenge whose resource_metadata points at /.well-known/oauth-protected-resource. Must NOT throw a plain Error, and must NOT claim the handler can send an HTTP 401."
+  },
+  {
     "query": "I want to serve the signed-in user's data from an /api/user-data route on my MCP server. It already uses the oauth field.",
     "expected_behavior": "Must read oauth.md. Answer: the oauth field guards /mcp only, so mount your own verifier plus requireBearerAuth on the route via server.use(\"/api/user-data\", ...), using the same issuer/audience as the provider config. Must NOT claim the oauth field already covers custom routes, nor reuse the framework's internal JWKS verifier (it is not exported)."
   },

--- a/skills/chatgpt-app-builder/evals/skill.json
+++ b/skills/chatgpt-app-builder/evals/skill.json
@@ -24,6 +24,10 @@
     "expected_behavior": "Must read oauth.md. Answer: keep the oauth provider and set auth: { allowsAnonymous: true } on that tool (auth: { scopes: [...] } for gated ones); skybridge enforces it before the handler. Must NOT say mixed auth requires manual wiring with optionalBearerAuth, nor that handlers must check authInfo themselves."
   },
   {
+    "query": "I want to serve the signed-in user's data from an /api/user-data route on my MCP server. It already uses the oauth field.",
+    "expected_behavior": "Must read oauth.md. Answer: the oauth field guards /mcp only, so mount your own verifier plus requireBearerAuth on the route via server.use(\"/api/user-data\", ...), using the same issuer/audience as the provider config. Must NOT claim the oauth field already covers custom routes, nor reuse the framework's internal JWKS verifier (it is not exported)."
+  },
+  {
     "query": "What CSP property triggers stricter review during publishing?",
     "expected_behavior": "Must read csp.md. Answer: frameDomains (for iframe embeds) triggers stricter review."
   },

--- a/skills/chatgpt-app-builder/evals/skill.json
+++ b/skills/chatgpt-app-builder/evals/skill.json
@@ -28,10 +28,6 @@
     "expected_behavior": "Must read oauth.md. Answer: return isError: true with a _meta['mcp/www_authenticate'] array holding a Bearer challenge whose resource_metadata points at /.well-known/oauth-protected-resource. Must NOT throw a plain Error, and must NOT claim the handler can send an HTTP 401."
   },
   {
-    "query": "I want to serve the signed-in user's data from an /api/user-data route on my MCP server. It already uses the oauth field.",
-    "expected_behavior": "Must read oauth.md. Answer: the oauth field guards /mcp only, so mount your own verifier plus requireBearerAuth on the route via server.use(\"/api/user-data\", ...), using the same issuer/audience as the provider config. Must NOT claim the oauth field already covers custom routes, nor reuse the framework's internal JWKS verifier (it is not exported)."
-  },
-  {
     "query": "What CSP property triggers stricter review during publishing?",
     "expected_behavior": "Must read csp.md. Answer: frameDomains (for iframe embeds) triggers stricter review."
   },

--- a/skills/chatgpt-app-builder/references/oauth.md
+++ b/skills/chatgpt-app-builder/references/oauth.md
@@ -12,9 +12,19 @@ Enable user authentication so tools can access user-specific data.
 
 ## Which path?
 
-- **Every tool requires sign-in, and a branded provider fits your IdP** → [Pick a provider](#1-pick-a-provider).
-- **Every tool requires sign-in, no branded helper, but the IdP exposes OAuth discovery + JWKS** → [`customProvider`](#2-any-other-idp--customprovider).
-- **Mixed auth** (some tools public, some gated), **or the IdP has no discovery doc / issues opaque tokens** → [Manual wiring](#manual-wiring). The `oauth` field can't express either case.
+The `oauth` field handles all-or-nothing auth; mixed auth or an unsupported IdP needs manual wiring.
+
+```
+All tools require sign-in?
+├─ No — some public, some gated ──────────────────→ Manual wiring
+└─ Yes
+   ├─ A branded provider fits your IdP ────────────→ Pick a provider
+   │     (WorkOS · Auth0 · Clerk · Stytch · Descope)
+   ├─ No helper, but IdP has OAuth discovery + JWKS → customProvider
+   └─ No discovery doc, or opaque tokens ───────────→ Manual wiring
+```
+
+- [Pick a provider](#1-pick-a-provider) · [`customProvider`](#2-any-other-idp--customprovider) · [Manual wiring](#manual-wiring)
 
 ## 1. Pick a provider
 

--- a/skills/chatgpt-app-builder/references/oauth.md
+++ b/skills/chatgpt-app-builder/references/oauth.md
@@ -16,15 +16,14 @@ The branded providers discover the IdP's OAuth metadata and build the whole conf
 
 ```typescript
 // src/server.ts
-import { McpServer, workosProvider } from "skybridge/server";
+import { McpServer, descopeProvider } from "skybridge/server";
 
 const server = new McpServer(
   { name: "my-app", version: "0.0.1" },
   { capabilities: {} },
   {
-    oauth: await workosProvider({
-      domain: env.AUTHKIT_DOMAIN, // e.g. acme.authkit.app
-      audience: env.SERVER_URL,   // Resource Indicator
+    oauth: await descopeProvider({
+      url: env.DESCOPE_MCP_SERVER_URL, // MCP Server Discovery URL (Issuer)
     }),
   },
 );

--- a/skills/chatgpt-app-builder/references/oauth.md
+++ b/skills/chatgpt-app-builder/references/oauth.md
@@ -7,8 +7,14 @@ Enable user authentication so tools can access user-specific data.
 1. Pass an `oauth` config as the third `McpServer` argument
 2. Skybridge auto-mounts the OAuth discovery endpoints (`/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource`) and Bearer JWT verification on `/mcp`
 3. The host reads the metadata, walks the user through OAuth, refreshes tokens, and calls `/mcp` with `Authorization: Bearer <token>`
-4. Unauthenticated/invalid requests get HTTP 401 before any tool handler runs
+4. Unauthenticated/invalid requests **to `/mcp`** get HTTP 401 before any tool handler runs. The `oauth` field guards `/mcp` only — any custom route you mount yourself is unprotected; gate it explicitly (see [Manual wiring](#manual-wiring))
 5. Tool handlers read user identity from `extra.authInfo`
+
+## Which path?
+
+- **Every tool requires sign-in, and a branded provider fits your IdP** → [Pick a provider](#1-pick-a-provider).
+- **Every tool requires sign-in, no branded helper, but the IdP exposes OAuth discovery + JWKS** → [`customProvider`](#2-any-other-idp--customprovider).
+- **Mixed auth** (some tools public, some gated), **or the IdP has no discovery doc / issues opaque tokens** → [Manual wiring](#manual-wiring). The `oauth` field can't express either case.
 
 ## 1. Pick a provider
 
@@ -78,6 +84,80 @@ server.registerTool(
 );
 ```
 
-## Manual wiring (escape hatch)
+## Manual wiring
 
-The `oauth` field replaces hand-mounting `mcpAuthMetadataRouter` + `requireBearerAuth`. Those primitives are still exported from `skybridge/server` if you need full control, but prefer a provider.
+Reach for this when the `oauth` field can't express your setup: **mixed auth** (some tools public, some gated), or an **IdP with no OAuth discovery / opaque tokens** (you verify by introspection instead of JWKS). The same primitives are exported from `skybridge/server`.
+
+### Write a verifier
+
+`verifyAccessToken` resolves with `AuthInfo` for a good token, or throws `InvalidTokenError`. For a JWT IdP, verify against its JWKS:
+
+```typescript
+import { type AuthInfo, InvalidTokenError } from "skybridge/server";
+import * as jose from "jose";
+
+const jwks = jose.createRemoteJWKSet(new URL("https://your-idp.com/.well-known/jwks.json"));
+
+export async function verifyAccessToken(token: string): Promise<AuthInfo> {
+  try {
+    const { payload } = await jose.jwtVerify(token, jwks, { issuer: "https://your-idp.com" });
+    return {
+      token,
+      clientId: (payload.client_id ?? payload.azp ?? "") as string,
+      scopes: typeof payload.scope === "string" ? payload.scope.split(" ") : [],
+      expiresAt: payload.exp, // required: requireBearerAuth rejects tokens with no expiry
+      extra: { subject: payload.sub },
+    };
+  } catch (err) {
+    throw new InvalidTokenError(err instanceof Error ? err.message : String(err));
+  }
+}
+```
+
+### Mount metadata + enforcement
+
+`mcpAuthMetadataRouter` serves the well-known endpoints. `requireBearerAuth` rejects every unauthenticated request; `optionalBearerAuth` lets unauthenticated requests through (validating a token only when one is sent) — this is the mixed-auth path.
+
+```typescript
+import {
+  mcpAuthMetadataRouter,
+  optionalBearerAuth,
+} from "skybridge/server";
+import { verifyAccessToken } from "./auth.js";
+
+const server = new McpServer({ name: "my-app", version: "0.0.1" }, { capabilities: {} })
+  .use(
+    mcpAuthMetadataRouter({
+      oauthMetadata: {
+        issuer: "https://your-idp.com",
+        authorization_endpoint: "https://your-idp.com/authorize",
+        token_endpoint: "https://your-idp.com/token",
+        response_types_supported: ["code"],
+        code_challenge_methods_supported: ["S256"],
+      },
+      resourceServerUrl: new URL(process.env.SERVER_URL),
+    }),
+  )
+  .use("/mcp", optionalBearerAuth({ verifier: { verifyAccessToken } }));
+```
+
+Then declare each tool's requirement with `securitySchemes` (`{ type: "noauth" }` for public, `{ type: "oauth2", scopes? }` for gated):
+
+```typescript
+server.registerTool(
+  { name: "public-search", description: "...", securitySchemes: [{ type: "noauth" }] },
+  handler,
+);
+server.registerTool(
+  { name: "get-orders", description: "...", securitySchemes: [{ type: "oauth2" }] },
+  async (_input, extra) => {
+    // securitySchemes is advertised to the host only — NOT enforced at runtime.
+    // optionalBearerAuth lets token-less requests through, so a gated handler
+    // MUST verify authInfo itself.
+    if (!extra.authInfo) throw new Error("Unauthorized");
+    // ...
+  },
+);
+```
+
+For an all-or-nothing manual server, swap `optionalBearerAuth` for `requireBearerAuth` and drop the per-tool `securitySchemes` — then `authInfo` is guaranteed in every handler.

--- a/skills/chatgpt-app-builder/references/oauth.md
+++ b/skills/chatgpt-app-builder/references/oauth.md
@@ -55,11 +55,11 @@ oauth: await customProvider({
 }),
 ```
 
-`OAuthConfig` also accepts `baseUrl` (this server's public URL; inferred from request headers when omitted), `requiredScopes` (server-wide floor), and `metadataOverrides`.
+`customProvider` also accepts `baseUrl` (this server's public URL; inferred from request headers when omitted), `requiredScopes` (server-wide floor), and `metadataOverrides`.
 
 ## 3. Read auth in handlers
 
-`extra.authInfo` carries the verified token. `extra.subject` holds the `sub` claim; all other JWT claims (e.g. `email`) are spread alongside it.
+`extra.authInfo` carries the verified token. Its `extra.subject` holds the `sub` claim; all other JWT claims (e.g. `email`) are spread alongside it.
 
 ```typescript
 import type { AuthInfo } from "skybridge/server";

--- a/skills/chatgpt-app-builder/references/oauth.md
+++ b/skills/chatgpt-app-builder/references/oauth.md
@@ -4,108 +4,73 @@ Enable user authentication so tools can access user-specific data.
 
 ## How it works
 
-1. MCP server exposes OAuth discovery endpoints
-2. Host reads them, walks the user through OAuth, refreshes tokens
-3. Host calls `/mcp` with `Authorization: Bearer <token>`
-4. `requireBearerAuth` middleware verifies the token and rejects with HTTP 401 if invalid — tool handlers never run unauthenticated
+1. Pass an `oauth` config as the third `McpServer` argument
+2. Skybridge auto-mounts the OAuth discovery endpoints (`/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource`) and Bearer JWT verification on `/mcp`
+3. The host reads the metadata, walks the user through OAuth, refreshes tokens, and calls `/mcp` with `Authorization: Bearer <token>`
+4. Unauthenticated/invalid requests get HTTP 401 before any tool handler runs
 5. Tool handlers read user identity from `extra.authInfo`
 
-## 1. Discovery endpoints
+## 1. Pick a provider
 
-Mount OAuth metadata so MCP clients can discover the authorization server:
+The branded providers discover the IdP's OAuth metadata and build the whole config. All require **Dynamic Client Registration (DCR)** enabled in the provider dashboard, and return a `Promise` — `await` it.
 
 ```typescript
 // src/server.ts
-import { mcpAuthMetadataRouter } from "@modelcontextprotocol/sdk/server/auth/router.js";
-import { McpServer } from "skybridge/server";
+import { McpServer, workosProvider } from "skybridge/server";
 
 const server = new McpServer(
   { name: "my-app", version: "0.0.1" },
   { capabilities: {} },
-).use(
-  mcpAuthMetadataRouter({
-    oauthMetadata: {
-      issuer: "https://your-oauth-provider.com",
-      authorization_endpoint: "https://your-oauth-provider.com/oauth2/authorize",
-      token_endpoint: "https://your-oauth-provider.com/oauth2/token",
-      response_types_supported: ["code"],
-      grant_types_supported: ["authorization_code", "refresh_token"],
-      code_challenge_methods_supported: ["S256"],
-    },
-    // SERVER_URL: this server's public URL (localhost:3000, Alpic tunnel, or prod)
-    resourceServerUrl: new URL(process.env.SERVER_URL),
-  }),
+  {
+    oauth: await workosProvider({
+      domain: env.AUTHKIT_DOMAIN, // e.g. acme.authkit.app
+      audience: env.SERVER_URL,   // Resource Indicator
+    }),
+  },
 );
 ```
 
-This serves `/.well-known/oauth-authorization-server` and `/.well-known/oauth-protected-resource`.
+| Provider | Import | Required options | Notes |
+|---|---|---|---|
+| WorkOS AuthKit | `workosProvider` | `domain`, `audience` | `domain` = AuthKit domain; `audience` = Resource Indicator (this server's URL). DCR under Connect → Configuration. |
+| Auth0 | `auth0Provider` | `domain`, `audience`, `serverUrl` | `audience` = API Identifier. Runs skybridge-as-AS (`serverUrl`) and bakes `?audience=` into `/authorize`. Set `scopes` to what the app needs (e.g. `["openid","profile","email"]`) — Auth0 won't grant a DCR client its full OIDC set. |
+| Clerk | `clerkProvider` | `domain` | `domain` = Frontend API URL. No `audience` (Clerk tokens carry no `aud`). The OAuth app must issue **JWT** access tokens, not opaque. |
+| Stytch | `stytchProvider` | `domain`, `audience` | `domain` = project domain; `audience` = Stytch Project ID. |
+| Descope | `descopeProvider` | `url` | `url` = MCP Server Discovery URL (Issuer). `audience` defaults to the Project ID derived from the URL. DCR disabled + Alpic DCR proxy → use `customProvider` with `serverUrl` (see `examples/auth-descope-alpic`). |
 
-## 2. Write a token verifier
+Working servers for each: `examples/auth-workos`, `auth-auth0`, `auth-clerk`, `auth-stytch`, `auth-descope`.
 
-`requireBearerAuth` takes a `verifier` with `verifyAccessToken(token): Promise<AuthInfo>`. Verify the provider's JWT against its JWKS:
+## 2. Any other IdP — `customProvider`
 
-⚠️ Fetch your provider's docs for the exact JWKS URL and issuer.
+For an IdP without a branded helper, point `customProvider` at its issuer; it reads the OAuth discovery document (requires a `jwks_uri`):
 
 ```typescript
-// src/auth.ts
-import { InvalidTokenError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
-import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
-import * as jose from "jose";
+import { customProvider } from "skybridge/server";
 
-const jwks = jose.createRemoteJWKSet(
-  new URL("https://your-oauth-provider.com/oauth2/jwks"),
-);
-
-export async function verifyAccessToken(token: string): Promise<AuthInfo> {
-  const { payload } = await jose.jwtVerify(token, jwks, {
-    issuer: "https://your-oauth-provider.com",
-  });
-
-  if (!payload.sub || typeof payload.sub !== "string") {
-    throw new InvalidTokenError("missing sub claim");
-  }
-
-  return {
-    token,
-    clientId: (payload.client_id ?? payload.azp ?? "") as string,
-    scopes: typeof payload.scope === "string" ? payload.scope.split(" ") : [],
-    expiresAt: payload.exp,
-    extra: { sub: payload.sub },
-  };
-}
+oauth: await customProvider({
+  issuer: "https://your-idp.com",
+  audience: "my-api",            // omit only if the IdP binds no aud
+  scopes: ["openid", "email", "profile"],
+  // serverUrl: env.SERVER_URL,  // skybridge-as-AS: needed when skybridge must
+                                 // sit in the auth path (e.g. Alpic DCR proxy)
+}),
 ```
 
-## 3. Enforce auth on /mcp
+`OAuthConfig` also accepts `baseUrl` (this server's public URL; inferred from request headers when omitted), `requiredScopes` (server-wide floor), and `metadataOverrides`.
+
+## 3. Read auth in handlers
+
+`extra.authInfo` carries the verified token. `extra.subject` holds the `sub` claim; all other JWT claims (e.g. `email`) are spread alongside it.
 
 ```typescript
-// src/server.ts (continued)
-import { requireBearerAuth } from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js";
-import { verifyAccessToken } from "./auth.js";
-
-server.use(
-  "/mcp",
-  requireBearerAuth({
-    verifier: { verifyAccessToken },
-    requiredScopes: ["openid", "email", "profile"], // optional
-  }),
-);
-```
-
-Unauthenticated requests get HTTP 401 before any tool handler runs.
-
-## 4. Read auth in handlers
-
-```typescript
-import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import type { AuthInfo } from "skybridge/server";
 
 server.registerTool(
-  {
-    name: "get-orders",
-    description: "Get user orders",
-  },
+  { name: "get-orders", description: "Get user orders" },
   async (_input, extra) => {
     const auth = extra.authInfo as AuthInfo;
-    const orders = await fetchOrders(auth.extra?.sub as string);
+    const subject = auth.extra?.subject as string;
+    const orders = await fetchOrders(subject);
     return {
       structuredContent: { orders },
       content: [{ type: "text", text: `Found ${orders.length} orders` }],
@@ -113,3 +78,7 @@ server.registerTool(
   },
 );
 ```
+
+## Manual wiring (escape hatch)
+
+The `oauth` field replaces hand-mounting `mcpAuthMetadataRouter` + `requireBearerAuth`. Those primitives are still exported from `skybridge/server` if you need full control, but prefer a provider.

--- a/skills/chatgpt-app-builder/references/oauth.md
+++ b/skills/chatgpt-app-builder/references/oauth.md
@@ -29,7 +29,9 @@ Can the IdP be verified against a JWKS?
 
 ## 1. Pick a provider
 
-The branded providers discover the IdP's OAuth metadata and build the whole config. All return a `Promise` — `await` it. Most need **Dynamic Client Registration (DCR)** enabled in the provider dashboard (Authplane has it natively; Descope without DCR goes through the Alpic proxy).
+The branded providers discover the IdP's OAuth metadata and build the whole config. All return a `Promise` — `await` it. Most need **Dynamic Client Registration (DCR)** enabled on the IdP side (Authplane has it natively; Descope without DCR goes through the Alpic proxy).
+
+The table below covers what goes in the code. For the dashboard steps that produce those values, send the user to `docs/guides/auth-providers.mdx` — provider UIs change, and this file isn't the source of truth for them.
 
 ```typescript
 // src/server.ts
@@ -48,9 +50,9 @@ const server = new McpServer(
 
 | Provider | Import | Required options | Notes |
 |---|---|---|---|
-| WorkOS AuthKit | `workosProvider` | `domain`, `audience` | `domain` = AuthKit domain; `audience` = Resource Indicator (this server's URL). DCR under Connect → Configuration. |
+| WorkOS AuthKit | `workosProvider` | `domain`, `audience` | `domain` = AuthKit domain; `audience` = Resource Indicator (this server's URL). |
 | Auth0 | `auth0Provider` | `domain`, `audience`, `serverUrl` | `audience` = API Identifier. Runs skybridge-as-AS (`serverUrl`) and bakes `?audience=` into `/authorize`. Set `scopes` to what the app needs (e.g. `["openid","profile","email"]`) — Auth0 won't grant a DCR client its full OIDC set. |
-| Clerk | `clerkProvider` | `domain` | `domain` = Frontend API URL. No `audience` (Clerk tokens carry no `aud`). The OAuth app must issue **JWT** access tokens, not opaque. |
+| Clerk | `clerkProvider` | `domain` | `domain` = Frontend API URL. No `audience` (Clerk tokens carry no `aud`). Verification only works if the OAuth app issues **JWT** access tokens — opaque tokens fail. |
 | Stytch | `stytchProvider` | `domain`, `audience` | `domain` = project domain; `audience` = Stytch Project ID. |
 | Descope | `descopeProvider` | `url` | `url` = MCP Server Discovery URL (Issuer). `audience` defaults to the Project ID derived from the URL. DCR disabled + Alpic DCR proxy → use `customProvider` with `serverUrl` (see `examples/auth-descope-alpic`). |
 | Authplane | `authplaneProvider` | `issuer`, `resource` | `resource` = this server's public URL, and it also supplies the expected `aud` (RFC 8707). Pass it exactly as Authplane advertises it — the provider throws if URL normalization would rewrite it (bare origin, uppercase host, explicit default port). |

--- a/skills/chatgpt-app-builder/references/oauth.md
+++ b/skills/chatgpt-app-builder/references/oauth.md
@@ -7,7 +7,7 @@ Enable user authentication so tools can access user-specific data.
 1. Pass an `oauth` config as the third `McpServer` argument
 2. Skybridge auto-mounts the OAuth discovery endpoints (`/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource`) and Bearer JWT verification on `/mcp`
 3. The host reads the metadata, walks the user through OAuth, refreshes tokens, and calls `/mcp` with `Authorization: Bearer <token>`
-4. Unauthenticated/invalid requests **to `/mcp`** get HTTP 401 before any tool handler runs. The `oauth` field guards `/mcp` only — any custom route you mount yourself is unprotected; gate it explicitly (see [Manual wiring](#manual-wiring))
+4. Unauthenticated/invalid requests **to `/mcp`** get HTTP 401 before any tool handler runs. The `oauth` field guards `/mcp` only — see [Protect a custom route](#protect-a-custom-route) before serving user data anywhere else
 5. Tool handlers read user identity from `extra.authInfo`
 
 ## Which path?
@@ -120,6 +120,23 @@ Skybridge enforces this before the handler runs: as soon as one tool sets `allow
 `auth` compiles down to SEP-1488 `securitySchemes` (`{ type: "noauth" }` / `{ type: "oauth2", scopes }`) advertised on the tool descriptor. Setting `securitySchemes` by hand is the low-level escape hatch — it disables the `auth` shorthand for that tool (they're mutually exclusive) and skips no enforcement, but you own the mapping. `auth` without an `oauth` provider throws at registration.
 
 Working server: `examples/auth-descope-mixed`.
+
+## Protect a custom route
+
+Any route you mount with `.use()` sits outside the `oauth` field's middleware, and the internal JWKS verifier isn't exported — so gate the route with your own verifier plus `requireBearerAuth`:
+
+```typescript
+import { requireBearerAuth } from "skybridge/server";
+import { verifyAccessToken } from "./auth.js"; // see Write a verifier below
+
+server.use("/api/user-data", requireBearerAuth({ verifier: { verifyAccessToken } }));
+server.use("/api/user-data", (req, res) => {
+  const subject = (req as Request & { auth?: AuthInfo }).auth?.extra?.subject;
+  // ...
+});
+```
+
+Same `issuer`/`audience` as the provider config, or the route trusts tokens `/mcp` would reject.
 
 ## Manual wiring
 

--- a/skills/chatgpt-app-builder/references/oauth.md
+++ b/skills/chatgpt-app-builder/references/oauth.md
@@ -10,6 +10,8 @@ Enable user authentication so tools can access user-specific data.
 4. By default every tool requires sign-in: unauthenticated/invalid requests **to `/mcp`** get HTTP 401 before any tool handler runs
 5. Tool handlers read user identity from `extra.authInfo`
 
+The `oauth` field guards `/mcp` and nothing else. A route you mount yourself outside `/mcp` is unauthenticated — gate it with `requireBearerAuth` and your own verifier, and note that Alpic Cloud only routes traffic to `/mcp` (custom paths work locally and self-hosted).
+
 ## Which path?
 
 The `oauth` field covers all-or-nothing **and** mixed auth. Manual wiring is only for an IdP whose tokens the framework can't verify.

--- a/skills/chatgpt-app-builder/references/oauth.md
+++ b/skills/chatgpt-app-builder/references/oauth.md
@@ -12,23 +12,23 @@ Enable user authentication so tools can access user-specific data.
 
 ## Which path?
 
-The `oauth` field handles all-or-nothing auth; mixed auth or an unsupported IdP needs manual wiring.
+The `oauth` field covers all-or-nothing **and** mixed auth. Only an IdP the framework can't verify needs manual wiring.
 
 ```
-All tools require sign-in?
-├─ No — some public, some gated ──────────────────→ Manual wiring
-└─ Yes
-   ├─ A branded provider fits your IdP ────────────→ Pick a provider
-   │     (WorkOS · Auth0 · Clerk · Stytch · Descope)
-   ├─ No helper, but IdP has OAuth discovery + JWKS → customProvider
-   └─ No discovery doc, or opaque tokens ───────────→ Manual wiring
+Can the IdP be verified against a JWKS?
+├─ Yes
+│  ├─ A branded provider fits your IdP ─────────→ Pick a provider
+│  │    (WorkOS · Auth0 · Clerk · Stytch · Descope · Authplane)
+│  └─ No helper, but it has OAuth discovery ─────→ customProvider
+│     … then, if some tools must stay public ────→ add per-tool `auth`
+└─ No discovery doc, or opaque tokens ───────────→ Manual wiring
 ```
 
-- [Pick a provider](#1-pick-a-provider) · [`customProvider`](#2-any-other-idp--customprovider) · [Manual wiring](#manual-wiring)
+- [Pick a provider](#1-pick-a-provider) · [`customProvider`](#2-any-other-idp--customprovider) · [Per-tool auth](#4-mixed-auth-per-tool-auth) · [Manual wiring](#manual-wiring)
 
 ## 1. Pick a provider
 
-The branded providers discover the IdP's OAuth metadata and build the whole config. All require **Dynamic Client Registration (DCR)** enabled in the provider dashboard, and return a `Promise` — `await` it.
+The branded providers discover the IdP's OAuth metadata and build the whole config. All return a `Promise` — `await` it. Most need **Dynamic Client Registration (DCR)** enabled in the provider dashboard (Authplane has it natively; Descope without DCR goes through the Alpic proxy).
 
 ```typescript
 // src/server.ts
@@ -52,8 +52,9 @@ const server = new McpServer(
 | Clerk | `clerkProvider` | `domain` | `domain` = Frontend API URL. No `audience` (Clerk tokens carry no `aud`). The OAuth app must issue **JWT** access tokens, not opaque. |
 | Stytch | `stytchProvider` | `domain`, `audience` | `domain` = project domain; `audience` = Stytch Project ID. |
 | Descope | `descopeProvider` | `url` | `url` = MCP Server Discovery URL (Issuer). `audience` defaults to the Project ID derived from the URL. DCR disabled + Alpic DCR proxy → use `customProvider` with `serverUrl` (see `examples/auth-descope-alpic`). |
+| Authplane | `authplaneProvider` | `issuer`, `resource` | `resource` = this server's public URL, and it also supplies the expected `aud` (RFC 8707). Pass it exactly as Authplane advertises it — the provider throws if URL normalization would rewrite it (bare origin, uppercase host, explicit default port). |
 
-Working servers for each: `examples/auth-workos`, `auth-auth0`, `auth-clerk`, `auth-stytch`, `auth-descope`.
+Working servers for each: `examples/auth-workos`, `auth-auth0`, `auth-clerk`, `auth-stytch`, `auth-descope`, `auth-authplane`.
 
 ## 2. Any other IdP — `customProvider`
 
@@ -71,7 +72,7 @@ oauth: await customProvider({
 }),
 ```
 
-`customProvider` also accepts `baseUrl` (this server's public URL; inferred from request headers when omitted), `requiredScopes` (server-wide floor), and `metadataOverrides`.
+`customProvider` also accepts `baseUrl` (this server's public URL; inferred from request headers when omitted), `requiredScopes` (server-wide floor), `metadataOverrides`, and `authorizationServer` (advertise a different AS than the discovery issuer — `serverUrl` wins if both are set).
 
 ## 3. Read auth in handlers
 
@@ -94,9 +95,35 @@ server.registerTool(
 );
 ```
 
+## 4. Mixed auth: per-tool `auth`
+
+With an `oauth` provider set, each tool declares its own requirement. Omit `auth` for the secure default (sign-in required, no specific scope).
+
+```typescript
+server
+  .registerTool(
+    {
+      name: "browse-catalog",
+      description: "Browse the public catalog",
+      auth: { allowsAnonymous: true }, // callable signed out; token still read when present
+    },
+    (_input, extra) => ({ ...(extra.authInfo ? greet(extra.authInfo) : guest()) }),
+  )
+  .registerTool(
+    { name: "checkout", description: "Place an order", auth: { scopes: ["checkout"] } },
+    handler,
+  );
+```
+
+Skybridge enforces this before the handler runs: as soon as one tool sets `allowsAnonymous`, `/mcp` switches to optional Bearer, then each `tools/call` is checked against the calling tool's declaration — missing token → 401 `invalid_token`, missing scope → 403 `insufficient_scope` (ChatGPT gets the equivalent in-band `mcp/www_authenticate` challenge instead). So a gated handler can rely on `extra.authInfo` being present.
+
+`auth` compiles down to SEP-1488 `securitySchemes` (`{ type: "noauth" }` / `{ type: "oauth2", scopes }`) advertised on the tool descriptor. Setting `securitySchemes` by hand is the low-level escape hatch — it disables the `auth` shorthand for that tool (they're mutually exclusive) and skips no enforcement, but you own the mapping. `auth` without an `oauth` provider throws at registration.
+
+Working server: `examples/auth-descope-mixed`.
+
 ## Manual wiring
 
-Reach for this when the `oauth` field can't express your setup: **mixed auth** (some tools public, some gated), or an **IdP with no OAuth discovery / opaque tokens** (you verify by introspection instead of JWKS). The same primitives are exported from `skybridge/server`.
+Only needed when the framework can't verify the IdP's tokens: **no OAuth discovery document, or opaque tokens** (you verify by introspection instead of JWKS). Mixed auth does *not* require this — see [per-tool `auth`](#4-mixed-auth-per-tool-auth). The primitives are exported from `skybridge/server`.
 
 ### Write a verifier
 
@@ -126,7 +153,7 @@ export async function verifyAccessToken(token: string): Promise<AuthInfo> {
 
 ### Mount metadata + enforcement
 
-`mcpAuthMetadataRouter` serves the well-known endpoints. `requireBearerAuth` rejects every unauthenticated request; `optionalBearerAuth` lets unauthenticated requests through (validating a token only when one is sent) — this is the mixed-auth path.
+`mcpAuthMetadataRouter` serves the well-known endpoints. `requireBearerAuth` rejects every unauthenticated request; `optionalBearerAuth` lets unauthenticated requests through, validating a token only when one is sent.
 
 ```typescript
 import {
@@ -151,7 +178,7 @@ const server = new McpServer({ name: "my-app", version: "0.0.1" }, { capabilitie
   .use("/mcp", optionalBearerAuth({ verifier: { verifyAccessToken } }));
 ```
 
-Then declare each tool's requirement with `securitySchemes` (`{ type: "noauth" }` for public, `{ type: "oauth2", scopes? }` for gated):
+Without an `oauth` provider the `auth` shorthand is unavailable, so declare each tool's requirement with `securitySchemes` (`{ type: "noauth" }` for public, `{ type: "oauth2", scopes? }` for gated):
 
 ```typescript
 server.registerTool(
@@ -161,9 +188,9 @@ server.registerTool(
 server.registerTool(
   { name: "get-orders", description: "...", securitySchemes: [{ type: "oauth2" }] },
   async (_input, extra) => {
-    // securitySchemes is advertised to the host only — NOT enforced at runtime.
-    // optionalBearerAuth lets token-less requests through, so a gated handler
-    // MUST verify authInfo itself.
+    // No `oauth` provider means no framework enforcement: securitySchemes is
+    // advertised to the host only, and optionalBearerAuth lets token-less
+    // requests through. A gated handler MUST verify authInfo itself.
     if (!extra.authInfo) throw new Error("Unauthorized");
     // ...
   },

--- a/skills/chatgpt-app-builder/references/oauth.md
+++ b/skills/chatgpt-app-builder/references/oauth.md
@@ -10,7 +10,7 @@ Enable user authentication so tools can access user-specific data.
 4. By default every tool requires sign-in: unauthenticated/invalid requests **to `/mcp`** get HTTP 401 before any tool handler runs
 5. Tool handlers read user identity from `extra.authInfo`
 
-The `oauth` field guards `/mcp` and nothing else. A route you mount yourself outside `/mcp` is unauthenticated — gate it with `requireBearerAuth` and your own verifier, and note that Alpic Cloud only routes traffic to `/mcp` (custom paths work locally and self-hosted).
+The `oauth` field guards `/mcp` and nothing else. A route you mount yourself outside `/mcp` is unauthenticated — gate it with `requireBearerAuth`, your own verifier, and the same `requiredScopes` the `oauth` config sets, or it accepts under-scoped tokens `/mcp` rejects. Note that Alpic Cloud only routes traffic to `/mcp` (custom paths work locally and self-hosted).
 
 ## Which path?
 

--- a/skills/chatgpt-app-builder/references/oauth.md
+++ b/skills/chatgpt-app-builder/references/oauth.md
@@ -7,22 +7,26 @@ Enable user authentication so tools can access user-specific data.
 1. Pass an `oauth` config as the third `McpServer` argument
 2. Skybridge auto-mounts the OAuth discovery endpoints (`/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource`) and Bearer JWT verification on `/mcp`
 3. The host reads the metadata, walks the user through OAuth, refreshes tokens, and calls `/mcp` with `Authorization: Bearer <token>`
-4. By default every tool requires sign-in: unauthenticated/invalid requests **to `/mcp`** get HTTP 401 before any tool handler runs. Opting one tool into anonymous access relaxes this per tool, never server-wide — see [per-tool `auth`](#4-mixed-auth-per-tool-auth)
+4. By default every tool requires sign-in: unauthenticated/invalid requests **to `/mcp`** get HTTP 401 before any tool handler runs
 5. The `oauth` field guards `/mcp` only — see [Protect a custom route](#protect-a-custom-route) before serving user data anywhere else
 6. Tool handlers read user identity from `extra.authInfo`
 
 ## Which path?
 
-The `oauth` field covers all-or-nothing **and** mixed auth. Only an IdP the framework can't verify needs manual wiring.
+The `oauth` field covers all-or-nothing **and** mixed auth. Manual wiring is only for an IdP whose tokens the framework can't verify.
 
 ```
-Can the IdP be verified against a JWKS?
+Does the IdP publish an OAuth discovery document with a jwks_uri?
 ├─ Yes
 │  ├─ A branded provider fits your IdP ─────────→ Pick a provider
 │  │    (WorkOS · Auth0 · Clerk · Stytch · Descope · Authplane)
-│  └─ No helper, but it has OAuth discovery ─────→ customProvider
+│  └─ No helper for it ──────────────────────────→ customProvider
 │     … then, if some tools must stay public ────→ add per-tool `auth`
-└─ No discovery doc, or opaque tokens ───────────→ Manual wiring
+└─ No ───────────────────────────────────────────→ Manual wiring
+      (no discovery doc, or opaque tokens you
+       verify by introspection — a JWKS alone
+       isn't enough: customProvider reads the
+       jwks_uri *out of* the discovery document)
 ```
 
 - [Pick a provider](#1-pick-a-provider) · [`customProvider`](#2-any-other-idp--customprovider) · [Per-tool auth](#4-mixed-auth-per-tool-auth) · [Manual wiring](#manual-wiring)
@@ -118,28 +122,61 @@ server
   );
 ```
 
-Skybridge enforces this before the handler runs: as soon as one tool sets `allowsAnonymous`, `/mcp` switches to optional Bearer, then each `tools/call` is checked against the calling tool's declaration — missing token → 401 `invalid_token`, missing scope → 403 `insufficient_scope` (ChatGPT gets the equivalent in-band `mcp/www_authenticate` challenge instead). So a gated handler can rely on `extra.authInfo` being present.
+Skybridge enforces this before the handler runs: each `tools/call` is checked against the calling tool's declaration — missing token → 401 `invalid_token`, missing scope → 403 `insufficient_scope` (a non-batched ChatGPT request gets the equivalent in-band `mcp/www_authenticate` challenge instead of the transport status). So a gated handler can rely on `extra.authInfo` being present.
 
-`auth` compiles down to SEP-1488 `securitySchemes` (`{ type: "noauth" }` / `{ type: "oauth2", scopes }`) advertised on the tool descriptor. Setting `securitySchemes` by hand is the low-level escape hatch — it disables the `auth` shorthand for that tool (they're mutually exclusive) and skips no enforcement, but you own the mapping. `auth` without an `oauth` provider throws at registration.
+⚠️ **One anonymous tool unlocks every non-`tools/call` method.** Declaring `allowsAnonymous` anywhere switches the whole `/mcp` route to optional Bearer, and only `tools/call` is checked per tool. So `initialize`, `tools/list`, `prompts/*` and `resources/read` — **including your view resources** — become reachable with no token at all. In a mixed server, never put user-specific data in a view resource or a prompt; return it from a gated tool's response instead.
+
+`auth` compiles down to SEP-1488 `securitySchemes` advertised on the tool descriptor: `{ scopes }` becomes `[{ type: "oauth2", scopes }]`, and `allowsAnonymous` emits **both** `[{ type: "noauth" }, { type: "oauth2" }]`. Setting `securitySchemes` by hand is the low-level escape hatch — it disables the `auth` shorthand for that tool (they're mutually exclusive) and skips no enforcement, but you own the mapping.
+
+Requiring sign-in (`auth: { scopes }`, or `auth: {}`) throws at registration when the server has no `oauth` provider. `auth: { allowsAnonymous: true }` is accepted either way, but without a provider it's silently dropped and no `noauth` scheme is advertised.
 
 Working server: `examples/auth-descope-mixed`.
 
 ## Protect a custom route
 
-Any route you mount with `.use()` sits outside the `oauth` field's middleware, and the internal JWKS verifier isn't exported — so gate the route with your own verifier plus `requireBearerAuth`:
+A route you mount outside `/mcp` sits outside the `oauth` field's middleware, and the internal JWKS verifier isn't exported — so gate it with your own verifier plus `requireBearerAuth`.
+
+Don't retype the IdP values: the providers *derive* what they verify against (`descopeProvider` turns its `url` into `issuer = <base>/<projectId>` and `audience = projectId`; `customProvider` uses the **discovered** issuer). Keep the provider result and read them off it, or the route rejects every valid token — or worse, accepts tokens `/mcp` would reject:
 
 ```typescript
-import { requireBearerAuth } from "skybridge/server";
-import { verifyAccessToken } from "./auth.js"; // see Write a verifier below
+import type { Request } from "express";
+import * as jose from "jose";
+import { type AuthInfo, InvalidTokenError, McpServer, requireBearerAuth } from "skybridge/server";
 
-server.use("/api/user-data", requireBearerAuth({ verifier: { verifyAccessToken } }));
-server.use("/api/user-data", (req, res) => {
-  const subject = (req as Request & { auth?: AuthInfo }).auth?.extra?.subject;
-  // ...
-});
+const oauth = await descopeProvider({ url: env.DESCOPE_MCP_SERVER_URL });
+const server = new McpServer(info, { capabilities: {} }, { oauth });
+
+const jwks = jose.createRemoteJWKSet(new URL(oauth.verify.jwksUri));
+const verifyAccessToken = async (token: string): Promise<AuthInfo> => {
+  try {
+    const { payload } = await jose.jwtVerify(token, jwks, {
+      issuer: oauth.verify.issuer,
+      audience: oauth.verify.audience,
+    });
+    return {
+      token,
+      clientId: (payload.client_id ?? payload.azp ?? "") as string,
+      scopes: typeof payload.scope === "string" ? payload.scope.split(" ") : [],
+      expiresAt: payload.exp,
+      extra: { subject: payload.sub },
+    };
+  } catch (err) {
+    throw new InvalidTokenError(err instanceof Error ? err.message : String(err));
+  }
+};
+
+server
+  .use("/api/user-data", requireBearerAuth({
+    verifier: { verifyAccessToken },
+    resourceMetadataUrl: `${env.SERVER_URL}/.well-known/oauth-protected-resource`,
+  }))
+  .use("/api/user-data", (req, res) => {
+    const subject = (req as Request & { auth?: AuthInfo }).auth?.extra?.subject as string;
+    // ...
+  });
 ```
 
-Same `issuer`/`audience` as the provider config, or the route trusts tokens `/mcp` would reject.
+`resourceMetadataUrl` is what puts `resource_metadata` in the 401 — without it a client can't discover how to authenticate against the route. Paths under `/mcp/…` are already covered by the `oauth` middleware.
 
 ## Manual wiring
 
@@ -209,35 +246,45 @@ server.registerTool(
   handler,
 );
 server.registerTool(
-  { name: "get-orders", description: "...", securitySchemes: [{ type: "oauth2" }] },
+  { name: "get-orders", description: "...", securitySchemes: [{ type: "oauth2", scopes: ["orders:read"] }] },
   async (_input, extra) => {
     // No `oauth` provider means no framework enforcement: securitySchemes is
     // advertised to the host only, and optionalBearerAuth lets token-less
-    // requests through. A gated handler MUST verify authInfo itself.
-    if (!extra.authInfo) return signInChallenge();
+    // requests through. A gated handler MUST do both checks itself.
+    if (!extra.authInfo) return signInChallenge(["orders:read"]);
+    if (!extra.authInfo.scopes.includes("orders:read")) {
+      return insufficientScope(["orders:read"]);
+    }
     // ...
   },
 );
 ```
+
+Declaring `scopes` in `securitySchemes` enforces nothing on its own — the framework only acts on it when an `oauth` provider is set. `optionalBearerAuth` verifies the token's signature, not what it's allowed to do, so without the `scopes.includes` check every signed-in user passes a scope-gated tool.
 
 ### Reject from inside a handler
 
 Don't `throw` on missing auth. The handler runs after the transport, so it can't send a 401, and a thrown error reaches the host as an opaque tool failure — it never triggers the sign-in flow. Return the in-band challenge instead: `isError` plus a `mcp/www_authenticate` header array in `_meta`, pointing at your protected-resource metadata. This is the shape the `oauth` field emits for ChatGPT, and what ChatGPT acts on.
 
 ```typescript
-const signInChallenge = (scopes: string[] = []) => ({
+const challenge = (error: "invalid_token" | "insufficient_scope", text: string, scopes: string[]) => ({
   isError: true,
-  content: [{ type: "text" as const, text: "Sign in to use this tool." }],
+  content: [{ type: "text" as const, text }],
   _meta: {
     "mcp/www_authenticate": [
-      `Bearer error="invalid_token", error_description="Sign in to use this tool."` +
+      `Bearer error="${error}", error_description="${text}"` +
         (scopes.length ? `, scope="${scopes.join(" ")}"` : "") +
-        `, resource_metadata="${process.env.SERVER_URL}/.well-known/oauth-protected-resource"`,
+        `, resource_metadata="${env.SERVER_URL}/.well-known/oauth-protected-resource"`,
     ],
   },
 });
+
+const signInChallenge = (scopes: string[] = []) =>
+  challenge("invalid_token", "Sign in to use this tool.", scopes);
+const insufficientScope = (scopes: string[]) =>
+  challenge("insufficient_scope", "Missing required scope for this tool.", scopes);
 ```
 
-Use `error="insufficient_scope"` when a token is present but under-scoped.
+`env.SERVER_URL` must be a validated value, not raw `process.env` — an unset var interpolates to `undefined/.well-known/...` and the host silently fails to start the sign-in flow instead of erroring. The examples define a `requireEnv` helper in `src/env.ts` for this.
 
 For an all-or-nothing manual server, swap `optionalBearerAuth` for `requireBearerAuth` and drop the per-tool `securitySchemes` — then `authInfo` is guaranteed in every handler and no challenge is needed.

--- a/skills/chatgpt-app-builder/references/oauth.md
+++ b/skills/chatgpt-app-builder/references/oauth.md
@@ -8,8 +8,7 @@ Enable user authentication so tools can access user-specific data.
 2. Skybridge auto-mounts the OAuth discovery endpoints (`/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource`) and Bearer JWT verification on `/mcp`
 3. The host reads the metadata, walks the user through OAuth, refreshes tokens, and calls `/mcp` with `Authorization: Bearer <token>`
 4. By default every tool requires sign-in: unauthenticated/invalid requests **to `/mcp`** get HTTP 401 before any tool handler runs
-5. The `oauth` field guards `/mcp` only — see [Protect a custom route](#protect-a-custom-route) before serving user data anywhere else
-6. Tool handlers read user identity from `extra.authInfo`
+5. Tool handlers read user identity from `extra.authInfo`
 
 ## Which path?
 
@@ -21,7 +20,7 @@ Does the IdP publish an OAuth discovery document with a jwks_uri?
 │  ├─ A branded provider fits your IdP ─────────→ Pick a provider
 │  │    (WorkOS · Auth0 · Clerk · Stytch · Descope · Authplane)
 │  └─ No helper for it ──────────────────────────→ customProvider
-│     … then, if some tools must stay public ────→ add per-tool `auth`
+│  (either way, if some tools stay public ──────→ add per-tool `auth`)
 └─ No ───────────────────────────────────────────→ Manual wiring
       (no discovery doc, or opaque tokens you
        verify by introspection — a JWKS alone
@@ -132,53 +131,6 @@ Requiring sign-in (`auth: { scopes }`, or `auth: {}`) throws at registration whe
 
 Working server: `examples/auth-descope-mixed`.
 
-## Protect a custom route
-
-A route you mount outside `/mcp` sits outside the `oauth` field's middleware, and the internal JWKS verifier isn't exported — so gate it with your own verifier plus `requireBearerAuth`.
-
-Don't retype the IdP values: the providers *derive* what they verify against (`descopeProvider` turns its `url` into `issuer = <base>/<projectId>` and `audience = projectId`; `customProvider` uses the **discovered** issuer). Keep the provider result and read them off it, or the route rejects every valid token — or worse, accepts tokens `/mcp` would reject:
-
-```typescript
-import type { Request } from "express";
-import * as jose from "jose";
-import { type AuthInfo, InvalidTokenError, McpServer, requireBearerAuth } from "skybridge/server";
-
-const oauth = await descopeProvider({ url: env.DESCOPE_MCP_SERVER_URL });
-const server = new McpServer(info, { capabilities: {} }, { oauth });
-
-const jwks = jose.createRemoteJWKSet(new URL(oauth.verify.jwksUri));
-const verifyAccessToken = async (token: string): Promise<AuthInfo> => {
-  try {
-    const { payload } = await jose.jwtVerify(token, jwks, {
-      issuer: oauth.verify.issuer,
-      audience: oauth.verify.audience,
-    });
-    return {
-      token,
-      clientId: (payload.client_id ?? payload.azp ?? "") as string,
-      scopes: typeof payload.scope === "string" ? payload.scope.split(" ") : [],
-      expiresAt: payload.exp,
-      extra: { subject: payload.sub },
-    };
-  } catch (err) {
-    throw new InvalidTokenError(err instanceof Error ? err.message : String(err));
-  }
-};
-
-server
-  .use("/api/user-data", requireBearerAuth({
-    verifier: { verifyAccessToken },
-    requiredScopes: oauth.requiredScopes,
-    resourceMetadataUrl: `${env.SERVER_URL}/.well-known/oauth-protected-resource`,
-  }))
-  .use("/api/user-data", (req, res) => {
-    const subject = (req as Request & { auth?: AuthInfo }).auth?.extra?.subject as string;
-    // ...
-  });
-```
-
-Mirror `requiredScopes` too, or the route accepts under-scoped tokens that `/mcp` rejects. `resourceMetadataUrl` is what puts `resource_metadata` in the 401 — without it a client can't discover how to authenticate against the route. Paths under `/mcp/…` are already covered by the `oauth` middleware.
-
 ## Manual wiring
 
 Only needed when the framework can't verify the IdP's tokens: **no OAuth discovery document, or opaque tokens** (you verify by introspection instead of JWKS). Mixed auth does *not* require this — see [per-tool `auth`](#4-mixed-auth-per-tool-auth). The primitives are exported from `skybridge/server`.
@@ -268,24 +220,25 @@ Declaring `scopes` in `securitySchemes` enforces nothing on its own — the fram
 Don't `throw` on missing auth. The handler runs after the transport, so it can't send a 401, and a thrown error reaches the host as an opaque tool failure — it never triggers the sign-in flow. Return the in-band challenge instead: `isError` plus a `mcp/www_authenticate` header array in `_meta`, pointing at your protected-resource metadata. This is the shape the `oauth` field emits for ChatGPT, and what ChatGPT acts on.
 
 ```typescript
-const challenge = (error: "invalid_token" | "insufficient_scope", text: string, scopes: string[]) => ({
+const challenge = (
+  error: "invalid_token" | "insufficient_scope",
+  text: string,
+  scopes: string[],
+) => ({
   isError: true,
   content: [{ type: "text" as const, text }],
   _meta: {
     "mcp/www_authenticate": [
-      `Bearer error="${error}", error_description="${text}"` +
-        (scopes.length ? `, scope="${scopes.join(" ")}"` : "") +
-        `, resource_metadata="${env.SERVER_URL}/.well-known/oauth-protected-resource"`,
+      `Bearer error="${error}", error_description="${text}", scope="${scopes.join(" ")}", ` +
+        `resource_metadata="${process.env.SERVER_URL}/.well-known/oauth-protected-resource"`,
     ],
   },
 });
 
-const signInChallenge = (scopes: string[] = []) =>
+const signInChallenge = (scopes: string[]) =>
   challenge("invalid_token", "Sign in to use this tool.", scopes);
 const insufficientScope = (scopes: string[]) =>
   challenge("insufficient_scope", "Missing required scope for this tool.", scopes);
 ```
-
-`env.SERVER_URL` must be a validated value, not raw `process.env` — an unset var interpolates to `undefined/.well-known/...` and the host silently fails to start the sign-in flow instead of erroring. The examples define a `requireEnv` helper in `src/env.ts` for this.
 
 For an all-or-nothing manual server, swap `optionalBearerAuth` for `requireBearerAuth` and drop the per-tool `securitySchemes` — then `authInfo` is guaranteed in every handler and no challenge is needed.

--- a/skills/chatgpt-app-builder/references/oauth.md
+++ b/skills/chatgpt-app-builder/references/oauth.md
@@ -7,8 +7,9 @@ Enable user authentication so tools can access user-specific data.
 1. Pass an `oauth` config as the third `McpServer` argument
 2. Skybridge auto-mounts the OAuth discovery endpoints (`/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource`) and Bearer JWT verification on `/mcp`
 3. The host reads the metadata, walks the user through OAuth, refreshes tokens, and calls `/mcp` with `Authorization: Bearer <token>`
-4. Unauthenticated/invalid requests **to `/mcp`** get HTTP 401 before any tool handler runs. The `oauth` field guards `/mcp` only — see [Protect a custom route](#protect-a-custom-route) before serving user data anywhere else
-5. Tool handlers read user identity from `extra.authInfo`
+4. By default every tool requires sign-in: unauthenticated/invalid requests **to `/mcp`** get HTTP 401 before any tool handler runs. Opting one tool into anonymous access relaxes this per tool, never server-wide — see [per-tool `auth`](#4-mixed-auth-per-tool-auth)
+5. The `oauth` field guards `/mcp` only — see [Protect a custom route](#protect-a-custom-route) before serving user data anywhere else
+6. Tool handlers read user identity from `extra.authInfo`
 
 ## Which path?
 

--- a/skills/chatgpt-app-builder/references/oauth.md
+++ b/skills/chatgpt-app-builder/references/oauth.md
@@ -154,7 +154,10 @@ const jwks = jose.createRemoteJWKSet(new URL("https://your-idp.com/.well-known/j
 
 export async function verifyAccessToken(token: string): Promise<AuthInfo> {
   try {
-    const { payload } = await jose.jwtVerify(token, jwks, { issuer: "https://your-idp.com" });
+    const { payload } = await jose.jwtVerify(token, jwks, {
+      issuer: "https://your-idp.com",
+      audience: "my-api", // omit only if the IdP binds no aud
+    });
     return {
       token,
       clientId: (payload.client_id ?? payload.azp ?? "") as string,

--- a/skills/chatgpt-app-builder/references/oauth.md
+++ b/skills/chatgpt-app-builder/references/oauth.md
@@ -168,6 +168,7 @@ const verifyAccessToken = async (token: string): Promise<AuthInfo> => {
 server
   .use("/api/user-data", requireBearerAuth({
     verifier: { verifyAccessToken },
+    requiredScopes: oauth.requiredScopes,
     resourceMetadataUrl: `${env.SERVER_URL}/.well-known/oauth-protected-resource`,
   }))
   .use("/api/user-data", (req, res) => {
@@ -176,7 +177,7 @@ server
   });
 ```
 
-`resourceMetadataUrl` is what puts `resource_metadata` in the 401 — without it a client can't discover how to authenticate against the route. Paths under `/mcp/…` are already covered by the `oauth` middleware.
+Mirror `requiredScopes` too, or the route accepts under-scoped tokens that `/mcp` rejects. `resourceMetadataUrl` is what puts `resource_metadata` in the 401 — without it a client can't discover how to authenticate against the route. Paths under `/mcp/…` are already covered by the `oauth` middleware.
 
 ## Manual wiring
 

--- a/skills/chatgpt-app-builder/references/oauth.md
+++ b/skills/chatgpt-app-builder/references/oauth.md
@@ -211,10 +211,30 @@ server.registerTool(
     // No `oauth` provider means no framework enforcement: securitySchemes is
     // advertised to the host only, and optionalBearerAuth lets token-less
     // requests through. A gated handler MUST verify authInfo itself.
-    if (!extra.authInfo) throw new Error("Unauthorized");
+    if (!extra.authInfo) return signInChallenge();
     // ...
   },
 );
 ```
 
-For an all-or-nothing manual server, swap `optionalBearerAuth` for `requireBearerAuth` and drop the per-tool `securitySchemes` — then `authInfo` is guaranteed in every handler.
+### Reject from inside a handler
+
+Don't `throw` on missing auth. The handler runs after the transport, so it can't send a 401, and a thrown error reaches the host as an opaque tool failure — it never triggers the sign-in flow. Return the in-band challenge instead: `isError` plus a `mcp/www_authenticate` header array in `_meta`, pointing at your protected-resource metadata. This is the shape the `oauth` field emits for ChatGPT, and what ChatGPT acts on.
+
+```typescript
+const signInChallenge = (scopes: string[] = []) => ({
+  isError: true,
+  content: [{ type: "text" as const, text: "Sign in to use this tool." }],
+  _meta: {
+    "mcp/www_authenticate": [
+      `Bearer error="invalid_token", error_description="Sign in to use this tool."` +
+        (scopes.length ? `, scope="${scopes.join(" ")}"` : "") +
+        `, resource_metadata="${process.env.SERVER_URL}/.well-known/oauth-protected-resource"`,
+    ],
+  },
+});
+```
+
+Use `error="insufficient_scope"` when a token is present but under-scoped.
+
+For an all-or-nothing manual server, swap `optionalBearerAuth` for `requireBearerAuth` and drop the per-tool `securitySchemes` — then `authInfo` is guaranteed in every handler and no challenge is needed.


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the ChatGPT app builder OAuth guidance. The main changes are:

- Adds provider-based `oauth` setup for all-tools authentication.
- Clarifies that built-in auth protects `/mcp` only.
- Adds manual wiring guidance for mixed public and authenticated tools.
- Updates eval expectations for WorkOS sign-in and OAuth sign-in prompts.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the changes are limited to documentation and eval expectation updates.

No code defects were identified in the changed documentation or eval metadata.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex compared the before and after validation runs for auth-skill-docs to verify the updated prompts and contract signals.
- T-Rex confirmed that the after run shows both changed prompts present and all updated contract signals passing, including WorkOS provider args, no manual auth wiring for all-tools WorkOS, Skybridge auto-mounted discovery/Bearer verification, and /mcp HTTP 401 before handlers.

<a href="https://app.greptile.com/trex/runs/12648623/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["docs(skill): show auth path selection as..."](https://github.com/alpic-ai/skybridge/commit/ae4033d735185b3ff29fed019eeddf57db1acfb5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40526891)</sub>

<!-- /greptile_comment -->