### PR TITLE
chore: rebase renovate PRs when behind main so automerge can arm

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
   "timezone": "Europe/Paris",
   "rangeStrategy": "bump",
   "rebaseWhen": "behind-base-branch",
+  "platformAutomerge": false,
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   "prConcurrentLimit": 5,
   "timezone": "Europe/Paris",
   "rangeStrategy": "bump",
+  "rebaseWhen": "behind-base-branch",
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {


### PR DESCRIPTION
### Summary

- \`rebaseWhen: behind-base-branch\` — default only rebases on conflicts, so green-but-stale PRs never update and automerge never arms.
- \`platformAutomerge: false\` — GitHub native auto-merge ignores ruleset bypass, so armed PRs wait forever on the 1-review rule (observed on #635: green + armed + bypassed, still blocked). With this off, Renovate merges via API on its next run after CI passes; as a ruleset bypass actor that merge skips the review requirement.

Together these make the #918 automerge flow actually hands-off. Cost: CI re-runs when main moves, and merges land minutes after green instead of instantly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)