### PR TITLE
chore: stop renovate bumping engines.node in published packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,6 +26,17 @@
       "description": "Automerge devDependencies (including majors) once CI passes",
       "matchDepTypes": ["devDependencies"],
       "automerge": true
+    },
+    {
+      "description": "Automerge GitHub Actions updates (including majors) once CI passes",
+      "matchDepTypes": ["action"],
+      "automerge": true
+    },
+    {
+      "description": "Never bump engines.node in published packages; Node support changes are deliberate semver-major decisions",
+      "matchDepNames": ["node"],
+      "matchFileNames": ["packages/*/package.json"],
+      "enabled": false
     }
   ],
   "vulnerabilityAlerts": {

--- a/renovate.json
+++ b/renovate.json
@@ -28,11 +28,6 @@
       "automerge": true
     },
     {
-      "description": "Automerge GitHub Actions updates (including majors) once CI passes",
-      "matchDepTypes": ["action"],
-      "automerge": true
-    },
-    {
       "description": "Never bump engines.node in published packages; Node support changes are deliberate semver-major decisions",
       "matchDepNames": ["node"],
       "matchFileNames": ["packages/*/package.json"],


### PR DESCRIPTION
### Summary

- Stop proposing \`engines.node\` bumps in \`packages/*/package.json\`: those are published compatibility promises (skybridge currently supports Node >=22), so raising them is a deliberate semver-major decision, not a routine dep bump. #753 regenerates without the \`packages/core\` engines change and becomes safe to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)