### PR TITLE
feat: mixed-auth on branded/custom providers

### DIFF
--- a/docs/api-reference/register-tool.mdx
+++ b/docs/api-reference/register-tool.mdx
@@ -154,7 +154,7 @@ The recommended way to declare a tool's auth. With the [`oauth`](/api-reference/
 | `{ public: true }` | Callable signed out; uses the token when one is present. |
 | `{}` | Requires sign-in. |
 | `{ scopes: [...] }` | Requires sign-in with every listed scope. |
-| `{ public: true, scopes: [...] }` | Callable signed out; advertises the scopes for signed-in callers. |
+| `{ public: true, scopes: [...] }` | Callable signed out; a signed-in caller must carry every listed scope. |
 
 Declaring any `{ public: true }` tool turns the server [mixed](/build/auth#mix-public-and-authenticated-tools): it serves anonymous callers, and every other tool stays sign-in-gated by default. Requiring sign-in (`{}` or `{ scopes }`) needs the `oauth` provider and throws without it; `{ public: true }` works either way. Omit `auth` entirely for the secure default (sign-in required whenever the server has auth).
 

--- a/docs/api-reference/register-tool.mdx
+++ b/docs/api-reference/register-tool.mdx
@@ -154,7 +154,7 @@ The recommended way to declare a tool's auth. With the [`oauth`](/api-reference/
 | `{ public: true }` | Callable signed out; uses the token when one is present. |
 | `{}` | Requires sign-in. |
 | `{ scopes: [...] }` | Requires sign-in with every listed scope. |
-| `{ public: true, scopes: [...] }` | Callable signed out; a signed-in caller must carry every listed scope. |
+| `{ public: true, scopes: [...] }` | Callable signed out; advertises the scopes for signed-in callers (step-up hint, not enforced). |
 
 Declaring any `{ public: true }` tool turns the server [mixed](/build/auth#mix-public-and-authenticated-tools): it serves anonymous callers, and every other tool stays sign-in-gated by default. Requiring sign-in (`{}` or `{ scopes }`) needs the `oauth` provider and throws without it; `{ public: true }` works either way. Omit `auth` entirely for the secure default (sign-in required whenever the server has auth).
 

--- a/docs/api-reference/register-tool.mdx
+++ b/docs/api-reference/register-tool.mdx
@@ -147,7 +147,7 @@ type ViewCsp = {
 
 ### `auth`
 
-The recommended way to declare a tool's auth. Requires the [`oauth`](/api-reference/mcp-server#constructor) provider option; with it, Skybridge enforces the declaration for you (anonymous or under-scoped calls are rejected before the handler runs).
+The recommended way to declare a tool's auth. With the [`oauth`](/api-reference/mcp-server#constructor) provider option set, Skybridge enforces the declaration for you (anonymous or under-scoped calls are rejected before the handler runs).
 
 | Value | Meaning |
 | --- | --- |
@@ -155,11 +155,11 @@ The recommended way to declare a tool's auth. Requires the [`oauth`](/api-refere
 | `"required"` | Requires sign-in. |
 | `{ scopes: [...] }` | Requires sign-in with every listed scope. |
 
-Declaring any `"public"` tool turns the server [mixed](/build/auth#mix-public-and-authenticated-tools): it serves anonymous callers, and every other tool stays sign-in-gated by default. Setting `auth` without an `oauth` provider throws, as does setting both `auth` and `securitySchemes`.
+Declaring any `"public"` tool turns the server [mixed](/build/auth#mix-public-and-authenticated-tools): it serves anonymous callers, and every other tool stays sign-in-gated by default. `"required"` and `{ scopes }` need the `oauth` provider and throw without it; `"public"` works either way. If both `auth` and `securitySchemes` are set, `securitySchemes` wins.
 
 ### `securitySchemes`
 
-The low-level form behind `auth`, for cases it can't express (several alternative `oauth2` schemes, or pure `noauth` that never accepts a token). Mutually exclusive with `auth`.
+The low-level form behind `auth`, for cases it can't express (several alternative `oauth2` schemes, or pure `noauth` that never accepts a token). Takes precedence over `auth` when both are set.
 
 ```ts
 type SecurityScheme =

--- a/docs/api-reference/register-tool.mdx
+++ b/docs/api-reference/register-tool.mdx
@@ -61,7 +61,7 @@ type ToolConfig = {
   outputSchema?: ZodRawShape; // Zod shape; types structuredContent
   annotations?: ToolAnnotations; // standard MCP hints
   view?: ViewConfig; // bind a view to render the result
-  auth?: { public?: boolean; scopes?: string[] }; // per-tool auth
+  auth?: { allowsAnonymous?: boolean; scopes?: string[] }; // per-tool auth
   securitySchemes?: SecurityScheme[]; // low-level alternative to `auth` (mutually exclusive)
   _meta?: ToolMeta; // extra metadata
 };
@@ -151,12 +151,12 @@ The recommended way to declare a tool's auth. With the [`oauth`](/api-reference/
 
 | Value | Meaning |
 | --- | --- |
-| `{ public: true }` | Callable signed out; uses the token when one is present. |
-| `{}` | Requires sign-in. |
+| _omitted_ (default) | Requires sign-in, the secure default when the server has an `oauth` provider. |
+| `{ allowsAnonymous: true }` | Callable signed out; uses the token when one is present. |
 | `{ scopes: [...] }` | Requires sign-in with every listed scope. |
-| `{ public: true, scopes: [...] }` | Callable signed out; a signed-in caller missing a listed scope gets a step-up challenge (`insufficient_scope`) instead of the anonymous path. |
+| `{ allowsAnonymous: true, scopes: [...] }` | Callable signed out; a signed-in caller missing a listed scope gets a step-up challenge (`insufficient_scope`) instead of the anonymous path. |
 
-Declaring any `{ public: true }` tool turns the server [mixed](/build/auth#mix-public-and-authenticated-tools): it serves anonymous callers, and every other tool stays sign-in-gated by default. Requiring sign-in (`{}` or `{ scopes }`) needs the `oauth` provider and throws without it; `{ public: true }` works either way. Omit `auth` entirely for the secure default (sign-in required whenever the server has auth).
+Declaring any `{ allowsAnonymous: true }` tool turns the server [mixed](/build/auth#mix-public-and-authenticated-tools): it serves anonymous callers, and every other tool stays sign-in-gated by default. Requiring sign-in (`{ scopes }`) needs the `oauth` provider and throws without it; `{ allowsAnonymous: true }` works either way. Omit `auth` entirely for the secure default (sign-in required whenever the server has auth).
 
 ### `securitySchemes`
 

--- a/docs/api-reference/register-tool.mdx
+++ b/docs/api-reference/register-tool.mdx
@@ -160,7 +160,7 @@ Declaring any `{ public: true }` tool turns the server [mixed](/build/auth#mix-p
 
 ### `securitySchemes`
 
-The low-level form behind `auth`, for cases it can't express (several alternative `oauth2` schemes, or pure `noauth` that never accepts a token). Mutually exclusive with `auth` — setting both is a compile error.
+The low-level form behind `auth`, for cases it can't express (several alternative `oauth2` schemes, or pure `noauth` that never accepts a token). Mutually exclusive with `auth`.
 
 ```ts
 type SecurityScheme =

--- a/docs/api-reference/register-tool.mdx
+++ b/docs/api-reference/register-tool.mdx
@@ -61,7 +61,8 @@ type ToolConfig = {
   outputSchema?: ZodRawShape; // Zod shape; types structuredContent
   annotations?: ToolAnnotations; // standard MCP hints
   view?: ViewConfig; // bind a view to render the result
-  securitySchemes?: SecurityScheme[]; // declare per-tool auth
+  auth?: "public" | "required" | { scopes: string[] }; // per-tool auth
+  securitySchemes?: SecurityScheme[]; // low-level alternative to `auth`
   _meta?: ToolMeta; // extra metadata
 };
 ```
@@ -144,9 +145,21 @@ type ViewCsp = {
 | `redirectDomains` | `openExternal` targets that skip the safe-link modal. |
 | `baseUriDomains` | `<base href>` origins (MCP Apps only). |
 
+### `auth`
+
+The recommended way to declare a tool's auth. Requires the [`oauth`](/api-reference/mcp-server#constructor) provider option; with it, Skybridge enforces the declaration for you (anonymous or under-scoped calls are rejected before the handler runs).
+
+| Value | Meaning |
+| --- | --- |
+| `"public"` | Callable signed out; uses the token when one is present. |
+| `"required"` | Requires sign-in. |
+| `{ scopes: [...] }` | Requires sign-in with every listed scope. |
+
+Declaring any `"public"` tool turns the server [mixed](/build/auth#mix-public-and-authenticated-tools): it serves anonymous callers, and every other tool stays sign-in-gated by default. Setting `auth` without an `oauth` provider throws, as does setting both `auth` and `securitySchemes`.
+
 ### `securitySchemes`
 
-Declare which auth a tool supports so clients can label it public vs. requires-sign-in before invocation, and request the right scopes during sign-in.
+The low-level form behind `auth`, for cases it can't express (several alternative `oauth2` schemes, or pure `noauth` that never accepts a token). Mutually exclusive with `auth`.
 
 ```ts
 type SecurityScheme =
@@ -159,7 +172,7 @@ type SecurityScheme =
 - **`noauth` and `oauth2` together** means "works anonymously, but auth unlocks more."
 
 <Warning>
-`securitySchemes` is client-facing metadata, not self-enforcing. Pair it with an auth middleware ([`requireBearerAuth`](/api-reference/require-bearer-auth) or [`optionalBearerAuth`](/api-reference/optional-bearer-auth)) to authenticate requests, and enforce the tool's own requirements in the handler from `extra.authInfo`.
+With the [`oauth`](/api-reference/mcp-server#constructor) provider option, Skybridge enforces `securitySchemes` like `auth`. With hand-wired middleware ([`requireBearerAuth`](/api-reference/require-bearer-auth) or [`optionalBearerAuth`](/api-reference/optional-bearer-auth)) it stays client-facing metadata: enforce the tool's requirements in the handler from `extra.authInfo`.
 </Warning>
 
 ### `_meta`

--- a/docs/api-reference/register-tool.mdx
+++ b/docs/api-reference/register-tool.mdx
@@ -61,8 +61,8 @@ type ToolConfig = {
   outputSchema?: ZodRawShape; // Zod shape; types structuredContent
   annotations?: ToolAnnotations; // standard MCP hints
   view?: ViewConfig; // bind a view to render the result
-  auth?: "public" | "required" | { scopes: string[] }; // per-tool auth
-  securitySchemes?: SecurityScheme[]; // low-level alternative to `auth`
+  auth?: { public?: boolean; scopes?: string[] }; // per-tool auth
+  securitySchemes?: SecurityScheme[]; // low-level alternative to `auth` (mutually exclusive)
   _meta?: ToolMeta; // extra metadata
 };
 ```
@@ -151,15 +151,16 @@ The recommended way to declare a tool's auth. With the [`oauth`](/api-reference/
 
 | Value | Meaning |
 | --- | --- |
-| `"public"` | Callable signed out; uses the token when one is present. |
-| `"required"` | Requires sign-in. |
+| `{ public: true }` | Callable signed out; uses the token when one is present. |
+| `{}` | Requires sign-in. |
 | `{ scopes: [...] }` | Requires sign-in with every listed scope. |
+| `{ public: true, scopes: [...] }` | Callable signed out; advertises the scopes for signed-in callers. |
 
-Declaring any `"public"` tool turns the server [mixed](/build/auth#mix-public-and-authenticated-tools): it serves anonymous callers, and every other tool stays sign-in-gated by default. `"required"` and `{ scopes }` need the `oauth` provider and throw without it; `"public"` works either way. If both `auth` and `securitySchemes` are set, `securitySchemes` wins.
+Declaring any `{ public: true }` tool turns the server [mixed](/build/auth#mix-public-and-authenticated-tools): it serves anonymous callers, and every other tool stays sign-in-gated by default. Requiring sign-in (`{}` or `{ scopes }`) needs the `oauth` provider and throws without it; `{ public: true }` works either way. Omit `auth` entirely for the secure default (sign-in required whenever the server has auth).
 
 ### `securitySchemes`
 
-The low-level form behind `auth`, for cases it can't express (several alternative `oauth2` schemes, or pure `noauth` that never accepts a token). Takes precedence over `auth` when both are set.
+The low-level form behind `auth`, for cases it can't express (several alternative `oauth2` schemes, or pure `noauth` that never accepts a token). Mutually exclusive with `auth` — setting both is a compile error.
 
 ```ts
 type SecurityScheme =

--- a/docs/api-reference/register-tool.mdx
+++ b/docs/api-reference/register-tool.mdx
@@ -154,7 +154,7 @@ The recommended way to declare a tool's auth. With the [`oauth`](/api-reference/
 | `{ public: true }` | Callable signed out; uses the token when one is present. |
 | `{}` | Requires sign-in. |
 | `{ scopes: [...] }` | Requires sign-in with every listed scope. |
-| `{ public: true, scopes: [...] }` | Callable signed out; advertises the scopes for signed-in callers (step-up hint, not enforced). |
+| `{ public: true, scopes: [...] }` | Callable signed out; a signed-in caller missing a listed scope gets a step-up challenge (`insufficient_scope`) instead of the anonymous path. |
 
 Declaring any `{ public: true }` tool turns the server [mixed](/build/auth#mix-public-and-authenticated-tools): it serves anonymous callers, and every other tool stays sign-in-gated by default. Requiring sign-in (`{}` or `{ scopes }`) needs the `oauth` provider and throws without it; `{ public: true }` works either way. Omit `auth` entirely for the secure default (sign-in required whenever the server has auth).
 

--- a/docs/build/auth.mdx
+++ b/docs/build/auth.mdx
@@ -7,7 +7,7 @@ icon: "key"
 [Tool](/build/tools) calls are anonymous by default: nothing in the protocol tells you who's asking. [OAuth](https://oauth.net/2/) closes that gap, and the host does most of the work: it discovers your authorization server, signs the user in, refreshes tokens, and attaches a Bearer token to every request. Your server keeps three jobs: publish the discovery metadata, verify the tokens, and read the user in your handlers.
 
 <Tip>
-Using [Auth0](/guides/auth-providers#auth0), [Clerk](/guides/auth-providers#clerk), [Descope](/guides/auth-providers#descope), [Stytch](/guides/auth-providers#stytch), [WorkOS](/guides/auth-providers#workos), or [any other OAuth provider](/guides/auth-providers#any-other-provider)? Connect it in one line instead of wiring this by hand, and still [mix public and authenticated tools](#mix-public-and-authenticated-tools) with `auth: { public: true }`.
+Using [Auth0](/guides/auth-providers#auth0), [Clerk](/guides/auth-providers#clerk), [Descope](/guides/auth-providers#descope), [Stytch](/guides/auth-providers#stytch), [WorkOS](/guides/auth-providers#workos), or [any other OAuth provider](/guides/auth-providers#any-other-provider)? Connect it in one line instead of wiring this by hand, and still [mix public and authenticated tools](#mix-public-and-authenticated-tools) with `auth: { allowsAnonymous: true }`.
 </Tip>
 
 Here's a complete server where every tool requires sign-in:
@@ -144,11 +144,11 @@ On the [provider path](/guides/auth-providers) (the `oauth` constructor option),
 
 ```ts
 server
-  .registerTool({ name: "search-products", auth: { public: true }, /* … */ }, handler)
+  .registerTool({ name: "search-products", auth: { allowsAnonymous: true }, /* … */ }, handler)
   .registerTool({ name: "create-checkout", auth: { scopes: ["checkout"] }, /* … */ }, handler);
 ```
 
-Any `auth: { public: true }` tool makes the server serve anonymous callers; every other tool stays sign-in-gated, with scopes enforced before the handler. No manual middleware swap or handler guard. The lower-level steps below apply when you wire the middleware by hand instead.
+Any `auth: { allowsAnonymous: true }` tool makes the server serve anonymous callers; every other tool stays sign-in-gated, with scopes enforced before the handler. No manual middleware swap or handler guard. The lower-level steps below apply when you wire the middleware by hand instead.
 </Tip>
 
 ### Switch the Middleware

--- a/docs/build/auth.mdx
+++ b/docs/build/auth.mdx
@@ -7,7 +7,7 @@ icon: "key"
 [Tool](/build/tools) calls are anonymous by default: nothing in the protocol tells you who's asking. [OAuth](https://oauth.net/2/) closes that gap, and the host does most of the work: it discovers your authorization server, signs the user in, refreshes tokens, and attaches a Bearer token to every request. Your server keeps three jobs: publish the discovery metadata, verify the tokens, and read the user in your handlers.
 
 <Tip>
-Using [Auth0](/guides/auth-providers#auth0), [Clerk](/guides/auth-providers#clerk), [Descope](/guides/auth-providers#descope), [Stytch](/guides/auth-providers#stytch), [WorkOS](/guides/auth-providers#workos), or [any other OAuth provider](/guides/auth-providers#any-other-provider)? Connect it in one line instead of wiring this by hand. That path can't yet [mix public and authenticated tools](#mix-public-and-authenticated-tools).
+Using [Auth0](/guides/auth-providers#auth0), [Clerk](/guides/auth-providers#clerk), [Descope](/guides/auth-providers#descope), [Stytch](/guides/auth-providers#stytch), [WorkOS](/guides/auth-providers#workos), or [any other OAuth provider](/guides/auth-providers#any-other-provider)? Connect it in one line instead of wiring this by hand, and still [mix public and authenticated tools](#mix-public-and-authenticated-tools) by declaring a `noauth` tool.
 </Tip>
 
 Here's a complete server where every tool requires sign-in:
@@ -138,6 +138,18 @@ The validation body is provider-specific: [JWKS](https://datatracker.ietf.org/do
 ## Mix Public and Authenticated Tools
 
 Serving both anonymous and signed-in callers from one server takes three changes to the fully authenticated setup.
+
+<Tip>
+On the [provider path](/guides/auth-providers) (the `oauth` constructor option), these three steps collapse into one `auth` declaration per tool, and Skybridge enforces it for you:
+
+```ts
+server
+  .registerTool({ name: "search-products", auth: "public", /* … */ }, handler)
+  .registerTool({ name: "create-checkout", auth: { scopes: ["checkout"] }, /* … */ }, handler);
+```
+
+Any `auth: "public"` tool makes the server serve anonymous callers; every other tool stays sign-in-gated, with scopes enforced before the handler. No manual middleware swap or handler guard. The lower-level steps below apply when you wire the middleware by hand instead.
+</Tip>
 
 ### Switch the Middleware
 

--- a/docs/build/auth.mdx
+++ b/docs/build/auth.mdx
@@ -7,7 +7,7 @@ icon: "key"
 [Tool](/build/tools) calls are anonymous by default: nothing in the protocol tells you who's asking. [OAuth](https://oauth.net/2/) closes that gap, and the host does most of the work: it discovers your authorization server, signs the user in, refreshes tokens, and attaches a Bearer token to every request. Your server keeps three jobs: publish the discovery metadata, verify the tokens, and read the user in your handlers.
 
 <Tip>
-Using [Auth0](/guides/auth-providers#auth0), [Clerk](/guides/auth-providers#clerk), [Descope](/guides/auth-providers#descope), [Stytch](/guides/auth-providers#stytch), [WorkOS](/guides/auth-providers#workos), or [any other OAuth provider](/guides/auth-providers#any-other-provider)? Connect it in one line instead of wiring this by hand, and still [mix public and authenticated tools](#mix-public-and-authenticated-tools) with `auth: "public"`.
+Using [Auth0](/guides/auth-providers#auth0), [Clerk](/guides/auth-providers#clerk), [Descope](/guides/auth-providers#descope), [Stytch](/guides/auth-providers#stytch), [WorkOS](/guides/auth-providers#workos), or [any other OAuth provider](/guides/auth-providers#any-other-provider)? Connect it in one line instead of wiring this by hand, and still [mix public and authenticated tools](#mix-public-and-authenticated-tools) with `auth: { public: true }`.
 </Tip>
 
 Here's a complete server where every tool requires sign-in:
@@ -144,11 +144,11 @@ On the [provider path](/guides/auth-providers) (the `oauth` constructor option),
 
 ```ts
 server
-  .registerTool({ name: "search-products", auth: "public", /* … */ }, handler)
+  .registerTool({ name: "search-products", auth: { public: true }, /* … */ }, handler)
   .registerTool({ name: "create-checkout", auth: { scopes: ["checkout"] }, /* … */ }, handler);
 ```
 
-Any `auth: "public"` tool makes the server serve anonymous callers; every other tool stays sign-in-gated, with scopes enforced before the handler. No manual middleware swap or handler guard. The lower-level steps below apply when you wire the middleware by hand instead.
+Any `auth: { public: true }` tool makes the server serve anonymous callers; every other tool stays sign-in-gated, with scopes enforced before the handler. No manual middleware swap or handler guard. The lower-level steps below apply when you wire the middleware by hand instead.
 </Tip>
 
 ### Switch the Middleware

--- a/docs/build/auth.mdx
+++ b/docs/build/auth.mdx
@@ -7,7 +7,7 @@ icon: "key"
 [Tool](/build/tools) calls are anonymous by default: nothing in the protocol tells you who's asking. [OAuth](https://oauth.net/2/) closes that gap, and the host does most of the work: it discovers your authorization server, signs the user in, refreshes tokens, and attaches a Bearer token to every request. Your server keeps three jobs: publish the discovery metadata, verify the tokens, and read the user in your handlers.
 
 <Tip>
-Using [Auth0](/guides/auth-providers#auth0), [Clerk](/guides/auth-providers#clerk), [Descope](/guides/auth-providers#descope), [Stytch](/guides/auth-providers#stytch), [WorkOS](/guides/auth-providers#workos), or [any other OAuth provider](/guides/auth-providers#any-other-provider)? Connect it in one line instead of wiring this by hand, and still [mix public and authenticated tools](#mix-public-and-authenticated-tools) by declaring a `noauth` tool.
+Using [Auth0](/guides/auth-providers#auth0), [Clerk](/guides/auth-providers#clerk), [Descope](/guides/auth-providers#descope), [Stytch](/guides/auth-providers#stytch), [WorkOS](/guides/auth-providers#workos), or [any other OAuth provider](/guides/auth-providers#any-other-provider)? Connect it in one line instead of wiring this by hand, and still [mix public and authenticated tools](#mix-public-and-authenticated-tools) with `auth: "public"`.
 </Tip>
 
 Here's a complete server where every tool requires sign-in:

--- a/docs/guides/auth-providers.mdx
+++ b/docs/guides/auth-providers.mdx
@@ -8,7 +8,7 @@ icon: "fingerprint"
 [Authenticating users](/build/auth) wires sign-in through a hosted identity provider in one constructor option, so your tools receive a signed-in user. ChatGPT and Claude drive the flow the same way; what varies is the provider. The sections below cover one each: [Auth0](#auth0), [Clerk](#clerk), [Descope](#descope), [Stytch](#stytch), and [WorkOS](#workos), plus a [custom provider](#any-other-provider) for any other.
 
 <Info>
-These providers require sign-in on every request by default. Set [`auth: { public: true }`](/api-reference/register-tool#auth) on any tool to [mix public and authenticated tools](/build/auth#mix-public-and-authenticated-tools): the server then serves anonymous requests and Skybridge enforces each tool's own auth declaration before the handler runs.
+These providers require sign-in on every request by default. Set [`auth: { allowsAnonymous: true }`](/api-reference/register-tool#auth) on any tool to [mix public and authenticated tools](/build/auth#mix-public-and-authenticated-tools): the server then serves anonymous requests and Skybridge enforces each tool's own auth declaration before the handler runs.
 </Info>
 
 ## Auth0

--- a/docs/guides/auth-providers.mdx
+++ b/docs/guides/auth-providers.mdx
@@ -8,7 +8,7 @@ icon: "fingerprint"
 [Authenticating users](/build/auth) wires sign-in through a hosted identity provider in one constructor option, so your tools receive a signed-in user. ChatGPT and Claude drive the flow the same way; what varies is the provider. The sections below cover one each: [Auth0](#auth0), [Clerk](#clerk), [Descope](#descope), [Stytch](#stytch), and [WorkOS](#workos), plus a [custom provider](#any-other-provider) for any other.
 
 <Info>
-These providers enforce sign-in on every request. To [mix public and authenticated tools](/build/auth#mix-public-and-authenticated-tools) in one server, wire the middleware by hand instead.
+These providers require sign-in on every request by default. Declare a [`noauth`](/build/auth#mix-public-and-authenticated-tools) tool to [mix public and authenticated tools](/build/auth#mix-public-and-authenticated-tools): the server then serves anonymous requests and each tool enforces its own [`securitySchemes`](/api-reference/register-tool#securityschemes).
 </Info>
 
 ## Auth0

--- a/docs/guides/auth-providers.mdx
+++ b/docs/guides/auth-providers.mdx
@@ -8,7 +8,7 @@ icon: "fingerprint"
 [Authenticating users](/build/auth) wires sign-in through a hosted identity provider in one constructor option, so your tools receive a signed-in user. ChatGPT and Claude drive the flow the same way; what varies is the provider. The sections below cover one each: [Auth0](#auth0), [Clerk](#clerk), [Descope](#descope), [Stytch](#stytch), and [WorkOS](#workos), plus a [custom provider](#any-other-provider) for any other.
 
 <Info>
-These providers require sign-in on every request by default. Declare a [`noauth`](/build/auth#mix-public-and-authenticated-tools) tool to [mix public and authenticated tools](/build/auth#mix-public-and-authenticated-tools): the server then serves anonymous requests and each tool enforces its own [`securitySchemes`](/api-reference/register-tool#securityschemes).
+These providers require sign-in on every request by default. Set [`auth: "public"`](/api-reference/register-tool#auth) on any tool to [mix public and authenticated tools](/build/auth#mix-public-and-authenticated-tools): the server then serves anonymous requests and Skybridge enforces each tool's own auth declaration before the handler runs.
 </Info>
 
 ## Auth0

--- a/docs/guides/auth-providers.mdx
+++ b/docs/guides/auth-providers.mdx
@@ -8,7 +8,7 @@ icon: "fingerprint"
 [Authenticating users](/build/auth) wires sign-in through a hosted identity provider in one constructor option, so your tools receive a signed-in user. ChatGPT and Claude drive the flow the same way; what varies is the provider. The sections below cover one each: [Auth0](#auth0), [Clerk](#clerk), [Descope](#descope), [Stytch](#stytch), and [WorkOS](#workos), plus a [custom provider](#any-other-provider) for any other.
 
 <Info>
-These providers require sign-in on every request by default. Set [`auth: "public"`](/api-reference/register-tool#auth) on any tool to [mix public and authenticated tools](/build/auth#mix-public-and-authenticated-tools): the server then serves anonymous requests and Skybridge enforces each tool's own auth declaration before the handler runs.
+These providers require sign-in on every request by default. Set [`auth: { public: true }`](/api-reference/register-tool#auth) on any tool to [mix public and authenticated tools](/build/auth#mix-public-and-authenticated-tools): the server then serves anonymous requests and Skybridge enforces each tool's own auth declaration before the handler runs.
 </Info>
 
 ## Auth0

--- a/examples/auth-descope-mixed/.env.example
+++ b/examples/auth-descope-mixed/.env.example
@@ -1,0 +1,8 @@
+# Descope Configuration
+# The MCP Server's Discovery URL (a.k.a. Issuer) from the console's Connection
+# Information. Enable Dynamic Client Registration on the MCP Server, and grant a
+# `checkout` scope so the scoped tool can be exercised.
+DESCOPE_MCP_SERVER_URL=https://api.descope.com/v1/apps/agentic/<projectId>/<mcpServerId>
+
+# Environment
+NODE_ENV=development

--- a/examples/auth-descope-mixed/README.md
+++ b/examples/auth-descope-mixed/README.md
@@ -1,0 +1,60 @@
+# Skybridge Auth Example — Mixed public/authenticated tools (Descope)
+
+A single MCP server that serves both anonymous and signed-in callers, wired with
+the branded `descopeProvider`. It exists to exercise every mixed-auth case
+through the one `auth` field on a tool, with no hand-wired middleware and no
+per-handler auth guards.
+
+For the fully-authenticated variant (every tool requires sign-in), see
+[`auth-descope`](../auth-descope).
+
+> The `auth` field used here ships with the framework from this branch, so this
+> example links `skybridge` via `workspace:*` and is run from inside the
+> monorepo (`pnpm install` at the root). It switches to a published version once
+> `auth` is released.
+
+## The cases
+
+| Tool | `auth` declaration | Compiles to | Behavior |
+| --- | --- | --- | --- |
+| `browse-catalog` | `"public"` | `[{noauth},{oauth2}]` | Callable signed out; uses the token when present (greets you by name). |
+| `whoami` | `"required"` | `[{oauth2}]` | Requires sign-in. |
+| `checkout` | `{ scopes: ["checkout"] }` | `[{oauth2, scopes:["checkout"]}]` | Requires sign-in **and** the `checkout` scope. |
+| `account` | *(omitted)* | — | No declaration → secure default: sign-in required. |
+
+Declaring `browse-catalog` as `public` is what flips the server into mixed mode:
+the `/mcp` door starts accepting anonymous requests, and every other tool stays
+sign-in-gated, enforced by the framework before the handler runs.
+
+## What to test
+
+**Anonymous (no token)**
+- `browse-catalog` → succeeds, returns "Catalog for guest…".
+- `whoami`, `checkout`, `account` → denied with `mcp/www_authenticate`, so the
+  host surfaces its sign-in UI.
+
+**Signed in, without the `checkout` scope**
+- `browse-catalog` → greets you by name.
+- `whoami`, `account` → succeed.
+- `checkout` → denied with `insufficient_scope`.
+
+**Signed in, with the `checkout` scope**
+- All four tools succeed.
+
+## Setup
+
+1. Create a Descope project and an MCP Server with Dynamic Client Registration
+   enabled (see [`auth-descope`](../auth-descope) for the console walkthrough).
+2. Grant a `checkout` scope so it can be issued into a token, to exercise the
+   scoped case.
+3. Copy `.env.example` to `.env` and set `DESCOPE_MCP_SERVER_URL`.
+4. Install and run:
+
+   ```bash
+   npm install
+   npm run dev
+   ```
+
+The devtools emulator connects anonymously, shows a sign-in CTA, and disables the
+auth-required tools until you sign in — a quick way to walk the cases above
+before testing in a real host.

--- a/examples/auth-descope-mixed/README.md
+++ b/examples/auth-descope-mixed/README.md
@@ -17,8 +17,8 @@ For the fully-authenticated variant (every tool requires sign-in), see
 
 | Tool | `auth` declaration | Compiles to | Behavior |
 | --- | --- | --- | --- |
-| `browse-catalog` | `"public"` | `[{noauth},{oauth2}]` | Callable signed out; uses the token when present (greets you by name). |
-| `whoami` | `"required"` | `[{oauth2}]` | Requires sign-in. |
+| `browse-catalog` | `{ public: true }` | `[{noauth},{oauth2}]` | Callable signed out; uses the token when present (greets you by name). |
+| `whoami` | `{}` | `[{oauth2}]` | Requires sign-in. |
 | `checkout` | `{ scopes: ["checkout"] }` | `[{oauth2, scopes:["checkout"]}]` | Requires sign-in **and** the `checkout` scope. |
 | `account` | *(omitted)* | — | No declaration → secure default: sign-in required. |
 

--- a/examples/auth-descope-mixed/README.md
+++ b/examples/auth-descope-mixed/README.md
@@ -17,29 +17,28 @@ For the fully-authenticated variant (every tool requires sign-in), see
 
 | Tool | `auth` declaration | Compiles to | Behavior |
 | --- | --- | --- | --- |
-| `browse-catalog` | `{ public: true }` | `[{noauth},{oauth2}]` | Callable signed out; uses the token when present (greets you by name). |
-| `whoami` | `{}` | `[{oauth2}]` | Requires sign-in. |
+| `browse-catalog` | `{ allowsAnonymous: true }` | `[{noauth},{oauth2}]` | Callable signed out; uses the token when present (greets you by name). |
+| `whoami` | *(omitted)* | `[{oauth2}]` | No declaration → secure default: sign-in required. |
 | `checkout` | `{ scopes: ["checkout"] }` | `[{oauth2, scopes:["checkout"]}]` | Requires sign-in **and** the `checkout` scope. |
-| `account` | *(omitted)* | — | No declaration → secure default: sign-in required. |
 
-Declaring `browse-catalog` as `public` is what flips the server into mixed mode:
-the `/mcp` door starts accepting anonymous requests, and every other tool stays
-sign-in-gated, enforced by the framework before the handler runs.
+Declaring `browse-catalog` with `allowsAnonymous` is what flips the server into
+mixed mode: the `/mcp` door starts accepting anonymous requests, and every other
+tool stays sign-in-gated, enforced by the framework before the handler runs.
 
 ## What to test
 
 **Anonymous (no token)**
 - `browse-catalog` → succeeds, returns "Catalog for guest…".
-- `whoami`, `checkout`, `account` → denied with `mcp/www_authenticate`, so the
-  host surfaces its sign-in UI.
+- `whoami`, `checkout` → denied with `mcp/www_authenticate`, so the host
+  surfaces its sign-in UI.
 
 **Signed in, without the `checkout` scope**
 - `browse-catalog` → greets you by name.
-- `whoami`, `account` → succeed.
+- `whoami` → succeeds.
 - `checkout` → denied with `insufficient_scope`.
 
 **Signed in, with the `checkout` scope**
-- All four tools succeed.
+- All three tools succeed.
 
 ## Setup
 

--- a/examples/auth-descope-mixed/alpic.json
+++ b/examples/auth-descope-mixed/alpic.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://assets.alpic.ai/alpic.json",
+  "installCommand": "npm install",
+  "startCommand": "npm run --silent start"
+}

--- a/examples/auth-descope-mixed/nodemon.json
+++ b/examples/auth-descope-mixed/nodemon.json
@@ -1,0 +1,5 @@
+{
+  "watch": ["src"],
+  "ext": "ts,json",
+  "exec": "tsx src/server.ts"
+}

--- a/examples/auth-descope-mixed/package.json
+++ b/examples/auth-descope-mixed/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "skybridge-auth-descope-mixed-example",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Skybridge Auth Example - Mixed public/authenticated tools with Descope",
+  "type": "module",
+  "scripts": {
+    "dev": "skybridge dev",
+    "dev:tunnel": "skybridge dev --tunnel",
+    "build": "skybridge build",
+    "start": "skybridge start",
+    "deploy": "alpic deploy"
+  },
+  "dependencies": {
+    "dotenv": "^16.5.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "skybridge": "workspace:*",
+    "vite": "^8.0.0",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@skybridge/devtools": "^1.1.0",
+    "@types/express": "^5.0.6",
+    "@types/node": "^22.15.30",
+    "@types/react": "^19.2.13",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.1",
+    "alpic": "^1.136.3",
+    "nodemon": "^3.1.11",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3"
+  },
+  "workspaces": [],
+  "engines": {
+    "node": ">=24.0.0"
+  }
+}

--- a/examples/auth-descope-mixed/src/env.ts
+++ b/examples/auth-descope-mixed/src/env.ts
@@ -1,0 +1,16 @@
+import "dotenv/config";
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+export const env = {
+  NODE_ENV:
+    (process.env.NODE_ENV as "development" | "production") || "development",
+  DESCOPE_MCP_SERVER_URL: requireEnv("DESCOPE_MCP_SERVER_URL"),
+  SERVER_URL: process.env.SERVER_URL,
+};

--- a/examples/auth-descope-mixed/src/helpers.ts
+++ b/examples/auth-descope-mixed/src/helpers.ts
@@ -1,0 +1,4 @@
+import { generateHelpers } from "skybridge/web";
+import type { AppType } from "./server.js";
+
+export const { useCallTool, useToolInfo } = generateHelpers<AppType>();

--- a/examples/auth-descope-mixed/src/server.ts
+++ b/examples/auth-descope-mixed/src/server.ts
@@ -1,0 +1,75 @@
+import { type AuthInfo, descopeProvider, McpServer } from "skybridge/server";
+import * as z from "zod";
+import { env } from "./env.js";
+
+const text = (value: string) => ({
+  content: [{ type: "text" as const, text: value }],
+});
+
+const who = (auth?: AuthInfo) =>
+  auth ? ((auth.extra?.email as string | undefined) ?? auth.clientId) : "guest";
+
+const server = new McpServer(
+  {
+    name: "auth-coffee-mixed",
+    version: "0.0.1",
+  },
+  { capabilities: {} },
+  {
+    oauth: await descopeProvider({
+      url: env.DESCOPE_MCP_SERVER_URL,
+      baseUrl: env.SERVER_URL,
+    }),
+  },
+)
+  .registerTool(
+    {
+      name: "browse-catalog",
+      description:
+        "Browse the public coffee catalog. Works signed out, and greets you by name when a token is present.",
+      inputSchema: {},
+      auth: "public",
+      view: { component: "catalog", description: "The coffee catalog" },
+    },
+    (_args, extra) => {
+      const user = who(extra.authInfo);
+      const items = ["Espresso", "Latte", "Flat White", "Cold Brew"];
+      return {
+        structuredContent: { user, items },
+        content: [
+          { type: "text" as const, text: `Catalog for ${user}: ${items.join(", ")}.` },
+        ],
+      };
+    },
+  )
+  .registerTool(
+    {
+      name: "whoami",
+      description: "Return the signed-in user. Requires sign-in.",
+      inputSchema: {},
+      auth: "required",
+    },
+    (_args, extra) => text(`You are ${who(extra.authInfo)}.`),
+  )
+  .registerTool(
+    {
+      name: "checkout",
+      description: "Place an order. Requires sign-in with the `checkout` scope.",
+      inputSchema: { item: z.string().describe("The catalog item to order") },
+      auth: { scopes: ["checkout"] },
+    },
+    ({ item }, extra) => text(`Order placed for ${who(extra.authInfo)}: ${item}.`),
+  )
+  .registerTool(
+    {
+      name: "account",
+      description:
+        "View account details. No auth declared, so it falls back to the secure default (sign-in required).",
+      inputSchema: {},
+    },
+    (_args, extra) => text(`Account details for ${who(extra.authInfo)}.`),
+  );
+
+export default await server.run();
+
+export type AppType = typeof server;

--- a/examples/auth-descope-mixed/src/server.ts
+++ b/examples/auth-descope-mixed/src/server.ts
@@ -28,7 +28,7 @@ const server = new McpServer(
       description:
         "Browse the public coffee catalog. Works signed out, and greets you by name when a token is present.",
       inputSchema: {},
-      auth: { public: true },
+      auth: { allowsAnonymous: true },
       view: { component: "catalog", description: "The coffee catalog" },
     },
     (_args, extra) => {
@@ -45,9 +45,9 @@ const server = new McpServer(
   .registerTool(
     {
       name: "whoami",
-      description: "Return the signed-in user. Requires sign-in.",
+      description:
+        "Return the signed-in user. No auth declared, so it falls back to the secure default (sign-in required).",
       inputSchema: {},
-      auth: {},
     },
     (_args, extra) => text(`You are ${who(extra.authInfo)}.`),
   )
@@ -59,15 +59,6 @@ const server = new McpServer(
       auth: { scopes: ["checkout"] },
     },
     ({ item }, extra) => text(`Order placed for ${who(extra.authInfo)}: ${item}.`),
-  )
-  .registerTool(
-    {
-      name: "account",
-      description:
-        "View account details. No auth declared, so it falls back to the secure default (sign-in required).",
-      inputSchema: {},
-    },
-    (_args, extra) => text(`Account details for ${who(extra.authInfo)}.`),
   );
 
 export default await server.run();

--- a/examples/auth-descope-mixed/src/server.ts
+++ b/examples/auth-descope-mixed/src/server.ts
@@ -28,7 +28,7 @@ const server = new McpServer(
       description:
         "Browse the public coffee catalog. Works signed out, and greets you by name when a token is present.",
       inputSchema: {},
-      auth: "public",
+      auth: { public: true },
       view: { component: "catalog", description: "The coffee catalog" },
     },
     (_args, extra) => {
@@ -47,7 +47,7 @@ const server = new McpServer(
       name: "whoami",
       description: "Return the signed-in user. Requires sign-in.",
       inputSchema: {},
-      auth: "required",
+      auth: {},
     },
     (_args, extra) => text(`You are ${who(extra.authInfo)}.`),
   )

--- a/examples/auth-descope-mixed/src/views/catalog.tsx
+++ b/examples/auth-descope-mixed/src/views/catalog.tsx
@@ -1,0 +1,27 @@
+import { useToolInfo } from "../helpers.js";
+
+function Catalog() {
+  const { output, isPending, isSuccess } = useToolInfo<"browse-catalog">();
+
+  if (isPending) {
+    return <p>Loading catalog…</p>;
+  }
+
+  if (!isSuccess || !output) {
+    return <p>No catalog available.</p>;
+  }
+
+  return (
+    <div>
+      <h2>Coffee catalog</h2>
+      <p>Viewing as {output.user}</p>
+      <ul>
+        {output.items.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default Catalog;

--- a/examples/auth-descope-mixed/tsconfig.json
+++ b/examples/auth-descope-mixed/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "skybridge/tsconfig",
+
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+
+  "include": ["src", ".skybridge/**/*.d.ts"]
+}

--- a/examples/auth-descope-mixed/vite.config.ts
+++ b/examples/auth-descope-mixed/vite.config.ts
@@ -1,0 +1,13 @@
+import path from "node:path";
+import react from "@vitejs/plugin-react";
+import { skybridge } from "skybridge/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [skybridge(), react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});

--- a/packages/core/src/server/auth/security-schemes.test.ts
+++ b/packages/core/src/server/auth/security-schemes.test.ts
@@ -57,6 +57,20 @@ describe("evaluateSecuritySchemes", () => {
     expect(evaluateSecuritySchemes(schemes, undefined)).toBeUndefined();
   });
 
+  it("enforces oauth2 scopes on a public tool once a token is present", () => {
+    const schemes: SecurityScheme[] = [
+      { type: "noauth" },
+      { type: "oauth2", scopes: ["checkout"] },
+    ];
+    expect(evaluateSecuritySchemes(schemes, undefined)).toBeUndefined();
+    expect(evaluateSecuritySchemes(schemes, authInfo(["openid"]))?.error).toBe(
+      "insufficient_scope",
+    );
+    expect(
+      evaluateSecuritySchemes(schemes, authInfo(["checkout"])),
+    ).toBeUndefined();
+  });
+
   it("fails an oauth2-only tool with no token (invalid_token / 401)", () => {
     expect(
       evaluateSecuritySchemes([{ type: "oauth2" }], undefined)?.error,

--- a/packages/core/src/server/auth/security-schemes.test.ts
+++ b/packages/core/src/server/auth/security-schemes.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import type { AuthInfo } from "../auth.js";
+import type { SecurityScheme } from "../server.js";
+import {
+  authToSecuritySchemes,
+  clientPrefersInBandChallenge,
+  evaluateSecuritySchemes,
+  securitySchemesAllowAnonymous,
+  wwwAuthenticateHeader,
+} from "./security-schemes.js";
+
+describe("clientPrefersInBandChallenge", () => {
+  it("detects ChatGPT / OpenAI user agents", () => {
+    expect(clientPrefersInBandChallenge("openai-mcp/1.0")).toBe(true);
+    expect(clientPrefersInBandChallenge("ChatGPT")).toBe(true);
+    expect(clientPrefersInBandChallenge("Claude-User/1.0")).toBe(false);
+    expect(clientPrefersInBandChallenge(undefined)).toBe(false);
+  });
+});
+
+describe("authToSecuritySchemes", () => {
+  it("maps the three auth shorthands", () => {
+    expect(authToSecuritySchemes("public")).toEqual([
+      { type: "noauth" },
+      { type: "oauth2" },
+    ]);
+    expect(authToSecuritySchemes("required")).toEqual([{ type: "oauth2" }]);
+    expect(authToSecuritySchemes({ scopes: ["checkout"] })).toEqual([
+      { type: "oauth2", scopes: ["checkout"] },
+    ]);
+  });
+});
+
+const authInfo = (scopes: string[]): AuthInfo => ({
+  token: "t",
+  clientId: "c",
+  scopes,
+});
+
+describe("securitySchemesAllowAnonymous", () => {
+  it("is true only when a noauth scheme is present", () => {
+    expect(securitySchemesAllowAnonymous([{ type: "noauth" }])).toBe(true);
+    expect(
+      securitySchemesAllowAnonymous([{ type: "noauth" }, { type: "oauth2" }]),
+    ).toBe(true);
+    expect(securitySchemesAllowAnonymous([{ type: "oauth2" }])).toBe(false);
+    expect(securitySchemesAllowAnonymous(undefined)).toBe(false);
+  });
+});
+
+describe("evaluateSecuritySchemes", () => {
+  it("lets anonymous callers through a noauth tool", () => {
+    const schemes: SecurityScheme[] = [{ type: "noauth" }, { type: "oauth2" }];
+    expect(evaluateSecuritySchemes(schemes, undefined)).toBeUndefined();
+  });
+
+  it("fails an oauth2-only tool with no token (invalid_token / 401)", () => {
+    expect(
+      evaluateSecuritySchemes([{ type: "oauth2" }], undefined)?.error,
+    ).toBe("invalid_token");
+  });
+
+  it("fails when the token is missing a required scope (insufficient_scope / 403)", () => {
+    const schemes: SecurityScheme[] = [
+      { type: "oauth2", scopes: ["checkout"] },
+    ];
+    expect(evaluateSecuritySchemes(schemes, authInfo(["openid"]))?.error).toBe(
+      "insufficient_scope",
+    );
+  });
+
+  it("passes when the token carries every required scope", () => {
+    const schemes: SecurityScheme[] = [
+      { type: "oauth2", scopes: ["checkout"] },
+    ];
+    expect(
+      evaluateSecuritySchemes(schemes, authInfo(["openid", "checkout"])),
+    ).toBeUndefined();
+  });
+
+  it("treats an undeclared tool as auth-required, satisfied by any valid token", () => {
+    expect(evaluateSecuritySchemes(undefined, undefined)?.error).toBe(
+      "invalid_token",
+    );
+    expect(evaluateSecuritySchemes(undefined, authInfo([]))).toBeUndefined();
+  });
+
+  it("carries the tool's required scopes on the failure", () => {
+    const schemes: SecurityScheme[] = [
+      { type: "oauth2", scopes: ["checkout"] },
+    ];
+    expect(evaluateSecuritySchemes(schemes, undefined)?.scopes).toEqual([
+      "checkout",
+    ]);
+    expect(
+      evaluateSecuritySchemes(schemes, authInfo(["openid"]))?.scopes,
+    ).toEqual(["checkout"]);
+  });
+});
+
+describe("wwwAuthenticateHeader", () => {
+  it("names the required scopes so the client can step up", () => {
+    const header = wwwAuthenticateHeader({
+      error: "insufficient_scope",
+      description: "Missing required scope for this tool.",
+      scopes: ["checkout"],
+    });
+    expect(header).toContain('error="insufficient_scope"');
+    expect(header).toContain('scope="checkout"');
+  });
+
+  it("omits the scope parameter when there are none", () => {
+    const header = wwwAuthenticateHeader({
+      error: "invalid_token",
+      description: "Sign in to use this tool.",
+      scopes: [],
+    });
+    expect(header).not.toContain("scope=");
+  });
+});

--- a/packages/core/src/server/auth/security-schemes.test.ts
+++ b/packages/core/src/server/auth/security-schemes.test.ts
@@ -57,14 +57,17 @@ describe("evaluateSecuritySchemes", () => {
     expect(evaluateSecuritySchemes(schemes, undefined)).toBeUndefined();
   });
 
-  it("lets any caller through a public tool, scoped or not", () => {
+  it("enforces oauth2 scopes on a public tool once a token is present", () => {
     const schemes: SecurityScheme[] = [
       { type: "noauth" },
       { type: "oauth2", scopes: ["checkout"] },
     ];
     expect(evaluateSecuritySchemes(schemes, undefined)).toBeUndefined();
+    expect(evaluateSecuritySchemes(schemes, authInfo(["openid"]))?.error).toBe(
+      "insufficient_scope",
+    );
     expect(
-      evaluateSecuritySchemes(schemes, authInfo(["openid"])),
+      evaluateSecuritySchemes(schemes, authInfo(["checkout"])),
     ).toBeUndefined();
   });
 

--- a/packages/core/src/server/auth/security-schemes.test.ts
+++ b/packages/core/src/server/auth/security-schemes.test.ts
@@ -19,15 +19,18 @@ describe("clientPrefersInBandChallenge", () => {
 });
 
 describe("authToSecuritySchemes", () => {
-  it("maps the three auth shorthands", () => {
-    expect(authToSecuritySchemes("public")).toEqual([
+  it("maps the auth shorthand", () => {
+    expect(authToSecuritySchemes({ public: true })).toEqual([
       { type: "noauth" },
       { type: "oauth2" },
     ]);
-    expect(authToSecuritySchemes("required")).toEqual([{ type: "oauth2" }]);
+    expect(authToSecuritySchemes({})).toEqual([{ type: "oauth2" }]);
     expect(authToSecuritySchemes({ scopes: ["checkout"] })).toEqual([
       { type: "oauth2", scopes: ["checkout"] },
     ]);
+    expect(
+      authToSecuritySchemes({ public: true, scopes: ["checkout"] }),
+    ).toEqual([{ type: "noauth" }, { type: "oauth2", scopes: ["checkout"] }]);
   });
 });
 

--- a/packages/core/src/server/auth/security-schemes.test.ts
+++ b/packages/core/src/server/auth/security-schemes.test.ts
@@ -57,17 +57,14 @@ describe("evaluateSecuritySchemes", () => {
     expect(evaluateSecuritySchemes(schemes, undefined)).toBeUndefined();
   });
 
-  it("enforces oauth2 scopes on a public tool once a token is present", () => {
+  it("lets any caller through a public tool, scoped or not", () => {
     const schemes: SecurityScheme[] = [
       { type: "noauth" },
       { type: "oauth2", scopes: ["checkout"] },
     ];
     expect(evaluateSecuritySchemes(schemes, undefined)).toBeUndefined();
-    expect(evaluateSecuritySchemes(schemes, authInfo(["openid"]))?.error).toBe(
-      "insufficient_scope",
-    );
     expect(
-      evaluateSecuritySchemes(schemes, authInfo(["checkout"])),
+      evaluateSecuritySchemes(schemes, authInfo(["openid"])),
     ).toBeUndefined();
   });
 

--- a/packages/core/src/server/auth/security-schemes.test.ts
+++ b/packages/core/src/server/auth/security-schemes.test.ts
@@ -20,7 +20,7 @@ describe("clientPrefersInBandChallenge", () => {
 
 describe("authToSecuritySchemes", () => {
   it("maps the auth shorthand", () => {
-    expect(authToSecuritySchemes({ public: true })).toEqual([
+    expect(authToSecuritySchemes({ allowsAnonymous: true })).toEqual([
       { type: "noauth" },
       { type: "oauth2" },
     ]);
@@ -29,7 +29,7 @@ describe("authToSecuritySchemes", () => {
       { type: "oauth2", scopes: ["checkout"] },
     ]);
     expect(
-      authToSecuritySchemes({ public: true, scopes: ["checkout"] }),
+      authToSecuritySchemes({ allowsAnonymous: true, scopes: ["checkout"] }),
     ).toEqual([{ type: "noauth" }, { type: "oauth2", scopes: ["checkout"] }]);
   });
 });

--- a/packages/core/src/server/auth/security-schemes.ts
+++ b/packages/core/src/server/auth/security-schemes.ts
@@ -25,7 +25,7 @@ export function evaluateSecuritySchemes(
   schemes: SecurityScheme[] | undefined,
   authInfo: AuthInfo | undefined,
 ): SchemeFailure | undefined {
-  if (securitySchemesAllowAnonymous(schemes)) {
+  if (securitySchemesAllowAnonymous(schemes) && !authInfo) {
     return undefined;
   }
   const oauth2 = (schemes ?? []).filter((scheme) => scheme.type === "oauth2");

--- a/packages/core/src/server/auth/security-schemes.ts
+++ b/packages/core/src/server/auth/security-schemes.ts
@@ -25,7 +25,7 @@ export function evaluateSecuritySchemes(
   schemes: SecurityScheme[] | undefined,
   authInfo: AuthInfo | undefined,
 ): SchemeFailure | undefined {
-  if (securitySchemesAllowAnonymous(schemes) && !authInfo) {
+  if (securitySchemesAllowAnonymous(schemes)) {
     return undefined;
   }
   const oauth2 = (schemes ?? []).filter((scheme) => scheme.type === "oauth2");

--- a/packages/core/src/server/auth/security-schemes.ts
+++ b/packages/core/src/server/auth/security-schemes.ts
@@ -76,3 +76,18 @@ export function wwwAuthenticateHeader(
   }
   return header;
 }
+
+export function inBandChallengeResult(
+  failure: SchemeFailure,
+  resourceMetadataUrl?: string,
+) {
+  return {
+    isError: true,
+    content: [{ type: "text" as const, text: failure.description }],
+    _meta: {
+      "mcp/www_authenticate": [
+        wwwAuthenticateHeader(failure, resourceMetadataUrl),
+      ],
+    },
+  };
+}

--- a/packages/core/src/server/auth/security-schemes.ts
+++ b/packages/core/src/server/auth/security-schemes.ts
@@ -1,0 +1,80 @@
+import type { AuthInfo } from "../auth.js";
+import type { SecurityScheme, ToolAuth } from "../server.js";
+
+export function authToSecuritySchemes(auth: ToolAuth): SecurityScheme[] {
+  if (auth === "public") {
+    return [{ type: "noauth" }, { type: "oauth2" }];
+  }
+  if (auth === "required") {
+    return [{ type: "oauth2" }];
+  }
+  return [{ type: "oauth2", scopes: auth.scopes }];
+}
+
+export function securitySchemesAllowAnonymous(
+  schemes: SecurityScheme[] | undefined,
+): boolean {
+  return !!schemes?.some((scheme) => scheme.type === "noauth");
+}
+
+export type SchemeFailure = {
+  error: "invalid_token" | "insufficient_scope";
+  description: string;
+  scopes: string[];
+};
+
+export function evaluateSecuritySchemes(
+  schemes: SecurityScheme[] | undefined,
+  authInfo: AuthInfo | undefined,
+): SchemeFailure | undefined {
+  if (securitySchemesAllowAnonymous(schemes)) {
+    return undefined;
+  }
+  const oauth2 = (schemes ?? []).filter((scheme) => scheme.type === "oauth2");
+  const required = oauth2.length ? oauth2 : [{ type: "oauth2" as const }];
+  const scopes = [
+    ...new Set(required.flatMap((scheme) => scheme.scopes ?? [])),
+  ];
+  if (!authInfo) {
+    return {
+      error: "invalid_token",
+      description: "Sign in to use this tool.",
+      scopes,
+    };
+  }
+  const satisfied = required.some((scheme) =>
+    (scheme.scopes ?? []).every((scope) => authInfo.scopes.includes(scope)),
+  );
+  return satisfied
+    ? undefined
+    : {
+        error: "insufficient_scope",
+        description: "Missing required scope for this tool.",
+        scopes,
+      };
+}
+
+export function httpStatusForFailure(failure: SchemeFailure): 401 | 403 {
+  return failure.error === "insufficient_scope" ? 403 : 401;
+}
+
+export function clientPrefersInBandChallenge(
+  userAgent: string | undefined,
+): boolean {
+  const ua = (userAgent ?? "").toLowerCase();
+  return ua.includes("openai") || ua.includes("chatgpt");
+}
+
+export function wwwAuthenticateHeader(
+  failure: SchemeFailure,
+  resourceMetadataUrl?: string,
+): string {
+  let header = `Bearer error="${failure.error}", error_description="${failure.description}"`;
+  if (failure.scopes.length) {
+    header += `, scope="${failure.scopes.join(" ")}"`;
+  }
+  if (resourceMetadataUrl) {
+    header += `, resource_metadata="${resourceMetadataUrl}"`;
+  }
+  return header;
+}

--- a/packages/core/src/server/auth/security-schemes.ts
+++ b/packages/core/src/server/auth/security-schemes.ts
@@ -7,7 +7,7 @@ export function authToSecuritySchemes(auth: ToolAuth): SecurityScheme[] {
     type: "oauth2",
     ...(auth.scopes?.length ? { scopes: auth.scopes } : {}),
   };
-  return auth.public ? [{ type: "noauth" }, oauth2] : [oauth2];
+  return auth.allowsAnonymous ? [{ type: "noauth" }, oauth2] : [oauth2];
 }
 
 export function securitySchemesAllowAnonymous(

--- a/packages/core/src/server/auth/security-schemes.ts
+++ b/packages/core/src/server/auth/security-schemes.ts
@@ -1,4 +1,5 @@
 import type { AuthInfo } from "../auth.js";
+import { hostFromUserAgent } from "../host.js";
 import type { SecurityScheme, ToolAuth } from "../server.js";
 
 export function authToSecuritySchemes(auth: ToolAuth): SecurityScheme[] {
@@ -59,8 +60,7 @@ export function httpStatusForFailure(failure: SchemeFailure): 401 | 403 {
 export function clientPrefersInBandChallenge(
   userAgent: string | undefined,
 ): boolean {
-  const ua = (userAgent ?? "").toLowerCase();
-  return ua.includes("openai") || ua.includes("chatgpt");
+  return hostFromUserAgent(userAgent) === "openai";
 }
 
 export function wwwAuthenticateHeader(

--- a/packages/core/src/server/auth/security-schemes.ts
+++ b/packages/core/src/server/auth/security-schemes.ts
@@ -2,13 +2,11 @@ import type { AuthInfo } from "../auth.js";
 import type { SecurityScheme, ToolAuth } from "../server.js";
 
 export function authToSecuritySchemes(auth: ToolAuth): SecurityScheme[] {
-  if (auth === "public") {
-    return [{ type: "noauth" }, { type: "oauth2" }];
-  }
-  if (auth === "required") {
-    return [{ type: "oauth2" }];
-  }
-  return [{ type: "oauth2", scopes: auth.scopes }];
+  const oauth2: SecurityScheme = {
+    type: "oauth2",
+    ...(auth.scopes?.length ? { scopes: auth.scopes } : {}),
+  };
+  return auth.public ? [{ type: "noauth" }, oauth2] : [oauth2];
 }
 
 export function securitySchemesAllowAnonymous(

--- a/packages/core/src/server/auth/setup.test.ts
+++ b/packages/core/src/server/auth/setup.test.ts
@@ -434,6 +434,32 @@ describe("mixed-auth door", () => {
     expect(challenge[0]).toMatch(/error="invalid_token"/);
     expect(challenge[0]).toMatch(/resource_metadata=/);
   });
+
+  it("fails closed on a ChatGPT batch (transport 401, no in-band challenge)", async () => {
+    const { jwksUri } = await startJwks();
+    const base = await bootMixedServer(jwksUri);
+
+    const res = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        "User-Agent": "openai-mcp/1.0",
+      },
+      body: JSON.stringify([
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: { name: "private-whoami", arguments: {} },
+        },
+      ]),
+    });
+    expect(res.status).toBe(401);
+    expect(res.headers.get("www-authenticate")).toMatch(/^Bearer /);
+    const text = await res.text();
+    expect(text).not.toContain("client-1");
+  });
 });
 
 async function bootScopedServer(jwksUri: string) {

--- a/packages/core/src/server/auth/setup.test.ts
+++ b/packages/core/src/server/auth/setup.test.ts
@@ -46,10 +46,10 @@ async function startJwks() {
   return { privateKey, jwksUri: `http://localhost:${port}/jwks` };
 }
 
-function signToken(key: CryptoKey) {
+function signToken(key: CryptoKey, scope = "openid email") {
   return new jose.SignJWT({
     client_id: "client-1",
-    scope: "openid email",
+    scope,
     sub: "user-1",
   })
     .setProtectedHeader({ alg: "RS256", kid: "test-key" })
@@ -212,6 +212,291 @@ describe("baseUrl inferred from headers", () => {
     expect(res.headers.get("www-authenticate")).toMatch(
       /resource_metadata="https:\/\/infer\.example\.test\//,
     );
+  });
+});
+
+async function bootMixedServer(jwksUri: string) {
+  const { createApp } = await import("../express.js");
+  const server = new McpServer(
+    { name: "mixed-auth-test", version: "0.0.0" },
+    { capabilities: {} },
+    {
+      oauth: {
+        baseUrl: "https://app.example.test",
+        oauthMetadata: {
+          issuer: ISSUER,
+          authorization_endpoint: `${ISSUER}/authorize`,
+          token_endpoint: `${ISSUER}/token`,
+          response_types_supported: ["code"],
+        },
+        verify: { issuer: ISSUER, audience: AUDIENCE, jwksUri },
+      },
+    },
+  )
+    .registerTool(
+      {
+        name: "public-whoami",
+        description: "Public.",
+        inputSchema: {},
+        securitySchemes: [{ type: "noauth" }, { type: "oauth2" }],
+      },
+      (_args, extra) => ({
+        content: [{ type: "text", text: extra.authInfo?.clientId ?? "anon" }],
+      }),
+    )
+    .registerTool(
+      {
+        name: "private-whoami",
+        description: "Private.",
+        inputSchema: {},
+        securitySchemes: [{ type: "oauth2" }],
+      },
+      (_args, extra) => ({
+        content: [{ type: "text", text: extra.authInfo?.clientId ?? "anon" }],
+      }),
+    );
+
+  const httpServer = http.createServer();
+  await createApp({ mcpServer: server, httpServer });
+  const listening = http.createServer(server.express);
+  await new Promise<void>((resolve) => listening.listen(0, resolve));
+  appServer = listening;
+  const port = (listening.address() as { port: number }).port;
+  return `http://localhost:${port}`;
+}
+
+describe("mixed-auth door", () => {
+  it("lets an anonymous caller initialize and run a noauth tool", async () => {
+    const { jwksUri } = await startJwks();
+    const base = await bootMixedServer(jwksUri);
+
+    const client = new Client({ name: "test-client", version: "0.0.0" });
+    await client.connect(
+      new StreamableHTTPClientTransport(new URL(`${base}/mcp`)),
+    );
+
+    const result = (await client.callTool({
+      name: "public-whoami",
+      arguments: {},
+    })) as unknown as { content: { text: string }[] };
+    expect(result.content[0]?.text).toBe("anon");
+
+    await client.close();
+  });
+
+  it("exposes securitySchemes at the top level of tools/list (not only _meta)", async () => {
+    const { jwksUri } = await startJwks();
+    const base = await bootMixedServer(jwksUri);
+    const headers = {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+    };
+    await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "c", version: "0" },
+        },
+      }),
+    });
+    const res = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list" }),
+    });
+    const text = await res.text();
+    const json = JSON.parse((text.match(/\{[\s\S]*\}/) ?? ["{}"])[0]) as {
+      result: { tools: Array<{ name: string; securitySchemes?: unknown }> };
+    };
+    const whoami = json.result.tools.find((t) => t.name === "private-whoami");
+    expect(whoami?.securitySchemes).toEqual([{ type: "oauth2" }]);
+  });
+
+  it("returns 401 + WWW-Authenticate for a protected tool while anonymous", async () => {
+    const { jwksUri } = await startJwks();
+    const base = await bootMixedServer(jwksUri);
+
+    const res = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "private-whoami", arguments: {} },
+      }),
+    });
+    expect(res.status).toBe(401);
+    expect(res.headers.get("www-authenticate")).toMatch(
+      /error="invalid_token"/,
+    );
+    expect(res.headers.get("www-authenticate")).toMatch(/resource_metadata=/);
+  });
+
+  it("returns an in-band mcp/www_authenticate array to ChatGPT (not a transport 401)", async () => {
+    const { jwksUri } = await startJwks();
+    const base = await bootMixedServer(jwksUri);
+
+    const res = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        "User-Agent": "openai-mcp/1.0",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 7,
+        method: "tools/call",
+        params: { name: "private-whoami", arguments: {} },
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("www-authenticate")).toBeNull();
+    const body = (await res.json()) as {
+      id: number;
+      result: {
+        isError: boolean;
+        _meta: { "mcp/www_authenticate": string[] };
+      };
+    };
+    expect(body.id).toBe(7);
+    expect(body.result.isError).toBe(true);
+    const challenge = body.result._meta["mcp/www_authenticate"];
+    expect(Array.isArray(challenge)).toBe(true);
+    expect(challenge[0]).toMatch(/error="invalid_token"/);
+    expect(challenge[0]).toMatch(/resource_metadata=/);
+  });
+});
+
+async function bootScopedServer(jwksUri: string) {
+  const { createApp } = await import("../express.js");
+  const server = new McpServer(
+    { name: "scoped-auth-test", version: "0.0.0" },
+    { capabilities: {} },
+    {
+      oauth: {
+        baseUrl: "https://app.example.test",
+        oauthMetadata: {
+          issuer: ISSUER,
+          authorization_endpoint: `${ISSUER}/authorize`,
+          token_endpoint: `${ISSUER}/token`,
+          response_types_supported: ["code"],
+        },
+        verify: { issuer: ISSUER, audience: AUDIENCE, jwksUri },
+      },
+    },
+  ).registerTool(
+    {
+      name: "checkout",
+      description: "Needs the checkout scope.",
+      inputSchema: {},
+      auth: { scopes: ["checkout"] },
+    },
+    () => ({ content: [{ type: "text", text: "ok" }] }),
+  );
+
+  const httpServer = http.createServer();
+  await createApp({ mcpServer: server, httpServer });
+  const listening = http.createServer(server.express);
+  await new Promise<void>((resolve) => listening.listen(0, resolve));
+  appServer = listening;
+  const port = (listening.address() as { port: number }).port;
+  return `http://localhost:${port}`;
+}
+
+describe("per-tool scope enforcement in fully-authenticated mode", () => {
+  it("returns 403 for a valid token missing the tool's scope", async () => {
+    const { privateKey, jwksUri } = await startJwks();
+    const base = await bootScopedServer(jwksUri);
+    const token = await signToken(privateKey, "openid");
+
+    const res = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "checkout", arguments: {} },
+      }),
+    });
+    expect(res.status).toBe(403);
+    const header = res.headers.get("www-authenticate");
+    expect(header).toMatch(/error="insufficient_scope"/);
+    expect(header).toMatch(/scope="checkout"/);
+  });
+
+  it("allows a token carrying the tool's scope", async () => {
+    const { privateKey, jwksUri } = await startJwks();
+    const base = await bootScopedServer(jwksUri);
+    const token = await signToken(privateKey, "openid checkout");
+
+    const client = new Client({ name: "test-client", version: "0.0.0" });
+    await client.connect(
+      new StreamableHTTPClientTransport(new URL(`${base}/mcp`), {
+        requestInit: { headers: { Authorization: `Bearer ${token}` } },
+      }),
+    );
+
+    const result = (await client.callTool({
+      name: "checkout",
+      arguments: {},
+    })) as unknown as { isError?: boolean; content: { text: string }[] };
+    expect(result.content[0]?.text).toBe("ok");
+
+    await client.close();
+  });
+});
+
+describe("auth shorthand validation", () => {
+  const oauth = {
+    baseUrl: "https://app.example.test",
+    oauthMetadata: {
+      issuer: ISSUER,
+      authorization_endpoint: `${ISSUER}/authorize`,
+      token_endpoint: `${ISSUER}/token`,
+      response_types_supported: ["code"],
+    },
+    verify: { issuer: ISSUER, audience: AUDIENCE },
+  };
+
+  it("throws when `auth` is set but no oauth provider is configured", () => {
+    expect(() =>
+      new McpServer({ name: "t", version: "0" }).registerTool(
+        { name: "x", inputSchema: {}, auth: "required" },
+        () => ({ content: [{ type: "text", text: "" }] }),
+      ),
+    ).toThrow(/no `oauth` provider/);
+  });
+
+  it("throws when both `auth` and `securitySchemes` are set", () => {
+    expect(() =>
+      new McpServer({ name: "t", version: "0" }, undefined, {
+        oauth,
+      }).registerTool(
+        {
+          name: "x",
+          inputSchema: {},
+          auth: "required",
+          securitySchemes: [{ type: "oauth2" }],
+        },
+        () => ({ content: [{ type: "text", text: "" }] }),
+      ),
+    ).toThrow(/use one/);
   });
 });
 

--- a/packages/core/src/server/auth/setup.test.ts
+++ b/packages/core/src/server/auth/setup.test.ts
@@ -238,7 +238,7 @@ async function bootMixedServer(jwksUri: string) {
         name: "public-whoami",
         description: "Public.",
         inputSchema: {},
-        auth: "public",
+        auth: { public: true },
       },
       (_args, extra) => ({
         content: [{ type: "text", text: extra.authInfo?.clientId ?? "anon" }],
@@ -249,7 +249,7 @@ async function bootMixedServer(jwksUri: string) {
         name: "private-whoami",
         description: "Private.",
         inputSchema: {},
-        auth: "required",
+        auth: {},
       },
       (_args, extra) => ({
         content: [{ type: "text", text: extra.authInfo?.clientId ?? "anon" }],
@@ -519,31 +519,44 @@ describe("per-tool scope enforcement in fully-authenticated mode", () => {
 });
 
 describe("auth shorthand validation", () => {
-  it("throws when `auth` is set but no oauth provider is configured", () => {
+  it("throws when `auth` requires sign-in but no oauth provider is configured", () => {
     expect(() =>
       new McpServer({ name: "t", version: "0" }).registerTool(
-        { name: "x", inputSchema: {}, auth: "required" },
+        { name: "x", inputSchema: {}, auth: {} },
         () => ({ content: [{ type: "text", text: "" }] }),
       ),
     ).toThrow(/no `oauth` provider/);
   });
 
-  it('allows `auth: "public"` without an oauth provider', () => {
+  it("throws when `auth` sets scopes but no oauth provider is configured", () => {
     expect(() =>
       new McpServer({ name: "t", version: "0" }).registerTool(
-        { name: "x", inputSchema: {}, auth: "public" },
+        { name: "x", inputSchema: {}, auth: { scopes: ["checkout"] } },
+        () => ({ content: [{ type: "text", text: "" }] }),
+      ),
+    ).toThrow(/no `oauth` provider/);
+  });
+
+  it("allows `auth: { public: true }` without an oauth provider", () => {
+    expect(() =>
+      new McpServer({ name: "t", version: "0" }).registerTool(
+        { name: "x", inputSchema: {}, auth: { public: true } },
         () => ({ content: [{ type: "text", text: "" }] }),
       ),
     ).not.toThrow();
   });
 
-  it("prefers `securitySchemes` over `auth` when both are set", () => {
+  it("prefers `securitySchemes` over `auth` when both are set (untyped path)", () => {
     expect(() =>
-      new McpServer({ name: "t", version: "0" }).registerTool(
+      (
+        new McpServer({ name: "t", version: "0" }).registerTool as (
+          ...a: unknown[]
+        ) => unknown
+      )(
         {
           name: "x",
           inputSchema: {},
-          auth: "required",
+          auth: {},
           securitySchemes: [{ type: "oauth2" }],
         },
         () => ({ content: [{ type: "text", text: "" }] }),

--- a/packages/core/src/server/auth/setup.test.ts
+++ b/packages/core/src/server/auth/setup.test.ts
@@ -238,7 +238,7 @@ async function bootMixedServer(jwksUri: string) {
         name: "public-whoami",
         description: "Public.",
         inputSchema: {},
-        securitySchemes: [{ type: "noauth" }, { type: "oauth2" }],
+        auth: "public",
       },
       (_args, extra) => ({
         content: [{ type: "text", text: extra.authInfo?.clientId ?? "anon" }],
@@ -249,7 +249,7 @@ async function bootMixedServer(jwksUri: string) {
         name: "private-whoami",
         description: "Private.",
         inputSchema: {},
-        securitySchemes: [{ type: "oauth2" }],
+        auth: "required",
       },
       (_args, extra) => ({
         content: [{ type: "text", text: extra.authInfo?.clientId ?? "anon" }],
@@ -316,6 +316,30 @@ describe("mixed-auth door", () => {
     };
     const whoami = json.result.tools.find((t) => t.name === "private-whoami");
     expect(whoami?.securitySchemes).toEqual([{ type: "oauth2" }]);
+  });
+
+  it("denies a protected tool inside an anonymous JSON-RPC batch", async () => {
+    const { jwksUri } = await startJwks();
+    const base = await bootMixedServer(jwksUri);
+
+    const res = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify([
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: { name: "private-whoami", arguments: {} },
+        },
+      ]),
+    });
+    const text = await res.text();
+    expect(text).not.toContain("client-1");
+    expect(text).toContain("Sign in to use this tool.");
   });
 
   it("returns 401 + WWW-Authenticate for a protected tool while anonymous", async () => {

--- a/packages/core/src/server/auth/setup.test.ts
+++ b/packages/core/src/server/auth/setup.test.ts
@@ -487,17 +487,6 @@ describe("per-tool scope enforcement in fully-authenticated mode", () => {
 });
 
 describe("auth shorthand validation", () => {
-  const oauth = {
-    baseUrl: "https://app.example.test",
-    oauthMetadata: {
-      issuer: ISSUER,
-      authorization_endpoint: `${ISSUER}/authorize`,
-      token_endpoint: `${ISSUER}/token`,
-      response_types_supported: ["code"],
-    },
-    verify: { issuer: ISSUER, audience: AUDIENCE },
-  };
-
   it("throws when `auth` is set but no oauth provider is configured", () => {
     expect(() =>
       new McpServer({ name: "t", version: "0" }).registerTool(
@@ -516,11 +505,9 @@ describe("auth shorthand validation", () => {
     ).not.toThrow();
   });
 
-  it("throws when both `auth` and `securitySchemes` are set", () => {
+  it("prefers `securitySchemes` over `auth` when both are set", () => {
     expect(() =>
-      new McpServer({ name: "t", version: "0" }, undefined, {
-        oauth,
-      }).registerTool(
+      new McpServer({ name: "t", version: "0" }).registerTool(
         {
           name: "x",
           inputSchema: {},
@@ -529,7 +516,7 @@ describe("auth shorthand validation", () => {
         },
         () => ({ content: [{ type: "text", text: "" }] }),
       ),
-    ).toThrow(/use one/);
+    ).not.toThrow();
   });
 });
 

--- a/packages/core/src/server/auth/setup.test.ts
+++ b/packages/core/src/server/auth/setup.test.ts
@@ -340,6 +340,7 @@ describe("mixed-auth door", () => {
     const text = await res.text();
     expect(text).not.toContain("client-1");
     expect(text).toContain("Sign in to use this tool.");
+    expect(text).toContain("resource_metadata=");
   });
 
   it("returns 401 + WWW-Authenticate for a protected tool while anonymous", async () => {
@@ -496,7 +497,7 @@ describe("auth shorthand validation", () => {
     ).toThrow(/no `oauth` provider/);
   });
 
-  it("allows `auth: \"public\"` without an oauth provider", () => {
+  it('allows `auth: "public"` without an oauth provider', () => {
     expect(() =>
       new McpServer({ name: "t", version: "0" }).registerTool(
         { name: "x", inputSchema: {}, auth: "public" },

--- a/packages/core/src/server/auth/setup.test.ts
+++ b/packages/core/src/server/auth/setup.test.ts
@@ -238,7 +238,7 @@ async function bootMixedServer(jwksUri: string) {
         name: "public-whoami",
         description: "Public.",
         inputSchema: {},
-        auth: { public: true },
+        auth: { allowsAnonymous: true },
       },
       (_args, extra) => ({
         content: [{ type: "text", text: extra.authInfo?.clientId ?? "anon" }],
@@ -565,10 +565,10 @@ describe("auth shorthand validation", () => {
     ).toThrow(/no `oauth` provider/);
   });
 
-  it("allows `auth: { public: true }` without an oauth provider", () => {
+  it("allows `auth: { allowsAnonymous: true }` without an oauth provider", () => {
     expect(() =>
       new McpServer({ name: "t", version: "0" }).registerTool(
-        { name: "x", inputSchema: {}, auth: { public: true } },
+        { name: "x", inputSchema: {}, auth: { allowsAnonymous: true } },
         () => ({ content: [{ type: "text", text: "" }] }),
       ),
     ).not.toThrow();

--- a/packages/core/src/server/auth/setup.test.ts
+++ b/packages/core/src/server/auth/setup.test.ts
@@ -348,10 +348,12 @@ describe("mixed-auth door", () => {
         },
       ]),
     });
+    expect(res.status).toBe(401);
+    const wwwAuthenticate = res.headers.get("www-authenticate") ?? "";
+    expect(wwwAuthenticate).toMatch(/^Bearer /);
+    expect(wwwAuthenticate).toContain("resource_metadata=");
     const text = await res.text();
     expect(text).not.toContain("client-1");
-    expect(text).toContain("Sign in to use this tool.");
-    expect(text).toContain("resource_metadata=");
   });
 
   it("gates a tool registered via the legacy string overload (secure default)", async () => {

--- a/packages/core/src/server/auth/setup.test.ts
+++ b/packages/core/src/server/auth/setup.test.ts
@@ -507,6 +507,15 @@ describe("auth shorthand validation", () => {
     ).toThrow(/no `oauth` provider/);
   });
 
+  it("allows `auth: \"public\"` without an oauth provider", () => {
+    expect(() =>
+      new McpServer({ name: "t", version: "0" }).registerTool(
+        { name: "x", inputSchema: {}, auth: "public" },
+        () => ({ content: [{ type: "text", text: "" }] }),
+      ),
+    ).not.toThrow();
+  });
+
   it("throws when both `auth` and `securitySchemes` are set", () => {
     expect(() =>
       new McpServer({ name: "t", version: "0" }, undefined, {

--- a/packages/core/src/server/auth/setup.test.ts
+++ b/packages/core/src/server/auth/setup.test.ts
@@ -256,6 +256,17 @@ async function bootMixedServer(jwksUri: string) {
       }),
     );
 
+  (server.registerTool as (...a: unknown[]) => unknown)(
+    "legacy-whoami",
+    {
+      description: "Registered via the legacy string overload.",
+      inputSchema: {},
+    },
+    (_args: unknown, extra: { authInfo?: { clientId?: string } }) => ({
+      content: [{ type: "text", text: extra.authInfo?.clientId ?? "anon" }],
+    }),
+  );
+
   const httpServer = http.createServer();
   await createApp({ mcpServer: server, httpServer });
   const listening = http.createServer(server.express);
@@ -341,6 +352,26 @@ describe("mixed-auth door", () => {
     expect(text).not.toContain("client-1");
     expect(text).toContain("Sign in to use this tool.");
     expect(text).toContain("resource_metadata=");
+  });
+
+  it("gates a tool registered via the legacy string overload (secure default)", async () => {
+    const { jwksUri } = await startJwks();
+    const base = await bootMixedServer(jwksUri);
+
+    const res = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "legacy-whoami", arguments: {} },
+      }),
+    });
+    expect(res.status).toBe(401);
   });
 
   it("returns 401 + WWW-Authenticate for a protected tool while anonymous", async () => {

--- a/packages/core/src/server/auth/setup.ts
+++ b/packages/core/src/server/auth/setup.ts
@@ -19,12 +19,16 @@ import {
 } from "./security-schemes.js";
 import { createJwksVerifier } from "./verify.js";
 
+export type ResourceMetadataUrlResolver = (
+  getHeader: (key: string) => string | undefined,
+) => string;
+
 /** Mounts the well-known OAuth metadata and bearer auth on `/mcp`. */
 export function setupOAuth(
   app: Express,
   config: OAuthConfig,
   schemesByTool: Map<string, SecurityScheme[] | undefined>,
-): void {
+): ResourceMetadataUrlResolver {
   if (!config.verify?.issuer) {
     throw new Error("oauth.verify requires an `issuer`");
   }
@@ -39,7 +43,7 @@ export function setupOAuth(
       (acceptsAnonymous() ? optional : required)(req, res, next);
   };
 
-  let resourceMetadataUrl: (req: Request) => string;
+  let resourceMetadataUrl: ResourceMetadataUrlResolver;
 
   // baseUrl known at boot: bake the resource URLs once, no Host-header trust.
   if (config.baseUrl !== undefined) {
@@ -66,8 +70,8 @@ export function setupOAuth(
     // No baseUrl: resolve the resource origin per request from forwarded headers
     // (same precedence the framework uses for view serverUrl). Origin headers are
     // pathless, so the PRM path stays at root, matching the SDK's static layout.
-    const resolveOrigin = (req: Request) =>
-      new URL(resolveServerOrigin((key) => req.get(key)));
+    const resolveOrigin = (getHeader: (key: string) => string | undefined) =>
+      new URL(resolveServerOrigin(getHeader));
     app.use(
       "/.well-known/oauth-authorization-server",
       cors(),
@@ -75,20 +79,20 @@ export function setupOAuth(
     );
     app.use("/.well-known/oauth-protected-resource", cors(), (req, res) => {
       res.json({
-        resource: resolveOrigin(req).href,
+        resource: resolveOrigin((key) => req.get(key)).href,
         authorization_servers: [config.oauthMetadata.issuer],
         scopes_supported: config.scopesSupported,
       });
     });
-    resourceMetadataUrl = (req) =>
-      getOAuthProtectedResourceMetadataUrl(resolveOrigin(req));
+    resourceMetadataUrl = (getHeader) =>
+      getOAuthProtectedResourceMetadataUrl(resolveOrigin(getHeader));
   }
 
   app.use("/mcp", (req, res, next) =>
     bearer({
       verifier,
       requiredScopes: config.requiredScopes,
-      resourceMetadataUrl: resourceMetadataUrl(req),
+      resourceMetadataUrl: resourceMetadataUrl((key) => req.get(key)),
     })(req, res, next),
   );
 
@@ -111,7 +115,10 @@ export function setupOAuth(
     if (!failure) {
       return next();
     }
-    const challenge = wwwAuthenticateHeader(failure, resourceMetadataUrl(req));
+    const challenge = wwwAuthenticateHeader(
+      failure,
+      resourceMetadataUrl((key) => req.get(key)),
+    );
     if (clientPrefersInBandChallenge(req.get("user-agent"))) {
       res.json({
         jsonrpc: "2.0",
@@ -130,4 +137,6 @@ export function setupOAuth(
       error_description: failure.description,
     });
   });
+
+  return resourceMetadataUrl;
 }

--- a/packages/core/src/server/auth/setup.ts
+++ b/packages/core/src/server/auth/setup.ts
@@ -14,6 +14,7 @@ import {
   clientPrefersInBandChallenge,
   evaluateSecuritySchemes,
   httpStatusForFailure,
+  type SchemeFailure,
   securitySchemesAllowAnonymous,
   wwwAuthenticateHeader,
 } from "./security-schemes.js";
@@ -97,21 +98,24 @@ export function setupOAuth(
   );
 
   app.use("/mcp", (req, res, next) => {
-    const body = req.body as
-      | {
-          id?: string | number | null;
-          method?: string;
-          params?: { name?: string };
+    type Call = {
+      id?: string | number | null;
+      method?: string;
+      params?: { name?: string };
+    };
+    const body = req.body as Call | Call[] | undefined;
+    const calls = Array.isArray(body) ? body : [body];
+    const auth = (req as Request & { auth?: AuthInfo }).auth;
+    let failure: SchemeFailure | undefined;
+    for (const call of calls) {
+      const tool = call?.params?.name;
+      if (call?.method === "tools/call" && tool && schemesByTool.has(tool)) {
+        failure = evaluateSecuritySchemes(schemesByTool.get(tool), auth);
+        if (failure) {
+          break;
         }
-      | undefined;
-    const tool = body?.params?.name;
-    if (body?.method !== "tools/call" || !tool || !schemesByTool.has(tool)) {
-      return next();
+      }
     }
-    const failure = evaluateSecuritySchemes(
-      schemesByTool.get(tool),
-      (req as Request & { auth?: AuthInfo }).auth,
-    );
     if (!failure) {
       return next();
     }
@@ -120,9 +124,12 @@ export function setupOAuth(
       resourceMetadataUrl((key) => req.get(key)),
     );
     if (clientPrefersInBandChallenge(req.get("user-agent"))) {
+      if (Array.isArray(body)) {
+        return next();
+      }
       res.json({
         jsonrpc: "2.0",
-        id: body.id ?? null,
+        id: body?.id ?? null,
         result: {
           content: [{ type: "text", text: failure.description }],
           isError: true,

--- a/packages/core/src/server/auth/setup.ts
+++ b/packages/core/src/server/auth/setup.ts
@@ -39,49 +39,7 @@ export function setupOAuth(
       (acceptsAnonymous() ? optional : required)(req, res, next);
   };
 
-  const perToolGate =
-    (resourceMetadataUrl: (req: Request) => string): RequestHandler =>
-    (req, res, next) => {
-      const body = req.body as
-        | {
-            id?: string | number | null;
-            method?: string;
-            params?: { name?: string };
-          }
-        | undefined;
-      const tool = body?.params?.name;
-      if (body?.method !== "tools/call" || !tool || !schemesByTool.has(tool)) {
-        return next();
-      }
-      const failure = evaluateSecuritySchemes(
-        schemesByTool.get(tool),
-        (req as Request & { auth?: AuthInfo }).auth,
-      );
-      if (!failure) {
-        return next();
-      }
-      const challenge = wwwAuthenticateHeader(
-        failure,
-        resourceMetadataUrl(req),
-      );
-      if (clientPrefersInBandChallenge(req.get("user-agent"))) {
-        res.json({
-          jsonrpc: "2.0",
-          id: body.id ?? null,
-          result: {
-            content: [{ type: "text", text: failure.description }],
-            isError: true,
-            _meta: { "mcp/www_authenticate": [challenge] },
-          },
-        });
-        return;
-      }
-      res.set("WWW-Authenticate", challenge);
-      res.status(httpStatusForFailure(failure)).json({
-        error: failure.error,
-        error_description: failure.description,
-      });
-    };
+  let resourceMetadataUrl: (req: Request) => string;
 
   // baseUrl known at boot: bake the resource URLs once, no Host-header trust.
   if (config.baseUrl !== undefined) {
@@ -95,7 +53,6 @@ export function setupOAuth(
         )}`,
       );
     }
-    const resourceMetadataUrl = getOAuthProtectedResourceMetadataUrl(baseUrl);
     app.use(
       mcpAuthMetadataRouter({
         oauthMetadata: config.oauthMetadata,
@@ -103,41 +60,30 @@ export function setupOAuth(
         scopesSupported: config.scopesSupported,
       }),
     );
+    const url = getOAuthProtectedResourceMetadataUrl(baseUrl);
+    resourceMetadataUrl = () => url;
+  } else {
+    // No baseUrl: resolve the resource origin per request from forwarded headers
+    // (same precedence the framework uses for view serverUrl). Origin headers are
+    // pathless, so the PRM path stays at root, matching the SDK's static layout.
+    const resolveOrigin = (req: Request) =>
+      new URL(resolveServerOrigin((key) => req.get(key)));
     app.use(
-      "/mcp",
-      bearer({
-        verifier,
-        requiredScopes: config.requiredScopes,
-        resourceMetadataUrl,
-      }),
+      "/.well-known/oauth-authorization-server",
+      cors(),
+      (_req, res) => void res.json(config.oauthMetadata),
     );
-    app.use(
-      "/mcp",
-      perToolGate(() => resourceMetadataUrl),
-    );
-    return;
+    app.use("/.well-known/oauth-protected-resource", cors(), (req, res) => {
+      res.json({
+        resource: resolveOrigin(req).href,
+        authorization_servers: [config.oauthMetadata.issuer],
+        scopes_supported: config.scopesSupported,
+      });
+    });
+    resourceMetadataUrl = (req) =>
+      getOAuthProtectedResourceMetadataUrl(resolveOrigin(req));
   }
 
-  // No baseUrl: resolve the resource origin per request from forwarded headers
-  // (same precedence the framework uses for view serverUrl). Origin headers are
-  // pathless, so the PRM path stays at root, matching the SDK's static layout.
-  const resolveOrigin = (req: Request) =>
-    new URL(resolveServerOrigin((key) => req.get(key)));
-  const resourceMetadataUrl = (req: Request) =>
-    getOAuthProtectedResourceMetadataUrl(resolveOrigin(req));
-
-  app.use(
-    "/.well-known/oauth-authorization-server",
-    cors(),
-    (_req, res) => void res.json(config.oauthMetadata),
-  );
-  app.use("/.well-known/oauth-protected-resource", cors(), (req, res) => {
-    res.json({
-      resource: resolveOrigin(req).href,
-      authorization_servers: [config.oauthMetadata.issuer],
-      scopes_supported: config.scopesSupported,
-    });
-  });
   app.use("/mcp", (req, res, next) =>
     bearer({
       verifier,
@@ -145,5 +91,43 @@ export function setupOAuth(
       resourceMetadataUrl: resourceMetadataUrl(req),
     })(req, res, next),
   );
-  app.use("/mcp", perToolGate(resourceMetadataUrl));
+
+  app.use("/mcp", (req, res, next) => {
+    const body = req.body as
+      | {
+          id?: string | number | null;
+          method?: string;
+          params?: { name?: string };
+        }
+      | undefined;
+    const tool = body?.params?.name;
+    if (body?.method !== "tools/call" || !tool || !schemesByTool.has(tool)) {
+      return next();
+    }
+    const failure = evaluateSecuritySchemes(
+      schemesByTool.get(tool),
+      (req as Request & { auth?: AuthInfo }).auth,
+    );
+    if (!failure) {
+      return next();
+    }
+    const challenge = wwwAuthenticateHeader(failure, resourceMetadataUrl(req));
+    if (clientPrefersInBandChallenge(req.get("user-agent"))) {
+      res.json({
+        jsonrpc: "2.0",
+        id: body.id ?? null,
+        result: {
+          content: [{ type: "text", text: failure.description }],
+          isError: true,
+          _meta: { "mcp/www_authenticate": [challenge] },
+        },
+      });
+      return;
+    }
+    res.set("WWW-Authenticate", challenge);
+    res.status(httpStatusForFailure(failure)).json({
+      error: failure.error,
+      error_description: failure.description,
+    });
+  });
 }

--- a/packages/core/src/server/auth/setup.ts
+++ b/packages/core/src/server/auth/setup.ts
@@ -14,34 +14,29 @@ import {
   clientPrefersInBandChallenge,
   evaluateSecuritySchemes,
   httpStatusForFailure,
+  securitySchemesAllowAnonymous,
   wwwAuthenticateHeader,
 } from "./security-schemes.js";
 import { createJwksVerifier } from "./verify.js";
-
-export type SetupOAuthHooks = {
-  acceptsAnonymous?: () => boolean;
-  securitySchemesForTool?: (
-    toolName: string,
-  ) => { schemes: SecurityScheme[] | undefined } | undefined;
-};
 
 /** Mounts the well-known OAuth metadata and bearer auth on `/mcp`. */
 export function setupOAuth(
   app: Express,
   config: OAuthConfig,
-  hooks: SetupOAuthHooks = {},
+  schemesByTool: Map<string, SecurityScheme[] | undefined>,
 ): void {
   if (!config.verify?.issuer) {
     throw new Error("oauth.verify requires an `issuer`");
   }
 
-  const { acceptsAnonymous, securitySchemesForTool } = hooks;
+  const acceptsAnonymous = () =>
+    [...schemesByTool.values()].some(securitySchemesAllowAnonymous);
   const verifier = createJwksVerifier(config.verify);
   const bearer = (options: BearerAuthMiddlewareOptions): RequestHandler => {
     const required = requireBearerAuth(options);
     const optional = optionalBearerAuth(options);
     return (req, res, next) =>
-      (acceptsAnonymous?.() ? optional : required)(req, res, next);
+      (acceptsAnonymous() ? optional : required)(req, res, next);
   };
 
   const perToolGate =
@@ -54,16 +49,12 @@ export function setupOAuth(
             params?: { name?: string };
           }
         | undefined;
-      if (body?.method !== "tools/call" || !securitySchemesForTool) {
-        return next();
-      }
-      const tool = body.params?.name;
-      const entry = tool ? securitySchemesForTool(tool) : undefined;
-      if (!entry) {
+      const tool = body?.params?.name;
+      if (body?.method !== "tools/call" || !tool || !schemesByTool.has(tool)) {
         return next();
       }
       const failure = evaluateSecuritySchemes(
-        entry.schemes,
+        schemesByTool.get(tool),
         (req as Request & { auth?: AuthInfo }).auth,
       );
       if (!failure) {

--- a/packages/core/src/server/auth/setup.ts
+++ b/packages/core/src/server/auth/setup.ts
@@ -1,21 +1,96 @@
+import type { BearerAuthMiddlewareOptions } from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js";
 import {
   getOAuthProtectedResourceMetadataUrl,
   mcpAuthMetadataRouter,
 } from "@modelcontextprotocol/sdk/server/auth/router.js";
 import cors from "cors";
-import type { Express, Request } from "express";
-import { requireBearerAuth } from "../auth.js";
+import type { Express, Request, RequestHandler } from "express";
+import type { AuthInfo } from "../auth.js";
+import { optionalBearerAuth, requireBearerAuth } from "../auth.js";
 import { resolveServerOrigin } from "../requestOrigin.js";
+import type { SecurityScheme } from "../server.js";
 import type { OAuthConfig } from "./index.js";
+import {
+  clientPrefersInBandChallenge,
+  evaluateSecuritySchemes,
+  httpStatusForFailure,
+  wwwAuthenticateHeader,
+} from "./security-schemes.js";
 import { createJwksVerifier } from "./verify.js";
 
+export type SetupOAuthHooks = {
+  acceptsAnonymous?: () => boolean;
+  securitySchemesForTool?: (
+    toolName: string,
+  ) => { schemes: SecurityScheme[] | undefined } | undefined;
+};
+
 /** Mounts the well-known OAuth metadata and bearer auth on `/mcp`. */
-export function setupOAuth(app: Express, config: OAuthConfig): void {
+export function setupOAuth(
+  app: Express,
+  config: OAuthConfig,
+  hooks: SetupOAuthHooks = {},
+): void {
   if (!config.verify?.issuer) {
     throw new Error("oauth.verify requires an `issuer`");
   }
 
+  const { acceptsAnonymous, securitySchemesForTool } = hooks;
   const verifier = createJwksVerifier(config.verify);
+  const bearer = (options: BearerAuthMiddlewareOptions): RequestHandler => {
+    const required = requireBearerAuth(options);
+    const optional = optionalBearerAuth(options);
+    return (req, res, next) =>
+      (acceptsAnonymous?.() ? optional : required)(req, res, next);
+  };
+
+  const perToolGate =
+    (resourceMetadataUrl: (req: Request) => string): RequestHandler =>
+    (req, res, next) => {
+      const body = req.body as
+        | {
+            id?: string | number | null;
+            method?: string;
+            params?: { name?: string };
+          }
+        | undefined;
+      if (body?.method !== "tools/call" || !securitySchemesForTool) {
+        return next();
+      }
+      const tool = body.params?.name;
+      const entry = tool ? securitySchemesForTool(tool) : undefined;
+      if (!entry) {
+        return next();
+      }
+      const failure = evaluateSecuritySchemes(
+        entry.schemes,
+        (req as Request & { auth?: AuthInfo }).auth,
+      );
+      if (!failure) {
+        return next();
+      }
+      const challenge = wwwAuthenticateHeader(
+        failure,
+        resourceMetadataUrl(req),
+      );
+      if (clientPrefersInBandChallenge(req.get("user-agent"))) {
+        res.json({
+          jsonrpc: "2.0",
+          id: body.id ?? null,
+          result: {
+            content: [{ type: "text", text: failure.description }],
+            isError: true,
+            _meta: { "mcp/www_authenticate": [challenge] },
+          },
+        });
+        return;
+      }
+      res.set("WWW-Authenticate", challenge);
+      res.status(httpStatusForFailure(failure)).json({
+        error: failure.error,
+        error_description: failure.description,
+      });
+    };
 
   // baseUrl known at boot: bake the resource URLs once, no Host-header trust.
   if (config.baseUrl !== undefined) {
@@ -29,6 +104,7 @@ export function setupOAuth(app: Express, config: OAuthConfig): void {
         )}`,
       );
     }
+    const resourceMetadataUrl = getOAuthProtectedResourceMetadataUrl(baseUrl);
     app.use(
       mcpAuthMetadataRouter({
         oauthMetadata: config.oauthMetadata,
@@ -38,11 +114,15 @@ export function setupOAuth(app: Express, config: OAuthConfig): void {
     );
     app.use(
       "/mcp",
-      requireBearerAuth({
+      bearer({
         verifier,
         requiredScopes: config.requiredScopes,
-        resourceMetadataUrl: getOAuthProtectedResourceMetadataUrl(baseUrl),
+        resourceMetadataUrl,
       }),
+    );
+    app.use(
+      "/mcp",
+      perToolGate(() => resourceMetadataUrl),
     );
     return;
   }
@@ -52,6 +132,8 @@ export function setupOAuth(app: Express, config: OAuthConfig): void {
   // pathless, so the PRM path stays at root, matching the SDK's static layout.
   const resolveOrigin = (req: Request) =>
     new URL(resolveServerOrigin((key) => req.get(key)));
+  const resourceMetadataUrl = (req: Request) =>
+    getOAuthProtectedResourceMetadataUrl(resolveOrigin(req));
 
   app.use(
     "/.well-known/oauth-authorization-server",
@@ -66,12 +148,11 @@ export function setupOAuth(app: Express, config: OAuthConfig): void {
     });
   });
   app.use("/mcp", (req, res, next) =>
-    requireBearerAuth({
+    bearer({
       verifier,
       requiredScopes: config.requiredScopes,
-      resourceMetadataUrl: getOAuthProtectedResourceMetadataUrl(
-        resolveOrigin(req),
-      ),
+      resourceMetadataUrl: resourceMetadataUrl(req),
     })(req, res, next),
   );
+  app.use("/mcp", perToolGate(resourceMetadataUrl));
 }

--- a/packages/core/src/server/auth/setup.ts
+++ b/packages/core/src/server/auth/setup.ts
@@ -14,6 +14,7 @@ import {
   clientPrefersInBandChallenge,
   evaluateSecuritySchemes,
   httpStatusForFailure,
+  inBandChallengeResult,
   type SchemeFailure,
   securitySchemesAllowAnonymous,
   wwwAuthenticateHeader,
@@ -119,26 +120,19 @@ export function setupOAuth(
     if (!failure) {
       return next();
     }
-    const challenge = wwwAuthenticateHeader(
-      failure,
-      resourceMetadataUrl((key) => req.get(key)),
-    );
-    if (clientPrefersInBandChallenge(req.get("user-agent"))) {
-      if (Array.isArray(body)) {
-        return next();
-      }
+    const url = resourceMetadataUrl((key) => req.get(key));
+    if (
+      !Array.isArray(body) &&
+      clientPrefersInBandChallenge(req.get("user-agent"))
+    ) {
       res.json({
         jsonrpc: "2.0",
         id: body?.id ?? null,
-        result: {
-          content: [{ type: "text", text: failure.description }],
-          isError: true,
-          _meta: { "mcp/www_authenticate": [challenge] },
-        },
+        result: inBandChallengeResult(failure, url),
       });
       return;
     }
-    res.set("WWW-Authenticate", challenge);
+    res.set("WWW-Authenticate", wwwAuthenticateHeader(failure, url));
     res.status(httpStatusForFailure(failure)).json({
       error: failure.error,
       error_description: failure.description,

--- a/packages/core/src/server/host.test.ts
+++ b/packages/core/src/server/host.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { hostFromUserAgent } from "./host.js";
+
+describe("hostFromUserAgent", () => {
+  it("classifies known hosts case-insensitively and defaults to unknown", () => {
+    expect(hostFromUserAgent("openai-mcp/1.0")).toBe("openai");
+    expect(hostFromUserAgent("ChatGPT")).toBe("openai");
+    expect(hostFromUserAgent("claude-user")).toBe("claude");
+    expect(hostFromUserAgent("Claude-User/1.0")).toBe("unknown");
+    expect(hostFromUserAgent("Mozilla/5.0")).toBe("unknown");
+    expect(hostFromUserAgent(undefined)).toBe("unknown");
+  });
+});

--- a/packages/core/src/server/host.ts
+++ b/packages/core/src/server/host.ts
@@ -1,0 +1,12 @@
+export type HostKind = "openai" | "claude" | "unknown";
+
+export function hostFromUserAgent(userAgent: string | undefined): HostKind {
+  const ua = (userAgent ?? "").toLowerCase();
+  if (ua.includes("openai") || ua.includes("chatgpt")) {
+    return "openai";
+  }
+  if (ua === "claude-user") {
+    return "claude";
+  }
+  return "unknown";
+}

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -168,7 +168,7 @@ export type SecurityScheme =
   | { type: "noauth" }
   | { type: "oauth2"; scopes?: string[] };
 
-export type ToolAuth = "public" | "required" | { scopes: string[] };
+export type ToolAuth = { public?: boolean; scopes?: string[] };
 
 /**
  * Options forwarded to the built-in `express.json()` body parser. Derived
@@ -345,7 +345,7 @@ type AddTool<
   }
 >;
 
-interface ToolConfig<TInput extends ZodRawShapeCompat | AnySchema> {
+interface ToolConfigBase<TInput extends ZodRawShapeCompat | AnySchema> {
   name: string;
   title?: string;
   description?: string;
@@ -353,17 +353,22 @@ interface ToolConfig<TInput extends ZodRawShapeCompat | AnySchema> {
   outputSchema?: ZodRawShapeCompat | AnySchema;
   annotations?: ToolAnnotations;
   view?: ViewConfig;
-  auth?: ToolAuth;
-  /**
-   * Declares which auth schemes this tool supports (e.g. `noauth`, `oauth2`).
-   * Lets clients label tools that require sign-in before calling, and pass
-   * the right scopes through the OAuth flow. Listing both `noauth` and
-   * `oauth2` signals that the tool works for anonymous callers and gives
-   * enhanced behavior to authenticated ones.
-   */
-  securitySchemes?: SecurityScheme[];
   _meta?: ToolMeta;
 }
+
+type ToolConfig<TInput extends ZodRawShapeCompat | AnySchema> =
+  | (ToolConfigBase<TInput> & { auth?: ToolAuth; securitySchemes?: never })
+  | (ToolConfigBase<TInput> & {
+      auth?: never;
+      /**
+       * Declares which auth schemes this tool supports (e.g. `noauth`, `oauth2`).
+       * Lets clients label tools that require sign-in before calling, and pass
+       * the right scopes through the OAuth flow. Listing both `noauth` and
+       * `oauth2` signals that the tool works for anonymous callers and gives
+       * enhanced behavior to authenticated ones.
+       */
+      securitySchemes?: SecurityScheme[];
+    });
 
 /**
  * Optional client-supplied hints attached to `params._meta` on every tool call
@@ -1407,10 +1412,11 @@ export class McpServer<
       ...toolFields
     } = config;
 
+    const authNeedsProvider =
+      auth !== undefined && (!auth.public || Boolean(auth.scopes?.length));
     if (
       rawSecuritySchemes === undefined &&
-      auth !== undefined &&
-      auth !== "public" &&
+      authNeedsProvider &&
       !this.oauthEnabled
     ) {
       throw new Error(

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -849,10 +849,6 @@ export class McpServer<
       ...this.mcpMiddlewareEntries,
     ];
 
-    if (entries.length === 0) {
-      return;
-    }
-
     const { requestHandlers, notificationHandlers } = getHandlerMaps(
       this.server,
     );
@@ -1224,7 +1220,7 @@ export class McpServer<
     );
   }
 
-  private wrapHandler<InputArgs extends ZodRawShapeCompat>(
+  private decorateToolHandler<InputArgs extends ZodRawShapeCompat>(
     cb: ToolHandler<InputArgs>,
     {
       attachViewUUID,
@@ -1394,15 +1390,17 @@ export class McpServer<
           `Tool "${name}" sets both \`auth\` and \`securitySchemes\`; use one.`,
         );
       }
-      if (!this.oauthEnabled) {
+      if (auth !== "public" && !this.oauthEnabled) {
         throw new Error(
-          `Tool "${name}" sets \`auth\` but the server has no \`oauth\` provider configured.`,
+          `Tool "${name}" sets \`auth: ${JSON.stringify(auth)}\` but the server has no \`oauth\` provider configured.`,
         );
       }
     }
 
     const securitySchemes = auth
-      ? authToSecuritySchemes(auth)
+      ? this.oauthEnabled
+        ? authToSecuritySchemes(auth)
+        : undefined
       : rawSecuritySchemes;
 
     const toolMeta: InternalToolMeta = { ...userToolMeta };
@@ -1423,7 +1421,7 @@ export class McpServer<
       this.registerViewResources(name, view, toolMeta);
     }
 
-    const wrappedCb = this.wrapHandler(cb, {
+    const wrappedCb = this.decorateToolHandler(cb, {
       attachViewUUID: Boolean(view),
       securitySchemes,
     });

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -35,7 +35,8 @@ import express, {
 import type { OAuthConfig } from "./auth/index.js";
 import {
   authToSecuritySchemes,
-  securitySchemesAllowAnonymous,
+  evaluateSecuritySchemes,
+  wwwAuthenticateHeader,
 } from "./auth/security-schemes.js";
 import { setupOAuth } from "./auth/setup.js";
 import { createApp } from "./express.js";
@@ -568,7 +569,6 @@ export class McpServer<
   private readonly serverInfo: Implementation;
   private readonly serverOptions?: ServerOptions;
   private oauthEnabled = false;
-  private acceptsAnonymous = false;
   private securitySchemesByTool = new Map<
     string,
     SecurityScheme[] | undefined
@@ -587,13 +587,11 @@ export class McpServer<
     this.express.use(express.json(skybridgeOptions?.json));
     if (skybridgeOptions?.oauth) {
       this.oauthEnabled = true;
-      setupOAuth(this.express, skybridgeOptions.oauth, {
-        acceptsAnonymous: () => this.acceptsAnonymous,
-        securitySchemesForTool: (name) =>
-          this.securitySchemesByTool.has(name)
-            ? { schemes: this.securitySchemesByTool.get(name) }
-            : undefined,
-      });
+      setupOAuth(
+        this.express,
+        skybridgeOptions.oauth,
+        this.securitySchemesByTool,
+      );
     }
     // Pick up the manifest if `dist/__entry.js` primed it before importing
     // user code. Consume-once: clear after the first construction so a
@@ -1228,9 +1226,25 @@ export class McpServer<
 
   private wrapHandler<InputArgs extends ZodRawShapeCompat>(
     cb: ToolHandler<InputArgs>,
-    { attachViewUUID }: { attachViewUUID: boolean },
+    {
+      attachViewUUID,
+      securitySchemes,
+    }: { attachViewUUID: boolean; securitySchemes?: SecurityScheme[] },
   ): ToolHandler<InputArgs> {
     return async (args, extra) => {
+      if (this.oauthEnabled) {
+        const failure = evaluateSecuritySchemes(
+          securitySchemes,
+          extra.authInfo,
+        );
+        if (failure) {
+          return {
+            isError: true,
+            content: [{ type: "text", text: failure.description }],
+            _meta: { "mcp/www_authenticate": [wwwAuthenticateHeader(failure)] },
+          };
+        }
+      }
       const result = await cb(args, extra);
       return {
         ...result,
@@ -1402,9 +1416,6 @@ export class McpServer<
       // `tools/list`. Use the `_meta` back-compat mirror documented in the
       // Apps SDK reference until SEP-1488 lands in the spec.
       toolMeta.securitySchemes = securitySchemes;
-      if (securitySchemesAllowAnonymous(securitySchemes)) {
-        this.acceptsAnonymous = true;
-      }
     }
 
     if (view) {
@@ -1412,7 +1423,10 @@ export class McpServer<
       this.registerViewResources(name, view, toolMeta);
     }
 
-    const wrappedCb = this.wrapHandler(cb, { attachViewUUID: Boolean(view) });
+    const wrappedCb = this.wrapHandler(cb, {
+      attachViewUUID: Boolean(view),
+      securitySchemes,
+    });
 
     baseFn.call(this, name, { ...toolFields, _meta: toolMeta }, wrappedCb);
 

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -531,6 +531,25 @@ function withSkillsCapability(
   };
 }
 
+function normalizeRegisterToolArgs(args: unknown[]): {
+  config: ToolConfig<ZodRawShapeCompat>;
+  cb: ToolHandler<ZodRawShapeCompat>;
+} {
+  if (typeof args[0] === "string") {
+    return {
+      config: {
+        name: args[0],
+        ...(args[1] as object),
+      } as ToolConfig<ZodRawShapeCompat>,
+      cb: args[2] as ToolHandler<ZodRawShapeCompat>,
+    };
+  }
+  return {
+    config: args[0] as ToolConfig<ZodRawShapeCompat>,
+    cb: args[1] as ToolHandler<ZodRawShapeCompat>,
+  };
+}
+
 export class McpServer<
   TTools extends Record<string, ToolDef> = Record<never, ToolDef>,
 > extends McpServerBaseOmitted {
@@ -1377,13 +1396,7 @@ export class McpServer<
       ...args: unknown[]
     ) => unknown;
 
-    if (typeof args[0] === "string") {
-      baseFn.call(this, args[0], args[1], args[2]);
-      return this;
-    }
-
-    const config = args[0] as ToolConfig<ZodRawShapeCompat>;
-    const cb = args[1] as ToolHandler<ZodRawShapeCompat>;
+    const { config, cb } = normalizeRegisterToolArgs(args);
 
     const {
       name,

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -1384,24 +1384,20 @@ export class McpServer<
       ...toolFields
     } = config;
 
-    if (auth !== undefined) {
-      if (rawSecuritySchemes) {
-        throw new Error(
-          `Tool "${name}" sets both \`auth\` and \`securitySchemes\`; use one.`,
-        );
-      }
-      if (auth !== "public" && !this.oauthEnabled) {
-        throw new Error(
-          `Tool "${name}" sets \`auth: ${JSON.stringify(auth)}\` but the server has no \`oauth\` provider configured.`,
-        );
-      }
+    if (
+      rawSecuritySchemes === undefined &&
+      auth !== undefined &&
+      auth !== "public" &&
+      !this.oauthEnabled
+    ) {
+      throw new Error(
+        `Tool "${name}" sets \`auth: ${JSON.stringify(auth)}\` but the server has no \`oauth\` provider configured.`,
+      );
     }
 
-    const securitySchemes = auth
-      ? this.oauthEnabled
-        ? authToSecuritySchemes(auth)
-        : undefined
-      : rawSecuritySchemes;
+    const securitySchemes =
+      rawSecuritySchemes ??
+      (auth && this.oauthEnabled ? authToSecuritySchemes(auth) : undefined);
 
     const toolMeta: InternalToolMeta = { ...userToolMeta };
 

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -38,7 +38,7 @@ import {
   evaluateSecuritySchemes,
   wwwAuthenticateHeader,
 } from "./auth/security-schemes.js";
-import { setupOAuth } from "./auth/setup.js";
+import { type ResourceMetadataUrlResolver, setupOAuth } from "./auth/setup.js";
 import { createApp } from "./express.js";
 import { createMiddlewareEntry } from "./metric.js";
 import type {
@@ -569,6 +569,7 @@ export class McpServer<
   private readonly serverInfo: Implementation;
   private readonly serverOptions?: ServerOptions;
   private oauthEnabled = false;
+  private resolveResourceMetadataUrl?: ResourceMetadataUrlResolver;
   private securitySchemesByTool = new Map<
     string,
     SecurityScheme[] | undefined
@@ -587,7 +588,7 @@ export class McpServer<
     this.express.use(express.json(skybridgeOptions?.json));
     if (skybridgeOptions?.oauth) {
       this.oauthEnabled = true;
-      setupOAuth(
+      this.resolveResourceMetadataUrl = setupOAuth(
         this.express,
         skybridgeOptions.oauth,
         this.securitySchemesByTool,
@@ -1234,10 +1235,19 @@ export class McpServer<
           extra.authInfo,
         );
         if (failure) {
+          const headers = extra?.requestInfo?.headers ?? {};
+          const header = (key: string) => {
+            const value = headers[key];
+            return Array.isArray(value) ? value[0] : value;
+          };
+          const challenge = wwwAuthenticateHeader(
+            failure,
+            this.resolveResourceMetadataUrl?.(header),
+          );
           return {
             isError: true,
             content: [{ type: "text", text: failure.description }],
-            _meta: { "mcp/www_authenticate": [wwwAuthenticateHeader(failure)] },
+            _meta: { "mcp/www_authenticate": [challenge] },
           };
         }
       }

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -33,6 +33,10 @@ import express, {
   type RequestHandler,
 } from "express";
 import type { OAuthConfig } from "./auth/index.js";
+import {
+  authToSecuritySchemes,
+  securitySchemesAllowAnonymous,
+} from "./auth/security-schemes.js";
 import { setupOAuth } from "./auth/setup.js";
 import { createApp } from "./express.js";
 import { createMiddlewareEntry } from "./metric.js";
@@ -162,6 +166,8 @@ export interface ViewConfig {
 export type SecurityScheme =
   | { type: "noauth" }
   | { type: "oauth2"; scopes?: string[] };
+
+export type ToolAuth = "public" | "required" | { scopes: string[] };
 
 /**
  * Options forwarded to the built-in `express.json()` body parser. Derived
@@ -346,6 +352,7 @@ interface ToolConfig<TInput extends ZodRawShapeCompat | AnySchema> {
   outputSchema?: ZodRawShapeCompat | AnySchema;
   annotations?: ToolAnnotations;
   view?: ViewConfig;
+  auth?: ToolAuth;
   /**
    * Declares which auth schemes this tool supports (e.g. `noauth`, `oauth2`).
    * Lets clients label tools that require sign-in before calling, and pass
@@ -560,6 +567,12 @@ export class McpServer<
   private viteManifest: Record<string, ViteManifestEntry> | null = null;
   private readonly serverInfo: Implementation;
   private readonly serverOptions?: ServerOptions;
+  private oauthEnabled = false;
+  private acceptsAnonymous = false;
+  private securitySchemesByTool = new Map<
+    string,
+    SecurityScheme[] | undefined
+  >();
 
   constructor(
     serverInfo: Implementation,
@@ -573,7 +586,14 @@ export class McpServer<
     this.express = express();
     this.express.use(express.json(skybridgeOptions?.json));
     if (skybridgeOptions?.oauth) {
-      setupOAuth(this.express, skybridgeOptions.oauth);
+      this.oauthEnabled = true;
+      setupOAuth(this.express, skybridgeOptions.oauth, {
+        acceptsAnonymous: () => this.acceptsAnonymous,
+        securitySchemesForTool: (name) =>
+          this.securitySchemesByTool.has(name)
+            ? { schemes: this.securitySchemesByTool.get(name) }
+            : undefined,
+      });
     }
     // Pick up the manifest if `dist/__entry.js` primed it before importing
     // user code. Consume-once: clear after the first construction so a
@@ -804,11 +824,30 @@ export class McpServer<
       },
     };
 
+    const toolsListSecuritySchemesEntry: McpMiddlewareEntry = {
+      filter: "tools/list",
+      handler: async (_req, _extra, next) => {
+        const result = (await next()) as {
+          tools: Array<
+            Record<string, unknown> & { _meta?: Record<string, unknown> }
+          >;
+        };
+        for (const tool of result.tools) {
+          const schemes = tool._meta?.securitySchemes;
+          if (schemes && !("securitySchemes" in tool)) {
+            tool.securitySchemes = schemes;
+          }
+        }
+        return result;
+      },
+    };
+
     const monitoringEntry = createMiddlewareEntry();
     const entries = [
       ...(monitoringEntry ? [monitoringEntry] : []),
       viewListMetaEntry,
       viewReadResolveEntry,
+      toolsListSecuritySchemesEntry,
       ...this.mcpMiddlewareEntries,
     ];
 
@@ -1329,12 +1368,32 @@ export class McpServer<
     const {
       name,
       view,
-      securitySchemes,
+      auth,
+      securitySchemes: rawSecuritySchemes,
       _meta: userToolMeta,
       ...toolFields
     } = config;
 
+    if (auth !== undefined) {
+      if (rawSecuritySchemes) {
+        throw new Error(
+          `Tool "${name}" sets both \`auth\` and \`securitySchemes\`; use one.`,
+        );
+      }
+      if (!this.oauthEnabled) {
+        throw new Error(
+          `Tool "${name}" sets \`auth\` but the server has no \`oauth\` provider configured.`,
+        );
+      }
+    }
+
+    const securitySchemes = auth
+      ? authToSecuritySchemes(auth)
+      : rawSecuritySchemes;
+
     const toolMeta: InternalToolMeta = { ...userToolMeta };
+
+    this.securitySchemesByTool.set(name, securitySchemes);
 
     if (securitySchemes) {
       // SEP-1488 puts `securitySchemes` at the top level of the tool
@@ -1343,6 +1402,9 @@ export class McpServer<
       // `tools/list`. Use the `_meta` back-compat mirror documented in the
       // Apps SDK reference until SEP-1488 lands in the spec.
       toolMeta.securitySchemes = securitySchemes;
+      if (securitySchemesAllowAnonymous(securitySchemes)) {
+        this.acceptsAnonymous = true;
+      }
     }
 
     if (view) {

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -40,6 +40,7 @@ import {
 } from "./auth/security-schemes.js";
 import { type ResourceMetadataUrlResolver, setupOAuth } from "./auth/setup.js";
 import { createApp } from "./express.js";
+import { hostFromUserAgent } from "./host.js";
 import { createMiddlewareEntry } from "./metric.js";
 import type {
   McpExtra,
@@ -1046,7 +1047,7 @@ export class McpServer<
       const val = headers[key];
       return Array.isArray(val) ? val[0] : val;
     };
-    const isClaude = header("user-agent") === "Claude-User";
+    const isClaude = hostFromUserAgent(header("user-agent")) === "claude";
 
     const serverUrl = resolveServerOrigin(header);
     // Path prefix the proxy routed this request under (e.g. `foo.com/v1`). Read

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -36,7 +36,7 @@ import type { OAuthConfig } from "./auth/index.js";
 import {
   authToSecuritySchemes,
   evaluateSecuritySchemes,
-  wwwAuthenticateHeader,
+  inBandChallengeResult,
 } from "./auth/security-schemes.js";
 import { type ResourceMetadataUrlResolver, setupOAuth } from "./auth/setup.js";
 import { createApp } from "./express.js";
@@ -537,6 +537,11 @@ function withSkillsCapability(
   };
 }
 
+// Collapses registerTool's two overloads into a single { config, cb } shape.
+//   registerTool("greet", { description }, handler)
+//     -> { config: { name: "greet", description }, cb: handler }
+//   registerTool({ name: "greet", description }, handler)
+//     -> { config: { name: "greet", description }, cb: handler }
 function normalizeRegisterToolArgs(args: unknown[]): {
   config: ToolConfig<ZodRawShapeCompat>;
   cb: ToolHandler<ZodRawShapeCompat>;
@@ -848,6 +853,12 @@ export class McpServer<
       },
     };
 
+    // ChatGPT reads `securitySchemes` at the tool descriptor top level (SEP-1488,
+    // still Draft), but the SDK's registerTool strips unknown top-level fields, so
+    // it's stashed in `_meta` at registration. This restores it to the top level
+    // on tools/list output. Remove once SEP-1488 lands and the SDK preserves it.
+    //   { name: "checkout", _meta: { securitySchemes: [{ type: "oauth2" }] } }
+    //     -> { name: "checkout", _meta: {…}, securitySchemes: [{ type: "oauth2" }] }
     const toolsListSecuritySchemesEntry: McpMiddlewareEntry = {
       filter: "tools/list",
       handler: async (_req, _extra, next) => {
@@ -1265,15 +1276,10 @@ export class McpServer<
             const value = headers[key];
             return Array.isArray(value) ? value[0] : value;
           };
-          const challenge = wwwAuthenticateHeader(
+          return inBandChallengeResult(
             failure,
             this.resolveResourceMetadataUrl?.(header),
           );
-          return {
-            isError: true,
-            content: [{ type: "text", text: failure.description }],
-            _meta: { "mcp/www_authenticate": [challenge] },
-          };
         }
       }
       const result = await cb(args, extra);

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -169,7 +169,20 @@ export type SecurityScheme =
   | { type: "noauth" }
   | { type: "oauth2"; scopes?: string[] };
 
-export type ToolAuth = { public?: boolean; scopes?: string[] };
+/**
+ * Declarative per-tool auth. Enforced when the server has an `oauth` provider:
+ * anonymous or under-scoped calls are rejected before the handler runs. Omit
+ * `auth` entirely for the secure default (sign-in required, no specific scope).
+ */
+export type ToolAuth = {
+  /**
+   * When `true`, the tool is callable signed out; the token is still used when
+   * one is present. Omit (or `false`) to require sign-in.
+   */
+  allowsAnonymous?: boolean;
+  /** OAuth scopes the caller's token must carry to invoke the tool. */
+  scopes?: string[];
+};
 
 /**
  * Options forwarded to the built-in `express.json()` body parser. Derived
@@ -357,9 +370,13 @@ interface ToolConfigBase<TInput extends ZodRawShapeCompat | AnySchema> {
   _meta?: ToolMeta;
 }
 
-type ToolConfig<TInput extends ZodRawShapeCompat | AnySchema> =
-  | (ToolConfigBase<TInput> & { auth?: ToolAuth; securitySchemes?: never })
-  | (ToolConfigBase<TInput> & {
+/**
+ * The auth face of a tool config: either the high-level `auth` shorthand or the
+ * low-level `securitySchemes` escape hatch, never both.
+ */
+type ToolAuthConfig =
+  | { auth?: ToolAuth; securitySchemes?: never }
+  | {
       auth?: never;
       /**
        * Declares which auth schemes this tool supports (e.g. `noauth`, `oauth2`).
@@ -369,7 +386,10 @@ type ToolConfig<TInput extends ZodRawShapeCompat | AnySchema> =
        * enhanced behavior to authenticated ones.
        */
       securitySchemes?: SecurityScheme[];
-    });
+    };
+
+type ToolConfig<TInput extends ZodRawShapeCompat | AnySchema> =
+  ToolConfigBase<TInput> & ToolAuthConfig;
 
 /**
  * Optional client-supplied hints attached to `params._meta` on every tool call
@@ -1420,7 +1440,8 @@ export class McpServer<
     } = config;
 
     const authNeedsProvider =
-      auth !== undefined && (!auth.public || Boolean(auth.scopes?.length));
+      auth !== undefined &&
+      (!auth.allowsAnonymous || Boolean(auth.scopes?.length));
     if (
       rawSecuritySchemes === undefined &&
       authNeedsProvider &&

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,7 +46,7 @@ importers:
     devDependencies:
       mintlify:
         specifier: ^4.2.715
-        version: 4.2.715(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/node@24.13.3)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
+        version: 4.2.715(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/node@25.9.5)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
 
   examples/auth-auth0:
     dependencies:
@@ -264,6 +264,58 @@ importers:
       tsx:
         specifier: ^4.22.4
         version: 4.22.4
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+  examples/auth-descope-mixed:
+    dependencies:
+      dotenv:
+        specifier: ^16.5.0
+        version: 16.6.1
+      react:
+        specifier: ^19.2.4
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.7(react@19.2.7)
+      skybridge:
+        specifier: workspace:*
+        version: link:../../packages/core
+      vite:
+        specifier: ^8.0.0
+        version: 8.1.5(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.1)(yaml@2.9.0)
+      zod:
+        specifier: ^4.3.6
+        version: 4.4.3
+    devDependencies:
+      '@skybridge/devtools':
+        specifier: ^1.1.0
+        version: 1.2.7(arktype@2.1.27)(typescript@5.9.3)
+      '@types/express':
+        specifier: ^5.0.6
+        version: 5.0.6
+      '@types/node':
+        specifier: ^22.15.30
+        version: 22.20.0
+      '@types/react':
+        specifier: ^19.2.13
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.1
+        version: 6.0.3(vite@8.1.5(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.1)(yaml@2.9.0))
+      alpic:
+        specifier: ^1.136.3
+        version: 1.156.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(arktype@2.1.27)(rxjs@7.8.2)(typescript@5.9.3)
+      nodemon:
+        specifier: ^3.1.11
+        version: 3.1.14
+      tsx:
+        specifier: ^4.21.0
+        version: 4.23.1
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -12302,6 +12354,24 @@ snapshots:
       - typescript
       - valibot
 
+  '@alpic-ai/sdk@1.156.0(@opentelemetry/api@1.9.1)(arktype@2.1.27)(typescript@5.9.3)':
+    dependencies:
+      '@alpic-ai/api': 1.156.0(@opentelemetry/api@1.9.1)
+      '@orpc/client': 1.14.8(@opentelemetry/api@1.9.1)
+      '@orpc/contract': 1.14.8(@opentelemetry/api@1.9.1)
+      '@orpc/openapi-client': 1.14.8(@opentelemetry/api@1.9.1)
+      '@t3-oss/env-core': 0.13.11(arktype@2.1.27)(typescript@5.9.3)(zod@4.4.3)
+      env-paths: 4.0.0
+      open: 11.0.0
+      openid-client: 6.8.4
+      tar: 7.5.20
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - arktype
+      - typescript
+      - valibot
+
   '@alpic-ai/sdk@1.156.0(@opentelemetry/api@1.9.1)(arktype@2.1.27)(typescript@6.0.3)':
     dependencies:
       '@alpic-ai/api': 1.156.0(@opentelemetry/api@1.9.1)
@@ -13346,15 +13416,15 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
-  '@inquirer/checkbox@4.3.2(@types/node@24.13.3)':
+  '@inquirer/checkbox@4.3.2(@types/node@25.9.5)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.13.3
+      '@types/node': 25.9.5
 
   '@inquirer/confirm@5.1.21(@types/node@24.13.3)':
     dependencies:
@@ -13362,6 +13432,7 @@ snapshots:
       '@inquirer/type': 3.0.10(@types/node@24.13.3)
     optionalDependencies:
       '@types/node': 24.13.3
+    optional: true
 
   '@inquirer/confirm@5.1.21(@types/node@25.9.5)':
     dependencies:
@@ -13369,7 +13440,6 @@ snapshots:
       '@inquirer/type': 3.0.10(@types/node@25.9.5)
     optionalDependencies:
       '@types/node': 25.9.5
-    optional: true
 
   '@inquirer/core@10.3.2(@types/node@24.13.3)':
     dependencies:
@@ -13383,6 +13453,7 @@ snapshots:
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 24.13.3
+    optional: true
 
   '@inquirer/core@10.3.2(@types/node@25.9.5)':
     dependencies:
@@ -13396,105 +13467,104 @@ snapshots:
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 25.9.5
-    optional: true
 
-  '@inquirer/editor@4.2.23(@types/node@24.13.3)':
+  '@inquirer/editor@4.2.23(@types/node@25.9.5)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.13.3)
-      '@inquirer/external-editor': 1.0.3(@types/node@24.13.3)
-      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
+      '@inquirer/external-editor': 1.0.3(@types/node@25.9.5)
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
     optionalDependencies:
-      '@types/node': 24.13.3
+      '@types/node': 25.9.5
 
-  '@inquirer/expand@4.0.23(@types/node@24.13.3)':
+  '@inquirer/expand@4.0.23(@types/node@25.9.5)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.13.3)
-      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.13.3
+      '@types/node': 25.9.5
 
-  '@inquirer/external-editor@1.0.3(@types/node@24.13.3)':
+  '@inquirer/external-editor@1.0.3(@types/node@25.9.5)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.1
     optionalDependencies:
-      '@types/node': 24.13.3
+      '@types/node': 25.9.5
 
   '@inquirer/figures@1.0.15': {}
 
-  '@inquirer/input@4.3.1(@types/node@24.13.3)':
+  '@inquirer/input@4.3.1(@types/node@25.9.5)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.13.3)
-      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
     optionalDependencies:
-      '@types/node': 24.13.3
+      '@types/node': 25.9.5
 
-  '@inquirer/number@3.0.23(@types/node@24.13.3)':
+  '@inquirer/number@3.0.23(@types/node@25.9.5)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.13.3)
-      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
     optionalDependencies:
-      '@types/node': 24.13.3
+      '@types/node': 25.9.5
 
-  '@inquirer/password@4.0.23(@types/node@24.13.3)':
+  '@inquirer/password@4.0.23(@types/node@25.9.5)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@24.13.3)
-      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
     optionalDependencies:
-      '@types/node': 24.13.3
+      '@types/node': 25.9.5
 
-  '@inquirer/prompts@7.9.0(@types/node@24.13.3)':
+  '@inquirer/prompts@7.9.0(@types/node@25.9.5)':
     dependencies:
-      '@inquirer/checkbox': 4.3.2(@types/node@24.13.3)
-      '@inquirer/confirm': 5.1.21(@types/node@24.13.3)
-      '@inquirer/editor': 4.2.23(@types/node@24.13.3)
-      '@inquirer/expand': 4.0.23(@types/node@24.13.3)
-      '@inquirer/input': 4.3.1(@types/node@24.13.3)
-      '@inquirer/number': 3.0.23(@types/node@24.13.3)
-      '@inquirer/password': 4.0.23(@types/node@24.13.3)
-      '@inquirer/rawlist': 4.1.11(@types/node@24.13.3)
-      '@inquirer/search': 3.2.2(@types/node@24.13.3)
-      '@inquirer/select': 4.4.2(@types/node@24.13.3)
+      '@inquirer/checkbox': 4.3.2(@types/node@25.9.5)
+      '@inquirer/confirm': 5.1.21(@types/node@25.9.5)
+      '@inquirer/editor': 4.2.23(@types/node@25.9.5)
+      '@inquirer/expand': 4.0.23(@types/node@25.9.5)
+      '@inquirer/input': 4.3.1(@types/node@25.9.5)
+      '@inquirer/number': 3.0.23(@types/node@25.9.5)
+      '@inquirer/password': 4.0.23(@types/node@25.9.5)
+      '@inquirer/rawlist': 4.1.11(@types/node@25.9.5)
+      '@inquirer/search': 3.2.2(@types/node@25.9.5)
+      '@inquirer/select': 4.4.2(@types/node@25.9.5)
     optionalDependencies:
-      '@types/node': 24.13.3
+      '@types/node': 25.9.5
 
-  '@inquirer/rawlist@4.1.11(@types/node@24.13.3)':
+  '@inquirer/rawlist@4.1.11(@types/node@25.9.5)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.13.3)
-      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.13.3
+      '@types/node': 25.9.5
 
-  '@inquirer/search@3.2.2(@types/node@24.13.3)':
+  '@inquirer/search@3.2.2(@types/node@25.9.5)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.13.3
+      '@types/node': 25.9.5
 
-  '@inquirer/select@4.4.2(@types/node@24.13.3)':
+  '@inquirer/select@4.4.2(@types/node@25.9.5)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.13.3
+      '@types/node': 25.9.5
 
   '@inquirer/type@3.0.10(@types/node@24.13.3)':
     optionalDependencies:
       '@types/node': 24.13.3
+    optional: true
 
   '@inquirer/type@3.0.10(@types/node@25.9.5)':
     optionalDependencies:
       '@types/node': 25.9.5
-    optional: true
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
@@ -13623,14 +13693,14 @@ snapshots:
       '@types/react': 19.2.17
       react: 19.2.3
 
-  '@mintlify/cli@4.0.1318(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/node@24.13.3)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)':
+  '@mintlify/cli@4.0.1318(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/node@25.9.5)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
-      '@inquirer/prompts': 7.9.0(@types/node@24.13.3)
-      '@mintlify/common': 1.0.1025(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
-      '@mintlify/link-rot': 3.0.1217(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
+      '@inquirer/prompts': 7.9.0(@types/node@25.9.5)
+      '@mintlify/common': 1.0.1025(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
+      '@mintlify/link-rot': 3.0.1217(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
       '@mintlify/models': 0.0.339
-      '@mintlify/prebuild': 1.0.1173(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
-      '@mintlify/previewing': 4.0.1242(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
+      '@mintlify/prebuild': 1.0.1173(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
+      '@mintlify/previewing': 4.0.1242(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
       '@mintlify/validation': 0.1.789(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       adm-zip: 0.5.16
       chalk: 5.2.0
@@ -13639,7 +13709,7 @@ snapshots:
       front-matter: 4.0.2
       fs-extra: 11.2.0
       ink: 6.3.0(@types/react@19.2.17)(react@19.2.3)
-      inquirer: 12.3.0(@types/node@24.13.3)
+      inquirer: 12.3.0(@types/node@25.9.5)
       js-yaml: 4.1.1
       mdast-util-mdx-jsx: 3.2.0
       open: 8.4.2
@@ -13669,7 +13739,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@mintlify/common@1.0.1025(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)':
+  '@mintlify/common@1.0.1025(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
       '@asyncapi/parser': 3.4.0
       '@asyncapi/specs': 6.8.1
@@ -13711,7 +13781,7 @@ snapshots:
       remark-rehype: 11.1.1
       remark-stringify: 11.0.0
       sucrase: 3.34.0
-      tailwindcss-v3: tailwindcss@3.4.17(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))
+      tailwindcss-v3: tailwindcss@3.4.17(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))
       unified: 11.0.5
       unist-builder: 4.0.0
       unist-util-map: 4.0.0
@@ -13732,13 +13802,13 @@ snapshots:
       - ts-node
       - typescript
 
-  '@mintlify/link-rot@3.0.1217(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)':
+  '@mintlify/link-rot@3.0.1217(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
-      '@mintlify/common': 1.0.1025(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
+      '@mintlify/common': 1.0.1025(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
       '@mintlify/models': 0.0.339
-      '@mintlify/prebuild': 1.0.1173(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
-      '@mintlify/previewing': 4.0.1242(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
-      '@mintlify/scraping': 4.0.890(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
+      '@mintlify/prebuild': 1.0.1173(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
+      '@mintlify/previewing': 4.0.1242(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
+      '@mintlify/scraping': 4.0.890(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
       '@mintlify/validation': 0.1.789(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       fs-extra: 11.1.0
       unist-util-visit: 4.1.2
@@ -13801,11 +13871,11 @@ snapshots:
       leven: 4.1.0
       yaml: 2.9.0
 
-  '@mintlify/prebuild@1.0.1173(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)':
+  '@mintlify/prebuild@1.0.1173(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
-      '@mintlify/common': 1.0.1025(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
+      '@mintlify/common': 1.0.1025(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
       '@mintlify/openapi-parser': 0.0.8
-      '@mintlify/scraping': 4.0.890(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
+      '@mintlify/scraping': 4.0.890(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
       '@mintlify/validation': 0.1.789(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       chalk: 5.3.0
       favicons: 7.2.0
@@ -13833,10 +13903,10 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@mintlify/previewing@4.0.1242(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)':
+  '@mintlify/previewing@4.0.1242(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
-      '@mintlify/common': 1.0.1025(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
-      '@mintlify/prebuild': 1.0.1173(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
+      '@mintlify/common': 1.0.1025(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
+      '@mintlify/prebuild': 1.0.1173(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
       '@mintlify/validation': 0.1.789(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       adm-zip: 0.5.16
       better-opn: 3.0.2
@@ -13872,9 +13942,9 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@mintlify/scraping@4.0.890(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)':
+  '@mintlify/scraping@4.0.890(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
-      '@mintlify/common': 1.0.1025(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
+      '@mintlify/common': 1.0.1025(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
       '@mintlify/openapi-parser': 0.0.8
       fs-extra: 11.1.1
       hast-util-to-mdast: 10.1.0
@@ -17506,6 +17576,18 @@ snapshots:
       - typescript
       - valibot
 
+  '@skybridge/devtools@1.2.7(arktype@2.1.27)(typescript@5.9.3)':
+    dependencies:
+      '@t3-oss/env-core': 0.13.11(arktype@2.1.27)(typescript@5.9.3)(zod@4.4.3)
+      cors: 2.8.6
+      express: 5.2.1
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - arktype
+      - supports-color
+      - typescript
+      - valibot
+
   '@skybridge/devtools@1.2.7(arktype@2.1.27)(typescript@6.0.3)':
     dependencies:
       '@t3-oss/env-core': 0.13.11(arktype@2.1.27)(typescript@6.0.3)(zod@4.4.3)
@@ -18293,6 +18375,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.0)(yaml@2.9.0)
 
+  '@vitejs/plugin-react@6.0.3(vite@8.1.5(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.1)(yaml@2.9.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.1.5(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.1)(yaml@2.9.0)
+
   '@vitejs/plugin-react@6.0.3(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
@@ -18515,6 +18602,37 @@ snapshots:
       jwt-decode: 4.0.0
       open: 11.0.0
       posthog-node: 5.39.4(rxjs@7.8.2)
+      semver: 7.8.5
+      undici: 6.27.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - arktype
+      - rxjs
+      - supports-color
+      - typescript
+      - valibot
+
+  alpic@1.156.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(arktype@2.1.27)(rxjs@7.8.2)(typescript@5.9.3):
+    dependencies:
+      '@alpic-ai/api': 1.156.0(@opentelemetry/api@1.9.1)
+      '@alpic-ai/sdk': 1.156.0(@opentelemetry/api@1.9.1)(arktype@2.1.27)(typescript@5.9.3)
+      '@clack/prompts': 1.7.0
+      '@oclif/core': 4.11.14
+      '@orpc/client': 1.14.8(@opentelemetry/api@1.9.1)
+      '@orpc/contract': 1.14.8(@opentelemetry/api@1.9.1)
+      '@orpc/openapi-client': 1.14.8(@opentelemetry/api@1.9.1)
+      '@sentry/node': 10.66.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))
+      '@t3-oss/env-core': 0.13.11(arktype@2.1.27)(typescript@5.9.3)(zod@4.4.3)
+      '@vercel/detect-agent': 1.2.3
+      chalk: 5.6.2
+      ci-info: 4.4.0
+      envfile: 7.1.0
+      jwt-decode: 4.0.0
+      open: 11.0.0
+      posthog-node: 5.45.2(rxjs@7.8.2)
       semver: 7.8.5
       undici: 6.27.0
       zod: 4.4.3
@@ -20548,12 +20666,12 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
-  inquirer@12.3.0(@types/node@24.13.3):
+  inquirer@12.3.0(@types/node@25.9.5):
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.13.3)
-      '@inquirer/prompts': 7.9.0(@types/node@24.13.3)
-      '@inquirer/type': 3.0.10(@types/node@24.13.3)
-      '@types/node': 24.13.3
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
+      '@inquirer/prompts': 7.9.0(@types/node@25.9.5)
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
+      '@types/node': 25.9.5
       ansi-escapes: 4.3.2
       mute-stream: 2.0.0
       run-async: 3.0.0
@@ -21657,9 +21775,9 @@ snapshots:
     dependencies:
       minipass: 7.1.2
 
-  mintlify@4.2.715(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/node@24.13.3)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3):
+  mintlify@4.2.715(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/node@25.9.5)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3):
     dependencies:
-      '@mintlify/cli': 4.0.1318(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/node@24.13.3)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
+      '@mintlify/cli': 4.0.1318(@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(@types/node@25.9.5)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))(typescript@6.0.3)
     transitivePeerDependencies:
       - '@radix-ui/react-popover'
       - '@types/node'
@@ -21891,7 +22009,7 @@ snapshots:
       ignore-by-default: 1.0.1
       minimatch: 10.2.5
       pstree.remy: 1.1.8
-      semver: 7.8.4
+      semver: 7.8.5
       simple-update-notifier: 2.0.0
       supports-color: 5.5.0
       touch: 3.1.1
@@ -22170,13 +22288,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.19
 
-  postcss-load-config@4.0.2(postcss@8.5.19)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3)):
+  postcss-load-config@4.0.2(postcss@8.5.19)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.9.0
     optionalDependencies:
       postcss: 8.5.19
-      ts-node: 10.9.2(@types/node@24.13.3)(typescript@6.0.3)
+      ts-node: 10.9.2(@types/node@25.9.5)(typescript@6.0.3)
 
   postcss-nested@6.2.0(postcss@8.5.19):
     dependencies:
@@ -23910,7 +24028,7 @@ snapshots:
     dependencies:
       tailwindcss: 4.3.3
 
-  tailwindcss@3.4.17(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3)):
+  tailwindcss@3.4.17(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -23929,7 +24047,7 @@ snapshots:
       postcss: 8.5.19
       postcss-import: 15.1.0(postcss@8.5.19)
       postcss-js: 4.1.0(postcss@8.5.19)
-      postcss-load-config: 4.0.2(postcss@8.5.19)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))
+      postcss-load-config: 4.0.2(postcss@8.5.19)(ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3))
       postcss-nested: 6.2.0(postcss@8.5.19)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
@@ -24592,6 +24710,22 @@ snapshots:
       jiti: 2.7.0
       terser: 5.44.1
       tsx: 4.23.0
+      yaml: 2.9.0
+
+  vite@8.1.5(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.1)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.19
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.20.0
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      terser: 5.44.1
+      tsx: 4.23.1
       yaml: 2.9.0
 
   vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.1)(yaml@2.9.0):


### PR DESCRIPTION
### Summary

- Lets branded/custom OAuth providers serve public and authenticated tools from one server.
- Per-tool `auth` field `{ public?: boolean; scopes?: string[] }`, mutually exclusive with the raw `securitySchemes` escape hatch.
- Anonymous by default once any tool is public; a protected tool returns `401/403 + WWW-Authenticate` (Claude) or an in-band `mcp/www_authenticate` result (ChatGPT) to trigger sign-in.
- With a server `oauth` provider set, undeclared tools default to sign-in required (secure default); with no provider, every tool is public.
- Adds the `auth-descope-mixed` example and refreshes the auth docs.

### Notes

- Per-tool scopes are enforced whenever an `oauth` provider is set (was advertised-only). Changelog + minor bump.
- Verified end to end on Claude and ChatGPT via tunnel. Does not yet work when deployed behind Alpic (see below).
- Supersedes #904 (same work, branch renamed to match Linear SKY-486).

### Why it doesn't work on Alpic yet

The server is correct: deployed as-is it serves `/.well-known/oauth-protected-resource` and emits `WWW-Authenticate` challenges (verified on the built dev package in production mode). The blocker is Alpic's connect-time auth detection.

Alpic's runtime probes the server once at startup and classifies it purely by the HTTP status of an unauthenticated `initialize`:

- `200` → treated as fully public, OAuth discovery never surfaced.
- `401 + WWW-Authenticate` → OAuth discovered and served.

A mixed-auth server returns `200` on `initialize` (it must serve anonymous callers; only individual tools require auth), so Alpic files it as fully public, never advertises its OAuth, and ChatGPT reports "does not implement OAuth" then connects anonymously. Protected tools then can't trigger sign-in.

The model treats `public` and `has-OAuth` as mutually exclusive; mixed auth is `public` **and** `has-OAuth`. Fix is on the Alpic platform side (detection + environment metadata model), not in this framework. Works on Claude / direct tunnel because the client discovers the server's own `/.well-known` directly.

### Conscious decision: a public tool challenges an under-scoped signed-in caller

For `{ public: true, scopes }`, scopes are enforced **once a bearer token is present**:

- No token → anonymous path, allowed.
- Token with the scopes → allowed.
- Token missing a scope → `insufficient_scope` (403 / in-band `mcp/www_authenticate`), so the host prompts a step-up.

Chosen deliberately over pure OR-semantics (where a signed-in-but-under-scoped caller would fall through to the anonymous path). A signed-in user should be prompted to complete the missing scopes rather than silently downgraded to the guest experience.

Tradeoff accepted: a signed-in caller can no longer use the anonymous/degraded path on such a tool. If a tool should stay fully open to signed-in callers regardless of scope, don't list scopes on the public form. If a scope must be a hard gate for everyone, make the tool non-public with `{ scopes }`.

Reverses the earlier advertise-only revert. Spec references (RFC 6750 §3.1 `insufficient_scope`, MCP runtime scope challenge): greptile thread on `security-schemes.ts` R27-R29.

Closes SKY-486 · https://linear.app/alpic/issue/SKY-486/implement-mixed-auth

