### PR TITLE
feat(sky-440): Deploy button in devtools

### DIFF
--- a/packages/devtools/e2e/tests/deploy.spec.ts
+++ b/packages/devtools/e2e/tests/deploy.spec.ts
@@ -2,7 +2,6 @@ import { expect, type Page, test } from "@playwright/test";
 
 const TEAM = { id: "t1", name: "Acme" };
 
-/** Mock the deploy router: `/status` (JSON) + `/events` (single SSE frame). */
 async function mockDeploy(
   page: Page,
   opts: {
@@ -49,12 +48,11 @@ test.describe("deploy button", () => {
 
     await deployTrigger(page).hover();
     await expect(page.getByText(/sign in to alpic to deploy/i)).toBeVisible();
-    // Clicking the trigger when signed out runs the same sign-in action as the
-    // in-popover button (avoids hover-popover reposition flakiness).
+    // Click the trigger rather than the in-popover button — same action,
+    // avoids hover-popover reposition flakiness.
     await deployTrigger(page).click();
 
-    // After login the status refetches → the dot turns green (deployed).
-    await expect(deployTrigger(page).locator(".bg-green-500")).toBeVisible();
+    await expect(deployTrigger(page).locator(".bg-success")).toBeVisible();
   });
 
   test("first deploy → modal prefilled with server name + team, surfaces conflict", async ({
@@ -76,7 +74,6 @@ test.describe("deploy button", () => {
     await page.goto("/");
 
     await deployTrigger(page).click();
-    // Default project name comes from the connected MCP server (client-side).
     await expect(page.getByLabel(/project name/i)).toHaveValue("e2e-fixture");
     await expect(page.getByText(/Team:/)).toContainText("Acme");
 
@@ -103,13 +100,11 @@ test.describe("deploy button", () => {
     await page.goto("/");
 
     await deployTrigger(page).click();
-    // Picker trigger defaults to the default team.
-    const picker = page.getByRole("button", { name: /^Acme/ });
-    await expect(picker).toBeVisible();
-    // Switch to the other team.
+    const picker = page.getByRole("combobox");
+    await expect(picker).toHaveText("Acme");
     await picker.click();
-    await page.getByRole("menuitem", { name: /Globex/ }).click();
-    await expect(page.getByRole("button", { name: /^Globex/ })).toBeVisible();
+    await page.getByRole("option", { name: /Globex/ }).click();
+    await expect(picker).toHaveText("Globex");
 
     await page.getByRole("button", { name: /create & deploy/i }).click();
     await expect.poll(() => sentTeamId).toBe("t2");
@@ -130,8 +125,7 @@ test.describe("deploy button", () => {
 
     const deploy = deployTrigger(page);
     await expect(deploy).toBeVisible();
-    // Green status dot for a successfully-deployed project.
-    await expect(deploy.locator(".bg-green-500")).toBeVisible();
+    await expect(deploy.locator(".bg-success")).toBeVisible();
     await deploy.hover();
     await expect(page.getByText("https://my-app.alpic.live")).toBeVisible();
     await expect(
@@ -160,7 +154,6 @@ test.describe("deploy button", () => {
     await expect(deploy).not.toHaveAttribute("aria-disabled", "true");
 
     await deploy.click();
-    // Flips to pending (disabled + pulsing) without waiting on a server frame.
     await expect(deploy).toHaveAttribute("aria-disabled", "true");
     await expect(deploy.locator(".animate-pulse")).toBeVisible();
   });
@@ -177,8 +170,6 @@ test.describe("deploy button", () => {
       progress: {
         status: "deploying",
         phase: "2/4 Uploading source",
-        // Started ~65s ago; the server (mock) replays this same startedAt on
-        // every connection, so the elapsed clock survives a page refresh.
         startedAt: Date.now() - 65_000,
         deploymentPageUrl: "https://app.alpic.ai/p1/logs",
       },
@@ -187,25 +178,19 @@ test.describe("deploy button", () => {
 
     const deploy = deployTrigger(page);
     await expect(deploy).toBeVisible();
-    // Animated orange dot, and the button is disabled (but still hoverable).
     await expect(deploy.locator(".animate-pulse")).toBeVisible();
     await expect(deploy).toHaveAttribute("aria-disabled", "true");
-    // The hover card still opens while deploying, showing progress + logs.
     await deploy.hover();
     await expect(page.getByText("2/4 Uploading source…")).toBeVisible();
     await expect(
       page.getByRole("link", { name: /go to logs/i }),
     ).toHaveAttribute("href", "https://app.alpic.ai/p1/logs");
-    // Elapsed clock reflects the server-provided start (XXm XXs format), which
-    // survives hover remounts + refresh because it's anchored to the SSE frame.
     await expect(page.getByText(/1m \d\ds/)).toBeVisible();
   });
 
   test("ongoing deploy per status → shows progress, not the idle CTA", async ({
     page,
   }) => {
-    // No active SSE progress this session, but the API reports an ongoing
-    // deploy (e.g. after refresh, or triggered by git/elsewhere).
     await mockDeploy(page, {
       status: {
         state: "ready",
@@ -220,7 +205,6 @@ test.describe("deploy button", () => {
     await expect(deploy.locator(".animate-pulse")).toBeVisible();
     await expect(deploy).toHaveAttribute("aria-disabled", "true");
     await deploy.hover();
-    // Deploying card (with logs + counter), never the "Click to deploy" CTA.
     await expect(page.getByText("Deploying…")).toBeVisible();
     await expect(page.getByText(/1m \d\ds/)).toBeVisible();
     await expect(
@@ -250,8 +234,6 @@ test.describe("deploy button", () => {
     });
     await page.goto("/");
 
-    // Main button is gated (disabled) so a git deploy can't be overwritten by a
-    // stray click — but it stays hoverable to show the warning.
     await expect(deployTrigger(page)).toHaveAttribute("aria-disabled", "true");
     await deployTrigger(page).hover();
     await expect(page.getByText(/last deployed from git/i)).toBeVisible();
@@ -259,8 +241,47 @@ test.describe("deploy button", () => {
     await expect(page.getByText("octocat")).toBeVisible();
     await expect(page.getByText(/Fix the thing/)).toBeVisible();
 
-    // Redeploy happens only through the explicit "Deploy anyway". force: the
-    // popover is mid-animation in headless CI, so skip the stability wait.
+    // force: the popover is mid-animation in headless CI, skip the stability wait.
+    await page
+      .getByRole("button", { name: /deploy anyway/i })
+      .click({ force: true });
+    await expect.poll(() => deployCalls).toBeGreaterThan(0);
+  });
+
+  test("stale session 'deployed' + git latest → gate still reachable", async ({
+    page,
+  }) => {
+    let deployCalls = 0;
+    await mockDeploy(page, {
+      status: {
+        state: "ready",
+        lastDeployStatus: "deployed",
+        lastDeployGit: {
+          ref: "main",
+          commitMessage: "Ship it",
+          author: "octocat",
+        },
+        mcpServerUrl: "https://my-app.alpic.live",
+      },
+      progress: {
+        status: "deployed",
+        mcpServerUrl: "https://stale-session.alpic.live",
+        deploymentPageUrl: null,
+      },
+    });
+    await page.route("**/__skybridge/deploy", (route) => {
+      deployCalls += 1;
+      return route.fulfill({ status: 202, json: { ok: true } });
+    });
+    await page.goto("/");
+
+    // The session's replayed "deployed" state must not mask the git gate:
+    // "Deploy anyway" is the only way to redeploy a git-deployed project.
+    await deployTrigger(page).hover();
+    await expect(page.getByText(/last deployed from git/i)).toBeVisible();
+    await expect(
+      page.getByText("https://stale-session.alpic.live"),
+    ).toHaveCount(0);
     await page
       .getByRole("button", { name: /deploy anyway/i })
       .click({ force: true });

--- a/packages/devtools/e2e/tests/deploy.spec.ts
+++ b/packages/devtools/e2e/tests/deploy.spec.ts
@@ -1,0 +1,321 @@
+import { expect, type Page, test } from "@playwright/test";
+
+const TEAM = { id: "t1", name: "Acme" };
+
+/** Mock the deploy router: `/status` (JSON) + `/events` (single SSE frame). */
+async function mockDeploy(
+  page: Page,
+  opts: {
+    status: unknown;
+    progress?: unknown;
+    onStatus?: () => unknown;
+  },
+) {
+  await page.route("**/__skybridge/deploy/events", (route) =>
+    route.fulfill({
+      contentType: "text/event-stream",
+      body: `event: state\ndata: ${JSON.stringify(opts.progress ?? { status: "idle" })}\n\n`,
+    }),
+  );
+  await page.route("**/__skybridge/deploy/status", (route) =>
+    route.fulfill({ json: (opts.onStatus?.() ?? opts.status) as object }),
+  );
+}
+
+const deployTrigger = (page: Page) =>
+  page.getByRole("button", { name: /^Deploy$/ });
+
+test.describe("deploy button", () => {
+  test("signed out → sign-in gate triggers login then re-resolves", async ({
+    page,
+  }) => {
+    let signedIn = false;
+    await page.route("**/__skybridge/deploy/login", (route) => {
+      signedIn = true;
+      return route.fulfill({ json: { ok: true } });
+    });
+    await mockDeploy(page, {
+      status: {},
+      onStatus: () =>
+        signedIn
+          ? {
+              state: "ready",
+              team: TEAM,
+              project: { id: "p1", name: "my-app" },
+              environmentId: "e1",
+              lastDeployStatus: "deployed",
+              mcpServerUrl: "https://my-app.alpic.live",
+            }
+          : { state: "signedOut" },
+    });
+    await page.goto("/");
+
+    await deployTrigger(page).hover();
+    await expect(page.getByText(/sign in to alpic to deploy/i)).toBeVisible();
+    // Clicking the trigger when signed out runs the same sign-in action as the
+    // in-popover button (avoids hover-popover reposition flakiness).
+    await deployTrigger(page).click();
+
+    // After login the status refetches → the dot turns green (deployed).
+    await expect(deployTrigger(page).locator(".bg-green-500")).toBeVisible();
+  });
+
+  test("no team → prompts team creation with a link to Alpic", async ({
+    page,
+  }) => {
+    await mockDeploy(page, { status: { state: "noTeam" } });
+    await page.goto("/");
+
+    await deployTrigger(page).hover();
+    await expect(page.getByText(/no team yet/i)).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /open alpic/i }),
+    ).toHaveAttribute("href", "https://app.alpic.ai");
+  });
+
+  test("first deploy → modal prefilled with server name + team, surfaces conflict", async ({
+    page,
+  }) => {
+    await mockDeploy(page, {
+      status: {
+        state: "needsProject",
+        teams: [TEAM],
+        defaultTeamId: TEAM.id,
+      },
+    });
+    await page.route("**/__skybridge/deploy/project", (route) =>
+      route.fulfill({
+        status: 409,
+        json: { message: "A project with that name already exists." },
+      }),
+    );
+    await page.goto("/");
+
+    await deployTrigger(page).click();
+    // Default project name comes from the connected MCP server (client-side).
+    await expect(page.getByLabel(/project name/i)).toHaveValue("e2e-fixture");
+    await expect(page.getByText(/Team:/)).toContainText("Acme");
+
+    await page.getByRole("button", { name: /create & deploy/i }).click();
+    await expect(page.getByText(/already exists/i)).toBeVisible();
+  });
+
+  test("multiple teams → can switch the target team before deploy", async ({
+    page,
+  }) => {
+    let sentTeamId: string | undefined;
+    await mockDeploy(page, {
+      status: {
+        state: "needsProject",
+        teams: [TEAM, { id: "t2", name: "Globex" }],
+        defaultTeamId: TEAM.id,
+      },
+    });
+    await page.route("**/__skybridge/deploy/project", (route) => {
+      sentTeamId = (route.request().postDataJSON() as { teamId: string })
+        .teamId;
+      return route.fulfill({ status: 202, json: { ok: true } });
+    });
+    await page.goto("/");
+
+    await deployTrigger(page).click();
+    // Picker trigger defaults to the default team.
+    const picker = page.getByRole("button", { name: /^Acme/ });
+    await expect(picker).toBeVisible();
+    // Switch to the other team.
+    await picker.click();
+    await page.getByRole("menuitem", { name: /Globex/ }).click();
+    await expect(page.getByRole("button", { name: /^Globex/ })).toBeVisible();
+
+    await page.getByRole("button", { name: /create & deploy/i }).click();
+    await expect.poll(() => sentTeamId).toBe("t2");
+  });
+
+  test("already deployed → shows live URL + deployment page on load", async ({
+    page,
+  }) => {
+    await mockDeploy(page, {
+      status: {
+        state: "ready",
+        team: TEAM,
+        project: { id: "p1", name: "my-app" },
+        environmentId: "e1",
+        mcpServerUrl: "https://my-app.alpic.live",
+        deploymentPageUrl: "https://app.alpic.ai/p1",
+      },
+    });
+    await page.goto("/");
+
+    const deploy = deployTrigger(page);
+    await expect(deploy).toBeVisible();
+    // Green status dot for a successfully-deployed project.
+    await expect(deploy.locator(".bg-green-500")).toBeVisible();
+    await deploy.hover();
+    await expect(page.getByText("https://my-app.alpic.live")).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /go to deployment page/i }),
+    ).toHaveAttribute("href", "https://app.alpic.ai/p1");
+  });
+
+  test("clicking deploy enters pending immediately (optimistic)", async ({
+    page,
+  }) => {
+    // /events only ever sends idle, so any pending state must be client-side.
+    await mockDeploy(page, {
+      status: {
+        state: "ready",
+        team: TEAM,
+        project: { id: "p1", name: "my-app" },
+        environmentId: "e1",
+        lastDeployStatus: "deployed",
+        mcpServerUrl: "https://my-app.alpic.live",
+      },
+    });
+    await page.route("**/__skybridge/deploy", (route) =>
+      route.fulfill({ status: 202, json: { ok: true } }),
+    );
+    await page.goto("/");
+
+    const deploy = deployTrigger(page);
+    await expect(deploy).toBeVisible();
+    await expect(deploy).not.toHaveAttribute("aria-disabled", "true");
+
+    await deploy.click();
+    // Flips to pending (disabled + pulsing) without waiting on a server frame.
+    await expect(deploy).toHaveAttribute("aria-disabled", "true");
+    await expect(deploy.locator(".animate-pulse")).toBeVisible();
+  });
+
+  test("deploying → orange dot and the button is disabled", async ({
+    page,
+  }) => {
+    await mockDeploy(page, {
+      status: {
+        state: "ready",
+        team: TEAM,
+        project: { id: "p1", name: "my-app" },
+        environmentId: "e1",
+        mcpServerUrl: "https://my-app.alpic.live",
+      },
+      progress: {
+        status: "deploying",
+        phase: "2/4 Uploading source",
+        // Started ~65s ago; the server (mock) replays this same startedAt on
+        // every connection, so the elapsed clock survives a page refresh.
+        startedAt: Date.now() - 65_000,
+        deploymentPageUrl: "https://app.alpic.ai/p1/logs",
+      },
+    });
+    await page.goto("/");
+
+    const deploy = deployTrigger(page);
+    await expect(deploy).toBeVisible();
+    // Animated orange dot, and the button is disabled (but still hoverable).
+    await expect(deploy.locator(".animate-pulse")).toBeVisible();
+    await expect(deploy).toHaveAttribute("aria-disabled", "true");
+    // The hover card still opens while deploying, showing progress + logs.
+    await deploy.hover();
+    await expect(page.getByText("2/4 Uploading source…")).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /go to logs/i }),
+    ).toHaveAttribute("href", "https://app.alpic.ai/p1/logs");
+    // Elapsed clock reflects the server-provided start (XXm XXs format), which
+    // survives hover remounts + refresh because it's anchored to the SSE frame.
+    await expect(page.getByText(/1m \d\ds/)).toBeVisible();
+  });
+
+  test("ongoing deploy per status → shows progress, not the idle CTA", async ({
+    page,
+  }) => {
+    // No active SSE progress this session, but the API reports an ongoing
+    // deploy (e.g. after refresh, or triggered by git/elsewhere).
+    await mockDeploy(page, {
+      status: {
+        state: "ready",
+        team: TEAM,
+        project: { id: "p1", name: "my-app" },
+        environmentId: "e1",
+        lastDeployStatus: "ongoing",
+        lastDeployStartedAt: Date.now() - 65_000,
+        deploymentPageUrl: "https://app.alpic.ai/p1/logs",
+      },
+    });
+    await page.goto("/");
+
+    const deploy = deployTrigger(page);
+    await expect(deploy.locator(".animate-pulse")).toBeVisible();
+    await expect(deploy).toHaveAttribute("aria-disabled", "true");
+    await deploy.hover();
+    // Deploying card (with logs + counter), never the "Click to deploy" CTA.
+    await expect(page.getByText("Deploying…")).toBeVisible();
+    await expect(page.getByText(/1m \d\ds/)).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /go to logs/i }),
+    ).toHaveAttribute("href", "https://app.alpic.ai/p1/logs");
+    await expect(page.getByText(/click to deploy/i)).toHaveCount(0);
+  });
+
+  test("git deploy → main button gated; redeploy only via explicit confirm", async ({
+    page,
+  }) => {
+    let deployCalls = 0;
+    await mockDeploy(page, {
+      status: {
+        state: "ready",
+        team: TEAM,
+        project: { id: "p1", name: "my-app" },
+        environmentId: "e1",
+        lastDeployGit: {
+          ref: "main",
+          commitMessage: "Fix the thing",
+          author: "octocat",
+        },
+      },
+    });
+    await page.route("**/__skybridge/deploy", (route) => {
+      deployCalls += 1;
+      return route.fulfill({ status: 202, json: { ok: true } });
+    });
+    await page.goto("/");
+
+    // Main button is gated (disabled) so a git deploy can't be overwritten by a
+    // stray click — but it stays hoverable to show the warning.
+    await expect(deployTrigger(page)).toHaveAttribute("aria-disabled", "true");
+    await deployTrigger(page).hover();
+    await expect(page.getByText(/last deployed from git/i)).toBeVisible();
+    await expect(page.getByText("main")).toBeVisible();
+    await expect(page.getByText("octocat")).toBeVisible();
+    await expect(page.getByText(/Fix the thing/)).toBeVisible();
+
+    // Redeploy happens only through the explicit "Deploy anyway". force: the
+    // popover is mid-animation in headless CI, so skip the stability wait.
+    await page
+      .getByRole("button", { name: /deploy anyway/i })
+      .click({ force: true });
+    await expect.poll(() => deployCalls).toBeGreaterThan(0);
+  });
+
+  test("failed deploy → shows error with a logs link", async ({ page }) => {
+    await mockDeploy(page, {
+      status: {
+        state: "ready",
+        team: TEAM,
+        project: { id: "p1", name: "my-app" },
+        environmentId: "e1",
+      },
+      progress: {
+        status: "failed",
+        message: "Build failed",
+        deploymentPageUrl: "https://app.alpic.ai/p1/logs",
+      },
+    });
+    await page.goto("/");
+
+    await deployTrigger(page).hover();
+    await expect(page.getByText(/deployment failed/i)).toBeVisible();
+    await expect(page.getByText("Build failed")).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /go to logs/i }),
+    ).toHaveAttribute("href", "https://app.alpic.ai/p1/logs");
+  });
+});

--- a/packages/devtools/e2e/tests/deploy.spec.ts
+++ b/packages/devtools/e2e/tests/deploy.spec.ts
@@ -40,9 +40,6 @@ test.describe("deploy button", () => {
         signedIn
           ? {
               state: "ready",
-              team: TEAM,
-              project: { id: "p1", name: "my-app" },
-              environmentId: "e1",
               lastDeployStatus: "deployed",
               mcpServerUrl: "https://my-app.alpic.live",
             }
@@ -58,19 +55,6 @@ test.describe("deploy button", () => {
 
     // After login the status refetches → the dot turns green (deployed).
     await expect(deployTrigger(page).locator(".bg-green-500")).toBeVisible();
-  });
-
-  test("no team → prompts team creation with a link to Alpic", async ({
-    page,
-  }) => {
-    await mockDeploy(page, { status: { state: "noTeam" } });
-    await page.goto("/");
-
-    await deployTrigger(page).hover();
-    await expect(page.getByText(/no team yet/i)).toBeVisible();
-    await expect(
-      page.getByRole("link", { name: /open alpic/i }),
-    ).toHaveAttribute("href", "https://app.alpic.ai");
   });
 
   test("first deploy → modal prefilled with server name + team, surfaces conflict", async ({
@@ -137,9 +121,7 @@ test.describe("deploy button", () => {
     await mockDeploy(page, {
       status: {
         state: "ready",
-        team: TEAM,
-        project: { id: "p1", name: "my-app" },
-        environmentId: "e1",
+        lastDeployStatus: "deployed",
         mcpServerUrl: "https://my-app.alpic.live",
         deploymentPageUrl: "https://app.alpic.ai/p1",
       },
@@ -164,9 +146,6 @@ test.describe("deploy button", () => {
     await mockDeploy(page, {
       status: {
         state: "ready",
-        team: TEAM,
-        project: { id: "p1", name: "my-app" },
-        environmentId: "e1",
         lastDeployStatus: "deployed",
         mcpServerUrl: "https://my-app.alpic.live",
       },
@@ -192,9 +171,7 @@ test.describe("deploy button", () => {
     await mockDeploy(page, {
       status: {
         state: "ready",
-        team: TEAM,
-        project: { id: "p1", name: "my-app" },
-        environmentId: "e1",
+        lastDeployStatus: "deployed",
         mcpServerUrl: "https://my-app.alpic.live",
       },
       progress: {
@@ -232,9 +209,6 @@ test.describe("deploy button", () => {
     await mockDeploy(page, {
       status: {
         state: "ready",
-        team: TEAM,
-        project: { id: "p1", name: "my-app" },
-        environmentId: "e1",
         lastDeployStatus: "ongoing",
         lastDeployStartedAt: Date.now() - 65_000,
         deploymentPageUrl: "https://app.alpic.ai/p1/logs",
@@ -262,9 +236,7 @@ test.describe("deploy button", () => {
     await mockDeploy(page, {
       status: {
         state: "ready",
-        team: TEAM,
-        project: { id: "p1", name: "my-app" },
-        environmentId: "e1",
+        lastDeployStatus: "deployed",
         lastDeployGit: {
           ref: "main",
           commitMessage: "Fix the thing",
@@ -297,12 +269,7 @@ test.describe("deploy button", () => {
 
   test("failed deploy → shows error with a logs link", async ({ page }) => {
     await mockDeploy(page, {
-      status: {
-        state: "ready",
-        team: TEAM,
-        project: { id: "p1", name: "my-app" },
-        environmentId: "e1",
-      },
+      status: { state: "ready" },
       progress: {
         status: "failed",
         message: "Build failed",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -30,7 +30,7 @@
     "test:e2e:install": "playwright install --with-deps chromium"
   },
   "dependencies": {
-    "@alpic-ai/sdk": "0.0.0-dev.g9fb64c1",
+    "@alpic-ai/sdk": "^1.146.1",
     "@t3-oss/env-core": "^0.13.11",
     "cors": "^2.8.6",
     "express": "^5.2.1",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -19,16 +19,18 @@
     "dev": "vite",
     "build": "tsc -b && vite build && pnpm run build:server",
     "build:server": "tsc -p tsconfig.server.json",
-    "test": "pnpm run test:format && pnpm run test:types",
+    "test": "pnpm run test:format && pnpm run test:types && pnpm run test:unit",
     "format": "biome check --write --error-on-warnings",
     "test:format": "biome ci",
     "test:types": "tsc --noEmit -p e2e/tsconfig.json",
+    "test:unit": "vitest run",
     "preview": "vite preview",
     "e2e:fixture": "tsx ./e2e/fixtures/server.ts",
     "test:e2e": "playwright test --config e2e/playwright.config.ts",
     "test:e2e:install": "playwright install --with-deps chromium"
   },
   "dependencies": {
+    "@alpic-ai/sdk": "^1.145.0",
     "@t3-oss/env-core": "^0.13.11",
     "cors": "^2.8.6",
     "express": "^5.2.1",
@@ -81,6 +83,7 @@
     "tw-animate-css": "^1.4.0",
     "typescript": "~6.0.2",
     "vite": "^8.0.3",
+    "vitest": "^4.1.4",
     "zustand": "^5.0.12"
   }
 }

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -30,7 +30,7 @@
     "test:e2e:install": "playwright install --with-deps chromium"
   },
   "dependencies": {
-    "@alpic-ai/sdk": "^1.145.0",
+    "@alpic-ai/sdk": "0.0.0-dev.g9fb64c1",
     "@t3-oss/env-core": "^0.13.11",
     "cors": "^2.8.6",
     "express": "^5.2.1",

--- a/packages/devtools/src/App.tsx
+++ b/packages/devtools/src/App.tsx
@@ -2,11 +2,13 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { NuqsAdapter } from "nuqs/adapters/react";
 import AppLayout from "./components/layout/app-layout.js";
 import { useDocumentTitle } from "./hooks/use-document-title.js";
+import { useConnectDeploy } from "./lib/deploy-store.js";
 import { queryClient } from "./lib/query-client.js";
 import { useConnectTunnel } from "./lib/tunnel-store.js";
 
 function App() {
   useConnectTunnel();
+  useConnectDeploy();
   useDocumentTitle();
 
   return (

--- a/packages/devtools/src/alpic-sdk.ts
+++ b/packages/devtools/src/alpic-sdk.ts
@@ -1,0 +1,3 @@
+import { Alpic } from "@alpic-ai/sdk";
+
+export const alpic = new Alpic();

--- a/packages/devtools/src/components/layout/deploy-project-dialog.tsx
+++ b/packages/devtools/src/components/layout/deploy-project-dialog.tsx
@@ -36,7 +36,7 @@ export function DeployProjectDialog({
   teams: Team[];
   defaultTeamId: string;
   staleConfig?: boolean;
-  onCreate: (name: string, teamId: string) => Promise<void>;
+  onCreate: (name: string, teamId: string, teamName?: string) => Promise<void>;
 }) {
   const inputId = useId();
   const [name, setName] = useState(defaultName);
@@ -63,7 +63,7 @@ export function DeployProjectDialog({
     setSubmitting(true);
     setError(null);
     try {
-      await onCreate(trimmed, teamId);
+      await onCreate(trimmed, teamId, selectedTeam?.name);
       onOpenChange(false);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to create project");

--- a/packages/devtools/src/components/layout/deploy-project-dialog.tsx
+++ b/packages/devtools/src/components/layout/deploy-project-dialog.tsx
@@ -1,0 +1,155 @@
+import { Button } from "@alpic-ai/ui/components/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@alpic-ai/ui/components/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@alpic-ai/ui/components/dropdown-menu";
+import { Input } from "@alpic-ai/ui/components/input";
+import { Label } from "@alpic-ai/ui/components/label";
+import { Check, ChevronDown } from "lucide-react";
+import { type FormEvent, useEffect, useId, useState } from "react";
+import { cn } from "@/lib/utils.js";
+
+type Team = { id: string; name: string };
+
+export function DeployProjectDialog({
+  open,
+  onOpenChange,
+  defaultName,
+  teams,
+  defaultTeamId,
+  staleConfig,
+  onCreate,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  defaultName: string;
+  teams: Team[];
+  defaultTeamId: string;
+  staleConfig?: boolean;
+  onCreate: (name: string, teamId: string) => Promise<void>;
+}) {
+  const inputId = useId();
+  const [name, setName] = useState(defaultName);
+  const [teamId, setTeamId] = useState(defaultTeamId);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setName(defaultName);
+      setTeamId(defaultTeamId);
+      setError(null);
+    }
+  }, [open, defaultName, defaultTeamId]);
+
+  const trimmed = name.trim();
+  const selectedTeam = teams.find((t) => t.id === teamId) ?? teams[0];
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!trimmed || submitting) {
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onCreate(trimmed, teamId);
+      onOpenChange(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create project");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Deploy to Alpic</DialogTitle>
+          <DialogDescription>
+            {staleConfig
+              ? "The linked project is no longer available. Create a new one to deploy."
+              : "Name your project to create it and run the first deployment."}
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div className="space-y-1.5">
+            <Label htmlFor={inputId}>Project name</Label>
+            <Input
+              id={inputId}
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="my-mcp-app"
+              autoFocus
+            />
+            {teams.length > 1 ? (
+              <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <span>Team:</span>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      type="button"
+                      className="inline-flex cursor-pointer items-center gap-1 rounded px-1 py-0.5 font-medium text-foreground transition-colors hover:bg-background-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                    >
+                      <span>{selectedTeam?.name}</span>
+                      <ChevronDown className="size-3 shrink-0" />
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="start" className="min-w-48">
+                    {teams.map((team) => (
+                      <DropdownMenuItem
+                        key={team.id}
+                        onSelect={() => setTeamId(team.id)}
+                        className="cursor-pointer text-xs"
+                      >
+                        <Check
+                          className={cn(
+                            "size-3.5 shrink-0",
+                            team.id === teamId ? "opacity-100" : "opacity-0",
+                          )}
+                        />
+                        <span className="truncate">{team.name}</span>
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                Team: <span className="font-medium">{selectedTeam?.name}</span>
+              </p>
+            )}
+            {error && <p className="text-xs text-red-500">{error}</p>}
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="primary"
+              disabled={!trimmed || submitting}
+            >
+              {submitting ? "Creating…" : "Create & deploy"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/devtools/src/components/layout/deploy-project-dialog.tsx
+++ b/packages/devtools/src/components/layout/deploy-project-dialog.tsx
@@ -7,17 +7,16 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@alpic-ai/ui/components/dialog";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@alpic-ai/ui/components/dropdown-menu";
 import { Input } from "@alpic-ai/ui/components/input";
 import { Label } from "@alpic-ai/ui/components/label";
-import { Check, ChevronDown } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@alpic-ai/ui/components/select";
 import { type FormEvent, useEffect, useId, useState } from "react";
-import { cn } from "@/lib/utils.js";
 
 type Team = { id: string; name: string };
 
@@ -96,41 +95,32 @@ export function DeployProjectDialog({
             {teams.length > 1 ? (
               <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
                 <span>Team:</span>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <button
-                      type="button"
-                      className="inline-flex cursor-pointer items-center gap-1 rounded px-1 py-0.5 font-medium text-foreground transition-colors hover:bg-background-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                    >
-                      <span>{selectedTeam?.name}</span>
-                      <ChevronDown className="size-3 shrink-0" />
-                    </button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="start" className="min-w-48">
+                <Select value={teamId} onValueChange={setTeamId}>
+                  <SelectTrigger
+                    size="sm"
+                    className="h-6 gap-1 border-none bg-transparent px-1 font-medium text-foreground text-xs shadow-none hover:bg-background-hover"
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent align="start" className="min-w-48">
                     {teams.map((team) => (
-                      <DropdownMenuItem
+                      <SelectItem
                         key={team.id}
-                        onSelect={() => setTeamId(team.id)}
+                        value={team.id}
                         className="cursor-pointer text-xs"
                       >
-                        <Check
-                          className={cn(
-                            "size-3.5 shrink-0",
-                            team.id === teamId ? "opacity-100" : "opacity-0",
-                          )}
-                        />
-                        <span className="truncate">{team.name}</span>
-                      </DropdownMenuItem>
+                        {team.name}
+                      </SelectItem>
                     ))}
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                  </SelectContent>
+                </Select>
               </div>
             ) : (
               <p className="text-xs text-muted-foreground">
                 Team: <span className="font-medium">{selectedTeam?.name}</span>
               </p>
             )}
-            {error && <p className="text-xs text-red-500">{error}</p>}
+            {error && <p className="text-destructive text-xs">{error}</p>}
           </div>
           <DialogFooter>
             <Button

--- a/packages/devtools/src/components/layout/toolbar-actions.tsx
+++ b/packages/devtools/src/components/layout/toolbar-actions.tsx
@@ -568,8 +568,6 @@ function deployDotClass(
         return "bg-red-500";
       case "deployed":
         return "bg-green-500";
-      default:
-        return status.mcpServerUrl ? "bg-green-500" : "bg-gray-400";
     }
   }
   return "bg-gray-400";

--- a/packages/devtools/src/components/layout/toolbar-actions.tsx
+++ b/packages/devtools/src/components/layout/toolbar-actions.tsx
@@ -5,14 +5,14 @@ import {
   PopoverContent,
 } from "@alpic-ai/ui/components/popover";
 import { Separator } from "@alpic-ai/ui/components/separator";
-import { useQuery } from "@tanstack/react-query";
 import {
   Check,
   ClipboardCheck,
   Copy,
+  ExternalLinkIcon,
   Loader2Icon,
   MessagesSquareIcon,
-  RocketIcon,
+  TriangleAlertIcon,
   UnplugIcon,
 } from "lucide-react";
 import {
@@ -27,33 +27,15 @@ import {
   useState,
 } from "react";
 import { useCopyToClipboard } from "@/lib/copy.js";
+import {
+  type DeployProgress,
+  type DeployStatus,
+  useDeployStore,
+} from "@/lib/deploy-store.js";
+import { useServerInfo } from "@/lib/mcp/index.js";
 import { useTunnelStore } from "@/lib/tunnel-store.js";
 import { cn } from "@/lib/utils.js";
-
-type PackageManager = "pnpm" | "npm" | "yarn" | "bun";
-
-const RUN_PREFIX_BY_PM: Record<PackageManager, string> = {
-  pnpm: "pnpm run",
-  npm: "npm run",
-  yarn: "yarn",
-  bun: "bun run",
-};
-
-function useDeployCommand(): string {
-  const { data } = useQuery({
-    queryKey: ["devtools-project"],
-    queryFn: async () => {
-      const res = await fetch("/__skybridge/devtools/project");
-      if (!res.ok) {
-        return { packageManager: "npm" as PackageManager };
-      }
-      return (await res.json()) as { packageManager: PackageManager };
-    },
-    staleTime: Infinity,
-  });
-  const pm = data?.packageManager ?? "npm";
-  return `${RUN_PREFIX_BY_PM[pm]} deploy`;
-}
+import { DeployProjectDialog } from "./deploy-project-dialog.js";
 
 const DOT_BY_STATUS = {
   idle: "bg-gray-400",
@@ -248,50 +230,419 @@ export function AuditButton() {
   );
 }
 
+const ALPIC_APP_URL = "https://app.alpic.ai";
+
 export function DeployButton() {
-  const command = useDeployCommand();
-  const { copied, copy } = useCopyToClipboard();
+  const { status, progress, redeploy, createAndDeploy, signIn } =
+    useDeployStore();
+  const serverInfo = useServerInfo();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [signingIn, setSigningIn] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  // A deploy is in progress per this session's SSE stream, or per the API's
+  // latest deployment (survives refresh / triggered elsewhere) — keep the dot,
+  // the popover, and the disabled state in agreement.
+  const deploying =
+    progress.status === "deploying" ||
+    (status.state === "ready" && status.lastDeployStatus === "ongoing");
+  // A git-linked project routes redeploy through the popover's explicit
+  // "Deploy anyway" (an overwrite guard), so the main button is gated there.
+  const gitGated = status.state === "ready" && !!status.lastDeployGit;
+  // aria-disabled (not the native attribute) so the button stays hoverable —
+  // the popover keeps showing progress/guidance while it's disabled. Only
+  // enabled when a plain click does something (signedOut, needsProject, ready
+  // without a git overwrite to confirm).
+  const disabled =
+    signingIn ||
+    deploying ||
+    gitGated ||
+    status.state === "loading" ||
+    status.state === "noTeam" ||
+    status.state === "error";
+
+  const onSignIn = () => {
+    setActionError(null);
+    setSigningIn(true);
+    signIn()
+      .catch((err) =>
+        setActionError(err instanceof Error ? err.message : "Sign-in failed"),
+      )
+      .finally(() => setSigningIn(false));
+  };
+
+  const doRedeploy = () => {
+    setActionError(null);
+    redeploy().catch((err) =>
+      setActionError(err instanceof Error ? err.message : "Deploy failed"),
+    );
+  };
+
+  const onTriggerClick = () => {
+    setActionError(null);
+    if (status.state === "signedOut") {
+      onSignIn();
+      return;
+    }
+    if (status.state === "ready") {
+      doRedeploy();
+      return;
+    }
+    if (status.state === "needsProject") {
+      setDialogOpen(true);
+    }
+  };
 
   return (
-    <HoverPopover
-      className="w-60"
-      trigger={
-        <Button
-          variant="cta"
-          className="h-8 px-2 gap-1"
-          icon={<RocketIcon className="size-3.5" />}
-          onClick={() => copy(command)}
-        >
-          Deploy
-        </Button>
-      }
-    >
-      <div className="space-y-3">
-        <p
-          className={cn(
-            "text-sm text-muted-foreground py-2 mx-auto text-center",
-            DESCRIPTION_MAX_W,
-          )}
-        >
-          Run this command to deploy your project to the Alpic platform
-        </p>
-        <button
-          type="button"
-          aria-label="Copy command"
-          onClick={() => copy(command)}
-          className="flex w-full items-center gap-2 rounded-md border bg-light-gray px-2 py-1.5 text-left hover:bg-background-hover"
-        >
-          <span className="flex-1 truncate font-mono text-xs">{command}</span>
-          <span className="text-quaternary-foreground">
-            {copied ? (
-              <Check className="size-3.5" />
-            ) : (
-              <Copy className="size-3.5" />
+    <>
+      <HoverPopover
+        className="w-72"
+        trigger={
+          <Button
+            variant="cta"
+            className={cn(
+              "h-8 px-2 gap-1",
+              disabled && "opacity-50 cursor-not-allowed",
             )}
-          </span>
-        </button>
+            aria-disabled={disabled}
+            icon={
+              signingIn ? (
+                <Loader2Icon className="size-3.5 animate-spin" />
+              ) : (
+                <span
+                  className={`h-2 w-2 rounded-full ${deployDotClass(status, progress)}`}
+                  aria-hidden
+                />
+              )
+            }
+            onClick={disabled ? undefined : onTriggerClick}
+          >
+            Deploy
+          </Button>
+        }
+      >
+        <DeployPopoverContent
+          status={status}
+          progress={progress}
+          signingIn={signingIn}
+          actionError={actionError}
+          onRedeploy={doRedeploy}
+          onSignIn={onSignIn}
+        />
+      </HoverPopover>
+      {status.state === "needsProject" && (
+        <DeployProjectDialog
+          open={dialogOpen}
+          onOpenChange={setDialogOpen}
+          defaultName={serverInfo?.name ?? "my-mcp-app"}
+          teams={status.teams}
+          defaultTeamId={status.defaultTeamId}
+          staleConfig={status.staleConfig}
+          onCreate={createAndDeploy}
+        />
+      )}
+    </>
+  );
+}
+
+function DeployPopoverContent({
+  status,
+  progress,
+  signingIn,
+  actionError,
+  onRedeploy,
+  onSignIn,
+}: {
+  status: DeployStatus;
+  progress: DeployProgress;
+  signingIn: boolean;
+  actionError: string | null;
+  onRedeploy: () => void;
+  onSignIn: () => void;
+}) {
+  if (progress.status === "deploying") {
+    return (
+      <DeployingContent
+        phase={progress.phase}
+        startedAt={progress.startedAt}
+        deploymentPageUrl={progress.deploymentPageUrl}
+      />
+    );
+  }
+
+  if (progress.status === "deployed") {
+    return (
+      <div className="space-y-3">
+        <p className="text-sm font-medium">Deployed</p>
+        <CopyUrlRow url={progress.mcpServerUrl} />
+        {progress.deploymentPageUrl && (
+          <>
+            <Separator />
+            <DeploymentPageButton href={progress.deploymentPageUrl} />
+          </>
+        )}
       </div>
-    </HoverPopover>
+    );
+  }
+
+  if (progress.status === "failed") {
+    return (
+      <div className="space-y-2">
+        <p className="text-sm font-medium text-red-500">Deployment failed</p>
+        <p className="text-xs text-muted-foreground">{progress.message}</p>
+        {progress.deploymentPageUrl && (
+          <>
+            <Separator />
+            <ExternalLinkRow
+              href={progress.deploymentPageUrl}
+              label="Go to logs"
+            />
+          </>
+        )}
+      </div>
+    );
+  }
+
+  // progress idle → reflect readiness/auth status
+  switch (status.state) {
+    case "loading":
+      return <p className="text-sm text-muted-foreground">Checking Alpic…</p>;
+    case "signedOut":
+      return (
+        <div className="space-y-2">
+          <p className="text-sm font-medium">Sign in to Alpic to deploy</p>
+          <p className="text-xs text-muted-foreground">
+            Connect your Alpic account to deploy this server.
+          </p>
+          <Button
+            variant="primary"
+            className="h-7 w-full"
+            disabled={signingIn}
+            onClick={onSignIn}
+          >
+            {signingIn ? "Signing in…" : "Sign in to Alpic"}
+          </Button>
+          {actionError && <p className="text-xs text-red-500">{actionError}</p>}
+        </div>
+      );
+    case "noTeam":
+      return (
+        <div className="space-y-2">
+          <p className="text-sm font-medium">No team yet</p>
+          <p className="text-xs text-muted-foreground">
+            Create a team on Alpic before deploying.
+          </p>
+          <ExternalLinkRow href={ALPIC_APP_URL} label="Open Alpic" />
+        </div>
+      );
+    case "needsProject":
+      return <p className="text-sm">Click to deploy to Alpic</p>;
+    case "ready":
+      // A deploy is running (this session's SSE stream ended, or it was
+      // triggered elsewhere/by git) — show progress, not the idle CTA.
+      if (status.lastDeployStatus === "ongoing") {
+        return (
+          <DeployingContent
+            phase="Deploying"
+            startedAt={status.lastDeployStartedAt ?? null}
+            deploymentPageUrl={status.deploymentPageUrl ?? null}
+          />
+        );
+      }
+      return (
+        <div className="space-y-2">
+          <p className="text-sm">Click to deploy to Alpic</p>
+          {status.mcpServerUrl && (
+            <>
+              <p className="text-xs font-medium text-muted-foreground">
+                Last Deployment:
+              </p>
+              <CopyUrlRow url={status.mcpServerUrl} />
+            </>
+          )}
+          {status.deploymentPageUrl && (
+            <>
+              <Separator />
+              <DeploymentPageButton href={status.deploymentPageUrl} />
+            </>
+          )}
+          {status.lastDeployGit && (
+            <div className="space-y-2 rounded-md border border-orange-300 bg-orange-50 p-2">
+              <p className="flex items-center gap-1.5 text-xs text-orange-700">
+                <TriangleAlertIcon className="size-3.5 shrink-0" />
+                Last deployed from Git — redeploying replaces it.
+              </p>
+              <GitDeployInfo git={status.lastDeployGit} />
+              <Button
+                variant="primary"
+                className="h-7 w-full"
+                onClick={onRedeploy}
+              >
+                Deploy anyway
+              </Button>
+            </div>
+          )}
+          {actionError && <p className="text-xs text-red-500">{actionError}</p>}
+        </div>
+      );
+    case "error":
+      return <p className="text-xs text-red-500">{status.message}</p>;
+  }
+}
+
+function formatElapsed(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return minutes > 0
+    ? `${minutes}m ${String(seconds).padStart(2, "0")}s`
+    : `${seconds}s`;
+}
+
+function DeployingContent({
+  phase,
+  startedAt,
+  deploymentPageUrl,
+}: {
+  phase: string;
+  // Anchored to the server-provided start (replayed over SSE, or the latest
+  // deployment's startedAt on reconnect) so the clock survives hover remounts
+  // and page refreshes. Absent only when no start is known.
+  startedAt: number | null;
+  deploymentPageUrl: string | null;
+}) {
+  const [elapsedMs, setElapsedMs] = useState(() =>
+    startedAt == null ? 0 : Date.now() - startedAt,
+  );
+  useEffect(() => {
+    if (startedAt == null) {
+      return;
+    }
+    const tick = () => setElapsedMs(Date.now() - startedAt);
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [startedAt]);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <Loader2Icon className="size-3.5 shrink-0 animate-spin" />
+        <p className="text-sm">{phase}…</p>
+        {startedAt != null && (
+          <span className="ml-auto font-mono text-xs text-muted-foreground">
+            {formatElapsed(elapsedMs)}
+          </span>
+        )}
+      </div>
+      {deploymentPageUrl && (
+        <>
+          <Separator />
+          <ExternalLinkRow href={deploymentPageUrl} label="Go to logs" />
+        </>
+      )}
+    </div>
+  );
+}
+
+function deployDotClass(
+  status: DeployStatus,
+  progress: DeployProgress,
+): string {
+  if (progress.status === "deploying") {
+    return "bg-orange-500 animate-pulse";
+  }
+  if (progress.status === "failed") {
+    return "bg-red-500";
+  }
+  if (progress.status === "deployed") {
+    return "bg-green-500";
+  }
+  // No active deploy this session — reflect the linked project's last deploy.
+  if (status.state === "ready") {
+    switch (status.lastDeployStatus) {
+      case "ongoing":
+        return "bg-orange-500 animate-pulse";
+      case "failed":
+      case "canceled":
+        return "bg-red-500";
+      case "deployed":
+        return "bg-green-500";
+      default:
+        return status.mcpServerUrl ? "bg-green-500" : "bg-gray-400";
+    }
+  }
+  return "bg-gray-400";
+}
+
+function CopyUrlRow({ url }: { url: string }) {
+  const { copied, copy } = useCopyToClipboard();
+  return (
+    <button
+      type="button"
+      aria-label="Copy MCP server URL"
+      onClick={() => copy(url)}
+      className="flex w-full items-center gap-2 rounded-md border bg-light-gray px-2 py-1.5 text-left hover:bg-background-hover"
+    >
+      <span className="flex-1 truncate font-mono text-xs">{url}</span>
+      <span className="text-quaternary-foreground">
+        {copied ? (
+          <Check className="size-3.5" />
+        ) : (
+          <Copy className="size-3.5" />
+        )}
+      </span>
+    </button>
+  );
+}
+
+function DeploymentPageButton({ href }: { href: string }) {
+  return (
+    <Button asChild variant="tertiary" className="w-full">
+      <a href={href} target="_blank" rel="noreferrer noopener">
+        <ExternalLinkIcon className="size-3.5" />
+        Go to deployment page
+      </a>
+    </Button>
+  );
+}
+
+function GitDeployInfo({
+  git,
+}: {
+  git: {
+    ref: string | null;
+    commitMessage: string | null;
+    author: string | null;
+  };
+}) {
+  if (!git.ref && !git.commitMessage && !git.author) {
+    return null;
+  }
+  return (
+    <div className="space-y-0.5 text-xs text-orange-700/90">
+      {git.ref && (
+        <p>
+          Branch <span className="font-mono">{git.ref}</span>
+          {git.author && <> · by {git.author}</>}
+        </p>
+      )}
+      {git.commitMessage && <p className="truncate">“{git.commitMessage}”</p>}
+    </div>
+  );
+}
+
+function ExternalLinkRow({ href, label }: { href: string; label: string }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+    >
+      <ExternalLinkIcon className="size-3.5" />
+      {label}
+    </a>
   );
 }
 

--- a/packages/devtools/src/components/layout/toolbar-actions.tsx
+++ b/packages/devtools/src/components/layout/toolbar-actions.tsx
@@ -1,3 +1,4 @@
+import { WarningAlert } from "@alpic-ai/ui/components/alert";
 import { Button } from "@alpic-ai/ui/components/button";
 import {
   Popover,
@@ -5,14 +6,17 @@ import {
   PopoverContent,
 } from "@alpic-ai/ui/components/popover";
 import { Separator } from "@alpic-ai/ui/components/separator";
+import { Spinner } from "@alpic-ai/ui/components/spinner";
+import {
+  StatusDot,
+  type StatusDotVariantProps,
+} from "@alpic-ai/ui/components/status-dot";
 import {
   Check,
   ClipboardCheck,
   Copy,
   ExternalLinkIcon,
-  Loader2Icon,
   MessagesSquareIcon,
-  TriangleAlertIcon,
   UnplugIcon,
 } from "lucide-react";
 import {
@@ -38,11 +42,11 @@ import { cn } from "@/lib/utils.js";
 import { DeployProjectDialog } from "./deploy-project-dialog.js";
 
 const DOT_BY_STATUS = {
-  idle: "bg-gray-400",
-  starting: "bg-orange-500 animate-pulse",
-  connected: "bg-green-500",
-  error: "bg-red-500",
-} as const;
+  idle: { variant: "muted", pulse: false },
+  starting: { variant: "warning", pulse: true },
+  connected: { variant: "success", pulse: false },
+  error: { variant: "destructive", pulse: false },
+} as const satisfies Record<string, StatusDotVariantProps>;
 
 const HOVER_CLOSE_DELAY_MS = 120;
 const DESCRIPTION_MAX_W = "max-w-[200px]";
@@ -174,11 +178,7 @@ function TunnelLinkButton({
           aria-disabled={isDisabled}
           className={cn(isDisabled && "opacity-50 cursor-not-allowed")}
           icon={
-            isLaunching ? (
-              <Loader2Icon className="size-3.5 animate-spin" />
-            ) : (
-              icon
-            )
+            isLaunching ? <Spinner size="sm" className="text-current" /> : icon
           }
           onClick={isDisabled ? undefined : onClick}
         >
@@ -240,19 +240,12 @@ export function DeployButton() {
   const [signingIn, setSigningIn] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
 
-  // A deploy is in progress per this session's SSE stream, or per the API's
-  // latest deployment (survives refresh / triggered elsewhere) — keep the dot,
-  // the popover, and the disabled state in agreement.
   const deploying =
     progress.status === "deploying" ||
     (status.state === "ready" && status.lastDeployStatus === "ongoing");
-  // A git-linked project routes redeploy through the popover's explicit
-  // "Deploy anyway" (an overwrite guard), so the main button is gated there.
   const gitGated = status.state === "ready" && !!status.lastDeployGit;
-  // aria-disabled (not the native attribute) so the button stays hoverable —
-  // the popover keeps showing progress/guidance while it's disabled. Only
-  // enabled when a plain click does something (signedOut, needsProject, ready
-  // without a git overwrite to confirm).
+  // aria-disabled (not the native attribute) so the button stays hoverable and
+  // the popover keeps showing progress/guidance while disabled.
   const disabled =
     signingIn ||
     deploying ||
@@ -307,10 +300,11 @@ export function DeployButton() {
             aria-disabled={disabled}
             icon={
               signingIn ? (
-                <Loader2Icon className="size-3.5 animate-spin" />
+                <Spinner size="sm" className="text-current" />
               ) : (
-                <span
-                  className={`h-2 w-2 rounded-full ${deployDotClass(status, progress)}`}
+                <StatusDot
+                  className="size-2"
+                  {...deployDotVariant(status, progress)}
                   aria-hidden
                 />
               )
@@ -370,7 +364,9 @@ function DeployPopoverContent({
     );
   }
 
-  if (progress.status === "deployed") {
+  const gitGated = status.state === "ready" && !!status.lastDeployGit;
+
+  if (progress.status === "deployed" && !gitGated) {
     return (
       <div className="space-y-3">
         <p className="text-sm font-medium">Deployed</p>
@@ -385,10 +381,12 @@ function DeployPopoverContent({
     );
   }
 
-  if (progress.status === "failed") {
+  if (progress.status === "failed" && !gitGated) {
     return (
       <div className="space-y-2">
-        <p className="text-sm font-medium text-red-500">Deployment failed</p>
+        <p className="text-sm font-medium text-destructive">
+          Deployment failed
+        </p>
         <p className="text-xs text-muted-foreground">{progress.message}</p>
         {progress.deploymentPageUrl && (
           <>
@@ -403,7 +401,6 @@ function DeployPopoverContent({
     );
   }
 
-  // progress idle → reflect readiness/auth status
   switch (status.state) {
     case "loading":
       return <p className="text-sm text-muted-foreground">Checking Alpic…</p>;
@@ -422,7 +419,9 @@ function DeployPopoverContent({
           >
             {signingIn ? "Signing in…" : "Sign in to Alpic"}
           </Button>
-          {actionError && <p className="text-xs text-red-500">{actionError}</p>}
+          {actionError && (
+            <p className="text-xs text-destructive">{actionError}</p>
+          )}
         </div>
       );
     case "noTeam":
@@ -438,8 +437,6 @@ function DeployPopoverContent({
     case "needsProject":
       return <p className="text-sm">Click to deploy to Alpic</p>;
     case "ready":
-      // A deploy is running (this session's SSE stream ended, or it was
-      // triggered elsewhere/by git) — show progress, not the idle CTA.
       if (status.lastDeployStatus === "ongoing") {
         return (
           <DeployingContent
@@ -451,7 +448,9 @@ function DeployPopoverContent({
       }
       return (
         <div className="space-y-2">
-          <p className="text-sm">Click to deploy to Alpic</p>
+          {!status.lastDeployGit && (
+            <p className="text-sm">Click to deploy to Alpic</p>
+          )}
           {status.mcpServerUrl && (
             <>
               <p className="text-xs font-medium text-muted-foreground">
@@ -467,26 +466,30 @@ function DeployPopoverContent({
             </>
           )}
           {status.lastDeployGit && (
-            <div className="space-y-2 rounded-md border border-orange-300 bg-orange-50 p-2">
-              <p className="flex items-center gap-1.5 text-xs text-orange-700">
-                <TriangleAlertIcon className="size-3.5 shrink-0" />
-                Last deployed from Git — redeploying replaces it.
-              </p>
-              <GitDeployInfo git={status.lastDeployGit} />
-              <Button
-                variant="primary"
-                className="h-7 w-full"
-                onClick={onRedeploy}
-              >
-                Deploy anyway
-              </Button>
-            </div>
+            <WarningAlert
+              className="px-3 py-2"
+              title="Last deployed from Git — redeploying replaces it."
+              description={
+                <div className="space-y-2">
+                  <GitDeployInfo git={status.lastDeployGit} />
+                  <Button
+                    variant="primary"
+                    className="h-7 w-full"
+                    onClick={onRedeploy}
+                  >
+                    Deploy anyway
+                  </Button>
+                </div>
+              }
+            />
           )}
-          {actionError && <p className="text-xs text-red-500">{actionError}</p>}
+          {actionError && (
+            <p className="text-xs text-destructive">{actionError}</p>
+          )}
         </div>
       );
     case "error":
-      return <p className="text-xs text-red-500">{status.message}</p>;
+      return <p className="text-xs text-destructive">{status.message}</p>;
   }
 }
 
@@ -505,9 +508,8 @@ function DeployingContent({
   deploymentPageUrl,
 }: {
   phase: string;
-  // Anchored to the server-provided start (replayed over SSE, or the latest
-  // deployment's startedAt on reconnect) so the clock survives hover remounts
-  // and page refreshes. Absent only when no start is known.
+  // Server-provided start, so the elapsed clock survives hover remounts and
+  // page refreshes.
   startedAt: number | null;
   deploymentPageUrl: string | null;
 }) {
@@ -527,7 +529,7 @@ function DeployingContent({
   return (
     <div className="space-y-2">
       <div className="flex items-center gap-2">
-        <Loader2Icon className="size-3.5 shrink-0 animate-spin" />
+        <Spinner size="sm" className="shrink-0 text-current" />
         <p className="text-sm">{phase}…</p>
         {startedAt != null && (
           <span className="ml-auto font-mono text-xs text-muted-foreground">
@@ -545,32 +547,32 @@ function DeployingContent({
   );
 }
 
-function deployDotClass(
+function deployDotVariant(
   status: DeployStatus,
   progress: DeployProgress,
-): string {
+): StatusDotVariantProps {
   if (progress.status === "deploying") {
-    return "bg-orange-500 animate-pulse";
+    return { variant: "warning", pulse: true };
   }
-  if (progress.status === "failed") {
-    return "bg-red-500";
+  const gitGated = status.state === "ready" && !!status.lastDeployGit;
+  if (progress.status === "failed" && !gitGated) {
+    return { variant: "destructive", pulse: false };
   }
-  if (progress.status === "deployed") {
-    return "bg-green-500";
+  if (progress.status === "deployed" && !gitGated) {
+    return { variant: "success", pulse: false };
   }
-  // No active deploy this session — reflect the linked project's last deploy.
   if (status.state === "ready") {
     switch (status.lastDeployStatus) {
       case "ongoing":
-        return "bg-orange-500 animate-pulse";
+        return { variant: "warning", pulse: true };
       case "failed":
       case "canceled":
-        return "bg-red-500";
+        return { variant: "destructive", pulse: false };
       case "deployed":
-        return "bg-green-500";
+        return { variant: "success", pulse: false };
     }
   }
-  return "bg-gray-400";
+  return { variant: "muted", pulse: false };
 }
 
 function CopyUrlRow({ url }: { url: string }) {
@@ -618,7 +620,7 @@ function GitDeployInfo({
     return null;
   }
   return (
-    <div className="space-y-0.5 text-xs text-orange-700/90">
+    <div className="space-y-0.5 text-xs">
       {git.ref && (
         <p>
           Branch <span className="font-mono">{git.ref}</span>
@@ -663,8 +665,9 @@ export function TunnelButton() {
       )}
       trigger={
         <Button variant="secondary" onClick={onClick}>
-          <span
-            className={`h-2 w-2 rounded-full ${DOT_BY_STATUS[state.status]}`}
+          <StatusDot
+            className="size-2"
+            {...DOT_BY_STATUS[state.status]}
             aria-hidden
           />
           {mcpUrl ? (
@@ -732,14 +735,11 @@ function StartingContent({ message }: { message: string }) {
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-center gap-2">
-        <span
-          className="h-2 w-2 rounded-full bg-orange-500 animate-pulse"
-          aria-hidden
-        />
+        <StatusDot className="size-2" variant="warning" pulse aria-hidden />
         <p className={cn("text-sm text-muted-foreground", DESCRIPTION_MAX_W)}>
           {message}
         </p>
-        <Loader2Icon className="size-3.5 animate-spin" />
+        <Spinner size="sm" className="text-current" />
       </div>
     </div>
   );

--- a/packages/devtools/src/components/layout/toolbar-actions.tsx
+++ b/packages/devtools/src/components/layout/toolbar-actions.tsx
@@ -468,7 +468,7 @@ function DeployPopoverContent({
           {status.lastDeployGit && (
             <WarningAlert
               className="px-3 py-2"
-              title="Last deployed from Git — redeploying replaces it."
+              title="Last deployed from Git"
               description={
                 <div className="space-y-2">
                   <GitDeployInfo git={status.lastDeployGit} />

--- a/packages/devtools/src/deploy-router.test.ts
+++ b/packages/devtools/src/deploy-router.test.ts
@@ -1,9 +1,11 @@
 import http from "node:http";
+import type { Alpic } from "@alpic-ai/sdk";
 import express from "express";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeployRouter } from "./deploy-router.js";
 
-type Alpic = NonNullable<Parameters<typeof createDeployRouter>[0]>;
+const mock = vi.hoisted(() => ({ alpic: {} as Record<string, unknown> }));
+vi.mock("./alpic-sdk.js", () => ({ alpic: mock.alpic }));
 
 const cleanups: Array<() => Promise<void>> = [];
 
@@ -47,9 +49,10 @@ function fakeAlpic(overrides: {
 }
 
 async function start(alpic: Alpic) {
+  Object.assign(mock.alpic, alpic);
   const app = express();
   app.use(express.json());
-  app.use(createDeployRouter(alpic));
+  app.use(createDeployRouter());
   const server = http.createServer(app);
   await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
   const port = (server.address() as { port: number }).port;

--- a/packages/devtools/src/deploy-router.test.ts
+++ b/packages/devtools/src/deploy-router.test.ts
@@ -1,0 +1,157 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import http from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import express from "express";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeployRouter } from "./deploy-router.js";
+
+type Alpic = NonNullable<Parameters<typeof createDeployRouter>[0]>;
+
+const cleanups: Array<() => Promise<void>> = [];
+
+// Isolate cwd per test: the router reads/writes `.alpic/project.json` against
+// process.cwd(), so a fresh tmp dir keeps tests independent and pollution-free.
+let originalCwd: string;
+let tmpCwd: string;
+beforeEach(() => {
+  originalCwd = process.cwd();
+  tmpCwd = mkdtempSync(join(tmpdir(), "deploy-router-"));
+  process.chdir(tmpCwd);
+});
+
+afterEach(async () => {
+  while (cleanups.length > 0) {
+    await cleanups.pop()?.();
+  }
+  process.chdir(originalCwd);
+  rmSync(tmpCwd, { recursive: true, force: true });
+});
+
+function fakeAlpic(overrides: {
+  whoami?: unknown;
+  teams?: unknown[];
+  projects?: { id: string; name: string }[];
+}): Alpic {
+  return {
+    whoami: vi.fn().mockResolvedValue(overrides.whoami ?? { method: "oauth" }),
+    api: {
+      teams: { list: { v1: vi.fn().mockResolvedValue(overrides.teams ?? []) } },
+      projects: {
+        list: { v1: vi.fn().mockResolvedValue(overrides.projects ?? []) },
+        create: {
+          v1: vi.fn().mockResolvedValue({
+            id: "p-new",
+            teamId: "t1",
+            name: "ok",
+            productionEnvironment: { id: "env-1", name: "production" },
+          }),
+        },
+        get: { v1: vi.fn() },
+      },
+    },
+    deployments: {
+      getLatestForEnvironment: vi.fn(),
+      deploy: vi.fn().mockResolvedValue({ status: "deployed" }),
+    },
+  } as unknown as Alpic;
+}
+
+async function start(alpic: Alpic) {
+  const app = express();
+  app.use(express.json());
+  app.use(createDeployRouter(alpic));
+  const server = http.createServer(app);
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const port = (server.address() as { port: number }).port;
+  cleanups.push(() => new Promise<void>((r) => server.close(() => r())));
+  return `http://127.0.0.1:${port}/__skybridge/deploy`;
+}
+
+describe("deploy-router /status", () => {
+  it("reports signedOut when unauthenticated", async () => {
+    const base = await start(
+      fakeAlpic({ whoami: { method: "unauthenticated" } }),
+    );
+    const res = await fetch(`${base}/status`);
+    expect(await res.json()).toEqual({ state: "signedOut" });
+  });
+
+  it("reports noTeam when the user has no teams", async () => {
+    const base = await start(fakeAlpic({ teams: [] }));
+    const res = await fetch(`${base}/status`);
+    expect(await res.json()).toEqual({ state: "noTeam" });
+  });
+
+  it("reports needsProject with all teams + a default team", async () => {
+    const base = await start(
+      fakeAlpic({
+        teams: [
+          { id: "t1", name: "Acme" },
+          { id: "t2", name: "Globex" },
+        ],
+      }),
+    );
+    const res = await fetch(`${base}/status`);
+    // No .alpic/project.json in the per-test tmp cwd → first-deploy state.
+    expect(await res.json()).toMatchObject({
+      state: "needsProject",
+      defaultTeamId: "t1",
+      teams: [
+        { id: "t1", name: "Acme" },
+        { id: "t2", name: "Globex" },
+      ],
+    });
+  });
+});
+
+describe("deploy-router POST /project", () => {
+  it("409s on a name conflict instead of creating", async () => {
+    const alpic = fakeAlpic({
+      teams: [{ id: "t1", name: "Acme" }],
+      projects: [{ id: "p1", name: "taken" }],
+    });
+    const base = await start(alpic);
+    const res = await fetch(`${base}/project`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "taken", teamId: "t1" }),
+    });
+    expect(res.status).toBe(409);
+    expect(alpic.api.projects.create.v1).not.toHaveBeenCalled();
+  });
+
+  it("prechecks + creates under the submitted team, not the default", async () => {
+    const alpic = fakeAlpic({ teams: [{ id: "t1", name: "Acme" }] });
+    const base = await start(alpic);
+    const res = await fetch(`${base}/project`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "fresh", teamId: "t2" }),
+    });
+    expect(res.status).toBe(202);
+    expect(alpic.api.projects.list.v1).toHaveBeenCalledWith({ teamId: "t2" });
+    expect(alpic.api.projects.create.v1).toHaveBeenCalledWith(
+      expect.objectContaining({ teamId: "t2", name: "fresh" }),
+    );
+  });
+
+  it("still writes config (no orphan) when the post-create team lookup fails", async () => {
+    const alpic = fakeAlpic({ teams: [{ id: "t1", name: "Acme" }] });
+    // The teamName lookup after create fails — must not 502 or skip saveConfig.
+    (alpic.api.teams.list.v1 as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("boom"),
+    );
+    const base = await start(alpic);
+    const res = await fetch(`${base}/project`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "fresh", teamId: "t1" }),
+    });
+    expect(res.status).toBe(202);
+    const cfg = JSON.parse(
+      readFileSync(join(process.cwd(), ".alpic", "project.json"), "utf8"),
+    );
+    expect(cfg.projectId).toBe("p-new");
+  });
+});

--- a/packages/devtools/src/deploy-router.test.ts
+++ b/packages/devtools/src/deploy-router.test.ts
@@ -121,37 +121,22 @@ describe("deploy-router POST /project", () => {
     expect(alpic.api.projects.create.v1).not.toHaveBeenCalled();
   });
 
-  it("prechecks + creates under the submitted team, not the default", async () => {
+  it("prechecks + creates under the submitted team, then writes config", async () => {
     const alpic = fakeAlpic({ teams: [{ id: "t1", name: "Acme" }] });
     const base = await start(alpic);
     const res = await fetch(`${base}/project`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name: "fresh", teamId: "t2" }),
+      body: JSON.stringify({ name: "fresh", teamId: "t2", teamName: "Globex" }),
     });
     expect(res.status).toBe(202);
     expect(alpic.api.projects.list.v1).toHaveBeenCalledWith({ teamId: "t2" });
     expect(alpic.api.projects.create.v1).toHaveBeenCalledWith(
       expect.objectContaining({ teamId: "t2", name: "fresh" }),
     );
-  });
-
-  it("still writes config (no orphan) when the post-create team lookup fails", async () => {
-    const alpic = fakeAlpic({ teams: [{ id: "t1", name: "Acme" }] });
-    // The teamName lookup after create fails — must not 502 or skip saveConfig.
-    (alpic.api.teams.list.v1 as ReturnType<typeof vi.fn>).mockRejectedValue(
-      new Error("boom"),
-    );
-    const base = await start(alpic);
-    const res = await fetch(`${base}/project`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name: "fresh", teamId: "t1" }),
-    });
-    expect(res.status).toBe(202);
     const cfg = JSON.parse(
       readFileSync(join(process.cwd(), ".alpic", "project.json"), "utf8"),
     );
-    expect(cfg.projectId).toBe("p-new");
+    expect(cfg).toMatchObject({ projectId: "p-new", teamName: "Globex" });
   });
 });

--- a/packages/devtools/src/deploy-router.test.ts
+++ b/packages/devtools/src/deploy-router.test.ts
@@ -1,31 +1,16 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import http from "node:http";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import express from "express";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeployRouter } from "./deploy-router.js";
 
 type Alpic = NonNullable<Parameters<typeof createDeployRouter>[0]>;
 
 const cleanups: Array<() => Promise<void>> = [];
 
-// Isolate cwd per test: the router reads/writes `.alpic/project.json` against
-// process.cwd(), so a fresh tmp dir keeps tests independent and pollution-free.
-let originalCwd: string;
-let tmpCwd: string;
-beforeEach(() => {
-  originalCwd = process.cwd();
-  tmpCwd = mkdtempSync(join(tmpdir(), "deploy-router-"));
-  process.chdir(tmpCwd);
-});
-
 afterEach(async () => {
   while (cleanups.length > 0) {
     await cleanups.pop()?.();
   }
-  process.chdir(originalCwd);
-  rmSync(tmpCwd, { recursive: true, force: true });
 });
 
 function fakeAlpic(overrides: {
@@ -39,16 +24,20 @@ function fakeAlpic(overrides: {
       teams: { list: { v1: vi.fn().mockResolvedValue(overrides.teams ?? []) } },
       projects: {
         list: { v1: vi.fn().mockResolvedValue(overrides.projects ?? []) },
-        create: {
-          v1: vi.fn().mockResolvedValue({
-            id: "p-new",
-            teamId: "t1",
-            name: "ok",
-            productionEnvironment: { id: "env-1", name: "production" },
-          }),
-        },
-        get: { v1: vi.fn() },
       },
+    },
+    projects: {
+      loadConfig: vi.fn().mockReturnValue(null),
+      validateLink: vi.fn().mockImplementation(async (cfg) => cfg),
+      detectRuntime: vi.fn().mockReturnValue(null),
+      createLinked: vi.fn().mockResolvedValue({
+        projectId: "p-new",
+        teamId: "t1",
+        teamName: "Globex",
+        projectName: "ok",
+        environmentId: "env-1",
+        environmentName: "production",
+      }),
     },
     deployments: {
       getLatestForEnvironment: vi.fn(),
@@ -93,7 +82,6 @@ describe("deploy-router /status", () => {
       }),
     );
     const res = await fetch(`${base}/status`);
-    // No .alpic/project.json in the per-test tmp cwd → first-deploy state.
     expect(await res.json()).toMatchObject({
       state: "needsProject",
       defaultTeamId: "t1",
@@ -101,6 +89,22 @@ describe("deploy-router /status", () => {
         { id: "t1", name: "Acme" },
         { id: "t2", name: "Globex" },
       ],
+    });
+  });
+
+  it("flags staleConfig when the linked project no longer validates", async () => {
+    const alpic = fakeAlpic({ teams: [{ id: "t1", name: "Acme" }] });
+    vi.mocked(alpic.projects.loadConfig).mockReturnValue({
+      projectId: "gone",
+      teamId: "t1",
+      projectName: "old",
+    });
+    vi.mocked(alpic.projects.validateLink).mockResolvedValue(null);
+    const base = await start(alpic);
+    const res = await fetch(`${base}/status`);
+    expect(await res.json()).toMatchObject({
+      state: "needsProject",
+      staleConfig: true,
     });
   });
 });
@@ -118,10 +122,10 @@ describe("deploy-router POST /project", () => {
       body: JSON.stringify({ name: "taken", teamId: "t1" }),
     });
     expect(res.status).toBe(409);
-    expect(alpic.api.projects.create.v1).not.toHaveBeenCalled();
+    expect(alpic.projects.createLinked).not.toHaveBeenCalled();
   });
 
-  it("prechecks + creates under the submitted team, then writes config", async () => {
+  it("prechecks the submitted team, then creates the linked project", async () => {
     const alpic = fakeAlpic({ teams: [{ id: "t1", name: "Acme" }] });
     const base = await start(alpic);
     const res = await fetch(`${base}/project`, {
@@ -131,12 +135,11 @@ describe("deploy-router POST /project", () => {
     });
     expect(res.status).toBe(202);
     expect(alpic.api.projects.list.v1).toHaveBeenCalledWith({ teamId: "t2" });
-    expect(alpic.api.projects.create.v1).toHaveBeenCalledWith(
-      expect.objectContaining({ teamId: "t2", name: "fresh" }),
-    );
-    const cfg = JSON.parse(
-      readFileSync(join(process.cwd(), ".alpic", "project.json"), "utf8"),
-    );
-    expect(cfg).toMatchObject({ projectId: "p-new", teamName: "Globex" });
+    expect(alpic.projects.createLinked).toHaveBeenCalledWith({
+      name: "fresh",
+      teamId: "t2",
+      teamName: "Globex",
+      runtime: "node24",
+    });
   });
 });

--- a/packages/devtools/src/deploy-router.ts
+++ b/packages/devtools/src/deploy-router.ts
@@ -1,10 +1,10 @@
-import {
-  Alpic,
-  type DeployEvent,
-  type DeploymentStatus,
-  type DeployResult,
+import type {
+  DeployEvent,
+  DeploymentStatus,
+  DeployResult,
 } from "@alpic-ai/sdk";
 import express, { type Router } from "express";
+import { alpic } from "./alpic-sdk.js";
 
 const TOTAL_STEPS = 4;
 const PHASE_STEPS: Record<
@@ -47,15 +47,8 @@ const errMessage = (err: unknown, fallback: string): string =>
  * in-process (no CLI spawning): `/status` is a plain request, deploy progress
  * streams over SSE at `/events`.
  */
-export function createDeployRouter(alpicOverride?: Alpic): Router {
+export function createDeployRouter(): Router {
   const router = express.Router();
-  // `new Alpic()` reads server-side env at construction — defer to the first
-  // request so mounting the router stays test-safe.
-  let alpicInstance = alpicOverride;
-  const alpic = () => {
-    alpicInstance ??= new Alpic();
-    return alpicInstance;
-  };
 
   let state: DeployState = { status: "idle" };
   const subscribers = new Set<express.Response>();
@@ -80,7 +73,7 @@ export function createDeployRouter(alpicOverride?: Alpic): Router {
     });
     let pageUrl: string | null = null;
     try {
-      const result: DeployResult = await alpic().deployments.deploy({
+      const result: DeployResult = await alpic.deployments.deploy({
         environmentId,
         teamId,
         onProgress: (event) => {
@@ -119,17 +112,17 @@ export function createDeployRouter(alpicOverride?: Alpic): Router {
 
   router.get("/__skybridge/deploy/status", async (_req, res) => {
     try {
-      const whoami = await alpic().whoami();
+      const whoami = await alpic.whoami();
       if (whoami.method === "unauthenticated") {
         res.json({ state: "signedOut" });
         return;
       }
 
-      const loaded = alpic().projects.loadConfig();
-      const cfg = loaded && (await alpic().projects.validateLink(loaded));
+      const loaded = alpic.projects.loadConfig();
+      const cfg = loaded && (await alpic.projects.validateLink(loaded));
       const staleConfig = loaded !== null && cfg === null;
       if (!cfg) {
-        const teams = await alpic().api.teams.list.v1();
+        const teams = await alpic.api.teams.list.v1();
         const team = teams[0];
         if (!team) {
           res.json({ state: "noTeam" });
@@ -155,7 +148,7 @@ export function createDeployRouter(alpicOverride?: Alpic): Router {
       let deploymentPageUrl: string | null = null;
       if (cfg.environmentId) {
         try {
-          const latest = await alpic().deployments.getLatestForEnvironment(
+          const latest = await alpic.deployments.getLatestForEnvironment(
             cfg.environmentId,
           );
           if (latest.sourceCommitId !== null) {
@@ -169,7 +162,7 @@ export function createDeployRouter(alpicOverride?: Alpic): Router {
           lastDeployStartedAt = latest.startedAt?.getTime();
           deploymentPageUrl = latest.deploymentPageUrl;
           if (latest.status === "deployed") {
-            const environment = await alpic().api.environments.get.v1({
+            const environment = await alpic.api.environments.get.v1({
               environmentId: cfg.environmentId,
             });
             mcpServerUrl = environment.mcpServerUrl;
@@ -209,7 +202,7 @@ export function createDeployRouter(alpicOverride?: Alpic): Router {
       return;
     }
     try {
-      const existing = await alpic().api.projects.list.v1({ teamId });
+      const existing = await alpic.api.projects.list.v1({ teamId });
       if (existing.some((p) => p.name === name)) {
         res
           .status(409)
@@ -217,11 +210,11 @@ export function createDeployRouter(alpicOverride?: Alpic): Router {
         return;
       }
 
-      const cfg = await alpic().projects.createLinked({
+      const cfg = await alpic.projects.createLinked({
         name,
         teamId,
         teamName,
-        runtime: alpic().projects.detectRuntime() ?? "node24",
+        runtime: alpic.projects.detectRuntime() ?? "node24",
       });
       res.status(202).json({ ok: true });
       void runDeploy(cfg.environmentId, cfg.teamId);
@@ -234,7 +227,7 @@ export function createDeployRouter(alpicOverride?: Alpic): Router {
 
   router.post("/__skybridge/deploy/login", async (_req, res) => {
     try {
-      await alpic().auth.login();
+      await alpic.auth.login();
       res.json({ ok: true });
     } catch (err) {
       res.status(502).json({
@@ -248,7 +241,7 @@ export function createDeployRouter(alpicOverride?: Alpic): Router {
       res.status(409).json({ message: "A deployment is already in progress." });
       return;
     }
-    const cfg = alpic().projects.loadConfig();
+    const cfg = alpic.projects.loadConfig();
     if (!cfg?.environmentId) {
       res.status(409).json({ message: "No linked project to redeploy." });
       return;

--- a/packages/devtools/src/deploy-router.ts
+++ b/packages/devtools/src/deploy-router.ts
@@ -1,5 +1,3 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
 import {
   Alpic,
   type DeployEvent,
@@ -8,16 +6,6 @@ import {
 } from "@alpic-ai/sdk";
 import express, { type Router } from "express";
 
-type ProjectConfig = {
-  projectId: string;
-  teamId: string;
-  teamName?: string;
-  projectName: string;
-  environmentId?: string;
-  environmentName?: string;
-};
-
-// `collecting`/`collected` share step 1, so there are 4 numbered steps.
 const TOTAL_STEPS = 4;
 const PHASE_STEPS: Record<
   DeployEvent["type"],
@@ -39,9 +27,8 @@ type DeployState =
   | {
       status: "deploying";
       phase: string;
-      // Epoch ms when this deploy started. Held in the (process-lived) server
-      // state and replayed over SSE, so the client's elapsed clock survives
-      // both hover remounts and page refreshes.
+      // Held in server state and replayed over SSE so the client's elapsed
+      // clock survives hover remounts and page refreshes.
       startedAt: number;
       deploymentPageUrl: string | null;
     }
@@ -55,34 +42,15 @@ type DeployState =
 const errMessage = (err: unknown, fallback: string): string =>
   err instanceof Error ? err.message : fallback;
 
-const configPath = () => join(process.cwd(), ".alpic", "project.json");
-
-function loadConfig(): ProjectConfig | null {
-  const path = configPath();
-  if (!existsSync(path)) {
-    return null;
-  }
-  return JSON.parse(readFileSync(path, "utf8")) as ProjectConfig;
-}
-
-function saveConfig(cfg: ProjectConfig): void {
-  mkdirSync(join(process.cwd(), ".alpic"), { recursive: true });
-  writeFileSync(configPath(), JSON.stringify(cfg, null, 2));
-}
-
 /**
  * Dev-only router that drives the devtools Deploy button. Runs `@alpic-ai/sdk`
  * in-process (no CLI spawning): `/status` is a plain request, deploy progress
  * streams over SSE at `/events`.
- *
- * ponytail: deploy state + subscriber set are per-router-instance (closure
- * scoped). The dev server mounts one router for one project, so a single
- * in-flight deploy is fine; no change needed unless it ever hosts several.
  */
 export function createDeployRouter(alpicOverride?: Alpic): Router {
   const router = express.Router();
-  // Lazy: `new Alpic()` reads server-side env at construction, so defer it to
-  // the first request rather than mount time (keeps createApp test-safe).
+  // `new Alpic()` reads server-side env at construction — defer to the first
+  // request so mounting the router stays test-safe.
   let alpicInstance = alpicOverride;
   const alpic = () => {
     alpicInstance ??= new Alpic();
@@ -157,17 +125,10 @@ export function createDeployRouter(alpicOverride?: Alpic): Router {
         return;
       }
 
-      const cfg = loadConfig();
-      let staleConfig = false;
-      if (cfg) {
-        try {
-          await alpic().api.projects.get.v1({ projectId: cfg.projectId });
-        } catch {
-          // Stale config: linked project deleted/inaccessible — fall back to first deploy.
-          staleConfig = true;
-        }
-      }
-      if (!cfg || staleConfig) {
+      const loaded = alpic().projects.loadConfig();
+      const cfg = loaded && (await alpic().projects.validateLink(loaded));
+      const staleConfig = loaded !== null && cfg === null;
+      if (!cfg) {
         const teams = await alpic().api.teams.list.v1();
         const team = teams[0];
         if (!team) {
@@ -183,13 +144,6 @@ export function createDeployRouter(alpicOverride?: Alpic): Router {
         return;
       }
 
-      // Surface the live URL + deployment page so the persistent "Deployed"
-      // view renders on load (not only after a fresh deploy). A git-driven
-      // latest deploy (commit/author set) means the last deploy came from a
-      // connected repo, not this local button — expose its details so the UI
-      // can inform + warn before redeploying over it.
-      // ponytail: git vs local is the only distinction the API exposes; CLI and
-      // devtools local deploys are indistinguishable.
       let lastDeployGit: {
         ref: string | null;
         commitMessage: string | null;
@@ -263,28 +217,14 @@ export function createDeployRouter(alpicOverride?: Alpic): Router {
         return;
       }
 
-      const created = await alpic().api.projects.create.v1({
+      const cfg = await alpic().projects.createLinked({
         name,
         teamId,
-        runtime: "node24",
-      });
-      const productionEnv = created.productionEnvironment;
-      if (!productionEnv) {
-        res.status(500).json({
-          message: "Project created without a Production environment.",
-        });
-        return;
-      }
-      saveConfig({
-        projectId: created.id,
-        teamId: created.teamId,
         teamName,
-        projectName: created.name,
-        environmentId: productionEnv.id,
-        environmentName: productionEnv.name,
+        runtime: alpic().projects.detectRuntime() ?? "node24",
       });
       res.status(202).json({ ok: true });
-      void runDeploy(productionEnv.id, created.teamId);
+      void runDeploy(cfg.environmentId, cfg.teamId);
     } catch (err) {
       res.status(502).json({
         message: errMessage(err, "Failed to create project"),
@@ -308,7 +248,7 @@ export function createDeployRouter(alpicOverride?: Alpic): Router {
       res.status(409).json({ message: "A deployment is already in progress." });
       return;
     }
-    const cfg = loadConfig();
+    const cfg = alpic().projects.loadConfig();
     if (!cfg?.environmentId) {
       res.status(409).json({ message: "No linked project to redeploy." });
       return;

--- a/packages/devtools/src/deploy-router.ts
+++ b/packages/devtools/src/deploy-router.ts
@@ -157,31 +157,28 @@ export function createDeployRouter(alpicOverride?: Alpic): Router {
         return;
       }
 
-      const teams = await alpic().api.teams.list.v1();
-      const team = teams[0];
-      if (!team) {
-        res.json({ state: "noTeam" });
-        return;
-      }
-
       const cfg = loadConfig();
-      if (!cfg) {
-        res.json({ state: "needsProject", teams, defaultTeamId: team.id });
-        return;
+      let staleConfig = false;
+      if (cfg) {
+        try {
+          await alpic().api.projects.get.v1({ projectId: cfg.projectId });
+        } catch {
+          // Stale config: linked project deleted/inaccessible — fall back to first deploy.
+          staleConfig = true;
+        }
       }
-
-      let project: Awaited<ReturnType<Alpic["api"]["projects"]["get"]["v1"]>>;
-      try {
-        project = await alpic().api.projects.get.v1({
-          projectId: cfg.projectId,
-        });
-      } catch {
-        // Stale config: linked project deleted/inaccessible — fall back to first deploy.
+      if (!cfg || staleConfig) {
+        const teams = await alpic().api.teams.list.v1();
+        const team = teams[0];
+        if (!team) {
+          res.json({ state: "noTeam" });
+          return;
+        }
         res.json({
           state: "needsProject",
           teams,
           defaultTeamId: team.id,
-          staleConfig: true,
+          staleConfig,
         });
         return;
       }
@@ -230,9 +227,6 @@ export function createDeployRouter(alpicOverride?: Alpic): Router {
 
       res.json({
         state: "ready",
-        team,
-        project: { id: project.id, name: project.name },
-        environmentId: cfg.environmentId,
         lastDeployGit,
         lastDeployStatus,
         lastDeployStartedAt,
@@ -254,6 +248,8 @@ export function createDeployRouter(alpicOverride?: Alpic): Router {
     }
     const name = typeof req.body?.name === "string" ? req.body.name.trim() : "";
     const teamId = typeof req.body?.teamId === "string" ? req.body.teamId : "";
+    const teamName =
+      typeof req.body?.teamName === "string" ? req.body.teamName : undefined;
     if (!name || !teamId) {
       res.status(400).json({ message: "name and teamId are required." });
       return;
@@ -278,17 +274,6 @@ export function createDeployRouter(alpicOverride?: Alpic): Router {
           message: "Project created without a Production environment.",
         });
         return;
-      }
-      // Best-effort: teamName is cosmetic + optional. A failure here must not
-      // skip saveConfig, or the created project is orphaned (config never
-      // written → next attempt hits the name-conflict 409).
-      let teamName: string | undefined;
-      try {
-        teamName = (await alpic().api.teams.list.v1()).find(
-          (t) => t.id === teamId,
-        )?.name;
-      } catch {
-        // ignore — proceed without teamName
       }
       saveConfig({
         projectId: created.id,

--- a/packages/devtools/src/deploy-router.ts
+++ b/packages/devtools/src/deploy-router.ts
@@ -1,0 +1,348 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  Alpic,
+  type DeployEvent,
+  type DeploymentStatus,
+  type DeployResult,
+} from "@alpic-ai/sdk";
+import express, { type Router } from "express";
+
+type ProjectConfig = {
+  projectId: string;
+  teamId: string;
+  teamName?: string;
+  projectName: string;
+  environmentId?: string;
+  environmentName?: string;
+};
+
+// `collecting`/`collected` share step 1, so there are 4 numbered steps.
+const TOTAL_STEPS = 4;
+const PHASE_STEPS: Record<
+  DeployEvent["type"],
+  { step: number; label: string }
+> = {
+  collecting: { step: 1, label: "Collecting files" },
+  collected: { step: 1, label: "Collecting files" },
+  uploading: { step: 2, label: "Uploading source" },
+  triggering: { step: 3, label: "Triggering deployment" },
+  deploying: { step: 4, label: "Deploying" },
+};
+const phaseText = (type: DeployEvent["type"]): string => {
+  const { step, label } = PHASE_STEPS[type];
+  return `${step}/${TOTAL_STEPS} ${label}`;
+};
+
+type DeployState =
+  | { status: "idle" }
+  | {
+      status: "deploying";
+      phase: string;
+      // Epoch ms when this deploy started. Held in the (process-lived) server
+      // state and replayed over SSE, so the client's elapsed clock survives
+      // both hover remounts and page refreshes.
+      startedAt: number;
+      deploymentPageUrl: string | null;
+    }
+  | {
+      status: "deployed";
+      mcpServerUrl: string;
+      deploymentPageUrl: string | null;
+    }
+  | { status: "failed"; message: string; deploymentPageUrl: string | null };
+
+const errMessage = (err: unknown, fallback: string): string =>
+  err instanceof Error ? err.message : fallback;
+
+const configPath = () => join(process.cwd(), ".alpic", "project.json");
+
+function loadConfig(): ProjectConfig | null {
+  const path = configPath();
+  if (!existsSync(path)) {
+    return null;
+  }
+  return JSON.parse(readFileSync(path, "utf8")) as ProjectConfig;
+}
+
+function saveConfig(cfg: ProjectConfig): void {
+  mkdirSync(join(process.cwd(), ".alpic"), { recursive: true });
+  writeFileSync(configPath(), JSON.stringify(cfg, null, 2));
+}
+
+/**
+ * Dev-only router that drives the devtools Deploy button. Runs `@alpic-ai/sdk`
+ * in-process (no CLI spawning): `/status` is a plain request, deploy progress
+ * streams over SSE at `/events`.
+ *
+ * ponytail: deploy state + subscriber set are per-router-instance (closure
+ * scoped). The dev server mounts one router for one project, so a single
+ * in-flight deploy is fine; no change needed unless it ever hosts several.
+ */
+export function createDeployRouter(alpicOverride?: Alpic): Router {
+  const router = express.Router();
+  // Lazy: `new Alpic()` reads server-side env at construction, so defer it to
+  // the first request rather than mount time (keeps createApp test-safe).
+  let alpicInstance = alpicOverride;
+  const alpic = () => {
+    alpicInstance ??= new Alpic();
+    return alpicInstance;
+  };
+
+  let state: DeployState = { status: "idle" };
+  const subscribers = new Set<express.Response>();
+
+  const write = (res: express.Response, s: DeployState) => {
+    res.write(`event: state\ndata: ${JSON.stringify(s)}\n\n`);
+  };
+  const setState = (s: DeployState) => {
+    state = s;
+    for (const res of subscribers) {
+      write(res, s);
+    }
+  };
+
+  const runDeploy = async (environmentId: string, teamId: string) => {
+    const startedAt = Date.now();
+    setState({
+      status: "deploying",
+      phase: phaseText("collecting"),
+      startedAt,
+      deploymentPageUrl: null,
+    });
+    let pageUrl: string | null = null;
+    try {
+      const result: DeployResult = await alpic().deployments.deploy({
+        environmentId,
+        teamId,
+        onProgress: (event) => {
+          if (event.type === "deploying" && event.deploymentPageUrl) {
+            pageUrl = event.deploymentPageUrl;
+          }
+          setState({
+            status: "deploying",
+            phase: phaseText(event.type),
+            startedAt,
+            deploymentPageUrl: pageUrl,
+          });
+        },
+      });
+      if (result.status === "deployed") {
+        setState({
+          status: "deployed",
+          mcpServerUrl: result.mcpServerUrl,
+          deploymentPageUrl: result.deploymentPageUrl,
+        });
+      } else {
+        setState({
+          status: "failed",
+          message: `Deployment ${result.status}.`,
+          deploymentPageUrl: result.deploymentPageUrl,
+        });
+      }
+    } catch (err) {
+      setState({
+        status: "failed",
+        message: errMessage(err, "Deployment failed"),
+        deploymentPageUrl: pageUrl,
+      });
+    }
+  };
+
+  router.get("/__skybridge/deploy/status", async (_req, res) => {
+    try {
+      const whoami = await alpic().whoami();
+      if (whoami.method === "unauthenticated") {
+        res.json({ state: "signedOut" });
+        return;
+      }
+
+      const teams = await alpic().api.teams.list.v1();
+      const team = teams[0];
+      if (!team) {
+        res.json({ state: "noTeam" });
+        return;
+      }
+
+      const cfg = loadConfig();
+      if (!cfg) {
+        res.json({ state: "needsProject", teams, defaultTeamId: team.id });
+        return;
+      }
+
+      let project: Awaited<ReturnType<Alpic["api"]["projects"]["get"]["v1"]>>;
+      try {
+        project = await alpic().api.projects.get.v1({
+          projectId: cfg.projectId,
+        });
+      } catch {
+        // Stale config: linked project deleted/inaccessible — fall back to first deploy.
+        res.json({
+          state: "needsProject",
+          teams,
+          defaultTeamId: team.id,
+          staleConfig: true,
+        });
+        return;
+      }
+
+      // Surface the live URL + deployment page so the persistent "Deployed"
+      // view renders on load (not only after a fresh deploy). A git-driven
+      // latest deploy (commit/author set) means the last deploy came from a
+      // connected repo, not this local button — expose its details so the UI
+      // can inform + warn before redeploying over it.
+      // ponytail: git vs local is the only distinction the API exposes; CLI and
+      // devtools local deploys are indistinguishable.
+      let lastDeployGit: {
+        ref: string | null;
+        commitMessage: string | null;
+        author: string | null;
+      } | null = null;
+      let lastDeployStatus: DeploymentStatus | undefined;
+      let lastDeployStartedAt: number | undefined;
+      let mcpServerUrl: string | undefined;
+      let deploymentPageUrl: string | null = null;
+      if (cfg.environmentId) {
+        try {
+          const latest = await alpic().deployments.getLatestForEnvironment(
+            cfg.environmentId,
+          );
+          if (latest.sourceCommitId !== null) {
+            lastDeployGit = {
+              ref: latest.sourceRef,
+              commitMessage: latest.sourceCommitMessage,
+              author: latest.authorUsername,
+            };
+          }
+          lastDeployStatus = latest.status;
+          lastDeployStartedAt = latest.startedAt?.getTime();
+          deploymentPageUrl = latest.deploymentPageUrl;
+          if (latest.status === "deployed") {
+            const environment = await alpic().api.environments.get.v1({
+              environmentId: cfg.environmentId,
+            });
+            mcpServerUrl = environment.mcpServerUrl;
+          }
+        } catch {
+          // no deployments yet — leave defaults
+        }
+      }
+
+      res.json({
+        state: "ready",
+        team,
+        project: { id: project.id, name: project.name },
+        environmentId: cfg.environmentId,
+        lastDeployGit,
+        lastDeployStatus,
+        lastDeployStartedAt,
+        mcpServerUrl,
+        deploymentPageUrl,
+      });
+    } catch (err) {
+      res.status(502).json({
+        state: "error",
+        message: errMessage(err, "Alpic API unavailable"),
+      });
+    }
+  });
+
+  router.post("/__skybridge/deploy/project", async (req, res) => {
+    if (state.status === "deploying") {
+      res.status(409).json({ message: "A deployment is already in progress." });
+      return;
+    }
+    const name = typeof req.body?.name === "string" ? req.body.name.trim() : "";
+    const teamId = typeof req.body?.teamId === "string" ? req.body.teamId : "";
+    if (!name || !teamId) {
+      res.status(400).json({ message: "name and teamId are required." });
+      return;
+    }
+    try {
+      const existing = await alpic().api.projects.list.v1({ teamId });
+      if (existing.some((p) => p.name === name)) {
+        res
+          .status(409)
+          .json({ message: `A project named "${name}" already exists.` });
+        return;
+      }
+
+      const created = await alpic().api.projects.create.v1({
+        name,
+        teamId,
+        runtime: "node24",
+      });
+      const productionEnv = created.productionEnvironment;
+      if (!productionEnv) {
+        res.status(500).json({
+          message: "Project created without a Production environment.",
+        });
+        return;
+      }
+      // Best-effort: teamName is cosmetic + optional. A failure here must not
+      // skip saveConfig, or the created project is orphaned (config never
+      // written → next attempt hits the name-conflict 409).
+      let teamName: string | undefined;
+      try {
+        teamName = (await alpic().api.teams.list.v1()).find(
+          (t) => t.id === teamId,
+        )?.name;
+      } catch {
+        // ignore — proceed without teamName
+      }
+      saveConfig({
+        projectId: created.id,
+        teamId: created.teamId,
+        teamName,
+        projectName: created.name,
+        environmentId: productionEnv.id,
+        environmentName: productionEnv.name,
+      });
+      res.status(202).json({ ok: true });
+      void runDeploy(productionEnv.id, created.teamId);
+    } catch (err) {
+      res.status(502).json({
+        message: errMessage(err, "Failed to create project"),
+      });
+    }
+  });
+
+  router.post("/__skybridge/deploy/login", async (_req, res) => {
+    try {
+      await alpic().auth.login();
+      res.json({ ok: true });
+    } catch (err) {
+      res.status(502).json({
+        message: errMessage(err, "Sign-in failed"),
+      });
+    }
+  });
+
+  router.post("/__skybridge/deploy", (_req, res) => {
+    if (state.status === "deploying") {
+      res.status(409).json({ message: "A deployment is already in progress." });
+      return;
+    }
+    const cfg = loadConfig();
+    if (!cfg?.environmentId) {
+      res.status(409).json({ message: "No linked project to redeploy." });
+      return;
+    }
+    res.status(202).json({ ok: true });
+    void runDeploy(cfg.environmentId, cfg.teamId);
+  });
+
+  router.get("/__skybridge/deploy/events", (req, res) => {
+    res.setHeader("Content-Type", "text/event-stream");
+    res.setHeader("Cache-Control", "no-cache, no-transform");
+    res.setHeader("Connection", "keep-alive");
+    res.flushHeaders?.();
+    write(res, state);
+    subscribers.add(res);
+    req.on("close", () => {
+      subscribers.delete(res);
+    });
+  });
+
+  return router;
+}

--- a/packages/devtools/src/devtoolsStaticServer.ts
+++ b/packages/devtools/src/devtoolsStaticServer.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import cors from "cors";
 import express, { type Router } from "express";
+import { createDeployRouter } from "./deploy-router.js";
 
 type PackageManager = "pnpm" | "npm" | "yarn" | "bun";
 
@@ -42,6 +43,7 @@ export const devtoolsStaticServer = async (): Promise<Router> => {
   router.get("/__skybridge/devtools/project", (_req, res) => {
     res.json({ packageManager: detectPackageManager() });
   });
+  router.use(createDeployRouter());
   router.use(express.static(distDir));
   router.get("/", (_req, res, next) => {
     const indexHtmlPath = path.join(distDir, "index.html");

--- a/packages/devtools/src/index.ts
+++ b/packages/devtools/src/index.ts
@@ -1,2 +1,1 @@
-export { createDeployRouter } from "./deploy-router.js";
 export { devtoolsStaticServer } from "./devtoolsStaticServer.js";

--- a/packages/devtools/src/index.ts
+++ b/packages/devtools/src/index.ts
@@ -1,1 +1,2 @@
+export { createDeployRouter } from "./deploy-router.js";
 export { devtoolsStaticServer } from "./devtoolsStaticServer.js";

--- a/packages/devtools/src/lib/deploy-store.ts
+++ b/packages/devtools/src/lib/deploy-store.ts
@@ -15,9 +15,6 @@ const statusSchema = z.discriminatedUnion("state", [
   }),
   z.object({
     state: z.literal("ready"),
-    team: teamSchema,
-    project: z.object({ id: z.string(), name: z.string() }),
-    environmentId: z.string().optional(),
     lastDeployGit: z
       .object({
         ref: z.string().nullable(),
@@ -65,7 +62,11 @@ type DeployStore = {
   progress: DeployProgress;
   refreshStatus: () => Promise<void>;
   signIn: () => Promise<void>;
-  createAndDeploy: (name: string, teamId: string) => Promise<void>;
+  createAndDeploy: (
+    name: string,
+    teamId: string,
+    teamName?: string,
+  ) => Promise<void>;
   redeploy: () => Promise<void>;
   connect: () => () => void;
 };
@@ -132,12 +133,12 @@ export const useDeployStore = create<DeployStore>()((set, get) => ({
     await get().refreshStatus();
   },
 
-  async createAndDeploy(name, teamId) {
+  async createAndDeploy(name, teamId, teamName) {
     set({ progress: optimisticDeploying() });
     try {
       await postJson(
         `${DEPLOY_PATH}/project`,
-        { name, teamId },
+        { name, teamId, teamName },
         "Failed to create project",
       );
     } catch (err) {
@@ -160,11 +161,10 @@ export const useDeployStore = create<DeployStore>()((set, get) => ({
     const source = new EventSource(`${DEPLOY_PATH}/events`);
 
     source.addEventListener("state", (event) => {
-      if (!(event instanceof MessageEvent)) {
-        return;
-      }
       try {
-        const parsed = progressSchema.safeParse(JSON.parse(event.data));
+        const parsed = progressSchema.safeParse(
+          JSON.parse((event as MessageEvent).data),
+        );
         if (parsed.success) {
           const prev = get().progress.status;
           set({ progress: parsed.data });

--- a/packages/devtools/src/lib/deploy-store.ts
+++ b/packages/devtools/src/lib/deploy-store.ts
@@ -163,9 +163,14 @@ export const useDeployStore = create<DeployStore>()((set, get) => ({
         if (parsed.success) {
           const prev = get().progress.status;
           set({ progress: parsed.data });
-          // A finished deploy writes .alpic/project.json — refresh so a first
-          // deploy flips needsProject → ready.
-          if (parsed.data.status === "deployed" && prev !== "deployed") {
+          // A finished deploy (even a failed one) has already written
+          // .alpic/project.json — refresh so a first deploy flips
+          // needsProject → ready instead of re-opening the create dialog.
+          if (
+            (parsed.data.status === "deployed" ||
+              parsed.data.status === "failed") &&
+            parsed.data.status !== prev
+          ) {
             void get().refreshStatus();
           }
         }

--- a/packages/devtools/src/lib/deploy-store.ts
+++ b/packages/devtools/src/lib/deploy-store.ts
@@ -1,0 +1,209 @@
+import { useEffect } from "react";
+import { z } from "zod";
+import { create } from "zustand";
+
+const teamSchema = z.object({ id: z.string(), name: z.string() });
+
+const statusSchema = z.discriminatedUnion("state", [
+  z.object({ state: z.literal("signedOut") }),
+  z.object({ state: z.literal("noTeam") }),
+  z.object({
+    state: z.literal("needsProject"),
+    teams: z.array(teamSchema),
+    defaultTeamId: z.string(),
+    staleConfig: z.boolean().optional(),
+  }),
+  z.object({
+    state: z.literal("ready"),
+    team: teamSchema,
+    project: z.object({ id: z.string(), name: z.string() }),
+    environmentId: z.string().optional(),
+    lastDeployGit: z
+      .object({
+        ref: z.string().nullable(),
+        commitMessage: z.string().nullable(),
+        author: z.string().nullable(),
+      })
+      .nullable()
+      .optional(),
+    lastDeployStatus: z
+      .enum(["ongoing", "deployed", "failed", "canceled"])
+      .optional(),
+    lastDeployStartedAt: z.number().optional(),
+    mcpServerUrl: z.string().optional(),
+    deploymentPageUrl: z.string().nullable().optional(),
+  }),
+  z.object({ state: z.literal("error"), message: z.string() }),
+]);
+
+export type DeployStatus = { state: "loading" } | z.infer<typeof statusSchema>;
+
+const progressSchema = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("idle") }),
+  z.object({
+    status: z.literal("deploying"),
+    phase: z.string(),
+    startedAt: z.number(),
+    deploymentPageUrl: z.string().nullable(),
+  }),
+  z.object({
+    status: z.literal("deployed"),
+    mcpServerUrl: z.string(),
+    deploymentPageUrl: z.string().nullable(),
+  }),
+  z.object({
+    status: z.literal("failed"),
+    message: z.string(),
+    deploymentPageUrl: z.string().nullable(),
+  }),
+]);
+
+export type DeployProgress = z.infer<typeof progressSchema>;
+
+type DeployStore = {
+  status: DeployStatus;
+  progress: DeployProgress;
+  refreshStatus: () => Promise<void>;
+  signIn: () => Promise<void>;
+  createAndDeploy: (name: string, teamId: string) => Promise<void>;
+  redeploy: () => Promise<void>;
+  connect: () => () => void;
+};
+
+const DEPLOY_PATH = "/__skybridge/deploy";
+
+// POST a deploy endpoint, surfacing the server's `message` (or a fallback) on
+// a non-2xx response.
+async function postJson(
+  path: string,
+  body?: unknown,
+  fallback = "Request failed",
+): Promise<void> {
+  const res = await fetch(path, {
+    method: "POST",
+    ...(body !== undefined && {
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  });
+  if (!res.ok) {
+    const { message } = (await res.json().catch(() => ({}))) as {
+      message?: string;
+    };
+    throw new Error(message ?? `${fallback} (${res.status})`);
+  }
+}
+
+// Shown the instant a deploy is triggered so the button flips to pending
+// without waiting for the first server SSE frame. Reconciled by real progress
+// (the server replaces startedAt with its own, ~ms apart).
+const optimisticDeploying = (): DeployProgress => ({
+  status: "deploying",
+  phase: "Preparing deployment",
+  startedAt: Date.now(),
+  deploymentPageUrl: null,
+});
+
+export const useDeployStore = create<DeployStore>()((set, get) => ({
+  status: { state: "loading" },
+  progress: { status: "idle" },
+
+  async refreshStatus() {
+    try {
+      const res = await fetch(`${DEPLOY_PATH}/status`);
+      const parsed = statusSchema.safeParse(await res.json());
+      set({
+        status: parsed.success
+          ? parsed.data
+          : { state: "error", message: "Unexpected status response" },
+      });
+    } catch (err) {
+      set({
+        status: {
+          state: "error",
+          message: err instanceof Error ? err.message : "Failed to load status",
+        },
+      });
+    }
+  },
+
+  async signIn() {
+    await postJson(`${DEPLOY_PATH}/login`, undefined, "Sign-in failed");
+    await get().refreshStatus();
+  },
+
+  async createAndDeploy(name, teamId) {
+    set({ progress: optimisticDeploying() });
+    try {
+      await postJson(
+        `${DEPLOY_PATH}/project`,
+        { name, teamId },
+        "Failed to create project",
+      );
+    } catch (err) {
+      set({ progress: { status: "idle" } });
+      throw err;
+    }
+  },
+
+  async redeploy() {
+    set({ progress: optimisticDeploying() });
+    try {
+      await postJson(DEPLOY_PATH, undefined, "Failed to deploy");
+    } catch (err) {
+      set({ progress: { status: "idle" } });
+      throw err;
+    }
+  },
+
+  connect() {
+    const source = new EventSource(`${DEPLOY_PATH}/events`);
+
+    source.addEventListener("state", (event) => {
+      if (!(event instanceof MessageEvent)) {
+        return;
+      }
+      try {
+        const parsed = progressSchema.safeParse(JSON.parse(event.data));
+        if (parsed.success) {
+          const prev = get().progress.status;
+          set({ progress: parsed.data });
+          // A finished deploy creates/updates .alpic/project.json — refresh so
+          // a first deploy flips needsProject → ready for the next click.
+          if (parsed.data.status === "deployed" && prev !== "deployed") {
+            void get().refreshStatus();
+          }
+        }
+      } catch {
+        // ignore malformed frame
+      }
+    });
+
+    return () => {
+      source.close();
+    };
+  },
+}));
+
+export function useConnectDeploy() {
+  const connect = useDeployStore((s) => s.connect);
+  const refreshStatus = useDeployStore((s) => s.refreshStatus);
+  // SSE only streams this session's deploy; a deploy finishing out-of-session
+  // (git, CLI, killed session) never pushes. Poll /status while it's ongoing
+  // so the dot self-corrects to its terminal state.
+  const ongoing = useDeployStore(
+    (s) =>
+      s.status.state === "ready" && s.status.lastDeployStatus === "ongoing",
+  );
+  useEffect(() => {
+    void refreshStatus();
+    return connect();
+  }, [connect, refreshStatus]);
+  useEffect(() => {
+    if (!ongoing) {
+      return;
+    }
+    const id = setInterval(() => void refreshStatus(), 4000);
+    return () => clearInterval(id);
+  }, [ongoing, refreshStatus]);
+}

--- a/packages/devtools/src/lib/deploy-store.ts
+++ b/packages/devtools/src/lib/deploy-store.ts
@@ -73,8 +73,6 @@ type DeployStore = {
 
 const DEPLOY_PATH = "/__skybridge/deploy";
 
-// POST a deploy endpoint, surfacing the server's `message` (or a fallback) on
-// a non-2xx response.
 async function postJson(
   path: string,
   body?: unknown,
@@ -95,9 +93,6 @@ async function postJson(
   }
 }
 
-// Shown the instant a deploy is triggered so the button flips to pending
-// without waiting for the first server SSE frame. Reconciled by real progress
-// (the server replaces startedAt with its own, ~ms apart).
 const optimisticDeploying = (): DeployProgress => ({
   status: "deploying",
   phase: "Preparing deployment",
@@ -168,8 +163,8 @@ export const useDeployStore = create<DeployStore>()((set, get) => ({
         if (parsed.success) {
           const prev = get().progress.status;
           set({ progress: parsed.data });
-          // A finished deploy creates/updates .alpic/project.json — refresh so
-          // a first deploy flips needsProject → ready for the next click.
+          // A finished deploy writes .alpic/project.json — refresh so a first
+          // deploy flips needsProject → ready.
           if (parsed.data.status === "deployed" && prev !== "deployed") {
             void get().refreshStatus();
           }
@@ -188,9 +183,8 @@ export const useDeployStore = create<DeployStore>()((set, get) => ({
 export function useConnectDeploy() {
   const connect = useDeployStore((s) => s.connect);
   const refreshStatus = useDeployStore((s) => s.refreshStatus);
-  // SSE only streams this session's deploy; a deploy finishing out-of-session
-  // (git, CLI, killed session) never pushes. Poll /status while it's ongoing
-  // so the dot self-corrects to its terminal state.
+  // SSE only streams this session's deploy — poll while ongoing so a deploy
+  // finishing out-of-session (git, CLI) still reaches its terminal state.
   const ongoing = useDeployStore(
     (s) =>
       s.status.state === "ready" && s.status.lastDeployStatus === "ongoing",

--- a/packages/devtools/vitest.config.ts
+++ b/packages/devtools/vitest.config.ts
@@ -4,6 +4,5 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],
-    exclude: ["**/node_modules/**", "**/dist/**", "e2e/**"],
   },
 });

--- a/packages/devtools/vitest.config.ts
+++ b/packages/devtools/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    exclude: ["**/node_modules/**", "**/dist/**", "e2e/**"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1431,8 +1431,8 @@ importers:
   packages/devtools:
     dependencies:
       '@alpic-ai/sdk':
-        specifier: 0.0.0-dev.g9fb64c1
-        version: 0.0.0-dev.g9fb64c1(@opentelemetry/api@1.9.1)(arktype@2.1.27)(typescript@6.0.2)
+        specifier: ^1.146.1
+        version: 1.146.1(@opentelemetry/api@1.9.1)(arktype@2.1.27)(typescript@6.0.2)
       '@t3-oss/env-core':
         specifier: ^0.13.11
         version: 0.13.11(arktype@2.1.27)(typescript@6.0.2)(zod@4.4.3)
@@ -1608,11 +1608,11 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@alpic-ai/api@0.0.0-dev.g9fb64c1':
-    resolution: {integrity: sha512-ocOC/orDjO/psF7zNMpsCzGeXjn3owZiIPuIg4wKHid/EW4ZVQmZT7H+DpBNTfjnGUtLdC+IwceeIlBvL/o2nQ==}
-
   '@alpic-ai/api@1.136.3':
     resolution: {integrity: sha512-d2NsEsanyBLaATvjn9TS2riycH8Z/UQkyr/SipuNJ4dgGt5AmRo2mwZnSUYXziuBbbUropqzK/A+tJSo2r02Mg==}
+
+  '@alpic-ai/api@1.146.1':
+    resolution: {integrity: sha512-5u+NsrWWiDWjCb9hLSHL13EGEJneKPAsPSxU24/xC5FfRE9P901iTEc8fpkLMKk5YqjePzgvw2OUXtdfHJ1SfA==}
 
   '@alpic-ai/insights@1.127.1':
     resolution: {integrity: sha512-VLeva10Ft30MeQhZnGTBbyU8rXp2I3Oqpv9gfyEUIbmu6k4lkGcAnpE834rJ7RI0/yT8JHTW5a21MrloUzj5tQ==}
@@ -1623,8 +1623,8 @@ packages:
       skybridge:
         optional: true
 
-  '@alpic-ai/sdk@0.0.0-dev.g9fb64c1':
-    resolution: {integrity: sha512-R+wD4VXwcm6hKlOw88sRJ9r0ZKcb4v9MSM3mWmmUOmMGb1X3aQKtuT4s+HbrDkyRpUb2l72739gP/6Bx5dgi3w==}
+  '@alpic-ai/sdk@1.146.1':
+    resolution: {integrity: sha512-4UmRQPfo5VfDdAecR2Z4VQo2fDGmN7qi+nhTps/tAQbr8MJl2VWYreYOeNd1lg6sRbUI1dDNe3qF2X0lzkaENA==}
     engines: {node: '>= 18.20.8'}
 
   '@alpic-ai/ui@1.116.0':
@@ -10780,7 +10780,7 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@alpic-ai/api@0.0.0-dev.g9fb64c1(@opentelemetry/api@1.9.1)':
+  '@alpic-ai/api@1.136.3(@opentelemetry/api@1.9.1)':
     dependencies:
       '@orpc/contract': 1.14.6(@opentelemetry/api@1.9.1)
       ms: 2.1.3
@@ -10788,7 +10788,7 @@ snapshots:
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
-  '@alpic-ai/api@1.136.3(@opentelemetry/api@1.9.1)':
+  '@alpic-ai/api@1.146.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@orpc/contract': 1.14.6(@opentelemetry/api@1.9.1)
       ms: 2.1.3
@@ -10802,9 +10802,9 @@ snapshots:
     optionalDependencies:
       skybridge: link:packages/core
 
-  '@alpic-ai/sdk@0.0.0-dev.g9fb64c1(@opentelemetry/api@1.9.1)(arktype@2.1.27)(typescript@6.0.2)':
+  '@alpic-ai/sdk@1.146.1(@opentelemetry/api@1.9.1)(arktype@2.1.27)(typescript@6.0.2)':
     dependencies:
-      '@alpic-ai/api': 0.0.0-dev.g9fb64c1(@opentelemetry/api@1.9.1)
+      '@alpic-ai/api': 1.146.1(@opentelemetry/api@1.9.1)
       '@orpc/client': 1.14.6(@opentelemetry/api@1.9.1)
       '@orpc/contract': 1.14.6(@opentelemetry/api@1.9.1)
       '@orpc/openapi-client': 1.14.6(@opentelemetry/api@1.9.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1431,8 +1431,8 @@ importers:
   packages/devtools:
     dependencies:
       '@alpic-ai/sdk':
-        specifier: ^1.145.0
-        version: 1.145.0(@opentelemetry/api@1.9.1)(arktype@2.1.27)(typescript@6.0.2)
+        specifier: 0.0.0-dev.g9fb64c1
+        version: 0.0.0-dev.g9fb64c1(@opentelemetry/api@1.9.1)(arktype@2.1.27)(typescript@6.0.2)
       '@t3-oss/env-core':
         specifier: ^0.13.11
         version: 0.13.11(arktype@2.1.27)(typescript@6.0.2)(zod@4.4.3)
@@ -1608,11 +1608,11 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@alpic-ai/api@0.0.0-dev.g9fb64c1':
+    resolution: {integrity: sha512-ocOC/orDjO/psF7zNMpsCzGeXjn3owZiIPuIg4wKHid/EW4ZVQmZT7H+DpBNTfjnGUtLdC+IwceeIlBvL/o2nQ==}
+
   '@alpic-ai/api@1.136.3':
     resolution: {integrity: sha512-d2NsEsanyBLaATvjn9TS2riycH8Z/UQkyr/SipuNJ4dgGt5AmRo2mwZnSUYXziuBbbUropqzK/A+tJSo2r02Mg==}
-
-  '@alpic-ai/api@1.145.0':
-    resolution: {integrity: sha512-f0TEzXpg4/QuYsEh0ctJ+z/NeezFIu+5ZgBP38sOrUwcJ89R0W+7ct1MYqwW+jaIFMhV5fSPe/+0dBgZK8YuhQ==}
 
   '@alpic-ai/insights@1.127.1':
     resolution: {integrity: sha512-VLeva10Ft30MeQhZnGTBbyU8rXp2I3Oqpv9gfyEUIbmu6k4lkGcAnpE834rJ7RI0/yT8JHTW5a21MrloUzj5tQ==}
@@ -1623,8 +1623,8 @@ packages:
       skybridge:
         optional: true
 
-  '@alpic-ai/sdk@1.145.0':
-    resolution: {integrity: sha512-QFrtVJZpWUqSJNumwjESJthwYxlfSzFPZ1xPXqnnkDpTFHAwR2gUg+XJmMgmeWVy2D7uJzXrfXM6uYECxDz3mw==}
+  '@alpic-ai/sdk@0.0.0-dev.g9fb64c1':
+    resolution: {integrity: sha512-R+wD4VXwcm6hKlOw88sRJ9r0ZKcb4v9MSM3mWmmUOmMGb1X3aQKtuT4s+HbrDkyRpUb2l72739gP/6Bx5dgi3w==}
     engines: {node: '>= 18.20.8'}
 
   '@alpic-ai/ui@1.116.0':
@@ -10780,7 +10780,7 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@alpic-ai/api@1.136.3(@opentelemetry/api@1.9.1)':
+  '@alpic-ai/api@0.0.0-dev.g9fb64c1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@orpc/contract': 1.14.6(@opentelemetry/api@1.9.1)
       ms: 2.1.3
@@ -10788,7 +10788,7 @@ snapshots:
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
-  '@alpic-ai/api@1.145.0(@opentelemetry/api@1.9.1)':
+  '@alpic-ai/api@1.136.3(@opentelemetry/api@1.9.1)':
     dependencies:
       '@orpc/contract': 1.14.6(@opentelemetry/api@1.9.1)
       ms: 2.1.3
@@ -10802,9 +10802,9 @@ snapshots:
     optionalDependencies:
       skybridge: link:packages/core
 
-  '@alpic-ai/sdk@1.145.0(@opentelemetry/api@1.9.1)(arktype@2.1.27)(typescript@6.0.2)':
+  '@alpic-ai/sdk@0.0.0-dev.g9fb64c1(@opentelemetry/api@1.9.1)(arktype@2.1.27)(typescript@6.0.2)':
     dependencies:
-      '@alpic-ai/api': 1.145.0(@opentelemetry/api@1.9.1)
+      '@alpic-ai/api': 0.0.0-dev.g9fb64c1(@opentelemetry/api@1.9.1)
       '@orpc/client': 1.14.6(@opentelemetry/api@1.9.1)
       '@orpc/contract': 1.14.6(@opentelemetry/api@1.9.1)
       '@orpc/openapi-client': 1.14.6(@opentelemetry/api@1.9.1)
@@ -17200,7 +17200,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(@vitest/ui@4.1.4)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.4(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.12.0)(@vitest/ui@4.1.4)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.4(@types/node@24.12.0)(typescript@6.0.2))(vite@8.0.3(@types/node@24.12.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
 
   '@vitest/utils@4.1.4':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,7 +74,7 @@ importers:
     devDependencies:
       '@skybridge/devtools':
         specifier: ^1.1.0
-        version: 1.1.0(arktype@2.1.27)(typescript@5.9.3)
+        version: 1.2.3(arktype@2.1.27)(typescript@5.9.3)
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
@@ -129,7 +129,7 @@ importers:
     devDependencies:
       '@skybridge/devtools':
         specifier: ^1.1.0
-        version: 1.1.0(arktype@2.1.27)(typescript@5.9.3)
+        version: 1.2.3(arktype@2.1.27)(typescript@5.9.3)
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
@@ -184,7 +184,7 @@ importers:
     devDependencies:
       '@skybridge/devtools':
         specifier: ^1.1.0
-        version: 1.1.0(arktype@2.1.27)(typescript@5.9.3)
+        version: 1.2.3(arktype@2.1.27)(typescript@5.9.3)
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
@@ -239,7 +239,7 @@ importers:
     devDependencies:
       '@skybridge/devtools':
         specifier: ^1.1.0
-        version: 1.1.0(arktype@2.1.27)(typescript@5.9.3)
+        version: 1.2.3(arktype@2.1.27)(typescript@5.9.3)
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
@@ -294,7 +294,7 @@ importers:
     devDependencies:
       '@skybridge/devtools':
         specifier: ^1.1.0
-        version: 1.1.0(arktype@2.1.27)(typescript@5.9.3)
+        version: 1.2.3(arktype@2.1.27)(typescript@5.9.3)
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
@@ -349,7 +349,7 @@ importers:
     devDependencies:
       '@skybridge/devtools':
         specifier: ^1.1.0
-        version: 1.1.0(arktype@2.1.27)(typescript@5.9.3)
+        version: 1.2.3(arktype@2.1.27)(typescript@5.9.3)
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
@@ -431,7 +431,7 @@ importers:
     devDependencies:
       '@skybridge/devtools':
         specifier: ^1.1.0
-        version: 1.1.0(arktype@2.1.27)(typescript@5.9.3)
+        version: 1.2.3(arktype@2.1.27)(typescript@5.9.3)
       '@tailwindcss/vite':
         specifier: ^4.1.14
         version: 4.1.18(vite@8.0.0(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
@@ -501,7 +501,7 @@ importers:
     devDependencies:
       '@skybridge/devtools':
         specifier: ^1.1.0
-        version: 1.1.0(arktype@2.1.27)(typescript@5.9.3)
+        version: 1.2.3(arktype@2.1.27)(typescript@5.9.3)
       '@tailwindcss/vite':
         specifier: ^4.1.14
         version: 4.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
@@ -562,7 +562,7 @@ importers:
     devDependencies:
       '@skybridge/devtools':
         specifier: ^1.1.0
-        version: 1.1.0(arktype@2.1.27)(typescript@5.9.3)
+        version: 1.2.3(arktype@2.1.27)(typescript@5.9.3)
       '@types/node':
         specifier: ^22.19.3
         version: 22.19.3
@@ -623,7 +623,7 @@ importers:
     devDependencies:
       '@skybridge/devtools':
         specifier: ^1.1.0
-        version: 1.1.0(arktype@2.1.27)(typescript@5.9.3)
+        version: 1.2.3(arktype@2.1.27)(typescript@5.9.3)
       '@tailwindcss/vite':
         specifier: ^4.3.0
         version: 4.3.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
@@ -678,7 +678,7 @@ importers:
     devDependencies:
       '@skybridge/devtools':
         specifier: ^1.1.0
-        version: 1.1.0(arktype@2.1.27)(typescript@5.9.3)
+        version: 1.2.3(arktype@2.1.27)(typescript@5.9.3)
       '@types/node':
         specifier: ^22.19.3
         version: 22.19.3
@@ -742,7 +742,7 @@ importers:
     devDependencies:
       '@skybridge/devtools':
         specifier: ^1.1.0
-        version: 1.1.0(arktype@2.1.27)(typescript@5.9.3)
+        version: 1.2.3(arktype@2.1.27)(typescript@5.9.3)
       '@types/node':
         specifier: ^25.0.10
         version: 25.2.3
@@ -803,7 +803,7 @@ importers:
     devDependencies:
       '@skybridge/devtools':
         specifier: ^1.1.0
-        version: 1.1.0(arktype@2.1.27)(typescript@5.9.3)
+        version: 1.2.3(arktype@2.1.27)(typescript@5.9.3)
       '@tailwindcss/vite':
         specifier: ^4.1.14
         version: 4.1.18(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
@@ -882,7 +882,7 @@ importers:
     devDependencies:
       '@skybridge/devtools':
         specifier: ^1.1.0
-        version: 1.1.0(arktype@2.1.27)(typescript@5.9.3)
+        version: 1.2.3(arktype@2.1.27)(typescript@5.9.3)
       '@types/node':
         specifier: ^25.0.10
         version: 25.2.3
@@ -946,7 +946,7 @@ importers:
     devDependencies:
       '@skybridge/devtools':
         specifier: ^1.1.0
-        version: 1.1.0(arktype@2.1.27)(typescript@5.9.3)
+        version: 1.2.3(arktype@2.1.27)(typescript@5.9.3)
       '@types/node':
         specifier: ^25.0.10
         version: 25.5.0
@@ -992,7 +992,7 @@ importers:
     devDependencies:
       '@skybridge/devtools':
         specifier: ^1.1.0
-        version: 1.1.0(arktype@2.1.27)(typescript@5.9.3)
+        version: 1.2.3(arktype@2.1.27)(typescript@5.9.3)
       '@types/node':
         specifier: ^25.2.3
         version: 25.2.3
@@ -1050,7 +1050,7 @@ importers:
     devDependencies:
       '@skybridge/devtools':
         specifier: ^1.1.0
-        version: 1.1.0(arktype@2.1.27)(typescript@5.9.3)
+        version: 1.2.3(arktype@2.1.27)(typescript@5.9.3)
       '@types/node':
         specifier: ^22.19.3
         version: 22.19.3
@@ -1108,7 +1108,7 @@ importers:
     devDependencies:
       '@skybridge/devtools':
         specifier: ^1.1.0
-        version: 1.1.0(arktype@2.1.27)(typescript@5.9.3)
+        version: 1.2.3(arktype@2.1.27)(typescript@5.9.3)
       '@tailwindcss/vite':
         specifier: ^4.1.8
         version: 4.2.0(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
@@ -1200,7 +1200,7 @@ importers:
         version: 4.10.3
       '@skybridge/devtools':
         specifier: ^1.1.0
-        version: 1.1.0(arktype@2.1.27)(typescript@6.0.2)
+        version: 1.2.3(arktype@2.1.27)(typescript@6.0.2)
       ci-info:
         specifier: ^4.4.0
         version: 4.4.0
@@ -1350,7 +1350,7 @@ importers:
     devDependencies:
       '@skybridge/devtools':
         specifier: ^1.1.0
-        version: 1.1.0(arktype@2.1.27)(typescript@6.0.2)
+        version: 1.2.3(arktype@2.1.27)(typescript@6.0.2)
       '@types/node':
         specifier: ^24.12.0
         version: 24.12.0
@@ -1399,7 +1399,7 @@ importers:
     devDependencies:
       '@skybridge/devtools':
         specifier: ^1.1.0
-        version: 1.1.0(arktype@2.1.27)(typescript@6.0.2)
+        version: 1.2.3(arktype@2.1.27)(typescript@6.0.2)
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.3(@types/node@24.12.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
@@ -1430,6 +1430,9 @@ importers:
 
   packages/devtools:
     dependencies:
+      '@alpic-ai/sdk':
+        specifier: ^1.145.0
+        version: 1.145.0(@opentelemetry/api@1.9.1)(arktype@2.1.27)(typescript@6.0.2)
       '@t3-oss/env-core':
         specifier: ^0.13.11
         version: 0.13.11(arktype@2.1.27)(typescript@6.0.2)(zod@4.4.3)
@@ -1581,6 +1584,9 @@ importers:
       vite:
         specifier: ^8.0.3
         version: 8.0.3(@types/node@25.5.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(@vitest/ui@4.1.4)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.4(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       zustand:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@19.2.14)(immer@9.0.21)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
@@ -1605,6 +1611,9 @@ packages:
   '@alpic-ai/api@1.136.3':
     resolution: {integrity: sha512-d2NsEsanyBLaATvjn9TS2riycH8Z/UQkyr/SipuNJ4dgGt5AmRo2mwZnSUYXziuBbbUropqzK/A+tJSo2r02Mg==}
 
+  '@alpic-ai/api@1.145.0':
+    resolution: {integrity: sha512-f0TEzXpg4/QuYsEh0ctJ+z/NeezFIu+5ZgBP38sOrUwcJ89R0W+7ct1MYqwW+jaIFMhV5fSPe/+0dBgZK8YuhQ==}
+
   '@alpic-ai/insights@1.127.1':
     resolution: {integrity: sha512-VLeva10Ft30MeQhZnGTBbyU8rXp2I3Oqpv9gfyEUIbmu6k4lkGcAnpE834rJ7RI0/yT8JHTW5a21MrloUzj5tQ==}
     peerDependencies:
@@ -1613,6 +1622,10 @@ packages:
     peerDependenciesMeta:
       skybridge:
         optional: true
+
+  '@alpic-ai/sdk@1.145.0':
+    resolution: {integrity: sha512-QFrtVJZpWUqSJNumwjESJthwYxlfSzFPZ1xPXqnnkDpTFHAwR2gUg+XJmMgmeWVy2D7uJzXrfXM6uYECxDz3mw==}
+    engines: {node: '>= 18.20.8'}
 
   '@alpic-ai/ui@1.116.0':
     resolution: {integrity: sha512-bi/Qx1XHcETqjh8JdXLwG3mpS0Yf1EeSqZzlPJpWx3gUuQCTfG5ipLHg4/QB4olebZhNC1Uu7uvTkUSkVa3SCQ==}
@@ -4473,8 +4486,8 @@ packages:
     resolution: {integrity: sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==}
     engines: {node: '>=12'}
 
-  '@skybridge/devtools@1.1.0':
-    resolution: {integrity: sha512-Si9VZjnmoM/WuFwbpC+72qt1e/QdTEFn7+eiKqy5KFSWilmVVNkV0OH7CwFv5wdCpuVHe4V7IvPy5kwvKqv5RA==}
+  '@skybridge/devtools@1.2.3':
+    resolution: {integrity: sha512-15yRJzylede0+CKW4hRpyjLtm6tf5zZPNXlEvVWLMM9UQ4XrO0ZHyN3LKJKFS0X1L2DvtxTerMgPbba7F+cNmw==}
 
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
@@ -9864,6 +9877,10 @@ packages:
     resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
     engines: {node: '>=18'}
 
+  tar@7.5.19:
+    resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
+    engines: {node: '>=18'}
+
   terminal-size@4.0.1:
     resolution: {integrity: sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==}
     engines: {node: '>=18'}
@@ -10771,11 +10788,37 @@ snapshots:
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
+  '@alpic-ai/api@1.145.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@orpc/contract': 1.14.6(@opentelemetry/api@1.9.1)
+      ms: 2.1.3
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+
   '@alpic-ai/insights@1.127.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(skybridge@packages+core)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
     optionalDependencies:
       skybridge: link:packages/core
+
+  '@alpic-ai/sdk@1.145.0(@opentelemetry/api@1.9.1)(arktype@2.1.27)(typescript@6.0.2)':
+    dependencies:
+      '@alpic-ai/api': 1.145.0(@opentelemetry/api@1.9.1)
+      '@orpc/client': 1.14.6(@opentelemetry/api@1.9.1)
+      '@orpc/contract': 1.14.6(@opentelemetry/api@1.9.1)
+      '@orpc/openapi-client': 1.14.6(@opentelemetry/api@1.9.1)
+      '@t3-oss/env-core': 0.13.11(arktype@2.1.27)(typescript@6.0.2)(zod@4.4.3)
+      env-paths: 4.0.0
+      open: 11.0.0
+      openid-client: 6.8.4
+      tar: 7.5.19
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - arktype
+      - typescript
+      - valibot
 
   '@alpic-ai/ui@1.116.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(lucide-react@1.7.0(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-hook-form@7.75.0(react@19.2.4))(react@19.2.4)(sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tailwindcss@4.2.2)(tw-animate-css@1.4.0)':
     dependencies:
@@ -16075,7 +16118,7 @@ snapshots:
     dependencies:
       escape-string-regexp: 5.0.0
 
-  '@skybridge/devtools@1.1.0(arktype@2.1.27)(typescript@5.9.3)':
+  '@skybridge/devtools@1.2.3(arktype@2.1.27)(typescript@5.9.3)':
     dependencies:
       '@t3-oss/env-core': 0.13.11(arktype@2.1.27)(typescript@5.9.3)(zod@4.4.3)
       cors: 2.8.6
@@ -16087,7 +16130,7 @@ snapshots:
       - typescript
       - valibot
 
-  '@skybridge/devtools@1.1.0(arktype@2.1.27)(typescript@6.0.2)':
+  '@skybridge/devtools@1.2.3(arktype@2.1.27)(typescript@6.0.2)':
     dependencies:
       '@t3-oss/env-core': 0.13.11(arktype@2.1.27)(typescript@6.0.2)(zod@4.4.3)
       cors: 2.8.6
@@ -17157,7 +17200,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.12.0)(@vitest/ui@4.1.4)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.4(@types/node@24.12.0)(typescript@6.0.2))(vite@8.0.3(@types/node@24.12.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(@vitest/ui@4.1.4)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.4(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
 
   '@vitest/utils@4.1.4':
     dependencies:
@@ -22888,6 +22931,14 @@ snapshots:
       minizlib: 3.1.0
       yallist: 5.0.0
 
+  tar@7.5.19:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.2
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
   terminal-size@4.0.1: {}
 
   terser@5.44.1:
@@ -23586,7 +23637,7 @@ snapshots:
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.0.3(@types/node@24.12.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
@@ -23616,7 +23667,7 @@ snapshots:
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.0.3(@types/node@25.5.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,9 @@ minimumReleaseAgeExclude:
   - skybridge
   - "@skybridge/*"
   - create-skybridge
+  # TODO(sky-440): temporary for the @alpic-ai/sdk dev build (needs tar 7.5.19,
+  # 4 days old); drop once devtools is back on a stable SDK release.
+  - tar
 
 allowBuilds:
   esbuild: true


### PR DESCRIPTION
### Summary

- Rewire the devtools **Deploy** button to deploy to Alpic via `@alpic-ai/sdk`
- Sign-in gate, first-deploy modal (project name + team picker), and a live deploy lifecycle with a status dot.
- Persistent deployed view: copyable live URL + "Go to deployment page".
- Git-deployed projects surface the branch/author/commit and gate redeploy behind an explicit "Deploy anyway".
- Deploys through the SDK's project-link primitives (https://github.com/alpic-ai/alpic/pull/2106); requires `@alpic-ai/sdk@^1.146.1`.
- Entirely contained in devtools — **core is untouched**.

### Architecture Notes

- **Deploy runs in-process in a devtools dev-server router** — mounted via the existing `devtoolsStaticServer` (same origin as the UI, no CORS); the browser drives it over REST `/status` + SSE `/events`.
- **Server-owned progress + `startedAt`** — broadcast over SSE and replayed on connect, so the elapsed clock survives hover-remounts and a page refresh.
- **Default project name sourced client-side** (`useServerInfo`) — so the server never needs the MCP server name and core requires no new API; the feature ships to consumers on the next devtools release.

### Demo

https://www.loom.com/share/5c127b529eb140b6a9ef482f5a1a319f

### State machine

**Progress** — the deploy lifecycle, owned by the dev-server router and streamed over SSE (`/events` replays the current state on connect):

```mermaid
stateDiagram-v2
    [*] --> idle
    idle --> deploying: POST /project or POST /deploy
    state deploying {
        [*] --> collecting: 1/4 Collecting files
        collecting --> uploading: 2/4 Uploading source
        uploading --> triggering: 3/4 Triggering deployment
        triggering --> polling: 4/4 Deploying
    }
    deploying --> deployed: SDK deploy resolves deployed
    deploying --> failed: error, or canceled/failed result
    deployed --> deploying: redeploy
    failed --> deploying: retry
```

The client sets an optimistic `deploying` ("Preparing deployment") on click and rolls back to `idle` if the POST is rejected (409 in-progress, validation, etc.). A terminal transition (`deployed` or `failed`) also refetches status, flipping `needsProject → ready` after a first deploy — the project exists even when its first deploy failed.
