### PR TITLE
chore: build core on install via root prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Skybridge is a framework for building ChatGPT and MCP Apps",
   "type": "module",
   "scripts": {
+    "prepare": "pnpm --filter skybridge build",
     "build": "pnpm --filter \"./packages/*\" build",
     "test": "pnpm -r --if-present test",
     "format": "pnpm -r --if-present format",


### PR DESCRIPTION
## Summary
- `pnpm test` failed on a clean checkout because `packages/devtools` `test:types` imports `skybridge/server`, `skybridge/web`, and `skybridge/vite`, whose exports resolve to `packages/core/dist` — which doesn't exist until core is built.
- Added a root `prepare` script that builds core, so `pnpm install` regenerates `dist` before anyone runs the tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a root install lifecycle step for building the core package. The main change is:

- Adds a `prepare` script that runs `pnpm --filter skybridge build` so `packages/core/dist` exists after install.

<h3>Confidence Score: 5/5</h3>

The change is limited to the root package lifecycle script and is safe to merge.

The update directly addresses the clean-install test setup issue by ensuring the core package is built during install, with no code-path or API behavior changes.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Baseline state showed no root prepare script, dist was not built, and type tests failed due to missing skybridge modules (skybridge/server, skybridge/web, skybridge/vite).
- After changes, the head includes a prepare script (pnpm --filter skybridge build), install ran that lifecycle script, a packages/core/dist directory was generated, and test:types exited successfully.

<a href="https://app.greptile.com/trex/runs/12773992/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: build core on install via root pr..."](https://github.com/alpic-ai/skybridge/commit/446da78e9d8969eead9fd99243ee1af7cd67a655) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40809273)</sub>

<!-- /greptile_comment -->