### PR TITLE
ci: run on v0 and v1 branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: [main, v0, v1]
+  workflow_dispatch:
 
 jobs:
   test:
@@ -146,7 +147,7 @@ jobs:
         run: pnpm run build
 
   draft-release:
-    if: github.event_name == 'push'
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, v0, v1]
 
 jobs:
   test:


### PR DESCRIPTION
Adds `v0` and `v1` to the `push` trigger in ci.yml so CI runs on those branches alongside main.