### PR TITLE
fix(devtools): deploy button QA fixes

### DIFF
--- a/packages/devtools/e2e/tests/deploy.spec.ts
+++ b/packages/devtools/e2e/tests/deploy.spec.ts
@@ -138,6 +138,9 @@ test.describe("deploy button", () => {
     const deploy = deployTrigger(page);
     await expect(deploy).toBeVisible();
     await expect(deploy.locator(".bg-success")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /copy live mcp server url/i }),
+    ).toContainText("my-app.alpic.live");
     await hoverDeployPopover(page);
     await expect(page.getByText("https://my-app.alpic.live")).toBeVisible();
     await expect(
@@ -181,7 +184,7 @@ test.describe("deploy button", () => {
       },
       progress: {
         status: "deploying",
-        phase: "2/4 Uploading source",
+        phase: "Uploading source",
         startedAt: Date.now() - 65_000,
         deploymentPageUrl: "https://app.alpic.ai/p1/logs",
       },
@@ -193,7 +196,8 @@ test.describe("deploy button", () => {
     await expect(deploy.locator(".animate-pulse")).toBeVisible();
     await expect(deploy).toHaveAttribute("aria-disabled", "true");
     await hoverDeployPopover(page);
-    await expect(page.getByText("2/4 Uploading source…")).toBeVisible();
+    await expect(page.getByText("Deploying…")).toBeVisible();
+    await expect(page.getByText("Uploading source")).toBeVisible();
     await expect(
       page.getByRole("link", { name: /go to logs/i }),
     ).toHaveAttribute("href", "https://app.alpic.ai/p1/logs");

--- a/packages/devtools/e2e/tests/deploy.spec.ts
+++ b/packages/devtools/e2e/tests/deploy.spec.ts
@@ -184,7 +184,6 @@ test.describe("deploy button", () => {
       },
       progress: {
         status: "deploying",
-        phase: "Uploading source",
         startedAt: Date.now() - 65_000,
         deploymentPageUrl: "https://app.alpic.ai/p1/logs",
       },
@@ -197,7 +196,6 @@ test.describe("deploy button", () => {
     await expect(deploy).toHaveAttribute("aria-disabled", "true");
     await hoverDeployPopover(page);
     await expect(page.getByText("Deploying…")).toBeVisible();
-    await expect(page.getByText("Uploading source")).toBeVisible();
     await expect(
       page.getByRole("link", { name: /go to logs/i }),
     ).toHaveAttribute("href", "https://app.alpic.ai/p1/logs");

--- a/packages/devtools/src/components/layout/header.tsx
+++ b/packages/devtools/src/components/layout/header.tsx
@@ -7,6 +7,7 @@ import { StatusBadge } from "./status-badge.js";
 import {
   AuditButton,
   DeployButton,
+  LiveUrlChip,
   PlaygroundButton,
   TunnelButton,
 } from "./toolbar-actions.js";
@@ -56,8 +57,9 @@ export const Header = () => {
 
   return (
     <header className="flex h-13 items-center justify-between gap-3 border-b border-border px-4">
-      <div className="flex items-center gap-12">
+      <div className="flex items-center gap-2">
         <BrandChip />
+        <LiveUrlChip />
       </div>
 
       <div className="flex items-center gap-2">

--- a/packages/devtools/src/components/layout/toolbar-actions.tsx
+++ b/packages/devtools/src/components/layout/toolbar-actions.tsx
@@ -12,10 +12,6 @@ import {
   type StatusDotVariantProps,
 } from "@alpic-ai/ui/components/status-dot";
 import {
-  TaskProgress,
-  type TaskProgressStep,
-} from "@alpic-ai/ui/components/task-progress";
-import {
   Check,
   ClipboardCheck,
   Copy,
@@ -237,13 +233,6 @@ export function AuditButton() {
 
 const ALPIC_APP_URL = "https://app.alpic.ai";
 
-const DEPLOY_STEPS = [
-  { id: "collect", label: "Collecting files" },
-  { id: "upload", label: "Uploading source" },
-  { id: "trigger", label: "Triggering deployment" },
-  { id: "deploy", label: "Deploying" },
-] as const;
-
 export function LiveUrlChip() {
   const url = useDeployStore((s) =>
     s.status.state === "ready" && s.status.mcpServerUrl
@@ -402,7 +391,6 @@ function DeployPopoverContent({
   if (progress.status === "deploying") {
     return (
       <DeployingContent
-        phase={progress.phase}
         startedAt={progress.startedAt}
         deploymentPageUrl={progress.deploymentPageUrl}
       />
@@ -479,7 +467,6 @@ function DeployPopoverContent({
       if (status.lastDeployStatus === "ongoing") {
         return (
           <DeployingContent
-            phase="Deploying"
             startedAt={status.lastDeployStartedAt ?? null}
             deploymentPageUrl={status.deploymentPageUrl ?? null}
           />
@@ -539,11 +526,9 @@ function formatElapsed(ms: number): string {
 }
 
 function DeployingContent({
-  phase,
   startedAt,
   deploymentPageUrl,
 }: {
-  phase: string;
   // Server-provided start, so the elapsed clock survives hover remounts and
   // page refreshes.
   startedAt: number | null;
@@ -562,27 +547,17 @@ function DeployingContent({
     return () => clearInterval(id);
   }, [startedAt]);
 
-  const currentIdx = Math.max(
-    0,
-    DEPLOY_STEPS.findIndex((s) => s.label === phase),
-  );
-  const steps: TaskProgressStep[] = DEPLOY_STEPS.map((step, i) => ({
-    id: step.id,
-    label: step.label,
-    status: i < currentIdx ? "done" : i === currentIdx ? "running" : "pending",
-  }));
-
   return (
-    <div className="space-y-3">
-      <div className="flex items-center justify-between">
-        <p className="text-sm font-medium">Deploying…</p>
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <Spinner size="sm" className="shrink-0 text-current" />
+        <p className="text-sm">Deploying…</p>
         {startedAt != null && (
-          <span className="font-mono text-xs text-muted-foreground">
+          <span className="ml-auto font-mono text-xs text-muted-foreground">
             {formatElapsed(elapsedMs)}
           </span>
         )}
       </div>
-      <TaskProgress steps={steps} />
       {deploymentPageUrl && (
         <ExternalLinkRow href={deploymentPageUrl} label="Go to logs" />
       )}

--- a/packages/devtools/src/components/layout/toolbar-actions.tsx
+++ b/packages/devtools/src/components/layout/toolbar-actions.tsx
@@ -234,13 +234,15 @@ export function AuditButton() {
 const ALPIC_APP_URL = "https://app.alpic.ai";
 
 export function LiveUrlChip() {
-  const url = useDeployStore((s) =>
-    s.status.state === "ready" && s.status.mcpServerUrl
-      ? s.status.mcpServerUrl
-      : s.progress.status === "deployed"
-        ? s.progress.mcpServerUrl
-        : null,
-  );
+  const url = useDeployStore((s) => {
+    if (s.status.state === "ready" && s.status.mcpServerUrl) {
+      return s.status.mcpServerUrl;
+    }
+    if (s.progress.status === "deployed") {
+      return s.progress.mcpServerUrl;
+    }
+    return null;
+  });
   const { copied, copy } = useCopyToClipboard();
   if (!url) {
     return null;

--- a/packages/devtools/src/components/layout/toolbar-actions.tsx
+++ b/packages/devtools/src/components/layout/toolbar-actions.tsx
@@ -12,10 +12,15 @@ import {
   type StatusDotVariantProps,
 } from "@alpic-ai/ui/components/status-dot";
 import {
+  TaskProgress,
+  type TaskProgressStep,
+} from "@alpic-ai/ui/components/task-progress";
+import {
   Check,
   ClipboardCheck,
   Copy,
   ExternalLinkIcon,
+  Globe,
   MessagesSquareIcon,
   UnplugIcon,
 } from "lucide-react";
@@ -232,6 +237,46 @@ export function AuditButton() {
 
 const ALPIC_APP_URL = "https://app.alpic.ai";
 
+const DEPLOY_STEPS = [
+  { id: "collect", label: "Collecting files" },
+  { id: "upload", label: "Uploading source" },
+  { id: "trigger", label: "Triggering deployment" },
+  { id: "deploy", label: "Deploying" },
+] as const;
+
+export function LiveUrlChip() {
+  const url = useDeployStore((s) =>
+    s.status.state === "ready" && s.status.mcpServerUrl
+      ? s.status.mcpServerUrl
+      : s.progress.status === "deployed"
+        ? s.progress.mcpServerUrl
+        : null,
+  );
+  const { copied, copy } = useCopyToClipboard();
+  if (!url) {
+    return null;
+  }
+  const host = url.replace(/^https?:\/\//, "");
+  return (
+    <button
+      type="button"
+      aria-label="Copy live MCP server URL"
+      onClick={() => copy(url)}
+      className="inline-flex h-8 items-center gap-2 rounded-md border bg-light-gray px-2.5 text-sm hover:bg-background-hover"
+    >
+      <Globe className="size-3.5 text-quaternary-foreground" aria-hidden />
+      <span className="max-w-48 truncate font-mono text-xs">{host}</span>
+      <span className="text-quaternary-foreground">
+        {copied ? (
+          <Check className="size-3.5" />
+        ) : (
+          <Copy className="size-3.5" />
+        )}
+      </span>
+    </button>
+  );
+}
+
 export function DeployButton() {
   const { status, progress, redeploy, createAndDeploy, signIn } =
     useDeployStore();
@@ -372,10 +417,7 @@ function DeployPopoverContent({
         <p className="text-sm font-medium">Deployed</p>
         <CopyUrlRow url={progress.mcpServerUrl} />
         {progress.deploymentPageUrl && (
-          <>
-            <Separator />
-            <DeploymentPageButton href={progress.deploymentPageUrl} />
-          </>
+          <DeploymentPageButton href={progress.deploymentPageUrl} />
         )}
       </div>
     );
@@ -389,13 +431,10 @@ function DeployPopoverContent({
         </p>
         <p className="text-xs text-muted-foreground">{progress.message}</p>
         {progress.deploymentPageUrl && (
-          <>
-            <Separator />
-            <ExternalLinkRow
-              href={progress.deploymentPageUrl}
-              label="Go to logs"
-            />
-          </>
+          <ExternalLinkRow
+            href={progress.deploymentPageUrl}
+            label="Go to logs"
+          />
         )}
       </div>
     );
@@ -460,10 +499,7 @@ function DeployPopoverContent({
             </>
           )}
           {status.deploymentPageUrl && (
-            <>
-              <Separator />
-              <DeploymentPageButton href={status.deploymentPageUrl} />
-            </>
+            <DeploymentPageButton href={status.deploymentPageUrl} />
           )}
           {status.lastDeployGit && (
             <WarningAlert
@@ -526,22 +562,29 @@ function DeployingContent({
     return () => clearInterval(id);
   }, [startedAt]);
 
+  const currentIdx = Math.max(
+    0,
+    DEPLOY_STEPS.findIndex((s) => s.label === phase),
+  );
+  const steps: TaskProgressStep[] = DEPLOY_STEPS.map((step, i) => ({
+    id: step.id,
+    label: step.label,
+    status: i < currentIdx ? "done" : i === currentIdx ? "running" : "pending",
+  }));
+
   return (
-    <div className="space-y-2">
-      <div className="flex items-center gap-2">
-        <Spinner size="sm" className="shrink-0 text-current" />
-        <p className="text-sm">{phase}…</p>
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-medium">Deploying…</p>
         {startedAt != null && (
-          <span className="ml-auto font-mono text-xs text-muted-foreground">
+          <span className="font-mono text-xs text-muted-foreground">
             {formatElapsed(elapsedMs)}
           </span>
         )}
       </div>
+      <TaskProgress steps={steps} />
       {deploymentPageUrl && (
-        <>
-          <Separator />
-          <ExternalLinkRow href={deploymentPageUrl} label="Go to logs" />
-        </>
+        <ExternalLinkRow href={deploymentPageUrl} label="Go to logs" />
       )}
     </div>
   );

--- a/packages/devtools/src/deploy-router.ts
+++ b/packages/devtools/src/deploy-router.ts
@@ -6,21 +6,14 @@ import type {
 import express, { type Router } from "express";
 import { alpic } from "./alpic-sdk.js";
 
-const TOTAL_STEPS = 4;
-const PHASE_STEPS: Record<
-  DeployEvent["type"],
-  { step: number; label: string }
-> = {
-  collecting: { step: 1, label: "Collecting files" },
-  collected: { step: 1, label: "Collecting files" },
-  uploading: { step: 2, label: "Uploading source" },
-  triggering: { step: 3, label: "Triggering deployment" },
-  deploying: { step: 4, label: "Deploying" },
+const PHASE_LABELS: Record<DeployEvent["type"], string> = {
+  collecting: "Collecting files",
+  collected: "Collecting files",
+  uploading: "Uploading source",
+  triggering: "Triggering deployment",
+  deploying: "Deploying",
 };
-const phaseText = (type: DeployEvent["type"]): string => {
-  const { step, label } = PHASE_STEPS[type];
-  return `${step}/${TOTAL_STEPS} ${label}`;
-};
+const phaseText = (type: DeployEvent["type"]): string => PHASE_LABELS[type];
 
 type DeployState =
   | { status: "idle" }

--- a/packages/devtools/src/deploy-router.ts
+++ b/packages/devtools/src/deploy-router.ts
@@ -1,25 +1,11 @@
-import type {
-  DeployEvent,
-  DeploymentStatus,
-  DeployResult,
-} from "@alpic-ai/sdk";
+import type { DeploymentStatus, DeployResult } from "@alpic-ai/sdk";
 import express, { type Router } from "express";
 import { alpic } from "./alpic-sdk.js";
-
-const PHASE_LABELS: Record<DeployEvent["type"], string> = {
-  collecting: "Collecting files",
-  collected: "Collecting files",
-  uploading: "Uploading source",
-  triggering: "Triggering deployment",
-  deploying: "Deploying",
-};
-const phaseText = (type: DeployEvent["type"]): string => PHASE_LABELS[type];
 
 type DeployState =
   | { status: "idle" }
   | {
       status: "deploying";
-      phase: string;
       // Held in server state and replayed over SSE so the client's elapsed
       // clock survives hover remounts and page refreshes.
       startedAt: number;
@@ -58,12 +44,7 @@ export function createDeployRouter(): Router {
 
   const runDeploy = async (environmentId: string, teamId: string) => {
     const startedAt = Date.now();
-    setState({
-      status: "deploying",
-      phase: phaseText("collecting"),
-      startedAt,
-      deploymentPageUrl: null,
-    });
+    setState({ status: "deploying", startedAt, deploymentPageUrl: null });
     let pageUrl: string | null = null;
     try {
       const result: DeployResult = await alpic.deployments.deploy({
@@ -75,7 +56,6 @@ export function createDeployRouter(): Router {
           }
           setState({
             status: "deploying",
-            phase: phaseText(event.type),
             startedAt,
             deploymentPageUrl: pageUrl,
           });

--- a/packages/devtools/src/lib/deploy-store.ts
+++ b/packages/devtools/src/lib/deploy-store.ts
@@ -113,12 +113,9 @@ export const useDeployStore = create<DeployStore>()((set, get) => ({
           ? parsed.data
           : { state: "error", message: "Unexpected status response" },
       });
-    } catch (err) {
+    } catch {
       set({
-        status: {
-          state: "error",
-          message: err instanceof Error ? err.message : "Failed to load status",
-        },
+        status: { state: "error", message: "Can't reach the dev server." },
       });
     }
   },

--- a/packages/devtools/src/lib/deploy-store.ts
+++ b/packages/devtools/src/lib/deploy-store.ts
@@ -39,7 +39,6 @@ const progressSchema = z.discriminatedUnion("status", [
   z.object({ status: z.literal("idle") }),
   z.object({
     status: z.literal("deploying"),
-    phase: z.string(),
     startedAt: z.number(),
     deploymentPageUrl: z.string().nullable(),
   }),
@@ -95,7 +94,6 @@ async function postJson(
 
 const optimisticDeploying = (): DeployProgress => ({
   status: "deploying",
-  phase: "Preparing deployment",
   startedAt: Date.now(),
   deploymentPageUrl: null,
 });


### PR DESCRIPTION
Addresses QA findings from the [QA Deploy Button](https://app.notion.com/p/3951e5ce535b80969da9ca77e3410c87) session (08/07).

## Summary
- **Friendly dev-server error** — the deploy popover no longer surfaces a raw `"Failed to fetch"` when the loopback dev server is down; shows "Can't reach the dev server." Real Alpic 5xx responses still pass through with their message.
- **Simpler deploy progress** — dropped the confusing `4/4 Deploying` counter. The popover shows a steady spinner + "Deploying…" with the elapsed clock, no per-step breakdown.
- **Removed stray dividers** — dropped the `<Separator/>` before the deployment-page/logs links in the deployed, ready, and failed popover states.
- **Always-visible live URL** — new `LiveUrlChip` in the header next to the brand chip (`🌐 xxx.alpic.live`, copyable). Visible whenever a project is deployed and persists across redeploys.

Not addressed here: the "Go to logs → accordion should open" finding is an Alpic-app change, not this repo.

## Test
- `format` + `build` + unit (6/6) + e2e (10/10) green.
- Added one e2e assertion guarding the header live-URL chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)