### PR TITLE
feat: add carousel

### DIFF
--- a/packages/create-skybridge/templates/ecom/src/components/empty-state.stories.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/empty-state.stories.tsx
@@ -1,0 +1,3 @@
+import { EmptyState } from "./empty-state";
+
+export const NoResults = () => <EmptyState message="No products to show." />;

--- a/packages/create-skybridge/templates/ecom/src/components/empty-state.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/empty-state.tsx
@@ -1,0 +1,12 @@
+import { sprinkles, text } from "../design/tokens";
+
+/** Centered message shown when there is nothing to render (e.g. no results). */
+export function EmptyState({ message }: { message: string }) {
+  return (
+    <div
+      className={sprinkles({ p: "l", textAlign: "center", color: "subtle" })}
+    >
+      <p className={text({ style: "bodyM" })}>{message}</p>
+    </div>
+  );
+}

--- a/packages/create-skybridge/templates/ecom/src/components/product-card.css.ts
+++ b/packages/create-skybridge/templates/ecom/src/components/product-card.css.ts
@@ -1,0 +1,136 @@
+import { keyframes, style } from "@vanilla-extract/css";
+import { recipe } from "@vanilla-extract/recipes";
+import { colors, primitives } from "../design/tokens";
+
+// @todo: number of title lines before it truncates with an ellipsis. Exported
+// so the skeleton reserves the same number of lines.
+export const TITLE_LINES = 2;
+
+// `framed: true` gives each card its own container; the default is a plain
+// layout shell (pair it with a framed carousel instead). Pick one, not both.
+export const card = recipe({
+  base: {
+    display: "flex",
+    flexDirection: "column",
+    gap: primitives.space["3xs"],
+    width: "100%",
+    textAlign: "left",
+  },
+  variants: {
+    framed: {
+      // @todo: tune the card container to your brand.
+      true: {
+        padding: primitives.space["3xs"],
+        borderRadius: primitives.radius.m,
+        border: `${primitives.stroke.thin} solid ${colors.border.thin}`,
+        backgroundColor: colors.surface.extraLight,
+      },
+      false: {},
+    },
+  },
+  defaultVariants: { framed: false },
+});
+
+export const imageBox = style({
+  position: "relative",
+  aspectRatio: "1",
+  overflow: "hidden",
+  borderRadius: primitives.radius.m,
+  // Stage behind the product image. @todo: pick the surface token that suits
+  // your imagery (a neutral grey for transparent cutouts, `extraLight`/white
+  // for full-bleed photos).
+  backgroundColor: colors.surface.subtle,
+});
+
+export const image = style({
+  width: "100%",
+  height: "100%",
+  // @todo: `contain` never crops; switch to `cover` for uniform, bleed-friendly
+  // cutout images.
+  objectFit: "contain",
+  display: "block",
+  // Keep image drag from hijacking the swipe/scroll gesture.
+  pointerEvents: "none",
+  userSelect: "none",
+});
+
+export const imageDimmed = style({ opacity: 0.5 });
+
+export const placeholder = style({
+  width: "100%",
+  height: "100%",
+  backgroundColor: colors.surface.subtle,
+});
+
+export const oosBadge = style({
+  position: "absolute",
+  top: primitives.space["3xs"],
+  left: primitives.space["3xs"],
+  padding: `${primitives.space["5xs"]} ${primitives.space["3xs"]}`,
+  borderRadius: primitives.radius.s,
+  backgroundColor: colors.surface.extraLight,
+  color: colors.content.intense,
+  fontFamily: primitives.font.family.primary,
+  fontSize: primitives.font.size.xs,
+});
+
+export const body = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: primitives.space["5xs"],
+});
+
+export const title = style({
+  color: colors.content.intense,
+  display: "-webkit-box",
+  WebkitLineClamp: TITLE_LINES,
+  WebkitBoxOrient: "vertical",
+  overflow: "hidden",
+  // Reserve the clamp height (title line-height is 1.5) so prices line up
+  // across cards whatever the title length.
+  minHeight: `calc(${TITLE_LINES} * 1.5em)`,
+});
+
+export const price = style({ color: colors.content.subtle });
+
+// Skeleton (loading state).
+const pulse = keyframes({
+  "0%": { opacity: 1 },
+  "50%": { opacity: 0.4 },
+  "100%": { opacity: 1 },
+});
+
+export const skeletonBox = style({
+  backgroundColor: colors.surface.subtle,
+  borderRadius: primitives.radius.s,
+  animation: `${pulse} 1.5s ease-in-out infinite`,
+  "@media": {
+    "(prefers-reduced-motion: reduce)": { animation: "none" },
+  },
+});
+
+export const skeletonImage = style({
+  aspectRatio: "1",
+  borderRadius: primitives.radius.m,
+});
+
+// Text rows (title lines + price), evenly spaced. Its own container rather than
+// `body` so the skeleton can breathe a little more without moving the real card.
+export const skeletonBody = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: primitives.space["4xs"],
+});
+
+export const skeletonLine = style({ height: primitives.font.size.m });
+
+// Last title line and the price row are stubbed short, the way text ends.
+export const skeletonLineShort = style({
+  height: primitives.font.size.m,
+  width: "60%",
+});
+
+export const skeletonPrice = style({
+  height: primitives.font.size.m,
+  width: "40%",
+});

--- a/packages/create-skybridge/templates/ecom/src/components/product-card.stories.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/product-card.stories.tsx
@@ -1,0 +1,58 @@
+import { ProductCard, ProductCardSkeleton } from "./product-card";
+
+const IMAGE =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='240' height='240'%3E%3Crect width='240' height='240' fill='%23e5e5e5'/%3E%3Ccircle cx='120' cy='120' r='70' fill='%23bcbcbc'/%3E%3C/svg%3E";
+
+const frame = { maxWidth: 220 };
+
+export const Default = () => (
+  <div style={frame}>
+    <ProductCard
+      title="Merino wool sweater"
+      price={{ amount: 129.9, currency: "EUR" }}
+      media={[IMAGE]}
+    />
+  </div>
+);
+
+export const LongTitle = () => (
+  <div style={frame}>
+    <ProductCard
+      title="Extra long product title that wraps onto two lines and then clamps"
+      price={{ amount: 1290, currency: "USD" }}
+      media={[IMAGE]}
+    />
+  </div>
+);
+
+export const NoImage = () => (
+  <div style={frame}>
+    <ProductCard
+      title="Product without an image"
+      price={{ amount: 49, currency: "EUR" }}
+    />
+  </div>
+);
+
+export const NoPrice = () => (
+  <div style={frame}>
+    <ProductCard title="Price on request" media={[IMAGE]} />
+  </div>
+);
+
+export const OutOfStock = () => (
+  <div style={frame}>
+    <ProductCard
+      title="Sold out product"
+      price={{ amount: 89, currency: "EUR" }}
+      media={[IMAGE]}
+      outOfStock
+    />
+  </div>
+);
+
+export const Skeleton = () => (
+  <div style={frame}>
+    <ProductCardSkeleton />
+  </div>
+);

--- a/packages/create-skybridge/templates/ecom/src/components/product-card.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/product-card.tsx
@@ -1,0 +1,99 @@
+import type { ReactNode } from "react";
+import { useUser } from "skybridge/web";
+import { text } from "../design/tokens";
+import { cx } from "../lib/cx";
+import { formatPrice } from "../lib/format";
+import type { Price } from "../types.js";
+import * as styles from "./product-card.css";
+
+type ProductCardProps = {
+  title: string;
+  price?: Price;
+  media?: string[]; // all images; the card decides which to show
+  outOfStock?: boolean;
+};
+
+// @todo: for boxed cards (border + background), set this to true and leave the
+// carousel unframed. Pick one, not both.
+const FRAMED = false;
+
+/**
+ * A single product card: image, title, price, and an out-of-stock treatment.
+ * Maps a product's display fields to markup; the view passes them in.
+ */
+export function ProductCard({
+  title,
+  price,
+  media,
+  outOfStock,
+}: ProductCardProps) {
+  const { locale } = useUser();
+  // Show the first image. @todo: the rest of `media` is available here, e.g.
+  // to cross-fade to media[1] on hover.
+  const cover = media?.[0];
+  return (
+    <article className={styles.card({ framed: FRAMED })}>
+      <div className={styles.imageBox}>
+        {cover ? (
+          <img
+            className={cx(styles.image, outOfStock && styles.imageDimmed)}
+            src={cover}
+            alt={title}
+            loading="lazy"
+            draggable={false}
+          />
+        ) : (
+          <div className={styles.placeholder} />
+        )}
+        {outOfStock ? (
+          <span className={styles.oosBadge}>Out of stock</span>
+        ) : null}
+      </div>
+
+      <div className={styles.body}>
+        <p
+          className={cx(
+            text({ style: "bodyS", weight: "medium" }),
+            styles.title,
+          )}
+        >
+          {title}
+        </p>
+        {price ? (
+          <p className={cx(text({ style: "bodyS" }), styles.price)}>
+            {formatPrice(price, locale)}
+          </p>
+        ) : null}
+        {/* @todo: extra fields. Render catalog-specific data here, e.g. from the
+            product's `attributes`: ratings, discounts, tags, badges. */}
+      </div>
+    </article>
+  );
+}
+
+/** Placeholder card shown while the tool resolves. Same footprint as the card
+ *  so the layout does not jump when data arrives. */
+export function ProductCardSkeleton() {
+  const titleLines: ReactNode[] = [];
+  for (let i = 0; i < styles.TITLE_LINES; i++) {
+    const isLast = i === styles.TITLE_LINES - 1;
+    titleLines.push(
+      <div
+        key={i}
+        className={cx(
+          styles.skeletonBox,
+          isLast ? styles.skeletonLineShort : styles.skeletonLine,
+        )}
+      />,
+    );
+  }
+  return (
+    <div className={styles.card({ framed: FRAMED })} aria-hidden="true">
+      <div className={cx(styles.skeletonBox, styles.skeletonImage)} />
+      <div className={styles.skeletonBody}>
+        {titleLines}
+        <div className={cx(styles.skeletonBox, styles.skeletonPrice)} />
+      </div>
+    </div>
+  );
+}

--- a/packages/create-skybridge/templates/ecom/src/components/product-card.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/product-card.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { useUser } from "skybridge/web";
 import { text } from "../design/tokens";
+import { useLabels } from "../i18n";
 import { cx } from "../lib/cx";
 import { formatPrice } from "../lib/format";
 import type { Price } from "../types.js";
@@ -28,6 +29,7 @@ export function ProductCard({
   outOfStock,
 }: ProductCardProps) {
   const { locale } = useUser();
+  const labels = useLabels();
   // Show the first image. @todo: the rest of `media` is available here, e.g.
   // to cross-fade to media[1] on hover.
   const cover = media?.[0];
@@ -46,7 +48,7 @@ export function ProductCard({
           <div className={styles.placeholder} />
         )}
         {outOfStock ? (
-          <span className={styles.oosBadge}>Out of stock</span>
+          <span className={styles.oosBadge}>{labels.outOfStock}</span>
         ) : null}
       </div>
 

--- a/packages/create-skybridge/templates/ecom/src/components/product-carousel.css.ts
+++ b/packages/create-skybridge/templates/ecom/src/components/product-carousel.css.ts
@@ -1,0 +1,134 @@
+import { globalStyle, style } from "@vanilla-extract/css";
+import { recipe } from "@vanilla-extract/recipes";
+import { colors, primitives } from "../design/tokens";
+
+// Carousel tuning knobs. @todo: tune to your card design.
+const gap = primitives.space["2xs"]; // gap between cards
+// Cards visible at each width; the fractional part is the peek that signals the
+// row scrolls. If you change a count, adjust the gap multiplier in its
+// `--card-width` calc (full gaps visible = the whole-number part).
+const CARDS_VISIBLE = 2.5;
+const CARDS_VISIBLE_COMPACT = 1.5;
+// Below this container width, switch to the compact count.
+const COMPACT_MAX_WIDTH = "560px";
+
+// Structural wrapper (kept as a plain class so the nav-reveal globalStyle below
+// can target it). The recipe composes it as its base.
+const carouselBase = style({
+  position: "relative",
+  // Size cards against the carousel width, not the iframe viewport.
+  containerType: "inline-size",
+});
+
+// `framed: true` frames the whole carousel; the default is flush (pair it with
+// framed cards instead). Pick one of the two.
+export const carousel = recipe({
+  base: carouselBase,
+  variants: {
+    framed: {
+      // @todo: tune the outer frame to your brand. Soften the shadow in dark
+      // mode if the strip reads as a hard box against the host.
+      true: {
+        // Pad top/bottom only; the leading/trailing inset lives on the track's
+        // own `framed` variant so it scrolls away. Cards bleed to the left/right
+        // border, and `overflow: hidden` masks them to the rounded corners, so
+        // a scrolled card disappears exactly at the frame edge.
+        paddingBlock: primitives.space.xs,
+        borderRadius: primitives.radius.l,
+        border: `${primitives.stroke.thin} solid ${colors.border.thin}`,
+        backgroundColor: colors.surface.extraLight,
+        boxShadow: "0 10px 20px -20px rgba(0, 0, 0, 0.18)",
+        overflow: "hidden",
+      },
+      false: {},
+    },
+  },
+  defaultVariants: { framed: false },
+});
+
+// Kept as a plain class so the scrollbar-hiding globalStyle below can target it.
+// The recipe composes it as its base.
+const trackBase = style({
+  display: "flex",
+  gap,
+  overflowX: "auto",
+  scrollSnapType: "x mandatory",
+  scrollBehavior: "smooth",
+  scrollbarWidth: "none",
+  vars: { "--card-width": `calc((100% - 2 * ${gap}) / ${CARDS_VISIBLE})` },
+  "@container": {
+    [`(max-width: ${COMPACT_MAX_WIDTH})`]: {
+      vars: {
+        "--card-width": `calc((100% - ${gap}) / ${CARDS_VISIBLE_COMPACT})`,
+      },
+    },
+  },
+  "@media": {
+    "(prefers-reduced-motion: reduce)": { scrollBehavior: "auto" },
+  },
+});
+
+globalStyle(`${trackBase}::-webkit-scrollbar`, { display: "none" });
+
+// `framed: true` adds an inset on both ends. Padding on the scroll track (not on
+// the frame) so it shows before the first card and after the last at rest, but
+// scrolls away in between: a card scrolled past clips at the border, not at a
+// fixed gutter. scroll-padding keeps mandatory snap from collapsing the inset.
+export const track = recipe({
+  base: trackBase,
+  variants: {
+    framed: {
+      true: {
+        paddingInline: primitives.space.xs,
+        scrollPaddingInline: primitives.space.xs,
+      },
+      false: {},
+    },
+    // Skeleton state: lock the scroll, there is nothing to scroll to yet.
+    loading: {
+      true: { overflowX: "hidden" },
+      false: {},
+    },
+  },
+  defaultVariants: { framed: false, loading: false },
+});
+
+export const cell = style({
+  flex: "0 0 var(--card-width)",
+  scrollSnapAlign: "start",
+});
+
+// Prev/next buttons: desktop only. Hidden on touch, revealed on hover/focus,
+// disabled at the scroll ends.
+export const nav = style({
+  position: "absolute",
+  top: "50%",
+  transform: "translateY(-50%)",
+  display: "grid",
+  placeItems: "center",
+  width: "36px",
+  height: "36px",
+  padding: 0,
+  borderRadius: primitives.radius.full,
+  border: `${primitives.stroke.thin} solid ${colors.border.subtle}`,
+  backgroundColor: colors.surface.extraLight,
+  color: colors.content.intense,
+  cursor: "pointer",
+  opacity: 0,
+  transition: "opacity 150ms ease",
+  selectors: {
+    "&:disabled": { opacity: 0, pointerEvents: "none" },
+  },
+  "@media": {
+    "(hover: none)": { display: "none" },
+  },
+});
+
+export const navPrev = style({ left: primitives.space["3xs"] });
+export const navNext = style({ right: primitives.space["3xs"] });
+
+// Reveal the (enabled) buttons on hover or keyboard focus within the carousel.
+globalStyle(
+  `${carouselBase}:hover ${nav}:not(:disabled), ${carouselBase}:focus-within ${nav}:not(:disabled)`,
+  { opacity: 1 },
+);

--- a/packages/create-skybridge/templates/ecom/src/components/product-carousel.stories.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/product-carousel.stories.tsx
@@ -1,0 +1,64 @@
+import type { ReactNode } from "react";
+import type { Price } from "../types.js";
+import { ProductCard, ProductCardSkeleton } from "./product-card";
+import { ProductCarousel } from "./product-carousel";
+
+const IMAGE =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='240' height='240'%3E%3Crect width='240' height='240' fill='%23e5e5e5'/%3E%3Ccircle cx='120' cy='120' r='70' fill='%23bcbcbc'/%3E%3C/svg%3E";
+
+type Sample = { title: string; price: Price; outOfStock?: boolean };
+
+const SAMPLE: Sample[] = [
+  { title: "Merino wool sweater", price: { amount: 129.9, currency: "EUR" } },
+  { title: "Oxford cotton shirt", price: { amount: 79, currency: "EUR" } },
+  { title: "Slim chino trousers", price: { amount: 89.5, currency: "EUR" } },
+  {
+    title: "Leather derby shoes",
+    price: { amount: 210, currency: "EUR" },
+    outOfStock: true,
+  },
+  { title: "Cashmere scarf", price: { amount: 145, currency: "EUR" } },
+  { title: "Quilted field jacket", price: { amount: 320, currency: "EUR" } },
+];
+
+function sampleCards(): ReactNode[] {
+  const cards: ReactNode[] = [];
+  for (let i = 0; i < SAMPLE.length; i++) {
+    const item = SAMPLE[i];
+    cards.push(
+      <ProductCard
+        key={i}
+        title={item.title}
+        price={item.price}
+        media={[IMAGE]}
+        outOfStock={item.outOfStock}
+      />,
+    );
+  }
+  return cards;
+}
+
+export const Default = () => <ProductCarousel>{sampleCards()}</ProductCarousel>;
+
+export const Loading = () => {
+  const skeletons: ReactNode[] = [];
+  for (let i = 0; i < 4; i++) {
+    skeletons.push(<ProductCardSkeleton key={i} />);
+  }
+  return <ProductCarousel loading>{skeletons}</ProductCarousel>;
+};
+
+export const FewItems = () => (
+  <ProductCarousel>
+    <ProductCard
+      title="Merino wool sweater"
+      price={{ amount: 129.9, currency: "EUR" }}
+      media={[IMAGE]}
+    />
+    <ProductCard
+      title="Oxford cotton shirt"
+      price={{ amount: 79, currency: "EUR" }}
+      media={[IMAGE]}
+    />
+  </ProductCarousel>
+);

--- a/packages/create-skybridge/templates/ecom/src/components/product-carousel.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/product-carousel.tsx
@@ -1,0 +1,190 @@
+import {
+  Children,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { cx } from "../lib/cx";
+import * as styles from "./product-carousel.css";
+
+// How long to wait after the last intersection change before reporting, so a
+// fast scroll does not spam updates.
+const VISIBILITY_DEBOUNCE_MS = 200;
+
+// @todo: for boxed cards (border + background), set this to true and leave the
+// carousel unframed. Pick one, not both.
+const FRAMED = false;
+
+function Chevron({ direction }: { direction: "left" | "right" }) {
+  const d = direction === "left" ? "M15 18l-6-6 6-6" : "M9 18l6-6-6-6";
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d={d} />
+    </svg>
+  );
+}
+
+type ProductCarouselProps = {
+  children: ReactNode;
+  // Reports which child indices are at least half in view, in ascending order,
+  // debounced. Use it to narrate only what the user actually sees.
+  onVisibleChange?: (indices: number[]) => void;
+  // Skeleton state: locks the scroll and hides the nav buttons.
+  loading?: boolean;
+};
+
+/**
+ * Horizontal, scroll-snapping track of cards. Generic: it renders whatever
+ * children it is given, one per snap cell. Native scroll handles touch; the
+ * prev/next buttons are desktop-only affordances (see product-carousel.css.ts).
+ */
+export function ProductCarousel({
+  children,
+  onVisibleChange,
+  loading = false,
+}: ProductCarouselProps) {
+  const trackRef = useRef<HTMLElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  // Keep the latest callback in a ref so the observer effect does not
+  // re-subscribe when the parent passes a new function each render.
+  const onVisibleChangeRef = useRef(onVisibleChange);
+  onVisibleChangeRef.current = onVisibleChange;
+
+  const updateEdges = useCallback(() => {
+    const el = trackRef.current;
+    if (!el) {
+      return;
+    }
+    setCanScrollLeft(el.scrollLeft > 0);
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+  }, []);
+
+  useEffect(() => {
+    const el = trackRef.current;
+    if (!el) {
+      return;
+    }
+    updateEdges();
+    el.addEventListener("scroll", updateEdges, { passive: true });
+    const observer = new ResizeObserver(updateEdges);
+    observer.observe(el);
+    return () => {
+      el.removeEventListener("scroll", updateEdges);
+      observer.disconnect();
+    };
+  }, [updateEdges]);
+
+  // Track which cells are in view and report them (only when a consumer asks).
+  const childCount = Children.count(children);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: childCount re-subscribes the observer when the cell count changes; it is intentionally not read inside.
+  useEffect(() => {
+    const el = trackRef.current;
+    if (!el || !onVisibleChangeRef.current) {
+      return;
+    }
+    const cells = Array.from(el.children);
+    const visible = new Set<number>();
+    let timer: number | undefined;
+    const emit = () => {
+      const indices = [...visible].sort((a, b) => a - b);
+      onVisibleChangeRef.current?.(indices);
+    };
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          const index = cells.indexOf(entry.target);
+          if (index === -1) {
+            continue;
+          }
+          if (entry.isIntersecting) {
+            visible.add(index);
+          } else {
+            visible.delete(index);
+          }
+        }
+        window.clearTimeout(timer);
+        timer = window.setTimeout(emit, VISIBILITY_DEBOUNCE_MS);
+      },
+      { root: el, threshold: 0.5 },
+    );
+    for (const cell of cells) {
+      observer.observe(cell);
+    }
+    return () => {
+      window.clearTimeout(timer);
+      observer.disconnect();
+    };
+  }, [childCount]);
+
+  const step = (direction: 1 | -1) => {
+    const el = trackRef.current;
+    if (!el) {
+      return;
+    }
+    const cell = el.firstElementChild as HTMLElement | null;
+    const gap = Number.parseFloat(getComputedStyle(el).columnGap) || 0;
+    const distance = cell ? cell.offsetWidth + gap : el.clientWidth;
+    // No `behavior`: inherits the track's CSS scroll-behavior (respects
+    // prefers-reduced-motion).
+    el.scrollBy({ left: direction * distance });
+  };
+
+  const cells: ReactNode[] = [];
+  const items = Children.toArray(children);
+  for (let i = 0; i < items.length; i++) {
+    cells.push(
+      <div key={i} className={styles.cell}>
+        {items[i]}
+      </div>,
+    );
+  }
+
+  return (
+    <div className={styles.carousel({ framed: FRAMED })}>
+      <section
+        ref={trackRef}
+        className={styles.track({ framed: FRAMED, loading })}
+        aria-roledescription="carousel"
+        aria-label="Products"
+      >
+        {cells}
+      </section>
+      {loading ? null : (
+        <>
+          <button
+            type="button"
+            aria-label="Previous"
+            className={cx(styles.nav, styles.navPrev)}
+            disabled={!canScrollLeft}
+            onClick={() => step(-1)}
+          >
+            <Chevron direction="left" />
+          </button>
+          <button
+            type="button"
+            aria-label="Next"
+            className={cx(styles.nav, styles.navNext)}
+            disabled={!canScrollRight}
+            onClick={() => step(1)}
+          >
+            <Chevron direction="right" />
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/create-skybridge/templates/ecom/src/components/product-carousel.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/product-carousel.tsx
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { useLabels } from "../i18n";
 import { cx } from "../lib/cx";
 import * as styles from "./product-carousel.css";
 
@@ -55,6 +56,7 @@ export function ProductCarousel({
   onVisibleChange,
   loading = false,
 }: ProductCarouselProps) {
+  const labels = useLabels();
   const trackRef = useRef<HTMLElement>(null);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
@@ -158,8 +160,8 @@ export function ProductCarousel({
       <section
         ref={trackRef}
         className={styles.track({ framed: FRAMED, loading })}
-        aria-roledescription="carousel"
-        aria-label="Products"
+        aria-roledescription={labels.carousel}
+        aria-label={labels.products}
       >
         {cells}
       </section>
@@ -167,7 +169,7 @@ export function ProductCarousel({
         <>
           <button
             type="button"
-            aria-label="Previous"
+            aria-label={labels.previous}
             className={cx(styles.nav, styles.navPrev)}
             disabled={!canScrollLeft}
             onClick={() => step(-1)}
@@ -176,7 +178,7 @@ export function ProductCarousel({
           </button>
           <button
             type="button"
-            aria-label="Next"
+            aria-label={labels.next}
             className={cx(styles.nav, styles.navNext)}
             disabled={!canScrollRight}
             onClick={() => step(1)}

--- a/packages/create-skybridge/templates/ecom/src/components/product-carousel.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/product-carousel.tsx
@@ -92,10 +92,13 @@ export function ProductCarousel({
 
   // Track which cells are in view and report them (only when a consumer asks).
   const childCount = Children.count(children);
-  // biome-ignore lint/correctness/useExhaustiveDependencies: childCount re-subscribes the observer when the cell count changes; it is intentionally not read inside.
+  // Re-subscribe when a consumer starts (or stops) passing onVisibleChange, even
+  // if the child count is unchanged; the callback itself is read via the ref.
+  const observeVisibility = onVisibleChange != null;
+  // biome-ignore lint/correctness/useExhaustiveDependencies: childCount and observeVisibility drive re-subscription; neither is read inside the effect.
   useEffect(() => {
     const el = trackRef.current;
-    if (!el || !onVisibleChangeRef.current) {
+    if (!el || !observeVisibility) {
       return;
     }
     const cells = Array.from(el.children);
@@ -130,7 +133,7 @@ export function ProductCarousel({
       window.clearTimeout(timer);
       observer.disconnect();
     };
-  }, [childCount]);
+  }, [childCount, observeVisibility]);
 
   const step = (direction: 1 | -1) => {
     const el = trackRef.current;

--- a/packages/create-skybridge/templates/ecom/src/components/view-frame.css.ts
+++ b/packages/create-skybridge/templates/ecom/src/components/view-frame.css.ts
@@ -2,14 +2,12 @@ import { globalStyle, style } from "@vanilla-extract/css";
 import { colors, primitives } from "../design/tokens";
 
 /**
- * Base surface for the frame. Paints the page background (the theme's
- * surface.extraLight, so light and dark each get their own solid color) and
- * pins the design system's font + content color so descendants inherit from
- * the DS, not from the host page (whose text color could be white on a dark
- * host and make card text vanish).
+ * Base frame for every view. Transparent so the widget blends into the host
+ * surface; it pins the design system's font + content color so descendants
+ * inherit from the DS, not from the host page (whose text color could be white
+ * on a dark host and make card text vanish).
  */
 export const viewFrame = style({
-  backgroundColor: colors.surface.extraLight,
   color: colors.content.intense,
   fontFamily: primitives.font.family.primary,
   fontSize: primitives.font.size.m,

--- a/packages/create-skybridge/templates/ecom/src/i18n.ts
+++ b/packages/create-skybridge/templates/ecom/src/i18n.ts
@@ -1,0 +1,27 @@
+import { useUser } from "skybridge/web";
+
+// Centralized UI labels. The active locale comes from the host via useUser();
+// useLabels matches on the language subtag ("en-US" -> "en") and falls back to
+// English for anything unlisted.
+// @todo: adapt the English copy to your brand voice, and add a locale key (e.g.
+// `fr`) with the same shape for each language you want to support.
+const LABELS = {
+  en: {
+    outOfStock: "Out of stock",
+    noProducts: "No products to show.",
+    carousel: "carousel",
+    products: "Products",
+    previous: "Previous",
+    next: "Next",
+  },
+} as const;
+
+const DEFAULT_LOCALE = "en";
+
+type Labels = (typeof LABELS)[typeof DEFAULT_LOCALE];
+
+export function useLabels(): Labels {
+  const { locale } = useUser();
+  const lang = locale.split("-")[0] ?? DEFAULT_LOCALE;
+  return lang in LABELS ? LABELS[lang as keyof typeof LABELS] : LABELS.en;
+}

--- a/packages/create-skybridge/templates/ecom/src/lib/format.ts
+++ b/packages/create-skybridge/templates/ecom/src/lib/format.ts
@@ -1,0 +1,9 @@
+import type { Price } from "../types.js";
+
+// Pass useUser().locale from the view; omit for the runtime default.
+export function formatPrice(price: Price, locale?: string): string {
+  return new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency: price.currency,
+  }).format(price.amount);
+}

--- a/packages/create-skybridge/templates/ecom/src/tools/render-carousel.ts
+++ b/packages/create-skybridge/templates/ecom/src/tools/render-carousel.ts
@@ -55,7 +55,7 @@ type Variant = Meta & {
 
 // A product: one carousel card backed by one or more variants and the axes they
 // vary on (none for a single-variant product).
-type Product = {
+export type Product = {
   id: string; // stable product key
   options: Option[]; // the axes the variants vary on
   // Only the variants that actually exist. A missing combination (e.g. no
@@ -63,10 +63,10 @@ type Product = {
   // contingent variations are expressed. Derive the selectable values for an axis
   // by filtering this list on the choices already made.
   variants: Variant[];
-  // What the carousel card shows for the whole product. Optional: when omitted, the
-  // first variant is used. Set it to showcase a specific variant or give the product
-  // its own title/price, e.g. a "from" price spanning the variants.
-  card?: Meta;
+  // The product's carousel card. Surfaced both in the carousel (the view
+  // renders it) and to the model (structuredContent is projected from it).
+  // How you build it depends on your mapping strategy: see getProducts.
+  card: Meta;
 };
 
 // ---------------------------------------------------------------------------
@@ -122,7 +122,7 @@ async function getProducts(_ids: string[]): Promise<Product[]> {
   // `Product`s (rename `_ids` -> `ids` once you use it).
   //
   // First decide your mapping strategy — it depends on your catalog:
-  //   - no variants (simple products): one `Product`, a single variant, options: []
+  //   - no variants (simple products): one `Product`, a single variant, card = that variant, options: [],
   //   - grouped: one `Product` per product; `card` = union of its variants, one picture per requested variant
   //   - one card per requested variant: `card` = that variant
   // Either way, set `variants` to ALL variants the source returns for the product;
@@ -133,10 +133,10 @@ async function getProducts(_ids: string[]): Promise<Product[]> {
 }
 
 // ---------------------------------------------------------------------------
-// Mapping — trim products to the model-facing grounding (outputSchema). The full
-// data stays in `_meta` for the view. The card, else the first variant,
-// represents the product; options collapse to label + value labels.
-// @todo: choose what the model sees per product. Grounding only — no
+// Mapping: trim each product's `card` and `options` into the model-facing
+// grounding (outputSchema), dropping presentational fields (media, url). The
+// full data stays in `_meta` for the view.
+// @todo: choose what the model sees per product. Grounding only: no
 // presentational data (media, styling); that rides in `_meta` for the view.
 // ---------------------------------------------------------------------------
 
@@ -144,15 +144,7 @@ function toStructuredContent(products: Product[]): RenderOutput {
   const groundingProducts: RenderOutput["products"] = [];
 
   for (const product of products) {
-    const rep = product.card ?? product.variants[0];
-
-    let outOfStock = true;
-    for (const variant of product.variants) {
-      if (!variant.outOfStock) {
-        outOfStock = false;
-        break;
-      }
-    }
+    const { card } = product;
 
     const options: { label: string; values: string[] }[] = [];
     for (const option of product.options) {
@@ -165,12 +157,12 @@ function toStructuredContent(products: Product[]): RenderOutput {
 
     groundingProducts.push({
       id: product.id,
-      title: rep.title,
-      description: rep.description,
-      price: rep.price,
-      outOfStock,
+      title: card.title,
+      description: card.description,
+      price: card.price,
+      outOfStock: card.outOfStock ?? false,
       options,
-      attributes: rep.attributes,
+      attributes: card.attributes,
     });
   }
 
@@ -221,6 +213,7 @@ Use only the data returned for each product. Never invent attributes, materials,
   },
 
   inputSchema,
+  outputSchema,
 };
 
 export async function renderCarouselHandler({ ids }: RenderInput) {

--- a/packages/create-skybridge/templates/ecom/src/views/carousel/index.tsx
+++ b/packages/create-skybridge/templates/ecom/src/views/carousel/index.tsx
@@ -1,28 +1,89 @@
 import "../../index.css";
 
+import { type ReactNode, useState } from "react";
+import { EmptyState } from "../../components/empty-state";
+import {
+  ProductCard,
+  ProductCardSkeleton,
+} from "../../components/product-card";
+import { ProductCarousel } from "../../components/product-carousel";
 import { ViewFrame } from "../../components/view-frame";
-import { sprinkles, text } from "../../design/tokens";
+import { sprinkles } from "../../design/tokens";
 import { useToolInfo } from "../../helpers.js";
+import { formatPrice } from "../../lib/format";
+import type { Product } from "../../tools/render-carousel.js";
+
+const SKELETON_COUNT = 4;
+
+// One narration line per on-screen product. `id` ties the card back to its full
+// record in structuredContent.
+function narrate(product: Product, index: number): string {
+  const { card } = product;
+  const price = card.price ? ` - ${formatPrice(card.price)}` : "";
+  const oos = card.outOfStock ? " [out of stock]" : "";
+  return `${index + 1}. ${card.title} (id: ${product.id})${price}${oos}`;
+}
 
 /**
- * Carousel view for the `render-carousel` tool.
- *
- * The tool puts the full products (with variants + media) in `_meta.products`,
- * read here via useToolInfo().responseMetadata. `structuredContent` is the
- * model's grounding and is NOT used to render.
+ * Carousel view for the `render-carousel` tool. Reads the full products from
+ * `_meta` (via useToolInfo().responseMetadata) and renders one card each.
+ * `structuredContent` is the model's grounding and is not used to render.
  */
 function Carousel() {
   const { responseMetadata } = useToolInfo<"render-carousel">();
-  const products =
-    (responseMetadata as { products?: unknown[] } | null)?.products ?? [];
+  const [visibleIndices, setVisibleIndices] = useState<number[]>([]);
+
+  // Tool still resolving: reserve the layout with skeleton cards.
+  if (responseMetadata == null) {
+    const skeletons: ReactNode[] = [];
+    for (let i = 0; i < SKELETON_COUNT; i++) {
+      skeletons.push(<ProductCardSkeleton key={i} />);
+    }
+    return (
+      <ViewFrame>
+        <div className={sprinkles({ p: "3xs" })}>
+          <ProductCarousel loading>{skeletons}</ProductCarousel>
+        </div>
+      </ViewFrame>
+    );
+  }
+
+  const products = responseMetadata?.products ?? [];
+
+  if (products.length === 0) {
+    return (
+      <ViewFrame>
+        <EmptyState message="No products to show." />
+      </ViewFrame>
+    );
+  }
+
+  const cards: ReactNode[] = [];
+  for (const [index, product] of products.entries()) {
+    const { card } = product;
+    cards.push(
+      <ProductCard
+        key={product.id}
+        data-llm={visibleIndices.includes(index) ? narrate(product, index) : ""}
+        title={card.title}
+        price={card.price}
+        media={card.media}
+        outOfStock={card.outOfStock}
+      />,
+    );
+  }
+
+  const narration = `Carousel of ${products.length} product(s); the user scrolls horizontally. On screen now:`;
 
   return (
     <ViewFrame>
-      <div className={sprinkles({ p: "s" })}>
-        <p className={text({ style: "bodyM" })}>
-          {/* placeholder: replace this placeholder with the product carousel. */}
-          Carousel view: {products.length} product(s).
-        </p>
+      <div className={sprinkles({ p: "3xs" })}>
+        <ProductCarousel
+          onVisibleChange={setVisibleIndices}
+          data-llm={narration}
+        >
+          {cards}
+        </ProductCarousel>
       </div>
     </ViewFrame>
   );

--- a/packages/create-skybridge/templates/ecom/src/views/carousel/index.tsx
+++ b/packages/create-skybridge/templates/ecom/src/views/carousel/index.tsx
@@ -10,6 +10,7 @@ import { ProductCarousel } from "../../components/product-carousel";
 import { ViewFrame } from "../../components/view-frame";
 import { sprinkles } from "../../design/tokens";
 import { useToolInfo } from "../../helpers.js";
+import { useLabels } from "../../i18n";
 import { formatPrice } from "../../lib/format";
 import type { Product } from "../../tools/render-carousel.js";
 
@@ -32,6 +33,7 @@ function narrate(product: Product, index: number): string {
 function Carousel() {
   const { responseMetadata } = useToolInfo<"render-carousel">();
   const [visibleIndices, setVisibleIndices] = useState<number[]>([]);
+  const labels = useLabels();
 
   // Tool still resolving: reserve the layout with skeleton cards.
   if (responseMetadata == null) {
@@ -53,7 +55,7 @@ function Carousel() {
   if (products.length === 0) {
     return (
       <ViewFrame>
-        <EmptyState message="No products to show." />
+        <EmptyState message={labels.noProducts} />
       </ViewFrame>
     );
   }

--- a/skills/chatgpt-app-builder/references/ecommerce.md
+++ b/skills/chatgpt-app-builder/references/ecommerce.md
@@ -185,6 +185,12 @@ For an internal tool or prototype with no brand, keep the neutral primitives. Se
 
 The view layer under `src/components/` and `src/views/`, built on the design system. Preview any component in Ladle (`{pm} run ladle`; each `*.stories.tsx` is a story); the devtools emulator shows a view against a live tool call. One feature per subsection.
 
+#### Labels (i18n)
+
+All user-facing text is centralized in `src/i18n.ts`, shared across every component. `useLabels()` reads the host locale from `useUser()`, matches on the language subtag (`en-US` -> `en`), and falls back to English. Ships English only.
+
+- [ ] `src/i18n.ts`: adapt the English label copy to the brand voice, and add a locale key per language you want to support.
+
 #### Carousel
 
 `render-carousel`'s inline view (`src/views/carousel/`), plus `ProductCard` (image, title, price, out-of-stock; presentational), `ProductCarousel` (scroll-snap track and desktop nav buttons; reports on-screen cards), and `EmptyState`. The view reads `responseMetadata.products` (the tool's `_meta`), renders one card per product, and narrates the on-screen ones via `data-llm`.

--- a/skills/chatgpt-app-builder/references/ecommerce.md
+++ b/skills/chatgpt-app-builder/references/ecommerce.md
@@ -43,11 +43,11 @@ src/
     sprinkles.css.ts             atomic style props
     recipes/typography.css.ts    the `text` recipe
     tokens.ts                    barrel (single import door)
-  components/view-frame.tsx    ViewFrame: activates the theme
-  views/carousel/              carousel view skeleton (separate effort)
+  components/                  ViewFrame, ProductCard, ProductCarousel, EmptyState
+  views/carousel/              the render-carousel view (reads _meta, renders cards)
 ```
 
-The template is `@todo`-driven: `grep -rn "@todo" src` lists every decision point. The two subsections below, **Server** and **Design system**, are independent: do them in either order, resolving every `@todo` and verifying as you go. `{pm} run build` typechecks the whole tree at any point.
+The template is `@todo`-driven: `grep -rn "@todo" src` lists every decision point. The subsections below (**Server**, **Design system**, **Components**) each own their markers: Server and Design system are independent; Components build on the Design system. Resolve every `@todo` and verify as you go. `{pm} run build` typechecks the whole tree at any point.
 
 ### Server
 
@@ -93,18 +93,18 @@ Confirm `result.structuredContent` carries real products from the live source (`
 
 Takes the curated IDs and returns the products for the carousel. The full product data (variants, media, options) rides in `_meta` for the view; a trimmed grounding subset goes to `structuredContent` for the model.
 
-- [ ] Product model (`Product`, `Variant`, `Option`, `Meta`): match your catalog. A `Product` groups sibling `Variant`s and declares the `Option` axes. `variants` is sparse (list only the combinations that exist; a missing one encodes a contingent variation). `card` is the variant or union shown on the carousel card.
+- [ ] Product model (`Product`, `Variant`, `Option`, `Meta`): match your catalog. A `Product` groups sibling `Variant`s and declares the `Option` axes. `variants` is sparse (list only the combinations that exist; a missing one encodes a contingent variation). `card` (required) is what the carousel shows for the product: it is surfaced both in the view (rendered directly) and to the model (`structuredContent` is projected from it).
 - [ ] `getProducts()`: fetch each id and map results into `Product[]`. Pick a mapping strategy (see below).
-- [ ] `toStructuredContent()`: choose the model-facing fields per product (grounding only; the view reads the full data from `_meta`).
+- [ ] `toStructuredContent()`: trim each product's `card` and `options` into the model-facing grounding, dropping presentational fields (media, url). The view reads the full products from `_meta`.
 - [ ] `description`: adapt the wording and brand voice; the behavioral rules (order, no-repeat, accuracy) apply to any catalog.
 - [ ] `_meta`: the invoking and invoked status messages.
-- [ ] `view` (once built): point it at your carousel view under `src/views/render-carousel`.
+- [ ] `view`: already wired to the `carousel` view (`view: { component: "carousel" }`); customize it in the Components subsection.
 
 ##### Mapping ids to products (`getProducts`)
 
-`getProducts` turns the curated ids into `Product[]`. It is unprescriptive: choose what fits your catalog. Whatever `search-products` put in each `id` is what arrives here, so keep the two tools consistent.
+`getProducts` turns the curated ids into `Product[]`. It is unprescriptive: choose what fits your catalog. Whatever `search-products` put in each `id` is what arrives here, so keep the two tools consistent. Every `Product` must set `card` (displayed in carousel, surfaced to llm); how you build it depends on the strategy.
 
-**Products have no variants (simple products).** Map each id to a `Product` with a single variant and `options: []`. Nothing else to decide.
+**Products have no variants (simple products).** Map each id to a `Product` with a single variant, `card` set to that variant, and `options: []`. Nothing else to decide.
 
 **Products have variants.** Choose how variants become carousel cards:
 
@@ -128,7 +128,7 @@ Confirm `result._meta.products` carries the full products for the view and `resu
 
 ### Design system
 
-Reskin the vanilla-extract design system (`src/design/`) to the brand, using the assets gathered in step 1. The carousel view that consumes it is a skeleton; building it out is a separate effort, so this is only about the tokens and theme.
+Reskin the vanilla-extract design system (`src/design/`) to the brand, using the assets gathered in step 1. This subsection is only the tokens and theme; the components that consume them are in Components below.
 
 #### The layers
 
@@ -179,4 +179,17 @@ For an internal tool or prototype with no brand, keep the neutral primitives. Se
 
 #### Verify
 
-`{pm} run build` compiles the tokens and type-checks the themes (the contract fails the build if either theme leaves a slot unset). Preview the result in the devtools emulator, or with `{pm} run ladle` once you add component stories.
+`{pm} run build` compiles the tokens and type-checks the themes (the contract fails the build if either theme leaves a slot unset). Preview the result in the devtools emulator or with `{pm} run ladle`.
+
+### Components
+
+The view layer under `src/components/` and `src/views/`, built on the design system. Preview any component in Ladle (`{pm} run ladle`; each `*.stories.tsx` is a story); the devtools emulator shows a view against a live tool call. One feature per subsection.
+
+#### Carousel
+
+`render-carousel`'s inline view (`src/views/carousel/`), plus `ProductCard` (image, title, price, out-of-stock; presentational), `ProductCarousel` (scroll-snap track and desktop nav buttons; reports on-screen cards), and `EmptyState`. The view reads `responseMetadata.products` (the tool's `_meta`), renders one card per product, and narrates the on-screen ones via `data-llm`.
+
+- [ ] `product-card.css.ts`: `TITLE_LINES` (title clamp); the surface token behind the image; image fit (`contain` vs `cover`).
+- [ ] `product-card.tsx`: extra images from `media` (e.g. hover cross-fade to `media[1]`); extra fields from `attributes` (ratings, tags, badges).
+- [ ] `product-carousel.css.ts`: tuning knobs (`gap`, `CARDS_VISIBLE`, `CARDS_VISIBLE_COMPACT`, `COMPACT_MAX_WIDTH`).
+- [ ] Framing: the `FRAMED` flag boxes each card (`product-card.tsx`, includes its skeleton) or the whole strip (`product-carousel.tsx`). Both `false` for plain cards (default); set at most one to `true`, never both. If you enable one, tune the frame (padding, border, radius, shadow) in `product-card.css.ts` or `product-carousel.css.ts`.


### PR DESCRIPTION
this adds the carousel, not the product detail view

what's in it:
- components: ProductCard (image, title, price, out-of-stock) with a matching skeleton, ProductCarousel (scroll-snap track, desktop-only nav buttons, reports which cards are on screen), and EmptyState
- the carousel view: reads the full products from _meta, renders one card each, and narrates only the on-screen cards back to the model via data-llm
- i18n labels
- ladle stories for every component, so you can preview each state without a running server

framing is a template choice: the container chrome (border, background, rounded corners) can sit on each card or on the whole strip, toggled by a FRAMED flag in product-card.tsx or product-carousel.tsx. both default to false (plain, flush on the host surface), and you pick at most one. the framed carousel keeps its leading and trailing inset on the scroll track itself, so a card scrolled past clips right at the border instead of vanishing into a padding gutter, while the first and last card still rest with breathing room. the loading state locks the scroll and hides the nav buttons.

also synced the chatgpt-app-builder ecommerce.md reference so its component and framing todos match the code.