### PR TITLE
feat: add render-carousel tool

### DIFF
--- a/packages/create-skybridge/templates/ecom/src/server.ts
+++ b/packages/create-skybridge/templates/ecom/src/server.ts
@@ -1,6 +1,10 @@
 import { existsSync } from "node:fs";
 import { McpServer } from "skybridge/server";
-import { MIN_SEARCH_ITERATIONS } from "./config.js";
+import { CAROUSEL_RANGE, MIN_SEARCH_ITERATIONS } from "./config.js";
+import {
+  renderCarouselDefinition,
+  renderCarouselHandler,
+} from "./tools/render-carousel.js";
 import {
   searchProductsDefinition,
   searchProductsHandler,
@@ -27,9 +31,12 @@ Vary the keyword, apply filters from a prior response, or page deeper. \
 Stay silent while searching: emit NO text between calls. Speak only \
 once the carousel renders. Never call a category unavailable before searching.
 
-RENDER: not implemented yet`,
+RENDER: After curating, call render-carousel with the chosen product IDs (aim for ${CAROUSEL_RANGE}). \
+Speak only once it renders, then recommend in carousel order.`,
   },
-).registerTool(searchProductsDefinition, searchProductsHandler);
+)
+  .registerTool(searchProductsDefinition, searchProductsHandler)
+  .registerTool(renderCarouselDefinition, renderCarouselHandler);
 
 export default await server.run();
 

--- a/packages/create-skybridge/templates/ecom/src/tools/render-carousel.ts
+++ b/packages/create-skybridge/templates/ecom/src/tools/render-carousel.ts
@@ -1,0 +1,233 @@
+import { z } from "zod";
+import { CAROUSEL_MAX_SIZE, CAROUSEL_RANGE } from "../config.js";
+import {
+  type Attribute,
+  AttributeSchema,
+  type Price,
+  PriceSchema,
+} from "../types.js";
+
+// The `render-carousel` tool: takes the IDs the model curated and returns the
+// matching products for the carousel view to render.
+// Everything this tool needs lives in this file.
+
+// ---------------------------------------------------------------------------
+// Product model
+// ---------------------------------------------------------------------------
+// Model: variant-as-full-product. Each `Variant` is a complete, buyable product
+// (its own title, price, media). A `Product` ties sibling variants together and
+// declares the axes (`Option`s) they vary on. A product with no variations is
+// just a product with a single variant and no options.
+
+// One selectable value on an axis, e.g. the "Black" choice on the "Color" axis.
+type OptionValue = {
+  id: string; // stable key referenced by Variant.selection, e.g. "black"
+  label: string; // shown to the user, e.g. "Black"
+  media?: string; // optional swatch / image representing this value
+};
+
+// A variation axis the variants differ on, e.g. Color or Size.
+type Option = {
+  id: string; // stable key, used as a key in Variant.selection, e.g. "color"
+  label: string; // shown to the user, e.g. "Color"
+  values: OptionValue[]; // in display order
+};
+
+// Display fields shared by a Variant and by a product's `card`.
+type Meta = {
+  title: string;
+  description?: string;
+  price?: Price;
+  media: string[]; // images for this item; media[0] is the primary/cover
+  url?: string; // link to this item's external product page
+  outOfStock?: boolean; // true = not purchasable
+  // Facts to display: spec rows, promo labels, etc.
+  attributes: Attribute[];
+};
+
+// One buyable product: full display Meta plus which value it takes on each axis.
+type Variant = Meta & {
+  id: string; // SKU / article number; unique within the catalog
+  // The chosen value per axis: keys are Option.id, values are OptionValue.id.
+  // e.g. { color: "black", size: "40" }
+  selection: Record<string, string>;
+};
+
+// A product: one carousel card backed by one or more variants and the axes they
+// vary on (none for a single-variant product).
+type Product = {
+  id: string; // stable product key
+  options: Option[]; // the axes the variants vary on
+  // Only the variants that actually exist. A missing combination (e.g. no
+  // { color: "black", size: "40" }) is simply absent from this list — that is how
+  // contingent variations are expressed. Derive the selectable values for an axis
+  // by filtering this list on the choices already made.
+  variants: Variant[];
+  // What the carousel card shows for the whole product. Optional: when omitted, the
+  // first variant is used. Set it to showcase a specific variant or give the product
+  // its own title/price, e.g. a "from" price spanning the variants.
+  card?: Meta;
+};
+
+// ---------------------------------------------------------------------------
+// Input
+// ---------------------------------------------------------------------------
+
+const inputSchema = {
+  ids: z
+    .array(z.string())
+    .min(1)
+    .max(CAROUSEL_MAX_SIZE)
+    .describe("Product IDs to present, in display order."),
+};
+
+type RenderInput = z.infer<z.ZodObject<typeof inputSchema>>;
+
+// ---------------------------------------------------------------------------
+// Output — model-facing grounding, for the LLM ONLY. The carousel view is NOT
+// built from this; it renders from the full data in `_meta`. Keep it to what the
+// model needs to reference and compare the displayed products afterward.
+// ---------------------------------------------------------------------------
+
+const outputSchema = {
+  products: z
+    .array(
+      z.object({
+        id: z.string().describe("Product SKU or reference."),
+        title: z.string(),
+        options: z
+          .array(z.object({ label: z.string(), values: z.array(z.string()) }))
+          .describe("Variations available (e.g. colors, sizes)."),
+        description: z.string().optional(),
+        price: PriceSchema.optional(),
+        outOfStock: z.boolean(),
+        attributes: z
+          .array(AttributeSchema)
+          .describe("Product facts (specs, promo labels…)."),
+      }),
+    )
+    .describe(
+      "The products shown in the carousel, in display order. For your reference only — to curate, compare, and answer follow-ups. Ground every claim in this data; never invent attributes.",
+    ),
+};
+
+type RenderOutput = z.infer<z.ZodObject<typeof outputSchema>>;
+
+// ---------------------------------------------------------------------------
+// Data access
+// ---------------------------------------------------------------------------
+
+async function getProducts(_ids: string[]): Promise<Product[]> {
+  // @todo: fetch each id from your product API / DB and map the results into
+  // `Product`s (rename `_ids` -> `ids` once you use it).
+  //
+  // First decide your mapping strategy — it depends on your catalog:
+  //   - no variants (simple products): one `Product`, a single variant, options: []
+  //   - grouped: one `Product` per product; `card` = union of its variants, one picture per requested variant
+  //   - one card per requested variant: `card` = that variant
+  // Either way, set `variants` to ALL variants the source returns for the product;
+  // the detail view reads them so the client can switch variant.
+  //
+  // Returns [] for now, so the carousel is empty.
+  return [];
+}
+
+// ---------------------------------------------------------------------------
+// Mapping — trim products to the model-facing grounding (outputSchema). The full
+// data stays in `_meta` for the view. The card, else the first variant,
+// represents the product; options collapse to label + value labels.
+// @todo: choose what the model sees per product. Grounding only — no
+// presentational data (media, styling); that rides in `_meta` for the view.
+// ---------------------------------------------------------------------------
+
+function toStructuredContent(products: Product[]): RenderOutput {
+  const groundingProducts: RenderOutput["products"] = [];
+
+  for (const product of products) {
+    const rep = product.card ?? product.variants[0];
+
+    let outOfStock = true;
+    for (const variant of product.variants) {
+      if (!variant.outOfStock) {
+        outOfStock = false;
+        break;
+      }
+    }
+
+    const options: { label: string; values: string[] }[] = [];
+    for (const option of product.options) {
+      const values: string[] = [];
+      for (const value of option.values) {
+        values.push(value.label);
+      }
+      options.push({ label: option.label, values });
+    }
+
+    groundingProducts.push({
+      id: product.id,
+      title: rep.title,
+      description: rep.description,
+      price: rep.price,
+      outOfStock,
+      options,
+      attributes: rep.attributes,
+    });
+  }
+
+  return { products: groundingProducts };
+}
+
+// ---------------------------------------------------------------------------
+// Tool (registered from server.ts to keep the typed tool chain intact)
+// ---------------------------------------------------------------------------
+
+export const renderCarouselDefinition = {
+  name: "render-carousel" as const,
+
+  // @todo: adapt the wording to your catalog and brand voice (tone, vocabulary,
+  // how to present products). The behavioral rules below apply to any catalog.
+  description: `\
+Display the products you curated as an inline carousel for the client.
+
+## When to call
+Call this AFTER searching and curating, and BEFORE writing your recommendation. Do not describe the products in text first; the carousel shows them. Stay silent until it has rendered, then speak.
+
+## What to pass
+Pass the IDs of the ${CAROUSEL_RANGE} products you chose, in display order (most relevant first). Order is significant: the carousel shows them in this exact order and your recommendation must follow the same sequence. Pass distinct products, not several variants of the same one; the detail view lets the client explore a product's variants (colors, sizes, and so on).
+
+## After the carousel
+Recommend in carousel order so the client can follow along. The cards already show image, title, price, and key facts, so do not repeat them: add useful analysis tied to the client's need. Suggest a refinement the client has not addressed yet (from the available filters), never one they already used.
+
+## Accuracy
+Use only the data returned for each product. Never invent attributes, materials, or availability. If the client asks about something not present, open that product's detail or search again before answering.`,
+  annotations: {
+    readOnlyHint: true,
+    openWorldHint: false,
+    destructiveHint: false,
+  },
+
+  // @todo: customize the status messages shown in ChatGPT while the tool runs.
+  _meta: {
+    "openai/toolInvocation/invoking": "Loading product carousel",
+    "openai/toolInvocation/invoked": "Loaded product carousel",
+  },
+
+  inputSchema,
+};
+
+export async function renderCarouselHandler({ ids }: RenderInput) {
+  const products = await getProducts(ids);
+
+  return {
+    // Full products (incl. variants) for the view; not in model context.
+    _meta: { products },
+    structuredContent: toStructuredContent(products),
+    content: [
+      {
+        type: "text" as const,
+        text: `Rendered ${products.length} product(s) in the carousel.`,
+      },
+    ],
+    isError: false,
+  };
+}

--- a/packages/create-skybridge/templates/ecom/src/tools/search-products.ts
+++ b/packages/create-skybridge/templates/ecom/src/tools/search-products.ts
@@ -4,6 +4,7 @@ import {
   CAROUSEL_RANGE,
   MIN_SEARCH_ITERATIONS,
 } from "../config.js";
+import { AttributeSchema, PriceSchema } from "../types.js";
 
 // The `search-products` tool: keyword + filters in, matching products out as
 // structured output for the model. It has NO view — include only what the model
@@ -46,26 +47,22 @@ type SearchInput = z.infer<z.ZodObject<typeof inputSchema>>;
 // Output — model-facing grounding, returned in structuredContent.
 // ---------------------------------------------------------------------------
 
-// The property names the model curates on (grounding only, no presentational data).
-// @todo: replace with your catalog's property names.
-const propertyName = z.enum(["name", "price", "description"]);
+const productSchema = z.object({
+  id: z.string().describe("Stable product ID; pass to render-carousel."),
+  title: z.string(),
+  description: z.string().optional(),
+  price: PriceSchema.optional(),
+  outOfStock: z
+    .boolean()
+    .optional()
+    .describe("True when the product is not purchasable."),
+  attributes: z
+    .array(AttributeSchema)
+    .describe("Facts to curate on (specs, materials, promo labels…)."),
+});
 
 const outputSchema = {
-  products: z
-    .array(
-      z.object({
-        id: z.string().describe("Stable product ID; pass to render-carousel."),
-        properties: z
-          .array(
-            z.object({
-              name: propertyName.describe("Which property this is."),
-              value: z.array(z.string()).describe("The property's value(s)."),
-            }),
-          )
-          .describe("Product properties to curate on."),
-      }),
-    )
-    .describe("Matching products, sorted."),
+  products: z.array(productSchema).describe("Matching products, sorted."),
   pages: z
     .object({
       current: z.number(),
@@ -79,13 +76,13 @@ const outputSchema = {
     .describe("Total matching products across all pages."),
 };
 
-type SearchResults = z.infer<z.ZodObject<typeof outputSchema>>;
+type SearchOutput = z.infer<z.ZodObject<typeof outputSchema>>;
 
 // ---------------------------------------------------------------------------
 // Data access
 // ---------------------------------------------------------------------------
 
-function search(input: SearchInput): SearchResults {
+function search(_input: SearchInput): SearchOutput {
   // @todo: plug in your product API / DB. Query it with the input params and map
   // each result into `products` below. `pages` and `totalHits` are optional.
   return {
@@ -103,7 +100,7 @@ function search(input: SearchInput): SearchResults {
 // results and never invent attributes.
 // ---------------------------------------------------------------------------
 
-function narrate({ products }: SearchResults): string {
+function narrate({ products }: SearchOutput): string {
   const size = products.length;
 
   if (size === 0) {

--- a/packages/create-skybridge/templates/ecom/src/types.ts
+++ b/packages/create-skybridge/templates/ecom/src/types.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const PriceSchema = z.object({
+  amount: z.number(),
+  currency: z.string(),
+});
+export type Price = z.infer<typeof PriceSchema>;
+
+export const AttributeSchema = z.object({
+  name: z.string(),
+  value: z.string(),
+});
+export type Attribute = z.infer<typeof AttributeSchema>;

--- a/skills/chatgpt-app-builder/references/ecommerce.md
+++ b/skills/chatgpt-app-builder/references/ecommerce.md
@@ -1,15 +1,14 @@
 # Fill the template
 
-The `ecom` template is a skeleton: the wiring is in place, the data is not. One tool, `search-products`, takes a keyword plus filters, runs a `search()` stub, and returns the matching products as structured output plus next-step guidance for the model. This reference connects it to a real catalog.
+The `ecom` template is a skeleton: the wiring is in place, the data is not. Two tools: `search-products` (keyword + filters in, matching products out as model-facing structured output) and `render-carousel` (curated product/variant IDs in, an inline carousel out). This reference connects them to a real catalog.
 
-Not in a scaffolded `ecom` project (no `src/tools/search-products.ts`)? Scaffold it first with the `--ecom` flag: [copy-template.md](copy-template.md). Then return here.
+Not in a scaffolded `ecom` project (no `src/tools/`)? Scaffold it first with the `--ecom` flag: [copy-template.md](copy-template.md). Then return here.
 
 Work in the order below. Do not skip ahead: each step depends on the previous ones. Never invent a schema, endpoint, or credential.
 
 ## 1. Gather context
 
-Ask the user about their data source: API or database, base URL or connection string, auth method, the product schema (fields and types), the filters and sort options it supports, the image and price fields, and how it paginates.
-Request any reference docs and save them under `docs/` (create it if missing). Read them before writing code.
+Ask the user about their data source: API or database, base URL or connection string, auth method, the product schema (fields and types), the filters and sort options it supports, the image and price fields, and how it paginates. Request any reference docs and save them under `docs/` (create it if missing). Read them before writing code.
 
 ## 2. Configure access
 
@@ -19,11 +18,11 @@ List the credentials the data source needs. Have the user fill the `.env`; the s
 
 Delegate this to a dedicated subagent with a fresh context window: it runs the real queries and returns only the mapping, so the main agent's context isn't filled with large API payloads.
 
-Have it confirm the exact response shape, the real sort keys, the available filter facets and their values, the image and price fields, and the pagination model, then map each onto the tool's shape. Record the mapping in SPEC.md so later work doesn't re-run the exploration.
+Have it confirm the exact response shape, the real sort keys, the available filter facets and their values, the image and price fields, how variants/options are represented, and the pagination model, then map each onto the template's shapes. Document your findings in SPEC.md so later work doesn't re-run the exploration.
 
 ## 4. Fill the @todos and verify
 
-Layout: `src/config.ts` (shared tuning), `src/server.ts` (name/version, server prompt, tool registration), and one file per tool under `src/tools/`.
+Layout: `src/config.ts` (shared tuning), `src/types.ts` (shared `Price` and `Attribute` schemas), `src/server.ts` (name/version, server prompt, tool registration), and one file per tool under `src/tools/`.
 
 `grep -rn "@todo" src`, then resolve every marker. Fill the shared items, then each tool: complete its `@todo`s and verify it before moving to the next.
 
@@ -38,21 +37,22 @@ Each tool's verify curl is in its section below.
 ### Shared
 
 - [ ] `.env.template`: regenerate from the user's `.env` (same keys, values blanked) so the committed placeholder matches the credentials the integration needs.
-- [ ] `src/server.ts` — `name` / `version`.
-- [ ] `src/server.ts` — server `instructions`: adapt the server-wide prompt to the catalog.
-- [ ] `src/config.ts` — `CAROUSEL_MAX_SIZE`: number of products to curate toward.
-- [ ] `src/config.ts` — `MIN_SEARCH_ITERATIONS`: minimum searches before rendering.
+- [ ] `src/server.ts` `name` / `version`.
+- [ ] `src/server.ts` `instructions`: adapt the server-wide prompt to the catalog.
+- [ ] `src/config.ts` `CAROUSEL_MAX_SIZE`: max products the carousel shows.
+- [ ] `src/config.ts` `MIN_SEARCH_ITERATIONS`: minimum searches before rendering.
 
 ### `search-products` (`src/tools/search-products.ts`)
+
+Keyword/filter search that returns matching products as model-facing grounding. It has NO view, so keep the output to what the model needs to curate (ids + facts), never presentational data (images, media): render-carousel handles that.
 
 - [ ] `description`: describe the catalog, its categories, and the search/curate loop.
 - [ ] `_meta`: the invoking and invoked status messages.
 - [ ] `inputSchema.keyword`: rewrite the description for the catalog's vocabulary.
 - [ ] `inputSchema.sort`: set the real sort options, or remove.
 - [ ] `inputSchema` filters: replace `priceRange` with one optional param per real facet.
-- [ ] `propertyName`: set the property names the model curates on (e.g. `name`, `price`, `description`). Grounding only — no presentational data (images, media).
-- [ ] `outputSchema`: adjust the model-facing fields (product `id` + `properties`).
-- [ ] `search()`: query the data source with `keyword`, `sort`, and filters; map each hit into the `outputSchema` shape (`{ id, properties: [{ name, value: string[] }] }[]`); set `pages` and `totalHits`.
+- [ ] `productSchema` / `outputSchema`: adjust the model-facing fields (`id`, `title`, `description`, `price`, `outOfStock`, `attributes`).
+- [ ] `search()`: query the data source with the input params and map each hit into `productSchema`; set `pages` and `totalHits`.
 - [ ] `narrate()` NEXT STEPS: adapt the post-search guidance to your flow (framing only; it carries no result data).
 
 Verify: curl the stateless `/mcp` endpoint (`Accept` must include `text/event-stream` or the SDK rejects the request). Set `arguments` to `keyword` plus any `sort`/filters you implemented:
@@ -64,5 +64,41 @@ curl -s http://localhost:3000/mcp \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"search-products","arguments":{"keyword":"<real keyword>"}}}'
 ```
 
-Confirm `result.structuredContent` carries real products from the live source (`result.content` is just the next-step guidance text). (`"method":"tools/list"` with no `params` lists the registered schema.)
+Confirm `result.structuredContent` carries real products from the live source (`result.content` is just the next-step guidance). (`"method":"tools/list"` with no `params` lists the registered schema.)
 
+### `render-carousel` (`src/tools/render-carousel.ts`)
+
+Takes the curated IDs and returns the products for the carousel. The full product data (variants, media, options) rides in `_meta` for the view; a trimmed grounding subset goes to `structuredContent` for the model.
+
+- [ ] Product model (`Product`, `Variant`, `Option`, `Meta`): match your catalog. A `Product` groups sibling `Variant`s and declares the `Option` axes. `variants` is sparse (list only the combinations that exist; a missing one encodes a contingent variation). `card` is the variant or union shown on the carousel card.
+- [ ] `getProducts()`: fetch each id and map results into `Product[]`. Pick a mapping strategy (see below).
+- [ ] `toStructuredContent()`: choose the model-facing fields per product (grounding only; the view reads the full data from `_meta`).
+- [ ] `description`: adapt the wording and brand voice; the behavioral rules (order, no-repeat, accuracy) apply to any catalog.
+- [ ] `_meta`: the invoking and invoked status messages.
+- [ ] `view` (once built): point it at your carousel view under `src/views/render-carousel`.
+
+#### Mapping ids to products (`getProducts`)
+
+`getProducts` turns the curated ids into `Product[]`. It is unprescriptive: choose what fits your catalog. Whatever `search-products` put in each `id` is what arrives here, so keep the two tools consistent.
+
+**Products have no variants (simple products).** Map each id to a `Product` with a single variant and `options: []`. Nothing else to decide.
+
+**Products have variants.** Choose how variants become carousel cards:
+
+- **Group (one card per product).** All queried variants of a product collapse into a single carousel item. `card` is the union of the product's available variants returned by the data source (e.g. a "from" price, in stock if any variant is), and `card.media` holds one picture per requested variant.
+- **One card per requested variant.** Each requested variant is its own carousel item, with `card` set to that variant.
+
+> Either way, each carousel item's `Product` must hold ALL the variants the data source returned in `variants` (only `card` differs). The detail view reads `variants` so the client can switch to any variant.
+
+Cross-cutting: preserve the `ids` order, and decide how to handle ids with no match (skip, or surface them).
+
+Verify: `arguments.ids` is an array of product IDs, in display order:
+
+```bash
+curl -s http://localhost:3000/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"render-carousel","arguments":{"ids":["<real id>"]}}}'
+```
+
+Confirm `result._meta.products` carries the full products for the view and `result.structuredContent` the trimmed grounding.


### PR DESCRIPTION
- render-carousel tool: takes the curated product IDs and returns the products to show. Full data (variants, options, media) goes in _meta for the view; a trimmed grounding subset goes to structuredContent for the model. getProducts() is a stub you plug your catalog into.
- shared product model in types.ts (Price, Attribute), used by both tools. Product = one carousel card, its variants, and the option axes; variants are sparse so "this combo doesn't exist" just means it's not in the list.
- search-products output cleaned up to a flat product shape (id, title, price, outOfStock, attributes) instead of the old name/value properties bag.
- skill's ecommerce reference updated: documents both tools, the shared types, and a "mapping ids to products" section walking through the strategies (no variants / grouped / one card per variant) since that's the main thing a dev has to decide.