### PR TITLE
fix(dev): serve bundled views through the tunnel to fix slow first render (#847)

### DIFF
--- a/packages/core/src/cli/start-tunnel-view-build.ts
+++ b/packages/core/src/cli/start-tunnel-view-build.ts
@@ -1,17 +1,6 @@
 import path from "node:path";
 
-/**
- * Start a watch-mode Vite build of the views for `dev --tunnel`.
- *
- * Writes hashed bundles + a manifest to `dist/assets` and rebuilds
- * incrementally on view changes. The dev server serves that output to remote
- * (tunnel) hosts so the first render fetches ~2 files instead of the unbundled
- * dev server's per-module waterfall.
- *
- * Runs in the long-lived CLI process (not the nodemon-restarted server) and is
- * fire-and-forget: the view handler falls back to the unbundled entry until the
- * first build lands.
- */
+/** Fire-and-forget watch build of the views; the dev server serves its output to tunnel hosts. */
 export function startTunnelViewBuild(root = process.cwd()): void {
   void (async () => {
     const { build } = await import("vite");

--- a/packages/core/src/cli/start-tunnel-view-build.ts
+++ b/packages/core/src/cli/start-tunnel-view-build.ts
@@ -1,6 +1,5 @@
 import path from "node:path";
 
-/** Fire-and-forget watch build of the views; the dev server serves its output to tunnel hosts. */
 export function startTunnelViewBuild(root = process.cwd()): void {
   void (async () => {
     const { build } = await import("vite");

--- a/packages/core/src/cli/start-tunnel-view-build.ts
+++ b/packages/core/src/cli/start-tunnel-view-build.ts
@@ -1,0 +1,28 @@
+import path from "node:path";
+
+/**
+ * Start a watch-mode Vite build of the views for `dev --tunnel`.
+ *
+ * Writes hashed bundles + a manifest to `dist/assets` and rebuilds
+ * incrementally on view changes. The dev server serves that output to remote
+ * (tunnel) hosts so the first render fetches ~2 files instead of the unbundled
+ * dev server's per-module waterfall.
+ *
+ * Runs in the long-lived CLI process (not the nodemon-restarted server) and is
+ * fire-and-forget: the view handler falls back to the unbundled entry until the
+ * first build lands.
+ */
+export function startTunnelViewBuild(root = process.cwd()): void {
+  void (async () => {
+    const { build } = await import("vite");
+    await build({
+      root,
+      configFile: path.join(root, "vite.config.ts"),
+      mode: "development",
+      logLevel: "warn",
+      build: { watch: {}, minify: false },
+    });
+  })().catch((err) => {
+    console.error("skybridge: tunnel view build failed", err);
+  });
+}

--- a/packages/core/src/commands/dev.tsx
+++ b/packages/core/src/commands/dev.tsx
@@ -75,12 +75,20 @@ export default class Dev extends Command {
       ...process.env,
       __PORT: String(port),
       __TUNNEL_CONTROL_PORT: String(controlPort),
-      ...(flags.tunnel ? { __TUNNEL_BUNDLE: "1" } : {}),
     };
 
-    if (flags.tunnel) {
+    // Kick off the bundled view build the first time a tunnel becomes active,
+    // whether opened via `--tunnel` or the DevTools UI — both flip the manager
+    // off "idle". The server serves that build to remote hosts; until it lands
+    // the view falls back to the unbundled entry.
+    let viewBuildStarted = false;
+    tunnelManager.subscribe((state) => {
+      if (viewBuildStarted || state.status === "idle") {
+        return;
+      }
+      viewBuildStarted = true;
       startTunnelViewBuild(root);
-    }
+    });
 
     if (flags.plain) {
       const teardown = runPlain({

--- a/packages/core/src/commands/dev.tsx
+++ b/packages/core/src/commands/dev.tsx
@@ -4,6 +4,7 @@ import { resolvePort } from "../cli/detect-port.js";
 import { Header } from "../cli/header.js";
 import { resolveViewsDir } from "../cli/resolve-views-dir.js";
 import { runPlain } from "../cli/run-plain.js";
+import { startTunnelViewBuild } from "../cli/start-tunnel-view-build.js";
 import { startTunnelControlServer } from "../cli/tunnel-control-server.js";
 import { useMessages } from "../cli/use-messages.js";
 import { useNodemon } from "../cli/use-nodemon.js";
@@ -74,7 +75,12 @@ export default class Dev extends Command {
       ...process.env,
       __PORT: String(port),
       __TUNNEL_CONTROL_PORT: String(controlPort),
+      ...(flags.tunnel ? { __TUNNEL_BUNDLE: "1" } : {}),
     };
+
+    if (flags.tunnel) {
+      startTunnelViewBuild(root);
+    }
 
     if (flags.plain) {
       const teardown = runPlain({

--- a/packages/core/src/commands/dev.tsx
+++ b/packages/core/src/commands/dev.tsx
@@ -77,10 +77,6 @@ export default class Dev extends Command {
       __TUNNEL_CONTROL_PORT: String(controlPort),
     };
 
-    // Kick off the bundled view build the first time a tunnel becomes active,
-    // whether opened via `--tunnel` or the DevTools UI — both flip the manager
-    // off "idle". The server serves that build to remote hosts; until it lands
-    // the view falls back to the unbundled entry.
     let viewBuildStarted = false;
     tunnelManager.subscribe((state) => {
       if (viewBuildStarted || state.status === "idle") {

--- a/packages/core/src/server/express.ts
+++ b/packages/core/src/server/express.ts
@@ -67,6 +67,21 @@ export async function createApp({
   if (process.env.NODE_ENV !== "production") {
     const { devtoolsStaticServer } = await import("@skybridge/devtools");
     app.use(await devtoolsStaticServer());
+
+    // `dev --tunnel`: serve the bundled build of the views (like production) so
+    // the first render through the tunnel fetches ~2 files instead of the
+    // unbundled dev server's per-module waterfall (browsers cap ~6 HTTP/1.1
+    // connections per origin and each request pays a full round-trip to the
+    // tunnel edge). The CLI runs the watch build that writes dist/assets; here
+    // we just serve it, mounted before the Vite middleware so built hashed
+    // assets win. Unbundled dev module requests (localhost/DevTools) miss on
+    // disk and fall through to Vite unchanged.
+    if (process.env.__TUNNEL_BUNDLE === "1") {
+      const assetsPath = path.join(process.cwd(), "dist", "assets");
+      app.use("/assets", cors());
+      app.use("/assets", express.static(assetsPath));
+    }
+
     const { viewsDevServer } = await import("./viewsDevServer.js");
     app.use(await viewsDevServer(httpServer));
 

--- a/packages/core/src/server/express.ts
+++ b/packages/core/src/server/express.ts
@@ -68,19 +68,17 @@ export async function createApp({
     const { devtoolsStaticServer } = await import("@skybridge/devtools");
     app.use(await devtoolsStaticServer());
 
-    // `dev --tunnel`: serve the bundled build of the views (like production) so
-    // the first render through the tunnel fetches ~2 files instead of the
-    // unbundled dev server's per-module waterfall (browsers cap ~6 HTTP/1.1
-    // connections per origin and each request pays a full round-trip to the
-    // tunnel edge). The CLI runs the watch build that writes dist/assets; here
-    // we just serve it, mounted before the Vite middleware so built hashed
-    // assets win. Unbundled dev module requests (localhost/DevTools) miss on
-    // disk and fall through to Vite unchanged.
-    if (process.env.__TUNNEL_BUNDLE === "1") {
-      const assetsPath = path.join(process.cwd(), "dist", "assets");
-      app.use("/assets", cors());
-      app.use("/assets", express.static(assetsPath));
-    }
+    // Serve the bundled build of the views (like production) so remote hosts
+    // reach a view in ~2 requests instead of the unbundled dev server's
+    // per-module waterfall (browsers cap ~6 HTTP/1.1 connections per origin and
+    // each request pays a full round-trip to the tunnel edge). The CLI runs the
+    // watch build that writes dist/assets when a tunnel is active; here we just
+    // serve it, mounted before the Vite middleware so built hashed assets win.
+    // Unbundled dev module requests (localhost/DevTools) miss on disk and fall
+    // through to Vite unchanged.
+    const assetsPath = path.join(process.cwd(), "dist", "assets");
+    app.use("/assets", cors());
+    app.use("/assets", express.static(assetsPath));
 
     const { viewsDevServer } = await import("./viewsDevServer.js");
     app.use(await viewsDevServer(httpServer));

--- a/packages/core/src/server/express.ts
+++ b/packages/core/src/server/express.ts
@@ -68,14 +68,6 @@ export async function createApp({
     const { devtoolsStaticServer } = await import("@skybridge/devtools");
     app.use(await devtoolsStaticServer());
 
-    // Serve the bundled build of the views (like production) so remote hosts
-    // reach a view in ~2 requests instead of the unbundled dev server's
-    // per-module waterfall (browsers cap ~6 HTTP/1.1 connections per origin and
-    // each request pays a full round-trip to the tunnel edge). The CLI runs the
-    // watch build that writes dist/assets when a tunnel is active; here we just
-    // serve it, mounted before the Vite middleware so built hashed assets win.
-    // Unbundled dev module requests (localhost/DevTools) miss on disk and fall
-    // through to Vite unchanged.
     const assetsPath = path.join(process.cwd(), "dist", "assets");
     app.use("/assets", cors());
     app.use("/assets", express.static(assetsPath));

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -964,9 +964,11 @@ export class McpServer<
       contentMetaOverrides = { domain: `${hash}.claudemcpcontent.com` };
     }
 
+    const serverHostname = new URL(serverUrl).hostname;
     const isLocalhost =
-      serverUrl.startsWith("http://localhost") ||
-      serverUrl.startsWith("http://127.0.0.1");
+      serverHostname === "localhost" ||
+      serverHostname === "127.0.0.1" ||
+      serverHostname === "[::1]";
     const useBundledDevTemplate = !isProduction && !isLocalhost;
 
     return {

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -964,15 +964,16 @@ export class McpServer<
       contentMetaOverrides = { domain: `${hash}.claudemcpcontent.com` };
     }
 
-    // In `dev --tunnel` (`__TUNNEL_BUNDLE`), serve remote hosts the bundled
-    // build instead of the unbundled dev entry — the per-module waterfall is
-    // what makes the first render slow through the tunnel. Localhost/DevTools
-    // keep the unbundled entry so HMR is untouched.
+    // In dev, serve remote hosts the bundled build instead of the unbundled
+    // dev entry — the per-module waterfall is what makes the first render slow
+    // through the tunnel. A remote origin in dev means the request came through
+    // a tunnel (started via `--tunnel` or the DevTools UI), which is what the
+    // CLI keys the watch build off. Localhost/DevTools keep the unbundled entry
+    // so HMR is untouched.
     const isLocalhost =
       serverUrl.startsWith("http://localhost") ||
       serverUrl.startsWith("http://127.0.0.1");
-    const useBundledDevTemplate =
-      !isProduction && process.env.__TUNNEL_BUNDLE === "1" && !isLocalhost;
+    const useBundledDevTemplate = !isProduction && !isLocalhost;
 
     return {
       serverUrl,

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -964,12 +964,6 @@ export class McpServer<
       contentMetaOverrides = { domain: `${hash}.claudemcpcontent.com` };
     }
 
-    // In dev, serve remote hosts the bundled build instead of the unbundled
-    // dev entry — the per-module waterfall is what makes the first render slow
-    // through the tunnel. A remote origin in dev means the request came through
-    // a tunnel (started via `--tunnel` or the DevTools UI), which is what the
-    // CLI keys the watch build off. Localhost/DevTools keep the unbundled entry
-    // so HMR is untouched.
     const isLocalhost =
       serverUrl.startsWith("http://localhost") ||
       serverUrl.startsWith("http://127.0.0.1");
@@ -1126,16 +1120,12 @@ export class McpServer<
         let html: string;
         if (isProduction) {
           html = renderBundled();
-        } else if (useBundledDevTemplate) {
+        } else {
           try {
-            html = renderBundled();
+            html = useBundledDevTemplate ? renderBundled() : renderUnbundled();
           } catch {
-            // The watch build hasn't emitted a manifest yet — fall back to the
-            // unbundled dev entry so the first render still works (just slow).
             html = renderUnbundled();
           }
-        } else {
-          html = renderUnbundled();
         }
 
         return {

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -1120,12 +1120,14 @@ export class McpServer<
         let html: string;
         if (isProduction) {
           html = renderBundled();
-        } else {
+        } else if (useBundledDevTemplate) {
           try {
-            html = useBundledDevTemplate ? renderBundled() : renderUnbundled();
+            html = renderBundled();
           } catch {
             html = renderUnbundled();
           }
+        } else {
+          html = renderUnbundled();
         }
 
         return {

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -922,6 +922,7 @@ export class McpServer<
     assetsBasePath: string;
     connectDomains: string[];
     contentMetaOverrides: { domain?: string };
+    useBundledDevTemplate: boolean;
   } {
     const isProduction = process.env.NODE_ENV === "production";
     const headers = extra?.requestInfo?.headers || {};
@@ -963,7 +964,23 @@ export class McpServer<
       contentMetaOverrides = { domain: `${hash}.claudemcpcontent.com` };
     }
 
-    return { serverUrl, assetsBasePath, connectDomains, contentMetaOverrides };
+    // In `dev --tunnel` (`__TUNNEL_BUNDLE`), serve remote hosts the bundled
+    // build instead of the unbundled dev entry — the per-module waterfall is
+    // what makes the first render slow through the tunnel. Localhost/DevTools
+    // keep the unbundled entry so HMR is untouched.
+    const isLocalhost =
+      serverUrl.startsWith("http://localhost") ||
+      serverUrl.startsWith("http://127.0.0.1");
+    const useBundledDevTemplate =
+      !isProduction && process.env.__TUNNEL_BUNDLE === "1" && !isLocalhost;
+
+    return {
+      serverUrl,
+      assetsBasePath,
+      connectDomains,
+      contentMetaOverrides,
+      useBundledDevTemplate,
+    };
   }
 
   private registerViewResources(
@@ -1084,25 +1101,41 @@ export class McpServer<
       { description: view.description },
       async (uri, extra) => {
         const isProduction = process.env.NODE_ENV === "production";
-        const { serverUrl, assetsBasePath } =
+        const { serverUrl, assetsBasePath, useBundledDevTemplate } =
           this.resolveViewRequestContext(extra);
         // The view resolves all assets (template imports + runtime lazy chunks
         // via `window.skybridge.serverUrl`) against this base, so it carries the
         // proxy path prefix. CSP domains in `buildMeta` stay the bare origin.
         const viewBase = `${serverUrl}${assetsBasePath}`;
 
-        const html = isProduction
-          ? templateHelper.renderProduction({
-              hostType,
-              serverUrl: viewBase,
-              viewFile: this.lookupViewFile(view.component),
-              styleFile: this.lookupDistFile("style.css") ?? "",
-            })
-          : templateHelper.renderDevelopment({
-              hostType,
-              serverUrl: viewBase,
-              viewName: view.component,
-            });
+        const renderBundled = () =>
+          templateHelper.renderProduction({
+            hostType,
+            serverUrl: viewBase,
+            viewFile: this.lookupViewFile(view.component),
+            styleFile: this.lookupDistFile("style.css") ?? "",
+          });
+        const renderUnbundled = () =>
+          templateHelper.renderDevelopment({
+            hostType,
+            serverUrl: viewBase,
+            viewName: view.component,
+          });
+
+        let html: string;
+        if (isProduction) {
+          html = renderBundled();
+        } else if (useBundledDevTemplate) {
+          try {
+            html = renderBundled();
+          } catch {
+            // The watch build hasn't emitted a manifest yet — fall back to the
+            // unbundled dev entry so the first render still works (just slow).
+            html = renderUnbundled();
+          }
+        } else {
+          html = renderUnbundled();
+        }
 
         return {
           contents: [

--- a/packages/core/src/server/view-resource-resolution.test.ts
+++ b/packages/core/src/server/view-resource-resolution.test.ts
@@ -213,12 +213,7 @@ describe("view resource resolution (cache key)", () => {
     }
   });
 
-  // In dev, remote hosts (reached through the tunnel) get the bundled build —
-  // few requests, fast first render — while localhost keeps the unbundled dev
-  // entry (HMR). The split is per-request on the forwarded origin.
   it("serves bundled to remote and unbundled to localhost in dev", async () => {
-    // `__setBuildManifest` is consume-once (cleared on the next construction),
-    // so re-prime before each server.
     const primeManifest = () =>
       __setBuildManifest({
         "src/views/widget.tsx": {

--- a/packages/core/src/server/view-resource-resolution.test.ts
+++ b/packages/core/src/server/view-resource-resolution.test.ts
@@ -99,7 +99,6 @@ function textContent(contents: Array<{ uri: string }>): {
 describe("view resource resolution (cache key)", () => {
   afterEach(() => {
     delete process.env.NODE_ENV;
-    delete process.env.__TUNNEL_BUNDLE;
   });
 
   it("resolves regardless of the ?v= param and echoes the requested URI", async () => {
@@ -214,11 +213,10 @@ describe("view resource resolution (cache key)", () => {
     }
   });
 
-  // `dev --tunnel` (`__TUNNEL_BUNDLE`): remote hosts get the bundled build (few
-  // requests, fast first render through the tunnel) while localhost keeps the
-  // unbundled dev entry (HMR). The split is per-request on the forwarded origin.
-  it("serves bundled to remote and unbundled to localhost in tunnel-bundle dev", async () => {
-    process.env.__TUNNEL_BUNDLE = "1";
+  // In dev, remote hosts (reached through the tunnel) get the bundled build —
+  // few requests, fast first render — while localhost keeps the unbundled dev
+  // entry (HMR). The split is per-request on the forwarded origin.
+  it("serves bundled to remote and unbundled to localhost in dev", async () => {
     // `__setBuildManifest` is consume-once (cleared on the next construction),
     // so re-prime before each server.
     const primeManifest = () =>

--- a/packages/core/src/server/view-resource-resolution.test.ts
+++ b/packages/core/src/server/view-resource-resolution.test.ts
@@ -99,6 +99,7 @@ function textContent(contents: Array<{ uri: string }>): {
 describe("view resource resolution (cache key)", () => {
   afterEach(() => {
     delete process.env.NODE_ENV;
+    delete process.env.__TUNNEL_BUNDLE;
   });
 
   it("resolves regardless of the ?v= param and echoes the requested URI", async () => {
@@ -210,6 +211,58 @@ describe("view resource resolution (cache key)", () => {
       expect(text).not.toContain("foo.com/assets/");
     } finally {
       await teardown();
+    }
+  });
+
+  // `dev --tunnel` (`__TUNNEL_BUNDLE`): remote hosts get the bundled build (few
+  // requests, fast first render through the tunnel) while localhost keeps the
+  // unbundled dev entry (HMR). The split is per-request on the forwarded origin.
+  it("serves bundled to remote and unbundled to localhost in tunnel-bundle dev", async () => {
+    process.env.__TUNNEL_BUNDLE = "1";
+    // `__setBuildManifest` is consume-once (cleared on the next construction),
+    // so re-prime before each server.
+    const primeManifest = () =>
+      __setBuildManifest({
+        "src/views/widget.tsx": {
+          isEntry: true,
+          name: "widget",
+          file: "assets/widget-ABC123.js",
+        },
+        "style.css": { file: "assets/style-XYZ.css" },
+      } as unknown as Record<string, { file: string }>);
+
+    primeManifest();
+    const remote = await connectHttp(registerWidget, {
+      "x-forwarded-host": "foo.com",
+      "x-forwarded-proto": "https",
+    });
+    try {
+      const { text } = textContent(
+        (
+          await remote.client.readResource({
+            uri: "ui://views/ext-apps/widget.html",
+          })
+        ).contents,
+      );
+      expect(text).toContain("https://foo.com/assets/assets/widget-ABC123.js");
+      expect(text).not.toContain("/_skybridge/view/");
+    } finally {
+      await remote.teardown();
+    }
+
+    primeManifest();
+    const local = await connectHttp(registerWidget, {});
+    try {
+      const { text } = textContent(
+        (
+          await local.client.readResource({
+            uri: "ui://views/ext-apps/widget.html",
+          })
+        ).contents,
+      );
+      expect(text).toContain("/_skybridge/view/widget");
+    } finally {
+      await local.teardown();
     }
   });
 


### PR DESCRIPTION
Fixes #847

### Summary

- Views loaded slowly on their first render in ChatGPT through the dev tunnel.
- Root cause: `dev` serves views as unbundled Vite modules.
- Each view fans out into dozens of per-module requests.
- Through the tunnel these serialize (~6 HTTP/1.1 conns/origin) and each pays a full round-trip to the AWS edge.
- Dev now serves remote (tunnel) hosts the bundled build (~2 requests) instead.
- Localhost/DevTools keep the unbundled dev entry, so HMR is untouched.
- Covers tunnels opened both via `--tunnel` and the DevTools UI.

### Architecture Notes

- **Remote-origin split** — bundled vs unbundled is chosen per request from the forwarded origin; a remote origin in dev means the request arrived through a tunnel.
- **Build keyed off tunnel lifecycle** — the watch build starts when the `TunnelManager` leaves `idle`, so both start paths are covered by one trigger instead of a boot-time flag.
- **Build runs in the CLI, not the server** — it lives in the long-lived `dev` process so nodemon restarts and unit tests never trigger a Rollup build.
- **Graceful first render** — until the first build lands, the view handler falls back to the unbundled entry rather than erroring.
- **HTTP/2 is not an option** — the tunnel edge is `pipenet` (localtunnel fork) on Node `http`, so the browser connection cap can't be lifted upstream; cutting request count is the only lever.

### Verification

Packed this branch's `skybridge` + `@skybridge/devtools` and installed the tarballs into a throwaway one-view app, then drove the real dev server (`skybridge build` for the bundle + `resources/read` over `/mcp`):

- localhost request → **unbundled** dev entry (`@vite/client` + `/_skybridge/view/…`) — HMR path intact.
- request with tunnel forwarded headers → **bundled** build (single hashed `hello-*.js`, no dev entry).
- that hashed asset is served by the dev `/assets` handler → `200 text/javascript`.
- with `dist/assets` removed, the tunnel request **falls back to the unbundled entry without erroring**.
