### PR TITLE
feat: add descope.skybridge.tech CNAME for auth-descope example

### DIFF
--- a/infrastructure/lib/constructs/SkybridgeRecords.ts
+++ b/infrastructure/lib/constructs/SkybridgeRecords.ts
@@ -65,6 +65,7 @@ export class SkybridgeRecords extends Construct {
       "times-up",
       "auth0",
       "clerk",
+      "descope",
       "stytch",
       "workos",
     ]) {


### PR DESCRIPTION
Adds the descope subdomain to the showcase CNAME list, pointing descope.skybridge.tech -> cname.alpic.ai like the other auth examples (auth0, clerk, stytch, workos).

Unblocks alpic-ai/alpic#2153, which switches the Descope example card's Preview link to https://descope.skybridge.tech/try.

ALP-1586