### PR TITLE
feat: add publish-docs action

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,18 @@
+name: Publish Docs
+
+# Manually publish the Mintlify docs from the selected branch, without cutting a
+# release. Mintlify rebuilds from the `mintlify` branch, so we force-push HEAD to it.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  publish-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Deploy docs to Mintlify
+        run: git push origin HEAD:mintlify --force


### PR DESCRIPTION
so we can publish docs without releasing

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a manual workflow for publishing docs without creating a release. The main changes are:

- Adds a `Publish Docs` GitHub Actions workflow.
- Enables manual dispatch with `workflow_dispatch`.
- Pushes the selected branch `HEAD` to the `mintlify` branch for Mintlify rebuilds.

<h3>Confidence Score: 5/5</h3>

The workflow-only change is straightforward and appears safe to merge.

The change is limited to adding a manual GitHub Actions workflow for docs publishing, with no application runtime or security-sensitive code changes.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Verified the pre-run baseline by examining the before-artifact for the publish-docs-action, which reports workflow\_exists=False and exit code 0.
- Verified the post-run state after the base checks by examining the after-artifact, which shows all contract checks true and that git push origin HEAD:mintlify --force was executed against a local bare remote.
- Verified the sandbox state transition by examining the after-artifact, which shows sandbox\_remote\_refs\_before, sandbox\_remote\_refs\_after, and that sandbox\_mintlify\_sha equals sandbox\_selected\_head\_sha.

<a href="https://app.greptile.com/trex/runs/12762241/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add publish-docs action"](https://github.com/alpic-ai/skybridge/commit/18634a5c4ff8f3b46dcc776e13cb39d563f25693) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40786204)</sub>

<!-- /greptile_comment -->