### PR TITLE
Fix legacy apps sdk url

### DIFF
--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -1080,6 +1080,14 @@ export class McpServer<
       `ui://views/apps-sdk/${component}.html`,
       canonicalUri,
     );
+    this.viewUriByPath.set(
+      `ui://widgets/apps-sdk/${component}.html`,
+      canonicalUri,
+    );
+    this.viewUriByPath.set(
+      `ui://widgets/ext-apps/${component}.html`,
+      canonicalUri,
+    );
   }
 
   private wrapHandler<InputArgs extends ZodRawShapeCompat>(


### PR DESCRIPTION
### Summary

- Map legacy `widgets/apps-sdk` and `widgets/ext-apps` view URIs to the canonical URI.
- Keeps previously published apps resolving after the URI scheme change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR keeps old apps SDK resource links resolving after the URI change. The main changes are:

- Adds `ui://widgets/apps-sdk/...` as a legacy alias.
- Adds `ui://widgets/ext-apps/...` as a legacy alias.
- Maps both aliases to the canonical view resource URI.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is narrowly scoped to preserving legacy resource URI compatibility.

No correctness issues were identified in the updated URI mapping behavior, and the modified surface is limited to a single server file.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Observed the pre-change endpoint responses: ui://views/ext-apps/widget.html and ui://views/apps-sdk/widget.html returned 200 OK, while ui://widgets/apps-sdk/widget.html and ui://widgets/ext-apps/widget.html returned an error.
- After the change, the head responses returned 200 OK for canonical/current, legacy views/apps-sdk, and both legacy widget paths.
- Noted that legacy widget endpoints echoed the requested legacy URI while serving the same text/html;profile=mcp-app development view HTML content.

<a href="https://app.greptile.com/trex/runs/12640277/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix legacy apps sdk url"](https://github.com/alpic-ai/skybridge/commit/da7ba17be4e5bcafb9658f9af1c359871e0bf5ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40532797)</sub>

<!-- /greptile_comment -->