### PR TITLE
fix: remove options condition on sendFollowUpMessage

### DIFF
--- a/packages/core/src/web/bridges/adaptor.ts
+++ b/packages/core/src/web/bridges/adaptor.ts
@@ -171,10 +171,10 @@ export class HostAdaptor implements Adaptor {
     prompt: string,
     options?: SendFollowUpMessageOptions,
   ): Promise<void> => {
-    if (this.openai && options?.scrollToBottom !== undefined) {
+    if (this.openai) {
       await this.openai.sendFollowUpMessage({
         prompt,
-        scrollToBottom: options.scrollToBottom,
+        scrollToBottom: options?.scrollToBottom,
       });
       return;
     }


### PR DESCRIPTION
otherwise it falls back to the mcp app implementation which is moronic (fills the input without sending) on ChatGPT

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates follow-up message routing in the host adaptor. The main change is:

- `HostAdaptor.sendFollowUpMessage` now uses `window.openai.sendFollowUpMessage` whenever the OpenAI overlay is available.
- `scrollToBottom` is still passed through when provided.
- The MCP `sendMessage` fallback remains for hosts without the OpenAI overlay.

<h3>Confidence Score: 5/5</h3>

The change is narrowly scoped to follow-up message routing and preserves the existing fallback for hosts without the OpenAI overlay.

The modified behavior matches the stated intent, with no review comments identified for the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I reviewed the follow-up OpenAI routing change and confirmed the switch from a conditional fallback to a direct OpenAI call path in the head, with the after-state calling OpenAI with scrollToBottom undefined for scenarios 1 and 2 and with explicit true/false for scenarios 3 and 4.

<a href="https://app.greptile.com/trex/runs/12759716/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: remove options condition on sendFol..."](https://github.com/alpic-ai/skybridge/commit/c57ce3780f5387785cca183d7b3e11fd1130e2f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40781462)</sub>

<!-- /greptile_comment -->