### PR TITLE
feat(web): add useHost hook for best-effort host detection

### DIFF
--- a/packages/core/src/web/bridges/adaptor.ts
+++ b/packages/core/src/web/bridges/adaptor.ts
@@ -1,5 +1,6 @@
 import { AppsSdkBridge } from "./apps-sdk/bridge.js";
 import type { AppsSdkWidgetState } from "./apps-sdk/types.js";
+import { detectHost } from "./detect-host.js";
 import { McpAppBridge } from "./mcp-app/bridge.js";
 import type {
   Adaptor,
@@ -122,8 +123,26 @@ export class HostAdaptor implements Adaptor {
       getSnapshot: () => this._viewState,
     };
 
+    let cachedHost: HostContext["host"] | undefined;
+    const hostStore: HostContextStore<"host"> = {
+      subscribe: this.mcp.subscribe(["userAgent", "hostInfo"]),
+      getSnapshot: () => {
+        const nextHost = detectHost({
+          userAgent: this.mcp.getSnapshot("userAgent"),
+          hostInfoName: this.mcp.getSnapshot("hostInfo")?.name,
+          hasOpenAI: this.openai !== null,
+        });
+        if (cachedHost?.name === nextHost.name) {
+          return cachedHost;
+        }
+        cachedHost = nextHost;
+        return nextHost;
+      },
+    };
+
     this.stores = {
       ...this.mcp.createContextStores(),
+      host: hostStore,
       display: overlayStores?.display ?? this.polyfillDisplayStore,
       viewState: overlayStores?.viewState ?? this.polyfillViewStateStore,
     };

--- a/packages/core/src/web/bridges/detect-host.ts
+++ b/packages/core/src/web/bridges/detect-host.ts
@@ -1,0 +1,70 @@
+import type { Host, HostName } from "./types.js";
+
+type DetectHostOptions = {
+  userAgent?: string;
+  hostInfoName?: string;
+  hasOpenAI: boolean;
+};
+
+const HOSTS: Record<HostName, Host> = {
+  chatgpt: { name: "chatgpt" },
+  claude: { name: "claude" },
+  cursor: { name: "cursor" },
+  goose: { name: "goose" },
+  alpic: { name: "alpic" },
+  other: { name: "other" },
+};
+
+function normalizeSignal(value?: string): string {
+  return value?.trim().toLowerCase() ?? "";
+}
+
+function detectHostNameFromSignal(signal: string): HostName | null {
+  if (!signal) {
+    return null;
+  }
+
+  if (signal.includes("alpic")) {
+    return "alpic";
+  }
+
+  if (signal.includes("claude") || signal.includes("anthropic")) {
+    return "claude";
+  }
+
+  if (signal.includes("cursor")) {
+    return "cursor";
+  }
+
+  if (signal.includes("goose")) {
+    return "goose";
+  }
+
+  if (signal.includes("chatgpt") || signal === "openai") {
+    return "chatgpt";
+  }
+
+  return null;
+}
+
+export function detectHost(options: DetectHostOptions): Host {
+  const fromUserAgent = detectHostNameFromSignal(
+    normalizeSignal(options.userAgent),
+  );
+  if (fromUserAgent) {
+    return HOSTS[fromUserAgent];
+  }
+
+  const fromHostInfo = detectHostNameFromSignal(
+    normalizeSignal(options.hostInfoName),
+  );
+  if (fromHostInfo) {
+    return HOSTS[fromHostInfo];
+  }
+
+  if (options.hasOpenAI) {
+    return HOSTS.chatgpt;
+  }
+
+  return HOSTS.other;
+}

--- a/packages/core/src/web/bridges/mcp-app/bridge.ts
+++ b/packages/core/src/web/bridges/mcp-app/bridge.ts
@@ -86,6 +86,10 @@ export class McpAppBridge implements Bridge<McpAppContext> {
     try {
       await this.app.connect();
       const hostContext = this.app.getHostContext();
+      const hostInfo = this.app.getHostVersion();
+      if (hostInfo) {
+        this.updateContext({ hostInfo });
+      }
       if (hostContext) {
         this.updateContext(hostContext);
       }

--- a/packages/core/src/web/bridges/mcp-app/types.ts
+++ b/packages/core/src/web/bridges/mcp-app/types.ts
@@ -4,6 +4,7 @@ import type {
   McpUiToolInputNotification,
   McpUiToolResultNotification,
 } from "@modelcontextprotocol/ext-apps";
+import type { Implementation } from "@modelcontextprotocol/sdk/types.js";
 
 export type McpToolState = {
   toolInput: NonNullable<
@@ -13,6 +14,9 @@ export type McpToolState = {
   toolCancelled: McpUiToolCancelledNotification["params"] | null;
 };
 
-export type McpAppContext = McpUiHostContext & McpToolState;
+export type McpAppContext = McpUiHostContext &
+  McpToolState & {
+    hostInfo?: Implementation;
+  };
 
 export type McpAppContextKey = keyof McpAppContext;

--- a/packages/core/src/web/bridges/types.ts
+++ b/packages/core/src/web/bridges/types.ts
@@ -56,6 +56,20 @@ export type Theme = "light" | "dark";
 /** Coarse device class reported by the host. `"unknown"` when unavailable. */
 export type DeviceType = "mobile" | "tablet" | "desktop" | "unknown";
 
+/** Best-effort host name inferred from runtime signals. */
+export type HostName =
+  | "chatgpt"
+  | "claude"
+  | "cursor"
+  | "goose"
+  | "alpic"
+  | "other";
+
+/** Current host the view is rendered in. */
+export type Host = {
+  name: HostName;
+};
+
 /** Pixel insets the view should keep clear of (notches, home indicators, etc.). */
 export type SafeAreaInsets = {
   top: number;
@@ -86,6 +100,7 @@ export type UserAgent = {
  * `useToolInfo`, etc.) — read this directly only for advanced cases.
  */
 export interface HostContext {
+  host: Host;
   theme: Theme;
   locale: string;
   displayMode: DisplayMode;

--- a/packages/core/src/web/hooks/index.ts
+++ b/packages/core/src/web/hooks/index.ts
@@ -8,6 +8,7 @@ export {
 export { useDisplayMode } from "./use-display-mode.js";
 export { type DownloadFn, useDownload } from "./use-download.js";
 export { useFiles } from "./use-files.js";
+export { type HostState, useHost } from "./use-host.js";
 export { type LayoutState, useLayout } from "./use-layout.js";
 export { type OpenExternalFn, useOpenExternal } from "./use-open-external.js";
 export { useRegisterViewTool } from "./use-register-view-tool.js";

--- a/packages/core/src/web/hooks/use-host.ts
+++ b/packages/core/src/web/hooks/use-host.ts
@@ -1,0 +1,13 @@
+import { type Host, useHostContext } from "../bridges/index.js";
+
+export type HostState = Host;
+
+/**
+ * Hook for identifying the current host rendering the view.
+ *
+ * Returns a best-effort, normalized host name inferred from the MCP Apps
+ * host context and ChatGPT runtime signals.
+ */
+export function useHost(): HostState {
+  return useHostContext("host");
+}


### PR DESCRIPTION
 ## Summary

  Closes #909


  It returns a normalized host object in the form:

  ```ts
  {
    name: "chatgpt" | "claude" | "cursor" | "goose" | "alpic" |
    "other";
  }
```
  ## What changed

  - added useHost() as a new public web hook
  - added HostName / Host types to the web bridge types
  - added best-effort host detection logic
  - wired host detection into the existing host adaptor
  - surfaced MCP hostInfo from the ext-apps initialization handshake
    so detection can use it


  1. MCP Apps hostContext.userAgent
  2. MCP Apps hostInfo.name
  3. window.openai fallback for ChatGPT
  4. "other" when nothing matches
