### PR TITLE
fix: conformance useRequestModal

### DIFF
--- a/examples/conformance/notte/chatgpt_expected.json
+++ b/examples/conformance/notte/chatgpt_expected.json
@@ -7,7 +7,7 @@
   "useSetOpenInAppUrl": "supported",
   "useDisplayMode": "supported",
   "useRequestSize": "unsupported",
-  "useRequestModal": "supported",
+  "useRequestModal": "error",
   "useOpenExternal": "supported",
   "useDownload": "unsupported",
   "useFiles": "supported",

--- a/examples/conformance/src/tests.tsx
+++ b/examples/conformance/src/tests.tsx
@@ -336,9 +336,12 @@ function RequestModalTest({ onResult }: TestProps) {
       }
       await sleep(150);
     }
-    // No in-view flip: the host may have opened a separate modal instance
-    // (Apps SDK); only the user can tell.
-    return supported("modal requested");
+    // open() resolved but the display mode never flipped to "modal" within the
+    // window: the host acknowledged requestModal (e.g. blurs the background)
+    // yet never rendered the view as a modal. Treat as a real failure.
+    return failed(
+      'display mode never became "modal" after requestModal (host did not render the view as a modal)',
+    );
   });
   return null;
 }

--- a/packages/devtools/src/components/layout/tool-panel/view/create-openai-mock.ts
+++ b/packages/devtools/src/components/layout/tool-panel/view/create-openai-mock.ts
@@ -7,6 +7,7 @@ import type {
   CallToolResponse,
   DisplayMode,
   RequestDisplayMode,
+  RequestModalOptions,
   UnknownObject,
 } from "skybridge/web";
 
@@ -84,10 +85,10 @@ function createOpenaiMethods(
       openai.widgetState = state;
       setValue("widgetState", state);
     },
-    requestModal: async (args: { title?: string }) => {
+    requestModal: async (args: RequestModalOptions) => {
       log("requestModal", args);
       openai.displayMode = "modal" as DisplayMode; // TODO: To remove once https://github.com/alpic-ai/skybridge/pull/92 is merged
-      openai.view = { mode: "modal" };
+      openai.view = { mode: "modal", params: args.params };
       setValue("displayMode", "modal");
     },
     uploadFile: async (file: File) => {


### PR DESCRIPTION
window.requestModal seems to be [broken](https://community.openai.com/t/requestmodal-blurs-the-background-but-widget-stays-inline-never-switches-to-modal/1386666). this pr updates the conformance baseline and fix the false positive.

this also fixes devtools which was also broken (not reading params)