### PR TITLE
fix: default ViewName to string when registry is empty

### DIFF
--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -115,8 +115,15 @@ export interface ViewCsp {
 // biome-ignore lint/suspicious/noEmptyInterface: register pattern — augmented by `.skybridge/views.d.ts` to narrow ViewName
 export interface ViewNameRegistry {}
 
-/** Union of valid view component names. Narrowed by {@link ViewNameRegistry}. */
-export type ViewName = keyof ViewNameRegistry & string;
+/**
+ * Union of valid view component names. Narrowed by {@link ViewNameRegistry}.
+ * Falls back to `string` when the registry is empty (before
+ * `.skybridge/views.d.ts` is generated), so valid view names don't error
+ * on a fresh checkout — narrowing kicks in once the file exists.
+ */
+export type ViewName = [keyof ViewNameRegistry & string] extends [never]
+  ? string
+  : keyof ViewNameRegistry & string;
 
 /**
  * Pass under `view` in a tool's `registerTool` config to render the tool's

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -116,14 +116,18 @@ export interface ViewCsp {
 export interface ViewNameRegistry {}
 
 /**
- * Union of valid view component names. Narrowed by {@link ViewNameRegistry}.
- * Falls back to `string` when the registry is empty (before
- * `.skybridge/views.d.ts` is generated), so valid view names don't error
- * on a fresh checkout — narrowing kicks in once the file exists.
+ * Resolve view component names from a registry: the union of its keys, or
+ * `string` when the registry is empty. The empty case happens before
+ * `.skybridge/views.d.ts` is generated; falling back to `string` keeps valid
+ * view names from erroring on a fresh checkout, and narrowing kicks in once
+ * the generated file augments the registry.
  */
-export type ViewName = [keyof ViewNameRegistry & string] extends [never]
+export type ViewNameFor<Registry> = [keyof Registry & string] extends [never]
   ? string
-  : keyof ViewNameRegistry & string;
+  : keyof Registry & string;
+
+/** Union of valid view component names. Narrowed by {@link ViewNameRegistry}. */
+export type ViewName = ViewNameFor<ViewNameRegistry>;
 
 /**
  * Pass under `view` in a tool's `registerTool` config to render the tool's

--- a/packages/core/src/server/view-name.test-d.ts
+++ b/packages/core/src/server/view-name.test-d.ts
@@ -1,0 +1,12 @@
+import { expectTypeOf, test } from "vitest";
+import type { ViewNameFor } from "./server.js";
+
+test("ViewNameFor falls back to string when the registry is empty", () => {
+  expectTypeOf<ViewNameFor<Record<never, never>>>().toEqualTypeOf<string>();
+});
+
+test("ViewNameFor narrows to the registered view names when populated", () => {
+  expectTypeOf<ViewNameFor<{ home: true; about: true }>>().toEqualTypeOf<
+    "home" | "about"
+  >();
+});


### PR DESCRIPTION
## Summary

`ViewName` resolves to `never` when `ViewNameRegistry` is empty (`keyof {} & string`), so `component` in `registerTool` rejects every valid view name until `.skybridge/views.d.ts` is generated by `pnpm dev`/`pnpm build`.

This defaults `ViewName` to `string` when the registry is empty, then narrows to the concrete union once the generated file augments it. Valid view names no longer type-error on a fresh checkout.

Supersedes the troubleshooting note in #885 by removing the condition it documents.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates view-name typing so fresh checkouts can use view components before generated registry types exist. The main changes are:

- Adds `ViewNameFor` to fall back to `string` when the registry is empty.
- Keeps populated registries narrowed to their concrete view-name keys.
- Adds type coverage for the fallback and narrowing behavior.

<h3>Confidence Score: 3/5</h3>

The typing change is small and targeted, but the added declaration-based test file needs attention before the package build path is safe.

The review is based on the changed type definitions and package configuration, with limited execution confirmation because local package tooling could not complete cleanly in the available environment.

packages/core/src/server/view-name.test-d.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Tried to build the package with pnpm --filter skybridge, but the process could not start due to the Node.js v20.9.0 runtime limitation.
- Ran the direct pnpm exec tsc -p packages/core/tsconfig.json --pretty false, but it failed for the same Node.js startup reason as the build.
- Installed npm dependencies and ran tsc locally on packages/core/tsconfig.json, which failed type checking with many errors and only reported TS2307 for packages/core/src/server/view-name.test-d.ts.
- Executed a narrow tsc harness targeting view-name.test-d.ts with package-style settings and stubbed vitest declarations; it did not produce the TS1036 ambient-context error.
- Evaluated registry-related test artifacts for viewname, observing that the empty-registry before state fails, the after state passes, and the augmented-registry state passes with @ts-expect-error checks, indicating unregistered strings are rejected while registered keys are accepted.

<a href="https://app.greptile.com/trex/runs/12748523/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/core/src/server/view-name.test-d.ts:4-6
**Type test breaks build**
This file is included by `packages/core/tsconfig.json` via `"src/**/*"`, so `pnpm run build` runs plain `tsc` over it as a declaration file. In a `.d.ts` file, executable statements like this top-level `test(...)` call are invalid ambient declarations, producing `TS1036: Statements are not allowed in ambient contexts`; Vitest only supports this pattern when run through `vitest --typecheck`, which this package's scripts do not use. Rename this to a `.test.ts` file or add a dedicated typecheck setup that excludes it from the library build.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test: guard ViewName empty-registry fall..."](https://github.com/alpic-ai/skybridge/commit/1ef99f945d071b7d583f3a8e1d18815c7395a14c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40759153)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->