### PR TITLE
feat: support x-forwarded-prefix

### DIFF
--- a/docs/api-reference/cli.mdx
+++ b/docs/api-reference/cli.mdx
@@ -122,7 +122,7 @@ A scaffolded project wires the commands into `package.json`:
 | `dev:tunnel` | `skybridge dev --tunnel` | Start the dev server behind an Alpic tunnel. |
 | `build` | `skybridge build` | Build for production. |
 | `start` | `skybridge start` | Serve the production build. |
-| `deploy` | `alpic deploy` | Deploy through the Alpic CLI. See [Ship](/ship) for per-platform setup. |
+| `deploy` | `alpic deploy` | Deploy through the Alpic CLI. See [Deploy](/ship/deploy) for per-platform setup. |
 
 Run them with your package manager:
 

--- a/docs/api-reference/mcp-server.mdx
+++ b/docs/api-reference/mcp-server.mdx
@@ -116,7 +116,7 @@ server.mcpMiddleware("request", (request, extra, next) => {
 server.run(): Promise<{ fetch: (...args: unknown[]) => unknown } | Express | undefined>;
 ```
 
-Starts the HTTP server: applies your middleware, mounts `/mcp`, and listens (default port `3000`). On serverless platforms, export what it returns so the platform can route requests to it. See [Ship](/ship) for the per-platform setup.
+Starts the HTTP server: applies your middleware, mounts `/mcp`, and listens (default port `3000`). On serverless platforms, export what it returns so the platform can route requests to it. See [Deploy](/ship/deploy) for the per-platform setup.
 
 <CardGroup cols={3}>
   <Card title="registerTool" icon="wrench" href="/api-reference/register-tool">

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -56,7 +56,16 @@
             ],
             "expanded": true
           },
-          "ship",
+          {
+            "group": "Ship",
+            "icon": "ship",
+            "root": "ship/index",
+            "pages": [
+              "ship/deploy",
+              "ship/versioning"
+            ],
+            "expanded": true
+          },
           {
             "group": "Guides",
             "icon": "book-open",

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -112,7 +112,7 @@ deno task deploy
 
 After deployment succeeds, the CLI prints the app's public URL. You're now live!
 
-See [Ship](/ship) for all deployment options.
+See [Deploy](/ship/deploy) for all deployment options.
 
 ## Go Further
 <Columns cols={3}>

--- a/docs/ship/deploy.mdx
+++ b/docs/ship/deploy.mdx
@@ -1,6 +1,7 @@
 ---
-title: "Ship"
-description: "Deploy your app to a stable, public URL"
+title: "Deploy"
+description: "Take your app to production"
+sidebarTitle: "Deploy"
 icon: "cloud-upload"
 ---
 
@@ -132,3 +133,7 @@ bunx vercel deploy --prebuilt
 <Info>
 `.vercel/` is gitignored by [Vercel CLI](https://vercel.com/docs/cli) convention, so the build artifacts stay out of your tracked working tree.
 </Info>
+
+## Path Prefixes
+
+Skybridge can run under a path prefix like `https://your-domain.com/v1/mcp`, reading it from the `x-forwarded-prefix` header to serve assets under that path. This is how you run [several versions of one app](/ship/versioning) on a shared domain.

--- a/docs/ship/index.mdx
+++ b/docs/ship/index.mdx
@@ -1,0 +1,16 @@
+---
+title: "Ship"
+description: "Deploy and version your app"
+icon: "ship"
+---
+
+A deployed MCP App is a server on a public URL where hosts connect to `/mcp` and the built [views](/build/view) are served alongside it. Take it there on any [Node.js](https://nodejs.org/)-compatible platform, then run more than one version of it on the same domain.
+
+<Columns cols={2}>
+    <Card title="Deploy" icon="cloud-upload" href="/ship/deploy">
+        Deploy your app to a stable, public URL
+    </Card>
+    <Card title="Versioning" icon="layers" href="/ship/versioning">
+        Run several versions of one app on the same domain
+    </Card>
+</Columns>

--- a/docs/ship/versioning.mdx
+++ b/docs/ship/versioning.mdx
@@ -1,0 +1,27 @@
+---
+title: "Version Your App"
+description: "Run several versions of one app on the same domain"
+sidebarTitle: "Versioning"
+icon: "layers"
+---
+
+ChatGPT requires every version of an app to live on the same (sub)domain: you can't point `v1` and `v2` at separate hosts. You separate versions by path prefix on that shared origin instead, and a reverse proxy or your cloud platform routes each prefix to its deployment.
+
+```
+https://your-domain.com/v1/mcp   →  version 1
+https://your-domain.com/v2/mcp   →  version 2
+```
+
+## Serve versioned assets
+
+[Views](/build/view) fetch their assets by absolute URL, so a view served under `/v2` must request its bundle from `/v2/assets/...`. Skybridge reads the prefix from the `x-forwarded-prefix` header on each request and prepends it to every asset URL a view emits, alongside the origin it reads from `x-forwarded-host`.
+
+The build is identical across versions: the prefix is applied when the [server](/api-reference/mcp-server) renders the view, not baked into the bundle. One running process serves any number of versions at once, each gets view HTML pointing at its own asset path.
+
+## Set the header
+
+The prefix comes from your infrastructure, not your code: set `x-forwarded-prefix` on each version's route in your reverse proxy or cloud environment, for example `x-forwarded-prefix: /v1`.
+
+<Info>
+**[Alpic](https://app.alpic.ai)** injects `x-forwarded-prefix` natively, so versioned deployments work with no extra configuration. On other providers, make sure the header is set when you [deploy](/ship/deploy).
+</Info>

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -172,6 +172,20 @@ export interface SkybridgeServerOptions {
 }
 
 /**
+ * Normalize an `x-forwarded-prefix` value into a leading-slash, no-trailing-slash
+ * path. Takes the first hop of a comma-separated proxy chain.
+ * "/v1/", "v1", "/v1, /internal" → "/v1"; "", "/", undefined → "".
+ */
+function normalizeForwardedPrefix(raw: string | undefined): string {
+  const firstHop = raw?.split(",")[0]?.trim() ?? "";
+  const trimmed = firstHop.replace(/\/+$/, "");
+  if (trimmed === "") {
+    return "";
+  }
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+}
+
+/**
  * Well-known keys recognized by host runtimes when set on a tool's `_meta`.
  * Use {@link ToolMeta} to also pass arbitrary custom metadata alongside these.
  *
@@ -905,6 +919,7 @@ export class McpServer<
 
   private resolveViewRequestContext(extra: McpExtra | undefined): {
     serverUrl: string;
+    assetsBasePath: string;
     connectDomains: string[];
     contentMetaOverrides: { domain?: string };
   } {
@@ -917,6 +932,13 @@ export class McpServer<
     const isClaude = header("user-agent") === "Claude-User";
 
     const serverUrl = resolveServerOrigin(header);
+    // Path prefix the proxy routed this request under (e.g. `foo.com/v1`). Read
+    // per-request so one process can serve many hosts/prefixes at once: the
+    // origin is recovered from x-forwarded-host, the prefix from
+    // x-forwarded-prefix. Empty when served at the origin root.
+    const assetsBasePath = normalizeForwardedPrefix(
+      header("x-forwarded-prefix"),
+    );
 
     const connectDomains = [serverUrl];
     if (!isProduction) {
@@ -941,7 +963,7 @@ export class McpServer<
       contentMetaOverrides = { domain: `${hash}.claudemcpcontent.com` };
     }
 
-    return { serverUrl, connectDomains, contentMetaOverrides };
+    return { serverUrl, assetsBasePath, connectDomains, contentMetaOverrides };
   }
 
   private registerViewResources(
@@ -1062,18 +1084,23 @@ export class McpServer<
       { description: view.description },
       async (uri, extra) => {
         const isProduction = process.env.NODE_ENV === "production";
-        const { serverUrl } = this.resolveViewRequestContext(extra);
+        const { serverUrl, assetsBasePath } =
+          this.resolveViewRequestContext(extra);
+        // The view resolves all assets (template imports + runtime lazy chunks
+        // via `window.skybridge.serverUrl`) against this base, so it carries the
+        // proxy path prefix. CSP domains in `buildMeta` stay the bare origin.
+        const viewBase = `${serverUrl}${assetsBasePath}`;
 
         const html = isProduction
           ? templateHelper.renderProduction({
               hostType,
-              serverUrl,
+              serverUrl: viewBase,
               viewFile: this.lookupViewFile(view.component),
               styleFile: this.lookupDistFile("style.css") ?? "",
             })
           : templateHelper.renderDevelopment({
               hostType,
-              serverUrl,
+              serverUrl: viewBase,
               viewName: view.component,
             });
 

--- a/packages/core/src/server/view-resource-resolution.test.ts
+++ b/packages/core/src/server/view-resource-resolution.test.ts
@@ -1,7 +1,21 @@
+import http from "node:http";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { afterEach, describe, expect, it } from "vitest";
+import type { RequestHandler } from "express";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { __setBuildManifest, McpServer } from "./index.js";
+
+vi.mock("@skybridge/devtools", () => ({
+  devtoolsStaticServer: () =>
+    ((_req: unknown, _res: unknown, next: () => void) =>
+      next()) as RequestHandler,
+}));
+vi.mock("./viewsDevServer.js", () => ({
+  viewsDevServer: (_httpServer: unknown) =>
+    ((_req: unknown, _res: unknown, next: () => void) =>
+      next()) as RequestHandler,
+}));
 
 // Mirror what the Skybridge Vite plugin generates in `.skybridge/views.d.ts`:
 // narrow `ViewName` so `component: "widget"` typechecks against the registry.
@@ -25,6 +39,39 @@ async function connect(register: (server: McpServer) => void) {
     InMemoryTransport.createLinkedPair();
   await server.connect(serverTransport);
   await client.connect(clientTransport);
+  return {
+    client,
+    teardown: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+let openHttpServer: http.Server | undefined;
+afterEach(() => openHttpServer?.close());
+
+// Connect over real HTTP so forwarded proxy headers reach the resource handler.
+async function connectHttp(
+  register: (server: McpServer) => void,
+  headers: Record<string, string>,
+) {
+  const { createApp } = await import("./express.js");
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  register(server);
+  const httpServer = http.createServer();
+  await createApp({ mcpServer: server, httpServer });
+  const listening = http.createServer(server.express);
+  await new Promise<void>((resolve) => listening.listen(0, resolve));
+  openHttpServer = listening;
+  const port = (listening.address() as { port: number }).port;
+
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  const transport = new StreamableHTTPClientTransport(
+    new URL(`http://localhost:${port}/mcp`),
+    { requestInit: { headers } },
+  );
+  await client.connect(transport);
   return {
     client,
     teardown: async () => {
@@ -123,6 +170,47 @@ describe("view resource resolution (cache key)", () => {
     ).rejects.toThrow();
 
     await teardown();
+  });
+
+  // A proxy routing the request under a path prefix sends x-forwarded-prefix;
+  // the view's asset URLs must carry that prefix (and the forwarded origin) so
+  // they resolve back through the same routing. Per-request, so one process can
+  // serve many hosts/prefixes at once.
+  it("prefixes emitted asset URLs with x-forwarded-prefix (prod)", async () => {
+    process.env.NODE_ENV = "production";
+    __setBuildManifest({
+      "src/views/widget.tsx": {
+        isEntry: true,
+        name: "widget",
+        file: "assets/widget-ABC123.js",
+      },
+      "style.css": { file: "assets/style-XYZ.css" },
+    } as unknown as Record<string, { file: string }>);
+
+    const { client, teardown } = await connectHttp(registerWidget, {
+      "x-forwarded-host": "foo.com",
+      "x-forwarded-proto": "https",
+      "x-forwarded-prefix": "/v1/canary",
+    });
+    try {
+      const { contents } = await client.readResource({
+        uri: "ui://views/ext-apps/widget.html",
+      });
+      const { text } = textContent(contents);
+      // Forwarded origin + prefix. (`assets/assets` is the existing layout: the
+      // manifest `file` already carries `assets/` and the template prepends
+      // `/assets/`; build.tsx's `_redirects` collapses it on the asset host.)
+      expect(text).toContain(
+        "https://foo.com/v1/canary/assets/assets/widget-ABC123.js",
+      );
+      expect(text).toContain(
+        "https://foo.com/v1/canary/assets/assets/style-XYZ.css",
+      );
+      // No unprefixed asset URL leaks through.
+      expect(text).not.toContain("foo.com/assets/");
+    } finally {
+      await teardown();
+    }
   });
 
   // Back-compat: older Skybridge advertised the view at `ui://views/apps-sdk/...`


### PR DESCRIPTION
as of today assets are fetched on scheme+host. openai requires path prefix for versioning, so we need to support reverse proxy routing based on path for the assets to be fetched on the right url. x-forwarded-prefix is an unofficial but accepted way of achieving this. it'll be injected by alpic cloud for instance. refer to doc for more details

docs get a new "Ship" group: deploy + versioning