### PR TITLE
chore(deps): enable renovate automerge, reduce release-age window to 3 days

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,9 +7,9 @@ packages:
   - "packages/create-skybridge/templates/blank"
   - "examples/*"
 
-# Delay installing newly published versions by 2 weeks to reduce exposure to
+# Delay installing newly published versions by 3 days to reduce exposure to
 # supply-chain attacks via compromised releases.
-minimumReleaseAge: 20160
+minimumReleaseAge: 4320
 # First-party packages we publish ourselves: the delay buys no safety.
 minimumReleaseAgeExclude:
   - alpic

--- a/renovate.json
+++ b/renovate.json
@@ -8,11 +8,25 @@
   "prConcurrentLimit": 5,
   "timezone": "Europe/Paris",
   "rangeStrategy": "bump",
+  "minimumReleaseAge": "3 days",
   "packageRules": [
     {
       "description": "Ignore pnpm overrides (security floor pins managed manually)",
       "matchDepTypes": ["pnpm.overrides"],
       "enabled": false
+    },
+    {
+      "description": "Automerge non-major updates once CI passes",
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    },
+    {
+      "description": "Automerge devDependencies (including majors) once CI passes",
+      "matchDepTypes": ["devDependencies"],
+      "automerge": true
     }
-  ]
+  ],
+  "vulnerabilityAlerts": {
+    "automerge": true
+  }
 }


### PR DESCRIPTION
The idea is to stop stalling Renovate PRs that only get merged once in a while. We're protected by the minimumReleaseAge parameter as well as the release lifecycle.

### Summary

- Automerge renovate PRs: minor/patch, devDependencies, and security updates.
- Majors on runtime deps still require human review.
- Reduce `minimumReleaseAge` from 2 weeks to 3 days (pnpm).
- Mirror the 3-day window in renovate so it never proposes versions pnpm refuses.

### Required ruleset edits **before merge**

Automerge only works once the `main` ruleset is updated (admin UI):

- Add the non-required CI jobs to required status checks: `Build Examples`, `Docs Lint`, `Landing Build`, `Devtools E2E`.
  - Auto-merge only waits on required contexts; a PR failing a non-required job would merge anyway.
- Add the Renovate app to the ruleset bypass list.
  - The 1-review requirement applies to bots; without bypass, automerge arms and waits forever.

Repo setting `allow_auto_merge` is already enabled.