### PR TITLE
docs(auth-workos): Fix README drift from example code

### DIFF
--- a/examples/auth-workos/README.md
+++ b/examples/auth-workos/README.md
@@ -9,7 +9,7 @@ An example MCP app built with [Skybridge](https://docs.skybridge.tech/home): a p
 - **Branded provider via `oauth:`**: Passing `oauth: await workosProvider(...)` auto-mounts the well-known metadata endpoints and Bearer verification — no manual router
 - **Personalized Results**: Authenticated users see favorites highlighted and sorted first
 - **User Identity in Widgets**: Displays the signed-in user's name directly in the widget UI
-- **Simplified Server Setup**: Uses [`server.run()`](https://docs.skybridge.tech/api-reference/run) and `.use()` for a single-file server with no manual Express boilerplate
+- **Simplified Server Setup**: Uses [`server.run()`](https://docs.skybridge.tech/api-reference/run) for a single-file server with no manual Express boilerplate
 - **Structured Content & Metadata**: Server passes structured data to widgets via `structuredContent`
 - **Hot Module Replacement**: [Live reloading](https://docs.skybridge.tech/concepts/fast-iteration#hmr-with-vite-plugin) of widget components during development
 - **Local DevTools**: [DevTools](https://docs.skybridge.tech/devtools) at `http://localhost:3000` for local testing
@@ -68,14 +68,14 @@ This command starts:
 
 ```
 ├── src/
-│   ├── server.ts        # Server entry: McpServer + workosProvider auth + widget + run()
-│   ├── env.ts          # Env validation
-│   └── coffee-data.ts  # Mock coffee shop data & search
+│   ├── server.ts        # Server entry: McpServer + workosProvider auth + tool + run()
+│   ├── env.ts           # Env validation
+│   ├── coffee-data.ts   # Mock coffee shop data & search
 │   ├── views/
 │   │   └── search-coffee-paris.tsx  # Coffee shop widget
-│   ├── helpers.ts      # Type-safe Skybridge hooks
-│   └── index.css       # Parisian theme styles
-├── nodemon.json            # Dev server config
+│   ├── helpers.ts       # Type-safe Skybridge hooks
+│   └── index.css        # Parisian theme styles
+├── nodemon.json         # Dev server config
 └── package.json
 ```
 
@@ -92,7 +92,7 @@ Edit and save components in `src/views/` — changes will appear instantly insid
 
 #### 3. Edit server code
 
-Modify files in `server/` and refresh the connection with your testing MCP Client to see the changes.
+Modify files in `src/` and refresh the connection with your testing MCP Client to see the changes.
 
 ### Testing your App
 


### PR DESCRIPTION
## Summary

The auth-workos README described APIs and paths the example no longer uses; this brings the docs back in line with the actual source.
