### PR TITLE
feat: mixed-auth on providers via securitySchemes (no auth shorthand)

### DIFF
--- a/docs/api-reference/register-tool.mdx
+++ b/docs/api-reference/register-tool.mdx
@@ -158,8 +158,12 @@ type SecurityScheme =
 - **Within an `oauth2` entry's `scopes`, match all.** The token must carry every listed scope.
 - **`noauth` and `oauth2` together** means "works anonymously, but auth unlocks more."
 
+<Info>
+With an [`oauth`](/api-reference/mcp-server#constructor) provider configured, Skybridge enforces `securitySchemes` for you: anonymous or under-scoped calls are rejected before the handler runs, and any tool declaring a `noauth` scheme flips the server into mixed mode. Declaring no schemes falls back to the secure default (sign-in required).
+</Info>
+
 <Warning>
-`securitySchemes` is client-facing metadata, not self-enforcing. Pair it with an auth middleware ([`requireBearerAuth`](/api-reference/require-bearer-auth) or [`optionalBearerAuth`](/api-reference/optional-bearer-auth)) to authenticate requests, and enforce the tool's own requirements in the handler from `extra.authInfo`.
+If you wire auth by hand instead (`mcpAuthMetadataRouter` + [`requireBearerAuth`](/api-reference/require-bearer-auth) / [`optionalBearerAuth`](/api-reference/optional-bearer-auth)), `securitySchemes` is client-facing metadata only, not self-enforcing: enforce each tool's own requirements in the handler from `extra.authInfo`.
 </Warning>
 
 ### `_meta`

--- a/docs/build/auth.mdx
+++ b/docs/build/auth.mdx
@@ -7,7 +7,7 @@ icon: "key"
 [Tool](/build/tools) calls are anonymous by default: nothing in the protocol tells you who's asking. [OAuth](https://oauth.net/2/) closes that gap, and the host does most of the work: it discovers your authorization server, signs the user in, refreshes tokens, and attaches a Bearer token to every request. Your server keeps three jobs: publish the discovery metadata, verify the tokens, and read the user in your handlers.
 
 <Tip>
-Using [Auth0](/guides/auth-providers#auth0), [Clerk](/guides/auth-providers#clerk), [Descope](/guides/auth-providers#descope), [Stytch](/guides/auth-providers#stytch), [WorkOS](/guides/auth-providers#workos), or [any other OAuth provider](/guides/auth-providers#any-other-provider)? Connect it in one line instead of wiring this by hand. That path can't yet [mix public and authenticated tools](#mix-public-and-authenticated-tools).
+Using [Auth0](/guides/auth-providers#auth0), [Clerk](/guides/auth-providers#clerk), [Descope](/guides/auth-providers#descope), [Stytch](/guides/auth-providers#stytch), [WorkOS](/guides/auth-providers#workos), or [any other OAuth provider](/guides/auth-providers#any-other-provider)? Connect it in one line instead of wiring this by hand. With a provider configured you can also [mix public and authenticated tools](#mix-public-and-authenticated-tools) by declaring each tool's `securitySchemes` — Skybridge enforces them for you, no middleware or handler guards needed.
 </Tip>
 
 Here's a complete server where every tool requires sign-in:

--- a/examples/auth-descope-mixed/.env.example
+++ b/examples/auth-descope-mixed/.env.example
@@ -1,0 +1,8 @@
+# Descope Configuration
+# The MCP Server's Discovery URL (a.k.a. Issuer) from the console's Connection
+# Information. Enable Dynamic Client Registration on the MCP Server, and grant a
+# `checkout` scope so the scoped tool can be exercised.
+DESCOPE_MCP_SERVER_URL=https://api.descope.com/v1/apps/agentic/<projectId>/<mcpServerId>
+
+# Environment
+NODE_ENV=development

--- a/examples/auth-descope-mixed/README.md
+++ b/examples/auth-descope-mixed/README.md
@@ -1,0 +1,60 @@
+# Skybridge Auth Example — Mixed public/authenticated tools (Descope)
+
+A single MCP server that serves both anonymous and signed-in callers, wired with
+the branded `descopeProvider`. It exists to exercise every mixed-auth case
+through each tool's `securitySchemes`, with no hand-wired middleware and no
+per-handler auth guards: with an `oauth` provider configured, the framework
+enforces each tool's declared schemes before the handler runs.
+
+For the fully-authenticated variant (every tool requires sign-in), see
+[`auth-descope`](../auth-descope).
+
+> The per-tool enforcement used here ships with the framework from this branch,
+> so this example links `skybridge` via `workspace:*` and is run from inside the
+> monorepo (`pnpm install` at the root).
+
+## The cases
+
+| Tool | `securitySchemes` | Behavior |
+| --- | --- | --- |
+| `browse-catalog` | `[{noauth},{oauth2}]` | Callable signed out; uses the token when present (greets you by name). |
+| `whoami` | `[{oauth2}]` | Requires sign-in. |
+| `checkout` | `[{oauth2, scopes:["checkout"]}]` | Requires sign-in **and** the `checkout` scope. |
+| `account` | *(omitted)* | No declaration → secure default: sign-in required. |
+
+Declaring a `noauth` scheme on `browse-catalog` is what flips the server into
+mixed mode: the `/mcp` door starts accepting anonymous requests, and every other
+tool stays sign-in-gated, enforced by the framework before the handler runs.
+
+## What to test
+
+**Anonymous (no token)**
+- `browse-catalog` → succeeds, returns "Catalog for guest…".
+- `whoami`, `checkout`, `account` → denied with `mcp/www_authenticate`, so the
+  host surfaces its sign-in UI.
+
+**Signed in, without the `checkout` scope**
+- `browse-catalog` → greets you by name.
+- `whoami`, `account` → succeed.
+- `checkout` → denied with `insufficient_scope`.
+
+**Signed in, with the `checkout` scope**
+- All four tools succeed.
+
+## Setup
+
+1. Create a Descope project and an MCP Server with Dynamic Client Registration
+   enabled (see [`auth-descope`](../auth-descope) for the console walkthrough).
+2. Grant a `checkout` scope so it can be issued into a token, to exercise the
+   scoped case.
+3. Copy `.env.example` to `.env` and set `DESCOPE_MCP_SERVER_URL`.
+4. Install and run:
+
+   ```bash
+   npm install
+   npm run dev
+   ```
+
+The devtools emulator connects anonymously, shows a sign-in CTA, and disables the
+auth-required tools until you sign in — a quick way to walk the cases above
+before testing in a real host.

--- a/examples/auth-descope-mixed/alpic.json
+++ b/examples/auth-descope-mixed/alpic.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://assets.alpic.ai/alpic.json",
+  "installCommand": "npm install",
+  "startCommand": "npm run --silent start"
+}

--- a/examples/auth-descope-mixed/nodemon.json
+++ b/examples/auth-descope-mixed/nodemon.json
@@ -1,0 +1,5 @@
+{
+  "watch": ["src"],
+  "ext": "ts,json",
+  "exec": "tsx src/server.ts"
+}

--- a/examples/auth-descope-mixed/package.json
+++ b/examples/auth-descope-mixed/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "skybridge-auth-descope-mixed-example",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Skybridge Auth Example - Mixed public/authenticated tools with Descope",
+  "type": "module",
+  "scripts": {
+    "dev": "skybridge dev",
+    "dev:tunnel": "skybridge dev --tunnel",
+    "build": "skybridge build",
+    "start": "skybridge start",
+    "deploy": "alpic deploy"
+  },
+  "dependencies": {
+    "dotenv": "^16.5.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "skybridge": "workspace:*",
+    "vite": "^8.0.0",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@skybridge/devtools": "^1.1.0",
+    "@types/express": "^5.0.6",
+    "@types/node": "^22.15.30",
+    "@types/react": "^19.2.13",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.1",
+    "alpic": "^1.136.3",
+    "nodemon": "^3.1.11",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3"
+  },
+  "workspaces": [],
+  "engines": {
+    "node": ">=24.0.0"
+  }
+}

--- a/examples/auth-descope-mixed/src/env.ts
+++ b/examples/auth-descope-mixed/src/env.ts
@@ -1,0 +1,16 @@
+import "dotenv/config";
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+export const env = {
+  NODE_ENV:
+    (process.env.NODE_ENV as "development" | "production") || "development",
+  DESCOPE_MCP_SERVER_URL: requireEnv("DESCOPE_MCP_SERVER_URL"),
+  SERVER_URL: process.env.SERVER_URL,
+};

--- a/examples/auth-descope-mixed/src/helpers.ts
+++ b/examples/auth-descope-mixed/src/helpers.ts
@@ -1,0 +1,4 @@
+import { generateHelpers } from "skybridge/web";
+import type { AppType } from "./server.js";
+
+export const { useCallTool, useToolInfo } = generateHelpers<AppType>();

--- a/examples/auth-descope-mixed/src/server.ts
+++ b/examples/auth-descope-mixed/src/server.ts
@@ -1,0 +1,75 @@
+import { type AuthInfo, descopeProvider, McpServer } from "skybridge/server";
+import * as z from "zod";
+import { env } from "./env.js";
+
+const text = (value: string) => ({
+  content: [{ type: "text" as const, text: value }],
+});
+
+const who = (auth?: AuthInfo) =>
+  auth ? ((auth.extra?.email as string | undefined) ?? auth.clientId) : "guest";
+
+const server = new McpServer(
+  {
+    name: "auth-coffee-mixed",
+    version: "0.0.1",
+  },
+  { capabilities: {} },
+  {
+    oauth: await descopeProvider({
+      url: env.DESCOPE_MCP_SERVER_URL,
+      baseUrl: env.SERVER_URL,
+    }),
+  },
+)
+  .registerTool(
+    {
+      name: "browse-catalog",
+      description:
+        "Browse the public coffee catalog. Works signed out, and greets you by name when a token is present.",
+      inputSchema: {},
+      securitySchemes: [{ type: "noauth" }, { type: "oauth2" }],
+      view: { component: "catalog", description: "The coffee catalog" },
+    },
+    (_args, extra) => {
+      const user = who(extra.authInfo);
+      const items = ["Espresso", "Latte", "Flat White", "Cold Brew"];
+      return {
+        structuredContent: { user, items },
+        content: [
+          { type: "text" as const, text: `Catalog for ${user}: ${items.join(", ")}.` },
+        ],
+      };
+    },
+  )
+  .registerTool(
+    {
+      name: "whoami",
+      description: "Return the signed-in user. Requires sign-in.",
+      inputSchema: {},
+      securitySchemes: [{ type: "oauth2" }],
+    },
+    (_args, extra) => text(`You are ${who(extra.authInfo)}.`),
+  )
+  .registerTool(
+    {
+      name: "checkout",
+      description: "Place an order. Requires sign-in with the `checkout` scope.",
+      inputSchema: { item: z.string().describe("The catalog item to order") },
+      securitySchemes: [{ type: "oauth2", scopes: ["checkout"] }],
+    },
+    ({ item }, extra) => text(`Order placed for ${who(extra.authInfo)}: ${item}.`),
+  )
+  .registerTool(
+    {
+      name: "account",
+      description:
+        "View account details. No auth declared, so it falls back to the secure default (sign-in required).",
+      inputSchema: {},
+    },
+    (_args, extra) => text(`Account details for ${who(extra.authInfo)}.`),
+  );
+
+export default await server.run();
+
+export type AppType = typeof server;

--- a/examples/auth-descope-mixed/src/views/catalog.tsx
+++ b/examples/auth-descope-mixed/src/views/catalog.tsx
@@ -1,0 +1,27 @@
+import { useToolInfo } from "../helpers.js";
+
+function Catalog() {
+  const { output, isPending, isSuccess } = useToolInfo<"browse-catalog">();
+
+  if (isPending) {
+    return <p>Loading catalog…</p>;
+  }
+
+  if (!isSuccess || !output) {
+    return <p>No catalog available.</p>;
+  }
+
+  return (
+    <div>
+      <h2>Coffee catalog</h2>
+      <p>Viewing as {output.user}</p>
+      <ul>
+        {output.items.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default Catalog;

--- a/examples/auth-descope-mixed/tsconfig.json
+++ b/examples/auth-descope-mixed/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "skybridge/tsconfig",
+
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+
+  "include": ["src", ".skybridge/**/*.d.ts"]
+}

--- a/examples/auth-descope-mixed/vite.config.ts
+++ b/examples/auth-descope-mixed/vite.config.ts
@@ -1,0 +1,13 @@
+import path from "node:path";
+import react from "@vitejs/plugin-react";
+import { skybridge } from "skybridge/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [skybridge(), react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});

--- a/packages/core/src/server/auth/security-schemes.test.ts
+++ b/packages/core/src/server/auth/security-schemes.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import type { AuthInfo } from "../auth.js";
+import type { SecurityScheme } from "../server.js";
+import {
+  clientPrefersInBandChallenge,
+  evaluateSecuritySchemes,
+  securitySchemesAllowAnonymous,
+  wwwAuthenticateHeader,
+} from "./security-schemes.js";
+
+describe("clientPrefersInBandChallenge", () => {
+  it("detects ChatGPT / OpenAI user agents", () => {
+    expect(clientPrefersInBandChallenge("openai-mcp/1.0")).toBe(true);
+    expect(clientPrefersInBandChallenge("ChatGPT")).toBe(true);
+    expect(clientPrefersInBandChallenge("Claude-User/1.0")).toBe(false);
+    expect(clientPrefersInBandChallenge(undefined)).toBe(false);
+  });
+});
+
+const authInfo = (scopes: string[]): AuthInfo => ({
+  token: "t",
+  clientId: "c",
+  scopes,
+});
+
+describe("securitySchemesAllowAnonymous", () => {
+  it("is true only when a noauth scheme is present", () => {
+    expect(securitySchemesAllowAnonymous([{ type: "noauth" }])).toBe(true);
+    expect(
+      securitySchemesAllowAnonymous([{ type: "noauth" }, { type: "oauth2" }]),
+    ).toBe(true);
+    expect(securitySchemesAllowAnonymous([{ type: "oauth2" }])).toBe(false);
+    expect(securitySchemesAllowAnonymous(undefined)).toBe(false);
+  });
+});
+
+describe("evaluateSecuritySchemes", () => {
+  it("lets anonymous callers through a noauth tool", () => {
+    const schemes: SecurityScheme[] = [{ type: "noauth" }, { type: "oauth2" }];
+    expect(evaluateSecuritySchemes(schemes, undefined)).toBeUndefined();
+  });
+
+  it("fails an oauth2-only tool with no token (invalid_token / 401)", () => {
+    expect(
+      evaluateSecuritySchemes([{ type: "oauth2" }], undefined)?.error,
+    ).toBe("invalid_token");
+  });
+
+  it("fails when the token is missing a required scope (insufficient_scope / 403)", () => {
+    const schemes: SecurityScheme[] = [
+      { type: "oauth2", scopes: ["checkout"] },
+    ];
+    expect(evaluateSecuritySchemes(schemes, authInfo(["openid"]))?.error).toBe(
+      "insufficient_scope",
+    );
+  });
+
+  it("passes when the token carries every required scope", () => {
+    const schemes: SecurityScheme[] = [
+      { type: "oauth2", scopes: ["checkout"] },
+    ];
+    expect(
+      evaluateSecuritySchemes(schemes, authInfo(["openid", "checkout"])),
+    ).toBeUndefined();
+  });
+
+  it("treats an undeclared tool as auth-required, satisfied by any valid token", () => {
+    expect(evaluateSecuritySchemes(undefined, undefined)?.error).toBe(
+      "invalid_token",
+    );
+    expect(evaluateSecuritySchemes(undefined, authInfo([]))).toBeUndefined();
+  });
+
+  it("carries the tool's required scopes on the failure", () => {
+    const schemes: SecurityScheme[] = [
+      { type: "oauth2", scopes: ["checkout"] },
+    ];
+    expect(evaluateSecuritySchemes(schemes, undefined)?.scopes).toEqual([
+      "checkout",
+    ]);
+    expect(
+      evaluateSecuritySchemes(schemes, authInfo(["openid"]))?.scopes,
+    ).toEqual(["checkout"]);
+  });
+});
+
+describe("wwwAuthenticateHeader", () => {
+  it("names the required scopes so the client can step up", () => {
+    const header = wwwAuthenticateHeader({
+      error: "insufficient_scope",
+      description: "Missing required scope for this tool.",
+      scopes: ["checkout"],
+    });
+    expect(header).toContain('error="insufficient_scope"');
+    expect(header).toContain('scope="checkout"');
+  });
+
+  it("omits the scope parameter when there are none", () => {
+    const header = wwwAuthenticateHeader({
+      error: "invalid_token",
+      description: "Sign in to use this tool.",
+      scopes: [],
+    });
+    expect(header).not.toContain("scope=");
+  });
+});

--- a/packages/core/src/server/auth/security-schemes.ts
+++ b/packages/core/src/server/auth/security-schemes.ts
@@ -1,0 +1,70 @@
+import type { AuthInfo } from "../auth.js";
+import type { SecurityScheme } from "../server.js";
+
+export function securitySchemesAllowAnonymous(
+  schemes: SecurityScheme[] | undefined,
+): boolean {
+  return !!schemes?.some((scheme) => scheme.type === "noauth");
+}
+
+export type SchemeFailure = {
+  error: "invalid_token" | "insufficient_scope";
+  description: string;
+  scopes: string[];
+};
+
+export function evaluateSecuritySchemes(
+  schemes: SecurityScheme[] | undefined,
+  authInfo: AuthInfo | undefined,
+): SchemeFailure | undefined {
+  if (securitySchemesAllowAnonymous(schemes)) {
+    return undefined;
+  }
+  const oauth2 = (schemes ?? []).filter((scheme) => scheme.type === "oauth2");
+  const required = oauth2.length ? oauth2 : [{ type: "oauth2" as const }];
+  const scopes = [
+    ...new Set(required.flatMap((scheme) => scheme.scopes ?? [])),
+  ];
+  if (!authInfo) {
+    return {
+      error: "invalid_token",
+      description: "Sign in to use this tool.",
+      scopes,
+    };
+  }
+  const satisfied = required.some((scheme) =>
+    (scheme.scopes ?? []).every((scope) => authInfo.scopes.includes(scope)),
+  );
+  return satisfied
+    ? undefined
+    : {
+        error: "insufficient_scope",
+        description: "Missing required scope for this tool.",
+        scopes,
+      };
+}
+
+export function httpStatusForFailure(failure: SchemeFailure): 401 | 403 {
+  return failure.error === "insufficient_scope" ? 403 : 401;
+}
+
+export function clientPrefersInBandChallenge(
+  userAgent: string | undefined,
+): boolean {
+  const ua = (userAgent ?? "").toLowerCase();
+  return ua.includes("openai") || ua.includes("chatgpt");
+}
+
+export function wwwAuthenticateHeader(
+  failure: SchemeFailure,
+  resourceMetadataUrl?: string,
+): string {
+  let header = `Bearer error="${failure.error}", error_description="${failure.description}"`;
+  if (failure.scopes.length) {
+    header += `, scope="${failure.scopes.join(" ")}"`;
+  }
+  if (resourceMetadataUrl) {
+    header += `, resource_metadata="${resourceMetadataUrl}"`;
+  }
+  return header;
+}

--- a/packages/core/src/server/auth/setup.test.ts
+++ b/packages/core/src/server/auth/setup.test.ts
@@ -518,6 +518,37 @@ describe("per-tool scope enforcement in fully-authenticated mode", () => {
   });
 });
 
+describe("securitySchemes validation", () => {
+  it("throws when a tool mixes `noauth` with a scoped `oauth2` scheme", () => {
+    expect(() =>
+      new McpServer({ name: "t", version: "0" }).registerTool(
+        {
+          name: "x",
+          inputSchema: {},
+          securitySchemes: [
+            { type: "noauth" },
+            { type: "oauth2", scopes: ["checkout"] },
+          ],
+        },
+        () => ({ content: [{ type: "text", text: "" }] }),
+      ),
+    ).toThrow(/unenforceable/);
+  });
+
+  it("allows `noauth` with an unscoped `oauth2` scheme", () => {
+    expect(() =>
+      new McpServer({ name: "t", version: "0" }).registerTool(
+        {
+          name: "x",
+          inputSchema: {},
+          securitySchemes: [{ type: "noauth" }, { type: "oauth2" }],
+        },
+        () => ({ content: [{ type: "text", text: "" }] }),
+      ),
+    ).not.toThrow();
+  });
+});
+
 describe("oauth config validation", () => {
   const validMetadata = {
     issuer: ISSUER,

--- a/packages/core/src/server/auth/setup.test.ts
+++ b/packages/core/src/server/auth/setup.test.ts
@@ -46,10 +46,10 @@ async function startJwks() {
   return { privateKey, jwksUri: `http://localhost:${port}/jwks` };
 }
 
-function signToken(key: CryptoKey) {
+function signToken(key: CryptoKey, scope = "openid email") {
   return new jose.SignJWT({
     client_id: "client-1",
-    scope: "openid email",
+    scope,
     sub: "user-1",
   })
     .setProtectedHeader({ alg: "RS256", kid: "test-key" })
@@ -212,6 +212,309 @@ describe("baseUrl inferred from headers", () => {
     expect(res.headers.get("www-authenticate")).toMatch(
       /resource_metadata="https:\/\/infer\.example\.test\//,
     );
+  });
+});
+
+async function bootMixedServer(jwksUri: string) {
+  const { createApp } = await import("../express.js");
+  const server = new McpServer(
+    { name: "mixed-auth-test", version: "0.0.0" },
+    { capabilities: {} },
+    {
+      oauth: {
+        baseUrl: "https://app.example.test",
+        oauthMetadata: {
+          issuer: ISSUER,
+          authorization_endpoint: `${ISSUER}/authorize`,
+          token_endpoint: `${ISSUER}/token`,
+          response_types_supported: ["code"],
+        },
+        verify: { issuer: ISSUER, audience: AUDIENCE, jwksUri },
+      },
+    },
+  )
+    .registerTool(
+      {
+        name: "public-whoami",
+        description: "Public.",
+        inputSchema: {},
+        securitySchemes: [{ type: "noauth" }, { type: "oauth2" }],
+      },
+      (_args, extra) => ({
+        content: [{ type: "text", text: extra.authInfo?.clientId ?? "anon" }],
+      }),
+    )
+    .registerTool(
+      {
+        name: "private-whoami",
+        description: "Private.",
+        inputSchema: {},
+        securitySchemes: [{ type: "oauth2" }],
+      },
+      (_args, extra) => ({
+        content: [{ type: "text", text: extra.authInfo?.clientId ?? "anon" }],
+      }),
+    );
+
+  (server.registerTool as (...a: unknown[]) => unknown)(
+    "legacy-whoami",
+    {
+      description: "Registered via the legacy string overload.",
+      inputSchema: {},
+    },
+    (_args: unknown, extra: { authInfo?: { clientId?: string } }) => ({
+      content: [{ type: "text", text: extra.authInfo?.clientId ?? "anon" }],
+    }),
+  );
+
+  const httpServer = http.createServer();
+  await createApp({ mcpServer: server, httpServer });
+  const listening = http.createServer(server.express);
+  await new Promise<void>((resolve) => listening.listen(0, resolve));
+  appServer = listening;
+  const port = (listening.address() as { port: number }).port;
+  return `http://localhost:${port}`;
+}
+
+describe("mixed-auth door", () => {
+  it("lets an anonymous caller initialize and run a noauth tool", async () => {
+    const { jwksUri } = await startJwks();
+    const base = await bootMixedServer(jwksUri);
+
+    const client = new Client({ name: "test-client", version: "0.0.0" });
+    await client.connect(
+      new StreamableHTTPClientTransport(new URL(`${base}/mcp`)),
+    );
+
+    const result = (await client.callTool({
+      name: "public-whoami",
+      arguments: {},
+    })) as unknown as { content: { text: string }[] };
+    expect(result.content[0]?.text).toBe("anon");
+
+    await client.close();
+  });
+
+  it("exposes securitySchemes at the top level of tools/list (not only _meta)", async () => {
+    const { jwksUri } = await startJwks();
+    const base = await bootMixedServer(jwksUri);
+    const headers = {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+    };
+    await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "c", version: "0" },
+        },
+      }),
+    });
+    const res = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list" }),
+    });
+    const text = await res.text();
+    const json = JSON.parse((text.match(/\{[\s\S]*\}/) ?? ["{}"])[0]) as {
+      result: { tools: Array<{ name: string; securitySchemes?: unknown }> };
+    };
+    const whoami = json.result.tools.find((t) => t.name === "private-whoami");
+    expect(whoami?.securitySchemes).toEqual([{ type: "oauth2" }]);
+  });
+
+  it("denies a protected tool inside an anonymous JSON-RPC batch", async () => {
+    const { jwksUri } = await startJwks();
+    const base = await bootMixedServer(jwksUri);
+
+    const res = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify([
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: { name: "private-whoami", arguments: {} },
+        },
+      ]),
+    });
+    const text = await res.text();
+    expect(text).not.toContain("client-1");
+    expect(text).toContain("Sign in to use this tool.");
+    expect(text).toContain("resource_metadata=");
+  });
+
+  it("gates a tool registered via the legacy string overload (secure default)", async () => {
+    const { jwksUri } = await startJwks();
+    const base = await bootMixedServer(jwksUri);
+
+    const res = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "legacy-whoami", arguments: {} },
+      }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 + WWW-Authenticate for a protected tool while anonymous", async () => {
+    const { jwksUri } = await startJwks();
+    const base = await bootMixedServer(jwksUri);
+
+    const res = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "private-whoami", arguments: {} },
+      }),
+    });
+    expect(res.status).toBe(401);
+    expect(res.headers.get("www-authenticate")).toMatch(
+      /error="invalid_token"/,
+    );
+    expect(res.headers.get("www-authenticate")).toMatch(/resource_metadata=/);
+  });
+
+  it("returns an in-band mcp/www_authenticate array to ChatGPT (not a transport 401)", async () => {
+    const { jwksUri } = await startJwks();
+    const base = await bootMixedServer(jwksUri);
+
+    const res = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        "User-Agent": "openai-mcp/1.0",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 7,
+        method: "tools/call",
+        params: { name: "private-whoami", arguments: {} },
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("www-authenticate")).toBeNull();
+    const body = (await res.json()) as {
+      id: number;
+      result: {
+        isError: boolean;
+        _meta: { "mcp/www_authenticate": string[] };
+      };
+    };
+    expect(body.id).toBe(7);
+    expect(body.result.isError).toBe(true);
+    const challenge = body.result._meta["mcp/www_authenticate"];
+    expect(Array.isArray(challenge)).toBe(true);
+    expect(challenge[0]).toMatch(/error="invalid_token"/);
+    expect(challenge[0]).toMatch(/resource_metadata=/);
+  });
+});
+
+async function bootScopedServer(jwksUri: string) {
+  const { createApp } = await import("../express.js");
+  const server = new McpServer(
+    { name: "scoped-auth-test", version: "0.0.0" },
+    { capabilities: {} },
+    {
+      oauth: {
+        baseUrl: "https://app.example.test",
+        oauthMetadata: {
+          issuer: ISSUER,
+          authorization_endpoint: `${ISSUER}/authorize`,
+          token_endpoint: `${ISSUER}/token`,
+          response_types_supported: ["code"],
+        },
+        verify: { issuer: ISSUER, audience: AUDIENCE, jwksUri },
+      },
+    },
+  ).registerTool(
+    {
+      name: "checkout",
+      description: "Needs the checkout scope.",
+      inputSchema: {},
+      securitySchemes: [{ type: "oauth2", scopes: ["checkout"] }],
+    },
+    () => ({ content: [{ type: "text", text: "ok" }] }),
+  );
+
+  const httpServer = http.createServer();
+  await createApp({ mcpServer: server, httpServer });
+  const listening = http.createServer(server.express);
+  await new Promise<void>((resolve) => listening.listen(0, resolve));
+  appServer = listening;
+  const port = (listening.address() as { port: number }).port;
+  return `http://localhost:${port}`;
+}
+
+describe("per-tool scope enforcement in fully-authenticated mode", () => {
+  it("returns 403 for a valid token missing the tool's scope", async () => {
+    const { privateKey, jwksUri } = await startJwks();
+    const base = await bootScopedServer(jwksUri);
+    const token = await signToken(privateKey, "openid");
+
+    const res = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "checkout", arguments: {} },
+      }),
+    });
+    expect(res.status).toBe(403);
+    const header = res.headers.get("www-authenticate");
+    expect(header).toMatch(/error="insufficient_scope"/);
+    expect(header).toMatch(/scope="checkout"/);
+  });
+
+  it("allows a token carrying the tool's scope", async () => {
+    const { privateKey, jwksUri } = await startJwks();
+    const base = await bootScopedServer(jwksUri);
+    const token = await signToken(privateKey, "openid checkout");
+
+    const client = new Client({ name: "test-client", version: "0.0.0" });
+    await client.connect(
+      new StreamableHTTPClientTransport(new URL(`${base}/mcp`), {
+        requestInit: { headers: { Authorization: `Bearer ${token}` } },
+      }),
+    );
+
+    const result = (await client.callTool({
+      name: "checkout",
+      arguments: {},
+    })) as unknown as { isError?: boolean; content: { text: string }[] };
+    expect(result.content[0]?.text).toBe("ok");
+
+    await client.close();
   });
 });
 

--- a/packages/core/src/server/auth/setup.ts
+++ b/packages/core/src/server/auth/setup.ts
@@ -1,21 +1,49 @@
+import type { BearerAuthMiddlewareOptions } from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js";
 import {
   getOAuthProtectedResourceMetadataUrl,
   mcpAuthMetadataRouter,
 } from "@modelcontextprotocol/sdk/server/auth/router.js";
 import cors from "cors";
-import type { Express, Request } from "express";
-import { requireBearerAuth } from "../auth.js";
+import type { Express, Request, RequestHandler } from "express";
+import type { AuthInfo } from "../auth.js";
+import { optionalBearerAuth, requireBearerAuth } from "../auth.js";
 import { resolveServerOrigin } from "../requestOrigin.js";
+import type { SecurityScheme } from "../server.js";
 import type { OAuthConfig } from "./index.js";
+import {
+  clientPrefersInBandChallenge,
+  evaluateSecuritySchemes,
+  httpStatusForFailure,
+  securitySchemesAllowAnonymous,
+  wwwAuthenticateHeader,
+} from "./security-schemes.js";
 import { createJwksVerifier } from "./verify.js";
 
+export type ResourceMetadataUrlResolver = (
+  getHeader: (key: string) => string | undefined,
+) => string;
+
 /** Mounts the well-known OAuth metadata and bearer auth on `/mcp`. */
-export function setupOAuth(app: Express, config: OAuthConfig): void {
+export function setupOAuth(
+  app: Express,
+  config: OAuthConfig,
+  schemesByTool: Map<string, SecurityScheme[] | undefined>,
+): ResourceMetadataUrlResolver {
   if (!config.verify?.issuer) {
     throw new Error("oauth.verify requires an `issuer`");
   }
 
+  const acceptsAnonymous = () =>
+    [...schemesByTool.values()].some(securitySchemesAllowAnonymous);
   const verifier = createJwksVerifier(config.verify);
+  const bearer = (options: BearerAuthMiddlewareOptions): RequestHandler => {
+    const required = requireBearerAuth(options);
+    const optional = optionalBearerAuth(options);
+    return (req, res, next) =>
+      (acceptsAnonymous() ? optional : required)(req, res, next);
+  };
+
+  let resourceMetadataUrl: ResourceMetadataUrlResolver;
 
   // baseUrl known at boot: bake the resource URLs once, no Host-header trust.
   if (config.baseUrl !== undefined) {
@@ -36,42 +64,79 @@ export function setupOAuth(app: Express, config: OAuthConfig): void {
         scopesSupported: config.scopesSupported,
       }),
     );
+    const url = getOAuthProtectedResourceMetadataUrl(baseUrl);
+    resourceMetadataUrl = () => url;
+  } else {
+    // No baseUrl: resolve the resource origin per request from forwarded headers
+    // (same precedence the framework uses for view serverUrl). Origin headers are
+    // pathless, so the PRM path stays at root, matching the SDK's static layout.
+    const resolveOrigin = (getHeader: (key: string) => string | undefined) =>
+      new URL(resolveServerOrigin(getHeader));
     app.use(
-      "/mcp",
-      requireBearerAuth({
-        verifier,
-        requiredScopes: config.requiredScopes,
-        resourceMetadataUrl: getOAuthProtectedResourceMetadataUrl(baseUrl),
-      }),
+      "/.well-known/oauth-authorization-server",
+      cors(),
+      (_req, res) => void res.json(config.oauthMetadata),
     );
-    return;
+    app.use("/.well-known/oauth-protected-resource", cors(), (req, res) => {
+      res.json({
+        resource: resolveOrigin((key) => req.get(key)).href,
+        authorization_servers: [config.oauthMetadata.issuer],
+        scopes_supported: config.scopesSupported,
+      });
+    });
+    resourceMetadataUrl = (getHeader) =>
+      getOAuthProtectedResourceMetadataUrl(resolveOrigin(getHeader));
   }
 
-  // No baseUrl: resolve the resource origin per request from forwarded headers
-  // (same precedence the framework uses for view serverUrl). Origin headers are
-  // pathless, so the PRM path stays at root, matching the SDK's static layout.
-  const resolveOrigin = (req: Request) =>
-    new URL(resolveServerOrigin((key) => req.get(key)));
-
-  app.use(
-    "/.well-known/oauth-authorization-server",
-    cors(),
-    (_req, res) => void res.json(config.oauthMetadata),
-  );
-  app.use("/.well-known/oauth-protected-resource", cors(), (req, res) => {
-    res.json({
-      resource: resolveOrigin(req).href,
-      authorization_servers: [config.oauthMetadata.issuer],
-      scopes_supported: config.scopesSupported,
-    });
-  });
   app.use("/mcp", (req, res, next) =>
-    requireBearerAuth({
+    bearer({
       verifier,
       requiredScopes: config.requiredScopes,
-      resourceMetadataUrl: getOAuthProtectedResourceMetadataUrl(
-        resolveOrigin(req),
-      ),
+      resourceMetadataUrl: resourceMetadataUrl((key) => req.get(key)),
     })(req, res, next),
   );
+
+  app.use("/mcp", (req, res, next) => {
+    const body = req.body as
+      | {
+          id?: string | number | null;
+          method?: string;
+          params?: { name?: string };
+        }
+      | undefined;
+    const tool = body?.params?.name;
+    if (body?.method !== "tools/call" || !tool || !schemesByTool.has(tool)) {
+      return next();
+    }
+    const failure = evaluateSecuritySchemes(
+      schemesByTool.get(tool),
+      (req as Request & { auth?: AuthInfo }).auth,
+    );
+    if (!failure) {
+      return next();
+    }
+    const challenge = wwwAuthenticateHeader(
+      failure,
+      resourceMetadataUrl((key) => req.get(key)),
+    );
+    if (clientPrefersInBandChallenge(req.get("user-agent"))) {
+      res.json({
+        jsonrpc: "2.0",
+        id: body.id ?? null,
+        result: {
+          content: [{ type: "text", text: failure.description }],
+          isError: true,
+          _meta: { "mcp/www_authenticate": [challenge] },
+        },
+      });
+      return;
+    }
+    res.set("WWW-Authenticate", challenge);
+    res.status(httpStatusForFailure(failure)).json({
+      error: failure.error,
+      error_description: failure.description,
+    });
+  });
+
+  return resourceMetadataUrl;
 }

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -35,6 +35,7 @@ import express, {
 import type { OAuthConfig } from "./auth/index.js";
 import {
   evaluateSecuritySchemes,
+  securitySchemesAllowAnonymous,
   wwwAuthenticateHeader,
 } from "./auth/security-schemes.js";
 import { type ResourceMetadataUrlResolver, setupOAuth } from "./auth/setup.js";
@@ -1315,6 +1316,17 @@ export class McpServer<
       _meta: userToolMeta,
       ...toolFields
     } = config;
+
+    if (
+      securitySchemesAllowAnonymous(securitySchemes) &&
+      securitySchemes?.some(
+        (scheme) => scheme.type === "oauth2" && scheme.scopes?.length,
+      )
+    ) {
+      throw new Error(
+        `Tool "${name}": a \`noauth\` scheme makes its \`oauth2\` scopes unenforceable (the tool stays public). Drop \`noauth\` to gate this tool by scope.`,
+      );
+    }
 
     const toolMeta: InternalToolMeta = { ...userToolMeta };
 

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -33,7 +33,11 @@ import express, {
   type RequestHandler,
 } from "express";
 import type { OAuthConfig } from "./auth/index.js";
-import { setupOAuth } from "./auth/setup.js";
+import {
+  evaluateSecuritySchemes,
+  wwwAuthenticateHeader,
+} from "./auth/security-schemes.js";
+import { type ResourceMetadataUrlResolver, setupOAuth } from "./auth/setup.js";
 import { createApp } from "./express.js";
 import { createMiddlewareEntry } from "./metric.js";
 import type {
@@ -469,6 +473,25 @@ export function __setBuildManifest(
   pendingBuildManifest = manifest;
 }
 
+function normalizeRegisterToolArgs(args: unknown[]): {
+  config: ToolConfig<ZodRawShapeCompat>;
+  cb: ToolHandler<ZodRawShapeCompat>;
+} {
+  if (typeof args[0] === "string") {
+    return {
+      config: {
+        name: args[0],
+        ...(args[1] as object),
+      } as ToolConfig<ZodRawShapeCompat>,
+      cb: args[2] as ToolHandler<ZodRawShapeCompat>,
+    };
+  }
+  return {
+    config: args[0] as ToolConfig<ZodRawShapeCompat>,
+    cb: args[1] as ToolHandler<ZodRawShapeCompat>,
+  };
+}
+
 export class McpServer<
   TTools extends Record<string, ToolDef> = Record<never, ToolDef>,
 > extends McpServerBaseOmitted {
@@ -506,6 +529,12 @@ export class McpServer<
   private viteManifest: Record<string, ViteManifestEntry> | null = null;
   private readonly serverInfo: Implementation;
   private readonly serverOptions?: ServerOptions;
+  private oauthEnabled = false;
+  private resolveResourceMetadataUrl?: ResourceMetadataUrlResolver;
+  private securitySchemesByTool = new Map<
+    string,
+    SecurityScheme[] | undefined
+  >();
 
   constructor(
     serverInfo: Implementation,
@@ -518,7 +547,12 @@ export class McpServer<
     this.express = express();
     this.express.use(express.json(skybridgeOptions?.json));
     if (skybridgeOptions?.oauth) {
-      setupOAuth(this.express, skybridgeOptions.oauth);
+      this.oauthEnabled = true;
+      this.resolveResourceMetadataUrl = setupOAuth(
+        this.express,
+        skybridgeOptions.oauth,
+        this.securitySchemesByTool,
+      );
     }
     // Pick up the manifest if `dist/__entry.js` primed it before importing
     // user code. Consume-once: clear after the first construction so a
@@ -731,17 +765,32 @@ export class McpServer<
       },
     };
 
+    const toolsListSecuritySchemesEntry: McpMiddlewareEntry = {
+      filter: "tools/list",
+      handler: async (_req, _extra, next) => {
+        const result = (await next()) as {
+          tools: Array<
+            Record<string, unknown> & { _meta?: Record<string, unknown> }
+          >;
+        };
+        for (const tool of result.tools) {
+          const schemes = tool._meta?.securitySchemes;
+          if (schemes && !("securitySchemes" in tool)) {
+            tool.securitySchemes = schemes;
+          }
+        }
+        return result;
+      },
+    };
+
     const monitoringEntry = createMiddlewareEntry();
     const entries = [
       ...(monitoringEntry ? [monitoringEntry] : []),
       viewListMetaEntry,
       viewReadResolveEntry,
+      toolsListSecuritySchemesEntry,
       ...this.mcpMiddlewareEntries,
     ];
-
-    if (entries.length === 0) {
-      return;
-    }
 
     const { requestHandlers, notificationHandlers } = getHandlerMaps(
       this.server,
@@ -1101,11 +1150,36 @@ export class McpServer<
     );
   }
 
-  private wrapHandler<InputArgs extends ZodRawShapeCompat>(
+  private decorateToolHandler<InputArgs extends ZodRawShapeCompat>(
     cb: ToolHandler<InputArgs>,
-    { attachViewUUID }: { attachViewUUID: boolean },
+    {
+      attachViewUUID,
+      securitySchemes,
+    }: { attachViewUUID: boolean; securitySchemes?: SecurityScheme[] },
   ): ToolHandler<InputArgs> {
     return async (args, extra) => {
+      if (this.oauthEnabled) {
+        const failure = evaluateSecuritySchemes(
+          securitySchemes,
+          extra.authInfo,
+        );
+        if (failure) {
+          const headers = extra?.requestInfo?.headers ?? {};
+          const header = (key: string) => {
+            const value = headers[key];
+            return Array.isArray(value) ? value[0] : value;
+          };
+          const challenge = wwwAuthenticateHeader(
+            failure,
+            this.resolveResourceMetadataUrl?.(header),
+          );
+          return {
+            isError: true,
+            content: [{ type: "text", text: failure.description }],
+            _meta: { "mcp/www_authenticate": [challenge] },
+          };
+        }
+      }
       const result = await cb(args, extra);
       return {
         ...result,
@@ -1232,13 +1306,7 @@ export class McpServer<
       ...args: unknown[]
     ) => unknown;
 
-    if (typeof args[0] === "string") {
-      baseFn.call(this, args[0], args[1], args[2]);
-      return this;
-    }
-
-    const config = args[0] as ToolConfig<ZodRawShapeCompat>;
-    const cb = args[1] as ToolHandler<ZodRawShapeCompat>;
+    const { config, cb } = normalizeRegisterToolArgs(args);
 
     const {
       name,
@@ -1249,6 +1317,8 @@ export class McpServer<
     } = config;
 
     const toolMeta: InternalToolMeta = { ...userToolMeta };
+
+    this.securitySchemesByTool.set(name, securitySchemes);
 
     if (securitySchemes) {
       // SEP-1488 puts `securitySchemes` at the top level of the tool
@@ -1264,7 +1334,10 @@ export class McpServer<
       this.registerViewResources(name, view, toolMeta);
     }
 
-    const wrappedCb = this.wrapHandler(cb, { attachViewUUID: Boolean(view) });
+    const wrappedCb = this.decorateToolHandler(cb, {
+      attachViewUUID: Boolean(view),
+      securitySchemes,
+    });
 
     baseFn.call(this, name, { ...toolFields, _meta: toolMeta }, wrappedCb);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,6 +268,58 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  examples/auth-descope-mixed:
+    dependencies:
+      dotenv:
+        specifier: ^16.5.0
+        version: 16.6.1
+      react:
+        specifier: ^19.2.4
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.7(react@19.2.7)
+      skybridge:
+        specifier: workspace:*
+        version: link:../../packages/core
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.3(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      zod:
+        specifier: ^4.3.6
+        version: 4.4.3
+    devDependencies:
+      '@skybridge/devtools':
+        specifier: ^1.1.0
+        version: 1.1.0(arktype@2.1.27)(typescript@5.9.3)
+      '@types/express':
+        specifier: ^5.0.6
+        version: 5.0.6
+      '@types/node':
+        specifier: ^22.15.30
+        version: 22.19.3
+      '@types/react':
+        specifier: ^19.2.13
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.1
+        version: 6.0.1(vite@8.0.3(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      alpic:
+        specifier: ^1.136.3
+        version: 1.136.3(@opentelemetry/api@1.9.1)(arktype@2.1.27)(rxjs@7.8.2)(typescript@5.9.3)
+      nodemon:
+        specifier: ^3.1.11
+        version: 3.1.11
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   examples/auth-stytch:
     dependencies:
       '@alpic-ai/insights':
@@ -9421,11 +9473,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.8.3:
-    resolution: {integrity: sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.8.4:
     resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
     engines: {node: '>=10'}
@@ -12606,7 +12653,7 @@ snapshots:
       is-wsl: 2.2.0
       lilconfig: 3.1.3
       minimatch: 10.2.5
-      semver: 7.8.3
+      semver: 7.8.4
       string-width: 4.2.3
       supports-color: 8.1.1
       tinyglobby: 0.2.17
@@ -12830,7 +12877,7 @@ snapshots:
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
-      semver: 7.7.4
+      semver: 7.8.4
       tar-fs: 3.1.1
       unbzip2-stream: 1.4.3
       yargs: 17.7.2
@@ -20740,7 +20787,7 @@ snapshots:
       ignore-by-default: 1.0.1
       minimatch: 3.1.5
       pstree.remy: 1.1.8
-      semver: 7.7.4
+      semver: 7.8.4
       simple-update-notifier: 2.0.0
       supports-color: 5.5.0
       touch: 3.1.1
@@ -22210,8 +22257,6 @@ snapshots:
 
   semver@7.7.4: {}
 
-  semver@7.8.3: {}
-
   semver@7.8.4: {}
 
   send@0.19.2:
@@ -22356,7 +22401,7 @@ snapshots:
     dependencies:
       color: 4.2.3
       detect-libc: 2.1.2
-      semver: 7.7.4
+      semver: 7.8.4
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5
@@ -22382,7 +22427,7 @@ snapshots:
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
-      semver: 7.7.4
+      semver: 7.8.4
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5
@@ -22499,7 +22544,7 @@ snapshots:
 
   simple-update-notifier@2.0.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.4
 
   sirv@3.0.2:
     dependencies:


### PR DESCRIPTION
### Summary

- Variation of #904: mixed-auth on the `oauth` provider path, driven purely by `securitySchemes`.
- **No new `auth` shorthand** — the only per-tool auth surface is the existing `securitySchemes`.
- Scopes and schemes are enforced by the framework before the handler runs, with an `oauth` provider configured.
- Any tool declaring a `noauth` scheme flips the server into mixed mode; undeclared tools fall back to the secure default (sign-in required).
- Registration throws if a tool mixes `noauth` with a scoped `oauth2` scheme (the scopes would be unenforceable — the tool stays public).
- Reworks the `descope-mixed` example and docs to the `securitySchemes`-only API.

### Architecture Notes

- **Enforcement layers** — per-request `/mcp` gate (transport `401/403` for spec clients, in-band `mcp/www_authenticate` for ChatGPT) plus an in-handler backstop covering JSON-RPC batches.
- **Secure default** — with a provider, a tool that declares nothing is sign-in-gated; opening a tool requires an explicit `noauth` scheme.
- **Match-any semantics** — a scheme array is satisfied by any one entry, so a `noauth` entry makes the tool public regardless of other entries; the registration throw guards the resulting footgun (scoped `oauth2` alongside `noauth`) at boot rather than silently ignoring the scopes.
