### PR TITLE
feat: add product details

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,6 +91,10 @@ jobs:
         working-directory: ./packages/create-skybridge/templates/blank
         run: pnpm pkg set 'dependencies.skybridge=^${{ steps.version.outputs.version }}'
 
+      - name: Pin ecom template skybridge dep for publish
+        working-directory: ./packages/create-skybridge/templates/ecom
+        run: pnpm pkg set 'dependencies.skybridge=^${{ steps.version.outputs.version }}'
+
       - name: Publish create-skybridge to npm
         working-directory: ./packages/create-skybridge
         run: pnpm publish --tag ${{ steps.version.outputs.tag }} --access public --provenance --no-git-checks
@@ -101,7 +105,7 @@ jobs:
 
       - name: Restore templates workspace deps
         if: github.event_name == 'release'
-        run: git checkout -- packages/create-skybridge/templates/demo/package.json packages/create-skybridge/templates/blank/package.json
+        run: git checkout -- packages/create-skybridge/templates/demo/package.json packages/create-skybridge/templates/blank/package.json packages/create-skybridge/templates/ecom/package.json
 
       - name: Deploy docs to Mintlify
         if: github.event_name == 'release'

--- a/packages/create-skybridge/templates/ecom/src/components/chip.css.ts
+++ b/packages/create-skybridge/templates/ecom/src/components/chip.css.ts
@@ -1,0 +1,56 @@
+import { style } from "@vanilla-extract/css";
+import { recipe } from "@vanilla-extract/recipes";
+import { colors, primitives } from "../design/tokens";
+
+// A selectable pill used for option values (sizes, colors…). `selected` and
+// `disabled` are driven by the variant picker from the sparse variant list.
+// @todo: tune the chip to your brand (radius, borders, selected treatment).
+export const chip = recipe({
+  base: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: primitives.space["4xs"],
+    minHeight: "44px", // touch target
+    padding: `${primitives.space["4xs"]} ${primitives.space["3xs"]}`,
+    borderRadius: primitives.radius.m,
+    border: `${primitives.stroke.thin} solid ${colors.border.subtle}`,
+    backgroundColor: colors.surface.extraLight,
+    color: colors.content.intense,
+    fontFamily: primitives.font.family.primary,
+    fontSize: primitives.font.size.s,
+    cursor: "pointer",
+    transition: "border-color 150ms ease",
+    "@media": {
+      "(prefers-reduced-motion: reduce)": { transition: "none" },
+    },
+  },
+  variants: {
+    selected: {
+      true: {
+        borderColor: colors.common.accent,
+        borderWidth: primitives.stroke.medium,
+      },
+      false: {},
+    },
+    disabled: {
+      // Unreachable value given the other choices: greyed and struck, but kept
+      // visible so the client sees the axis exists (never silently hidden).
+      true: {
+        cursor: "not-allowed",
+        opacity: 0.4,
+        textDecoration: "line-through",
+      },
+      false: {},
+    },
+  },
+  defaultVariants: { selected: false, disabled: false },
+});
+
+// Small color/material swatch shown before the label on image chips.
+export const swatch = style({
+  width: "20px",
+  height: "20px",
+  borderRadius: primitives.radius.full,
+  objectFit: "cover",
+  display: "block",
+});

--- a/packages/create-skybridge/templates/ecom/src/components/chip.stories.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/chip.stories.tsx
@@ -3,7 +3,12 @@ import { Chip } from "./chip";
 const SWATCH =
   "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20'%3E%3Crect width='20' height='20' fill='%233b6cf0'/%3E%3C/svg%3E";
 
-const row = { display: "flex", gap: 8, flexWrap: "wrap" as const, maxWidth: 320 };
+const row = {
+  display: "flex",
+  gap: 8,
+  flexWrap: "wrap" as const,
+  maxWidth: 320,
+};
 
 export const States = () => (
   <div style={row}>

--- a/packages/create-skybridge/templates/ecom/src/components/chip.stories.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/chip.stories.tsx
@@ -1,0 +1,21 @@
+import { Chip } from "./chip";
+
+const SWATCH =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20'%3E%3Crect width='20' height='20' fill='%233b6cf0'/%3E%3C/svg%3E";
+
+const row = { display: "flex", gap: 8, flexWrap: "wrap" as const, maxWidth: 320 };
+
+export const States = () => (
+  <div style={row}>
+    <Chip label="M" />
+    <Chip label="L" selected />
+    <Chip label="XL" disabled />
+  </div>
+);
+
+export const WithSwatch = () => (
+  <div style={row}>
+    <Chip label="Blue" media={SWATCH} selected />
+    <Chip label="Black" media={SWATCH} />
+  </div>
+);

--- a/packages/create-skybridge/templates/ecom/src/components/chip.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/chip.tsx
@@ -1,0 +1,34 @@
+import * as styles from "./chip.css";
+
+type ChipProps = {
+  label: string;
+  selected?: boolean;
+  disabled?: boolean;
+  onSelect?: () => void;
+  // Optional swatch image (e.g. one per color); omit for a plain text chip.
+  media?: string;
+};
+
+/**
+ * One option value as a selectable pill. Rendered as a `radio` inside the
+ * variant picker's `radiogroup`; the picker owns selection state and passes
+ * `selected`/`disabled` computed from the sparse variant list.
+ */
+export function Chip({ label, selected, disabled, onSelect, media }: ChipProps) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={selected ?? false}
+      aria-disabled={disabled ?? false}
+      disabled={disabled}
+      className={styles.chip({ selected, disabled })}
+      onClick={disabled ? undefined : onSelect}
+    >
+      {media ? (
+        <img className={styles.swatch} src={media} alt="" draggable={false} />
+      ) : null}
+      {label}
+    </button>
+  );
+}

--- a/packages/create-skybridge/templates/ecom/src/components/chip.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/chip.tsx
@@ -22,6 +22,7 @@ export function Chip({
   media,
 }: ChipProps) {
   return (
+    // biome-ignore lint/a11y/useSemanticElements: custom radio; a styled button carries the swatch and disabled state a native radio cannot, inside the picker radiogroup.
     <button
       type="button"
       role="radio"

--- a/packages/create-skybridge/templates/ecom/src/components/chip.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/chip.tsx
@@ -14,7 +14,13 @@ type ChipProps = {
  * variant picker's `radiogroup`; the picker owns selection state and passes
  * `selected`/`disabled` computed from the sparse variant list.
  */
-export function Chip({ label, selected, disabled, onSelect, media }: ChipProps) {
+export function Chip({
+  label,
+  selected,
+  disabled,
+  onSelect,
+  media,
+}: ChipProps) {
   return (
     <button
       type="button"

--- a/packages/create-skybridge/templates/ecom/src/components/expandable-text.css.ts
+++ b/packages/create-skybridge/templates/ecom/src/components/expandable-text.css.ts
@@ -1,0 +1,49 @@
+import { style } from "@vanilla-extract/css";
+import { recipe } from "@vanilla-extract/recipes";
+import { colors, primitives } from "../design/tokens";
+
+// @todo: collapsed height before "read more" appears. Tune to your type scale.
+const COLLAPSED_MAX_HEIGHT = "6em";
+
+export const container = style({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "flex-start",
+  gap: primitives.space["4xs"],
+});
+
+// `clamp` caps the height (applied whenever collapsed, so overflow can be
+// measured); `fade` masks the last line to a soft cutoff instead of an ellipsis
+// and is applied only when the text actually overflows (never on short copy).
+export const body = recipe({
+  base: {
+    color: colors.content.intense,
+    whiteSpace: "pre-line", // preserve paragraph breaks from the source
+  },
+  variants: {
+    clamp: {
+      true: { maxHeight: COLLAPSED_MAX_HEIGHT, overflow: "hidden" },
+      false: {},
+    },
+    fade: {
+      true: {
+        maskImage:
+          "linear-gradient(to bottom, black 0%, black 55%, transparent 100%)",
+        WebkitMaskImage:
+          "linear-gradient(to bottom, black 0%, black 55%, transparent 100%)",
+      },
+      false: {},
+    },
+  },
+  defaultVariants: { clamp: false, fade: false },
+});
+
+export const toggle = style({
+  padding: 0,
+  border: "none",
+  background: "none",
+  color: colors.common.accent,
+  fontFamily: primitives.font.family.primary,
+  fontSize: primitives.font.size.s,
+  cursor: "pointer",
+});

--- a/packages/create-skybridge/templates/ecom/src/components/expandable-text.stories.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/expandable-text.stories.tsx
@@ -1,0 +1,18 @@
+import { ExpandableText } from "./expandable-text";
+
+const frame = { maxWidth: 360 };
+
+const LONG =
+  "A relaxed-fit jacket in water-repellent cotton.\n\nDropped shoulders, a two-way zip, and ribbed cuffs. Fully lined, with two zip pockets at the front and one inside. Designed to layer over a knit through the cooler months, and cut long enough to sit past the hip.";
+
+export const Long = () => (
+  <div style={frame}>
+    <ExpandableText>{LONG}</ExpandableText>
+  </div>
+);
+
+export const Short = () => (
+  <div style={frame}>
+    <ExpandableText>A short description that never needs a toggle.</ExpandableText>
+  </div>
+);

--- a/packages/create-skybridge/templates/ecom/src/components/expandable-text.stories.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/expandable-text.stories.tsx
@@ -13,6 +13,8 @@ export const Long = () => (
 
 export const Short = () => (
   <div style={frame}>
-    <ExpandableText>A short description that never needs a toggle.</ExpandableText>
+    <ExpandableText>
+      A short description that never needs a toggle.
+    </ExpandableText>
   </div>
 );

--- a/packages/create-skybridge/templates/ecom/src/components/expandable-text.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/expandable-text.tsx
@@ -1,0 +1,52 @@
+import { useLayoutEffect, useRef, useState } from "react";
+import { text } from "../design/tokens";
+import { useLabels } from "../i18n";
+import { cx } from "../lib/cx";
+import * as styles from "./expandable-text.css";
+
+/**
+ * Clamps long copy to a few lines with a "read more" toggle. Truncation is
+ * measured, not assumed: the toggle only appears when the text actually
+ * overflows the collapsed height, so short copy shows no button.
+ */
+export function ExpandableText({ children }: { children: string }) {
+  const labels = useLabels();
+  const bodyRef = useRef<HTMLParagraphElement>(null);
+  const [expanded, setExpanded] = useState(false);
+  const [overflows, setOverflows] = useState(false);
+
+  const collapsed = !expanded;
+
+  // Measure against the collapsed height (the clamp is applied whenever
+  // collapsed, so scrollHeight vs clientHeight is meaningful). Re-run when the
+  // text changes (e.g. the client switches variant) so the toggle tracks it.
+  useLayoutEffect(() => {
+    const el = bodyRef.current;
+    if (el && collapsed) {
+      setOverflows(el.scrollHeight > el.clientHeight + 1);
+    }
+  }, [children, collapsed]);
+
+  return (
+    <div className={styles.container}>
+      <p
+        ref={bodyRef}
+        className={cx(
+          text({ style: "bodyS" }),
+          styles.body({ clamp: collapsed, fade: collapsed && overflows }),
+        )}
+      >
+        {children}
+      </p>
+      {overflows ? (
+        <button
+          type="button"
+          className={styles.toggle}
+          onClick={() => setExpanded((v) => !v)}
+        >
+          {expanded ? labels.readLess : labels.readMore}
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/create-skybridge/templates/ecom/src/components/expandable-text.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/expandable-text.tsx
@@ -20,6 +20,7 @@ export function ExpandableText({ children }: { children: string }) {
   // Measure against the collapsed height (the clamp is applied whenever
   // collapsed, so scrollHeight vs clientHeight is meaningful). Re-run when the
   // text changes (e.g. the client switches variant) so the toggle tracks it.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: children re-triggers the measure, it is not read in the body.
   useLayoutEffect(() => {
     const el = bodyRef.current;
     if (el && collapsed) {

--- a/packages/create-skybridge/templates/ecom/src/components/image-gallery.css.ts
+++ b/packages/create-skybridge/templates/ecom/src/components/image-gallery.css.ts
@@ -14,7 +14,9 @@ export const galleryRail = style({
       display: "flex",
       flexDirection: "row",
       gap: primitives.space["2xs"],
-      alignItems: "stretch",
+      // Top-align so the rail sits beside the image; the rail's own max-height
+      // (set from the measured image height) caps it and scrolls the excess.
+      alignItems: "flex-start",
     },
   },
 });
@@ -116,7 +118,8 @@ export const progressMobileOnly = style({
 });
 
 // Desktop thumbnail rail (THUMBNAIL_RAIL). Hidden on mobile, where the swipe
-// track + progress bar own navigation. @todo: tune the rail width / thumb size.
+// track + progress bar own navigation. Capped to the image height via an inline
+// max-height and scrolls the excess. @todo: tune the rail width / thumb size.
 export const rail = style({
   display: "none",
   "@container": {

--- a/packages/create-skybridge/templates/ecom/src/components/image-gallery.css.ts
+++ b/packages/create-skybridge/templates/ecom/src/components/image-gallery.css.ts
@@ -1,0 +1,169 @@
+import { globalStyle, style } from "@vanilla-extract/css";
+import { colors, primitives } from "../design/tokens";
+
+export const gallery = style({
+  position: "relative",
+});
+
+// Rail mode only (THUMBNAIL_RAIL): lay the rail beside the image on desktop. The
+// breakpoint matches the PDP's two-column grid and resolves against the same
+// `.detail` container, so the rail appears exactly when the page goes two-column.
+export const galleryRail = style({
+  "@container": {
+    "(min-width: 560px)": {
+      display: "flex",
+      flexDirection: "row",
+      gap: primitives.space["2xs"],
+      alignItems: "stretch",
+    },
+  },
+});
+
+// Image column: the positioning context for the overlaid chevrons, and the flex
+// child that takes the width left of the rail on desktop.
+export const mainCol = style({
+  position: "relative",
+  minWidth: 0,
+  "@container": {
+    "(min-width: 560px)": { flex: 1 },
+  },
+});
+
+// Scroll-snap track: one image per view. Native swipe on touch; the chevrons
+// are the pointer affordance. Scrollbar hidden.
+export const track = style({
+  display: "flex",
+  overflowX: "auto",
+  scrollSnapType: "x mandatory",
+  scrollBehavior: "smooth",
+  scrollbarWidth: "none",
+  borderRadius: primitives.radius.m,
+  "@media": {
+    "(prefers-reduced-motion: reduce)": { scrollBehavior: "auto" },
+  },
+});
+
+globalStyle(`${track}::-webkit-scrollbar`, { display: "none" });
+
+export const slide = style({
+  flex: "0 0 100%",
+  scrollSnapAlign: "start",
+  // Reserve a square box so images load without shifting the page. @todo: match
+  // the carousel card's aspect ratio / fit if you changed them there.
+  aspectRatio: "1",
+  backgroundColor: colors.surface.subtle,
+});
+
+export const image = style({
+  width: "100%",
+  height: "100%",
+  objectFit: "contain",
+  display: "block",
+  pointerEvents: "none",
+  userSelect: "none",
+});
+
+// Prev/next chevrons, vertically centered, disabled at the ends.
+export const nav = style({
+  position: "absolute",
+  top: "50%",
+  transform: "translateY(-50%)",
+  display: "grid",
+  placeItems: "center",
+  width: "36px",
+  height: "36px",
+  padding: 0,
+  borderRadius: primitives.radius.full,
+  border: `${primitives.stroke.thin} solid ${colors.border.subtle}`,
+  backgroundColor: colors.surface.extraLight,
+  color: colors.content.intense,
+  cursor: "pointer",
+  transition: "opacity 150ms ease",
+  selectors: {
+    "&:disabled": { opacity: 0, pointerEvents: "none" },
+  },
+});
+
+export const navPrev = style({ left: primitives.space["3xs"] });
+export const navNext = style({ right: primitives.space["3xs"] });
+
+// Position indicator: a thin track with a fill sized to (index + 1) / count.
+// @todo: style to your brand — height, track/fill colors, radius, width, and placement.
+export const progress = style({
+  height: "3px",
+  marginTop: primitives.space["3xs"],
+  borderRadius: primitives.radius.full,
+  backgroundColor: colors.border.thin,
+  overflow: "hidden",
+});
+
+export const progressFill = style({
+  height: "100%",
+  borderRadius: primitives.radius.full,
+  backgroundColor: colors.content.intense,
+  transition: "width 200ms ease",
+  "@media": {
+    "(prefers-reduced-motion: reduce)": { transition: "none" },
+  },
+});
+
+// In rail mode the rail conveys position on desktop, so the progress bar is
+// mobile-only there.
+export const progressMobileOnly = style({
+  "@container": {
+    "(min-width: 560px)": { display: "none" },
+  },
+});
+
+// Desktop thumbnail rail (THUMBNAIL_RAIL). Hidden on mobile, where the swipe
+// track + progress bar own navigation. @todo: tune the rail width / thumb size.
+export const rail = style({
+  display: "none",
+  "@container": {
+    "(min-width: 560px)": {
+      display: "flex",
+      flexDirection: "column",
+      flexShrink: 0,
+      gap: primitives.space["2xs"],
+      width: "64px",
+      minHeight: 0,
+      overflowY: "auto",
+      scrollbarWidth: "none",
+    },
+  },
+});
+
+globalStyle(`${rail}::-webkit-scrollbar`, { display: "none" });
+
+export const thumb = style({
+  boxSizing: "border-box",
+  flexShrink: 0,
+  width: "100%",
+  aspectRatio: "1",
+  minHeight: 0, // let aspect-ratio win over the flex-item default min-height
+  padding: primitives.space["4xs"],
+  borderRadius: primitives.radius.m,
+  border: `${primitives.stroke.thin} solid ${colors.border.subtle}`,
+  backgroundColor: colors.surface.extraLight,
+  cursor: "pointer",
+  transition: "border-color 150ms ease",
+  "@media": {
+    "(prefers-reduced-motion: reduce)": { transition: "none" },
+  },
+});
+
+// Selected thumb: thicker, accented border. border-box keeps the width swap from
+// shifting the rail layout.
+export const thumbActive = style({
+  borderColor: colors.common.accent,
+  borderWidth: primitives.stroke.medium,
+});
+
+export const thumbImage = style({
+  width: "100%",
+  height: "100%",
+  objectFit: "contain",
+  display: "block",
+  pointerEvents: "none",
+  userSelect: "none",
+});

--- a/packages/create-skybridge/templates/ecom/src/components/image-gallery.stories.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/image-gallery.stories.tsx
@@ -1,0 +1,30 @@
+import { ImageGallery } from "./image-gallery";
+
+function shot(fill: string) {
+  return `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='400'%3E%3Crect width='400' height='400' fill='%23${fill}'/%3E%3Ccircle cx='200' cy='200' r='110' fill='%23ffffff' fill-opacity='0.5'/%3E%3C/svg%3E`;
+}
+
+// The gallery's desktop layout (and the optional THUMBNAIL_RAIL) query a
+// `container-type` host, which the PDP's `.detail` provides in the app. The
+// story supplies its own so it previews at a realistic width and renders
+// correctly whichever way THUMBNAIL_RAIL is set — swipe when off, rail when on.
+const frame = {
+  containerType: "inline-size" as const,
+  width: 600,
+  maxWidth: "100%",
+};
+
+export const Multiple = () => (
+  <div style={frame}>
+    <ImageGallery
+      media={[shot("e1e1e1"), shot("c9d4f5"), shot("f5d4c9")]}
+      alt="Product"
+    />
+  </div>
+);
+
+export const Single = () => (
+  <div style={frame}>
+    <ImageGallery media={[shot("e1e1e1")]} alt="Product" />
+  </div>
+);

--- a/packages/create-skybridge/templates/ecom/src/components/image-gallery.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/image-gallery.tsx
@@ -1,0 +1,164 @@
+import { useEffect, useRef, useState } from "react";
+import { useLabels } from "../i18n";
+import { cx } from "../lib/cx";
+import * as styles from "./image-gallery.css";
+
+// @todo: show a thumbnail rail beside the image on desktop (at the two-column
+// breakpoint); swipe-only when false. Off by default. When true, tune the rail
+// width / thumb size in image-gallery.css.ts. Deferred polish (add if the rail
+// earns it): an edge-fade mask and auto-centering the active thumb, both of
+// which need a vertical scroll-edges hook.
+const THUMBNAIL_RAIL: boolean = false;
+
+function Chevron({ direction }: { direction: "left" | "right" }) {
+  const d = direction === "left" ? "M15 18l-6-6 6-6" : "M9 18l6-6-6-6";
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d={d} />
+    </svg>
+  );
+}
+
+/**
+ * Product image gallery: a native scroll-snap track with prev/next chevrons and
+ * a progress bar; the current index is read from scroll position (no library).
+ * With the rail on, a desktop thumbnail rail is added as a second controller of
+ * the SAME track (shared index, click = scroll). Mobile is always the swipe
+ * track.
+ */
+export function ImageGallery({ media, alt }: { media: string[]; alt: string }) {
+  const labels = useLabels();
+  const trackRef = useRef<HTMLDivElement>(null);
+  const railRef = useRef<HTMLDivElement>(null);
+  const [index, setIndex] = useState(0);
+  const [imageHeight, setImageHeight] = useState<number>();
+
+  function onScroll() {
+    const el = trackRef.current;
+    if (el) {
+      setIndex(Math.round(el.scrollLeft / el.clientWidth));
+    }
+  }
+
+  function scrollToIndex(i: number) {
+    const el = trackRef.current;
+    if (el) {
+      el.scrollTo({ left: i * el.clientWidth });
+    }
+  }
+
+  // Rail only: cap the rail to the main image's height so it scrolls instead of
+  // stretching the layout. A vertical scroll container needs a definite height;
+  // the square image provides it, measured here.
+  useEffect(() => {
+    if (!THUMBNAIL_RAIL) {
+      return;
+    }
+    const el = trackRef.current;
+    if (!el) {
+      return;
+    }
+    const measure = () => setImageHeight(el.clientHeight);
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  const multiple = media.length > 1;
+
+  return (
+    <div
+      className={cx(styles.gallery, THUMBNAIL_RAIL && styles.galleryRail)}
+      aria-roledescription={labels.carousel}
+      aria-label={alt}
+    >
+      {THUMBNAIL_RAIL && multiple ? (
+        <div
+          ref={railRef}
+          className={styles.rail}
+          style={{ maxHeight: imageHeight ? `${imageHeight}px` : undefined }}
+        >
+          {media.map((src, i) => (
+            <button
+              key={src}
+              type="button"
+              className={cx(styles.thumb, i === index && styles.thumbActive)}
+              aria-label={`${alt} (${i + 1})`}
+              aria-current={i === index}
+              onClick={() => scrollToIndex(i)}
+            >
+              <img
+                className={styles.thumbImage}
+                src={src}
+                alt=""
+                draggable={false}
+              />
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      <div className={styles.mainCol}>
+        <div ref={trackRef} className={styles.track} onScroll={onScroll}>
+          {media.map((src, i) => (
+            <div key={src} className={styles.slide}>
+              <img
+                className={styles.image}
+                src={src}
+                alt={i === 0 ? alt : ""}
+                loading={i === 0 ? "eager" : "lazy"}
+                draggable={false}
+              />
+            </div>
+          ))}
+        </div>
+
+        {multiple ? (
+          <>
+            <button
+              type="button"
+              aria-label={labels.previous}
+              className={cx(styles.nav, styles.navPrev)}
+              disabled={index === 0}
+              onClick={() => scrollToIndex(index - 1)}
+            >
+              <Chevron direction="left" />
+            </button>
+            <button
+              type="button"
+              aria-label={labels.next}
+              className={cx(styles.nav, styles.navNext)}
+              disabled={index === media.length - 1}
+              onClick={() => scrollToIndex(index + 1)}
+            >
+              <Chevron direction="right" />
+            </button>
+            <div
+              className={cx(
+                styles.progress,
+                THUMBNAIL_RAIL && styles.progressMobileOnly,
+              )}
+              aria-hidden="true"
+            >
+              <div
+                className={styles.progressFill}
+                style={{ width: `${((index + 1) / media.length) * 100}%` }}
+              />
+            </div>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/packages/create-skybridge/templates/ecom/src/components/image-gallery.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/image-gallery.tsx
@@ -57,6 +57,14 @@ export function ImageGallery({ media, alt }: { media: string[]; alt: string }) {
     }
   }
 
+  // The gallery stays mounted across a variant switch, so reset to the first
+  // image when the media set changes; otherwise a stale index can point past a
+  // shorter set (bad progress width, wrong nav state).
+  useEffect(() => {
+    setIndex(0);
+    trackRef.current?.scrollTo({ left: 0 });
+  }, [media]);
+
   // Rail only: cap the rail to the main image's height so it scrolls instead of
   // stretching the layout. A vertical scroll container needs a definite height;
   // the square image provides it, measured here.

--- a/packages/create-skybridge/templates/ecom/src/components/image-gallery.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/image-gallery.tsx
@@ -39,7 +39,6 @@ function Chevron({ direction }: { direction: "left" | "right" }) {
 export function ImageGallery({ media, alt }: { media: string[]; alt: string }) {
   const labels = useLabels();
   const trackRef = useRef<HTMLDivElement>(null);
-  const railRef = useRef<HTMLDivElement>(null);
   const [index, setIndex] = useState(0);
   const [imageHeight, setImageHeight] = useState<number>();
 
@@ -56,14 +55,6 @@ export function ImageGallery({ media, alt }: { media: string[]; alt: string }) {
       el.scrollTo({ left: i * el.clientWidth });
     }
   }
-
-  // The gallery stays mounted across a variant switch, so reset to the first
-  // image when the media set changes; otherwise a stale index can point past a
-  // shorter set (bad progress width, wrong nav state).
-  useEffect(() => {
-    setIndex(0);
-    trackRef.current?.scrollTo({ left: 0 });
-  }, [media]);
 
   // Rail only: cap the rail to the main image's height so it scrolls instead of
   // stretching the layout. A vertical scroll container needs a definite height;
@@ -86,14 +77,13 @@ export function ImageGallery({ media, alt }: { media: string[]; alt: string }) {
   const multiple = media.length > 1;
 
   return (
-    <div
+    <section
       className={cx(styles.gallery, THUMBNAIL_RAIL && styles.galleryRail)}
       aria-roledescription={labels.carousel}
       aria-label={alt}
     >
       {THUMBNAIL_RAIL && multiple ? (
         <div
-          ref={railRef}
           className={styles.rail}
           style={{ maxHeight: imageHeight ? `${imageHeight}px` : undefined }}
         >
@@ -167,6 +157,6 @@ export function ImageGallery({ media, alt }: { media: string[]; alt: string }) {
           </>
         ) : null}
       </div>
-    </div>
+    </section>
   );
 }

--- a/packages/create-skybridge/templates/ecom/src/components/image-gallery.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/image-gallery.tsx
@@ -5,9 +5,9 @@ import * as styles from "./image-gallery.css";
 
 // @todo: show a thumbnail rail beside the image on desktop (at the two-column
 // breakpoint); swipe-only when false. Off by default. When true, tune the rail
-// width / thumb size in image-gallery.css.ts. Deferred polish (add if the rail
-// earns it): an edge-fade mask and auto-centering the active thumb, both of
-// which need a vertical scroll-edges hook.
+// width / thumb size in image-gallery.css.ts. The rail is capped to the image
+// height and scrolls its excess; deferred polish (add if it earns it): an
+// edge-fade mask and auto-centering the active thumb.
 const THUMBNAIL_RAIL: boolean = false;
 
 function Chevron({ direction }: { direction: "left" | "right" }) {
@@ -56,9 +56,9 @@ export function ImageGallery({ media, alt }: { media: string[]; alt: string }) {
     }
   }
 
-  // Rail only: cap the rail to the main image's height so it scrolls instead of
-  // stretching the layout. A vertical scroll container needs a definite height;
-  // the square image provides it, measured here.
+  // Rail only: cap the rail to the main image's height so its extra thumbnails
+  // scroll instead of dangling past the image. A vertical scroll container needs
+  // a definite height; the square image provides it, measured here.
   useEffect(() => {
     if (!THUMBNAIL_RAIL) {
       return;

--- a/packages/create-skybridge/templates/ecom/src/components/product-card.css.ts
+++ b/packages/create-skybridge/templates/ecom/src/components/product-card.css.ts
@@ -31,6 +31,25 @@ export const card = recipe({
   defaultVariants: { framed: false },
 });
 
+// Turns a whole card into one tap target (opens the detail view) using the
+// stretched-link pattern: the card renders normally, and a transparent <button>
+// overlays it. A real button (not role="button") gives keyboard + screen-reader
+// support for free, and it holds no flow content, so the markup stays valid
+// (a <button> wrapping the card's <article>/<p> would not be).
+export const cardClickable = style({ position: "relative" });
+
+export const cardButton = style({
+  position: "absolute",
+  inset: 0,
+  width: "100%",
+  height: "100%",
+  padding: 0,
+  border: "none",
+  background: "none",
+  cursor: "pointer",
+  borderRadius: primitives.radius.m,
+});
+
 export const imageBox = style({
   position: "relative",
   aspectRatio: "1",

--- a/packages/create-skybridge/templates/ecom/src/components/product-carousel.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/product-carousel.tsx
@@ -1,6 +1,7 @@
 import {
   Children,
   type ReactNode,
+  type RefObject,
   useCallback,
   useEffect,
   useRef,
@@ -44,6 +45,10 @@ type ProductCarouselProps = {
   onVisibleChange?: (indices: number[]) => void;
   // Skeleton state: locks the scroll and hides the nav buttons.
   loading?: boolean;
+  // Optional external ref to the scroll track. The orchestrator uses it to save
+  // and restore scroll position across the carousel ⇄ detail transition (the
+  // carousel is hidden, not unmounted, but display:none resets scrollLeft).
+  trackRef?: RefObject<HTMLElement | null>;
 };
 
 /**
@@ -55,9 +60,11 @@ export function ProductCarousel({
   children,
   onVisibleChange,
   loading = false,
+  trackRef: externalTrackRef,
 }: ProductCarouselProps) {
   const labels = useLabels();
-  const trackRef = useRef<HTMLElement>(null);
+  const internalTrackRef = useRef<HTMLElement>(null);
+  const trackRef = externalTrackRef ?? internalTrackRef;
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
 

--- a/packages/create-skybridge/templates/ecom/src/components/product-carousel.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/product-carousel.tsx
@@ -63,30 +63,31 @@ export function ProductCarousel({
   trackRef: externalTrackRef,
 }: ProductCarouselProps) {
   const labels = useLabels();
-  const internalTrackRef = useRef<HTMLElement>(null);
-  const trackRef = externalTrackRef ?? internalTrackRef;
+  const trackRef = useRef<HTMLElement>(null);
+  // Merge the internal ref with the optional external one via a callback ref, so
+  // the orchestrator can read/restore scroll while `trackRef` stays a plain
+  // useRef (its `.current` reads need no effect dependency).
+  const setTrackRef = useCallback(
+    (el: HTMLElement | null) => {
+      trackRef.current = el;
+      if (externalTrackRef) {
+        externalTrackRef.current = el;
+      }
+    },
+    [externalTrackRef],
+  );
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
-
-  // Keep the latest callback in a ref so the observer effect does not
-  // re-subscribe when the parent passes a new function each render.
-  const onVisibleChangeRef = useRef(onVisibleChange);
-  onVisibleChangeRef.current = onVisibleChange;
-
-  const updateEdges = useCallback(() => {
-    const el = trackRef.current;
-    if (!el) {
-      return;
-    }
-    setCanScrollLeft(el.scrollLeft > 0);
-    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
-  }, []);
 
   useEffect(() => {
     const el = trackRef.current;
     if (!el) {
       return;
     }
+    const updateEdges = () => {
+      setCanScrollLeft(el.scrollLeft > 0);
+      setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+    };
     updateEdges();
     el.addEventListener("scroll", updateEdges, { passive: true });
     const observer = new ResizeObserver(updateEdges);
@@ -95,17 +96,16 @@ export function ProductCarousel({
       el.removeEventListener("scroll", updateEdges);
       observer.disconnect();
     };
-  }, [updateEdges]);
+  }, []);
 
   // Track which cells are in view and report them (only when a consumer asks).
+  // Pass a stable `onVisibleChange` (e.g. a useState setter): a new identity
+  // each render re-subscribes the observer.
   const childCount = Children.count(children);
-  // Re-subscribe when a consumer starts (or stops) passing onVisibleChange, even
-  // if the child count is unchanged; the callback itself is read via the ref.
-  const observeVisibility = onVisibleChange != null;
-  // biome-ignore lint/correctness/useExhaustiveDependencies: childCount and observeVisibility drive re-subscription; neither is read inside the effect.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: childCount re-subscribes when the number of cells changes; it is not read in the body.
   useEffect(() => {
     const el = trackRef.current;
-    if (!el || !observeVisibility) {
+    if (!el || !onVisibleChange) {
       return;
     }
     const cells = Array.from(el.children);
@@ -113,7 +113,7 @@ export function ProductCarousel({
     let timer: number | undefined;
     const emit = () => {
       const indices = [...visible].sort((a, b) => a - b);
-      onVisibleChangeRef.current?.(indices);
+      onVisibleChange?.(indices);
     };
     const observer = new IntersectionObserver(
       (entries) => {
@@ -140,7 +140,7 @@ export function ProductCarousel({
       window.clearTimeout(timer);
       observer.disconnect();
     };
-  }, [childCount, observeVisibility]);
+  }, [childCount, onVisibleChange]);
 
   const step = (direction: 1 | -1) => {
     const el = trackRef.current;
@@ -168,7 +168,7 @@ export function ProductCarousel({
   return (
     <div className={styles.carousel({ framed: FRAMED })}>
       <section
-        ref={trackRef}
+        ref={setTrackRef}
         className={styles.track({ framed: FRAMED, loading })}
         aria-roledescription={labels.carousel}
         aria-label={labels.products}

--- a/packages/create-skybridge/templates/ecom/src/components/variant-picker.css.ts
+++ b/packages/create-skybridge/templates/ecom/src/components/variant-picker.css.ts
@@ -1,0 +1,27 @@
+import { style } from "@vanilla-extract/css";
+import { colors, primitives } from "../design/tokens";
+
+export const picker = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: primitives.space.xs,
+});
+
+export const section = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: primitives.space["3xs"],
+});
+
+export const label = style({
+  color: colors.content.subtle,
+});
+
+// Chip row: wraps to the next line when it overflows. @todo: swap for a
+// horizontal scroll row with an edge fade (as the carousel track) if you expect
+// many values on one axis.
+export const values = style({
+  display: "flex",
+  flexWrap: "wrap",
+  gap: primitives.space["3xs"],
+});

--- a/packages/create-skybridge/templates/ecom/src/components/variant-picker.stories.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/variant-picker.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import type { Product } from "../tools/render-carousel.js";
 import { initialSelection, type Selection } from "../lib/variants.js";
+import type { Product } from "../tools/render-carousel.js";
 import { VariantPicker } from "./variant-picker";
 
 // A sparse catalog: {black,40}, {black,42}, {white,40} exist — but not

--- a/packages/create-skybridge/templates/ecom/src/components/variant-picker.stories.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/variant-picker.stories.tsx
@@ -5,7 +5,11 @@ import { VariantPicker } from "./variant-picker";
 
 // A sparse catalog: {black,40}, {black,42}, {white,40} exist — but not
 // {white,42}. Picking "White" therefore disables "42".
-function variant(id: string, color: string, size: string): Product["variants"][number] {
+function variant(
+  id: string,
+  color: string,
+  size: string,
+): Product["variants"][number] {
   return {
     id,
     selection: { color, size },

--- a/packages/create-skybridge/templates/ecom/src/components/variant-picker.stories.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/variant-picker.stories.tsx
@@ -1,0 +1,60 @@
+import { useState } from "react";
+import type { Product } from "../tools/render-carousel.js";
+import { initialSelection, type Selection } from "../lib/variants.js";
+import { VariantPicker } from "./variant-picker";
+
+// A sparse catalog: {black,40}, {black,42}, {white,40} exist — but not
+// {white,42}. Picking "White" therefore disables "42".
+function variant(id: string, color: string, size: string): Product["variants"][number] {
+  return {
+    id,
+    selection: { color, size },
+    title: `Sneaker ${color} ${size}`,
+    price: { amount: 120, currency: "EUR" },
+    media: [],
+    attributes: [],
+  };
+}
+
+const PRODUCT: Product = {
+  id: "sneaker",
+  options: [
+    {
+      id: "color",
+      label: "Color",
+      values: [
+        { id: "black", label: "Black" },
+        { id: "white", label: "White" },
+      ],
+    },
+    {
+      id: "size",
+      label: "Size",
+      values: [
+        { id: "40", label: "40" },
+        { id: "42", label: "42" },
+      ],
+    },
+  ],
+  variants: [
+    variant("s-b-40", "black", "40"),
+    variant("s-b-42", "black", "42"),
+    variant("s-w-40", "white", "40"),
+  ],
+  card: { title: "Sneaker", media: [], attributes: [] },
+};
+
+export const Contingency = () => {
+  const [selection, setSelection] = useState<Selection>(() =>
+    initialSelection(PRODUCT),
+  );
+  return (
+    <div style={{ maxWidth: 320 }}>
+      <VariantPicker
+        product={PRODUCT}
+        selection={selection}
+        onChange={setSelection}
+      />
+    </div>
+  );
+};

--- a/packages/create-skybridge/templates/ecom/src/components/variant-picker.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/variant-picker.tsx
@@ -1,0 +1,82 @@
+import { text } from "../design/tokens";
+import { cx } from "../lib/cx";
+import type { Product } from "../tools/render-carousel.js";
+import {
+  type Selection,
+  selectableValues,
+} from "../lib/variants.js";
+import { Chip } from "./chip";
+import * as styles from "./variant-picker.css";
+
+type VariantPickerProps = {
+  product: Product;
+  selection: Selection;
+  onChange: (selection: Selection) => void;
+};
+
+/**
+ * Renders one section per option axis and resolves the client's choices against
+ * the product's SPARSE variant list. Values with no surviving variant (given
+ * the other choices) are disabled, not hidden. Selecting a value that strands an
+ * earlier choice drops that choice so the selection stays reachable.
+ *
+ * This is the in-place model: every axis is local state, no remount. @todo: if
+ * a catalog models an axis (e.g. color) as separate products, promote it to a
+ * cross-product switch that changes the opened product id instead.
+ */
+export function VariantPicker({
+  product,
+  selection,
+  onChange,
+}: VariantPickerProps) {
+  function choose(axisId: string, valueId: string) {
+    const next: Selection = { ...selection, [axisId]: valueId };
+    // Repair: drop any other-axis choice the new pick just made unreachable.
+    for (const option of product.options) {
+      if (option.id === axisId) {
+        continue;
+      }
+      const chosen = next[option.id];
+      if (chosen != null && !selectableValues(product, option.id, next).has(chosen)) {
+        delete next[option.id];
+      }
+    }
+    onChange(next);
+  }
+
+  return (
+    <div className={styles.picker}>
+      {product.options.map((option) => {
+        // A single-value axis is not a choice; skip it.
+        if (option.values.length <= 1) {
+          return null;
+        }
+        const reachable = selectableValues(product, option.id, selection);
+        return (
+          <div
+            key={option.id}
+            className={styles.section}
+            role="radiogroup"
+            aria-label={option.label}
+          >
+            <span className={cx(text({ style: "labelS" }), styles.label)}>
+              {option.label}
+            </span>
+            <div className={styles.values}>
+              {option.values.map((value) => (
+                <Chip
+                  key={value.id}
+                  label={value.label}
+                  media={value.media}
+                  selected={selection[option.id] === value.id}
+                  disabled={!reachable.has(value.id)}
+                  onSelect={() => choose(option.id, value.id)}
+                />
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/create-skybridge/templates/ecom/src/components/variant-picker.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/variant-picker.tsx
@@ -1,10 +1,7 @@
 import { text } from "../design/tokens";
 import { cx } from "../lib/cx";
 import type { Product } from "../tools/render-carousel.js";
-import {
-  type Selection,
-  selectableValues,
-} from "../lib/variants.js";
+import { type Selection, selectableValues } from "../lib/variants.js";
 import { Chip } from "./chip";
 import * as styles from "./variant-picker.css";
 
@@ -37,7 +34,10 @@ export function VariantPicker({
         continue;
       }
       const chosen = next[option.id];
-      if (chosen != null && !selectableValues(product, option.id, next).has(chosen)) {
+      if (
+        chosen != null &&
+        !selectableValues(product, option.id, next).has(chosen)
+      ) {
         delete next[option.id];
       }
     }

--- a/packages/create-skybridge/templates/ecom/src/components/variant-picker.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/variant-picker.tsx
@@ -1,7 +1,7 @@
 import { text } from "../design/tokens";
 import { cx } from "../lib/cx";
-import type { Product } from "../tools/render-carousel.js";
 import { type Selection, selectableValues } from "../lib/variants.js";
+import type { Product } from "../tools/render-carousel.js";
 import { Chip } from "./chip";
 import * as styles from "./variant-picker.css";
 

--- a/packages/create-skybridge/templates/ecom/src/i18n.ts
+++ b/packages/create-skybridge/templates/ecom/src/i18n.ts
@@ -13,12 +13,19 @@ const LABELS = {
     products: "Products",
     previous: "Previous",
     next: "Next",
+    // Detail view.
+    viewOnSite: "View on site",
+    selectOptions: "Select options",
+    priceOnRequest: "Price on request",
+    specifications: "Specifications",
+    readMore: "Read more",
+    readLess: "Read less",
   },
 } as const;
 
 const DEFAULT_LOCALE = "en";
 
-type Labels = (typeof LABELS)[typeof DEFAULT_LOCALE];
+export type Labels = (typeof LABELS)[typeof DEFAULT_LOCALE];
 
 export function useLabels(): Labels {
   const { locale } = useUser();

--- a/packages/create-skybridge/templates/ecom/src/lib/variants.ts
+++ b/packages/create-skybridge/templates/ecom/src/lib/variants.ts
@@ -1,0 +1,79 @@
+import type { Product, Variant } from "../tools/render-carousel.js";
+
+// Pure helpers that turn the client's option choices into a concrete variant.
+// The `variants` list is SPARSE: only combinations that exist are present, and
+// that is the whole contingency model. These helpers never encode rules; they
+// filter the list.
+
+// A selection is one chosen value per axis, keyed by Option.id -> OptionValue.id.
+export type Selection = Record<string, string>;
+
+/**
+ * The variant matching a full selection (one value per axis), or undefined if
+ * the selection is partial or the combination does not exist. A product with no
+ * options resolves to its single variant on an empty selection.
+ */
+export function resolveVariant(
+  product: Product,
+  selection: Selection,
+): Variant | undefined {
+  for (const option of product.options) {
+    if (selection[option.id] == null) {
+      return undefined; // partial selection: nothing resolved yet
+    }
+  }
+  return product.variants.find((variant) =>
+    product.options.every(
+      (option) => variant.selection[option.id] === selection[option.id],
+    ),
+  );
+}
+
+/**
+ * The values of `axisId` still reachable given the choices already made on the
+ * OTHER axes. A value is reachable if at least one variant carries it while
+ * matching every other current choice. Values not in this set have no surviving
+ * variant, so the picker disables them ("Red only in M").
+ */
+export function selectableValues(
+  product: Product,
+  axisId: string,
+  selection: Selection,
+): Set<string> {
+  const reachable = new Set<string>();
+  for (const variant of product.variants) {
+    let matchesOthers = true;
+    for (const option of product.options) {
+      if (option.id === axisId) {
+        continue;
+      }
+      const chosen = selection[option.id];
+      if (chosen != null && variant.selection[option.id] !== chosen) {
+        matchesOthers = false;
+        break;
+      }
+    }
+    if (matchesOthers) {
+      reachable.add(variant.selection[axisId]);
+    }
+  }
+  return reachable;
+}
+
+/**
+ * The selection to preselect when a product opens: the variant the client
+ * tapped (its id equals the opened product id), else the first variant. A
+ * variant is always preselected when the product has any, so the buy CTA is
+ * live on open rather than starting disabled.
+ */
+export function initialSelection(product: Product): Selection {
+  let base: Variant | undefined;
+  for (const variant of product.variants) {
+    if (variant.id === product.id) {
+      base = variant;
+      break;
+    }
+  }
+  base ??= product.variants[0];
+  return base ? { ...base.selection } : {};
+}

--- a/packages/create-skybridge/templates/ecom/src/tools/render-carousel.ts
+++ b/packages/create-skybridge/templates/ecom/src/tools/render-carousel.ts
@@ -46,7 +46,7 @@ type Meta = {
 };
 
 // One buyable product: full display Meta plus which value it takes on each axis.
-type Variant = Meta & {
+export type Variant = Meta & {
   id: string; // SKU / article number; unique within the catalog
   // The chosen value per axis: keys are Option.id, values are OptionValue.id.
   // e.g. { color: "black", size: "40" }
@@ -204,12 +204,20 @@ Use only the data returned for each product. Never invent attributes, materials,
     "openai/toolInvocation/invoked": "Loaded product carousel",
   },
 
-  // The carousel view rendered inline in the conversation.
+  // The carousel and product details UI rendered inline in the conversation.
   view: {
     // `as const` keeps this a literal (like `name` above) so it matches the
     // generated ViewNameRegistry; a bare string widens and fails the build.
     component: "carousel" as const,
     description: "Browse the curated products.",
+    // @todo: declare the CSP domains this view needs. Add your image origins to
+    // `resourceDomains` so product images load, and the product site to
+    // `redirectDomains` so the detail view's "View on site" link and the host's
+    // "Open in app" URL (useOpenExternal / setOpenInAppUrl) are allowed.
+    // csp: {
+    //   resourceDomains: ["https://images.example.com"],
+    //   redirectDomains: ["https://www.example.com"],
+    // },
   },
 
   inputSchema,

--- a/packages/create-skybridge/templates/ecom/src/views/carousel/detail/detail.css.ts
+++ b/packages/create-skybridge/templates/ecom/src/views/carousel/detail/detail.css.ts
@@ -72,7 +72,10 @@ export const specRow = style({
 });
 
 export const specName = style({ color: colors.content.subtle });
-export const specValue = style({ color: colors.content.intense, textAlign: "right" });
+export const specValue = style({
+  color: colors.content.intense,
+  textAlign: "right",
+});
 
 // Primary CTA. @todo: tune to your brand; add a secondary action beside it
 // (ask-the-assistant, contact) as a per-catalog extension.

--- a/packages/create-skybridge/templates/ecom/src/views/carousel/detail/detail.css.ts
+++ b/packages/create-skybridge/templates/ecom/src/views/carousel/detail/detail.css.ts
@@ -1,0 +1,97 @@
+import { style } from "@vanilla-extract/css";
+import { colors, primitives } from "../../../design/tokens";
+
+// Two-column breakpoint. Layout is driven by the pane's own width (container
+// query), never the viewport, so a phone and a resized desktop pane agree.
+const TWO_COLUMN_MIN_WIDTH = "560px";
+
+export const detail = style({
+  containerType: "inline-size",
+  padding: primitives.space.s,
+  // Clear the notch / home indicator when the page bleeds to the screen edge.
+  paddingBottom: `calc(${primitives.space.s} + env(safe-area-inset-bottom))`,
+});
+
+// Single column by default; two columns (gallery | info) once the pane is wide.
+export const grid = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: primitives.space.s,
+  maxWidth: "1099px",
+  marginInline: "auto",
+  "@container": {
+    [`(min-width: ${TWO_COLUMN_MIN_WIDTH})`]: {
+      display: "grid",
+      // `minmax(0, 1fr)` (not `1fr`) lets a column shrink below its content's
+      // intrinsic width, so a chip row scrolls/wraps instead of blowing out.
+      gridTemplateColumns: "minmax(0, 1fr) minmax(0, 1fr)",
+      gridTemplateAreas: '"gallery info"',
+      alignItems: "start",
+    },
+  },
+});
+
+export const galleryCell = style({
+  "@container": {
+    [`(min-width: ${TWO_COLUMN_MIN_WIDTH})`]: {
+      gridArea: "gallery",
+      position: "sticky",
+      top: primitives.space.s,
+    },
+  },
+});
+
+// The info column owns all inter-section spacing; sections set no outer margin.
+export const info = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: primitives.space.xs,
+  "@container": {
+    [`(min-width: ${TWO_COLUMN_MIN_WIDTH})`]: { gridArea: "info" },
+  },
+});
+
+export const title = style({ color: colors.content.intense });
+
+export const price = style({ color: colors.content.intense });
+
+export const oos = style({ color: colors.common.error });
+
+export const specs = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: primitives.space["4xs"],
+});
+
+export const specRow = style({
+  display: "flex",
+  justifyContent: "space-between",
+  gap: primitives.space.s,
+  borderBottom: `${primitives.stroke.thin} solid ${colors.border.thin}`,
+  paddingBottom: primitives.space["4xs"],
+});
+
+export const specName = style({ color: colors.content.subtle });
+export const specValue = style({ color: colors.content.intense, textAlign: "right" });
+
+// Primary CTA. @todo: tune to your brand; add a secondary action beside it
+// (ask-the-assistant, contact) as a per-catalog extension.
+export const cta = style({
+  minHeight: "44px",
+  padding: `${primitives.space["3xs"]} ${primitives.space.s}`,
+  borderRadius: primitives.radius.m,
+  border: "none",
+  backgroundColor: colors.common.accent,
+  color: colors.content.invertIntense,
+  fontFamily: primitives.font.family.primary,
+  fontSize: primitives.font.size.m,
+  fontWeight: primitives.font.weight.medium,
+  cursor: "pointer",
+  selectors: {
+    "&:disabled": {
+      backgroundColor: colors.surface.intense,
+      color: colors.content.subtle,
+      cursor: "not-allowed",
+    },
+  },
+});

--- a/packages/create-skybridge/templates/ecom/src/views/carousel/detail/detail.stories.tsx
+++ b/packages/create-skybridge/templates/ecom/src/views/carousel/detail/detail.stories.tsx
@@ -10,7 +10,12 @@ const DESCRIPTION =
 
 // Two axes with a sparse variant set: {black,M}, {black,L}, {sand,M} exist —
 // so choosing "Sand" disables "L".
-function jacket(id: string, color: string, colorLabel: string, size: string): Product["variants"][number] {
+function jacket(
+  id: string,
+  color: string,
+  colorLabel: string,
+  size: string,
+): Product["variants"][number] {
   return {
     id,
     selection: { color, size },
@@ -59,9 +64,7 @@ const PRODUCT: Product = {
   },
 };
 
-export const Default = () => (
-  <DetailView product={PRODUCT} />
-);
+export const Default = () => <DetailView product={PRODUCT} />;
 
 // Single-variant product: no picker, buyable immediately.
 const SIMPLE: Product = {
@@ -87,6 +90,4 @@ const SIMPLE: Product = {
   },
 };
 
-export const SingleVariant = () => (
-  <DetailView product={SIMPLE} />
-);
+export const SingleVariant = () => <DetailView product={SIMPLE} />;

--- a/packages/create-skybridge/templates/ecom/src/views/carousel/detail/detail.stories.tsx
+++ b/packages/create-skybridge/templates/ecom/src/views/carousel/detail/detail.stories.tsx
@@ -1,0 +1,92 @@
+import type { Product } from "../../../tools/render-carousel.js";
+import { DetailView } from "./index";
+
+function shot(fill: string) {
+  return `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='400'%3E%3Crect width='400' height='400' fill='%23${fill}'/%3E%3Ccircle cx='200' cy='200' r='110' fill='%23ffffff' fill-opacity='0.5'/%3E%3C/svg%3E`;
+}
+
+const DESCRIPTION =
+  "A relaxed-fit jacket in water-repellent cotton.\n\nDropped shoulders, a two-way zip, and ribbed cuffs. Fully lined, with two zip pockets at the front and one inside.";
+
+// Two axes with a sparse variant set: {black,M}, {black,L}, {sand,M} exist —
+// so choosing "Sand" disables "L".
+function jacket(id: string, color: string, colorLabel: string, size: string): Product["variants"][number] {
+  return {
+    id,
+    selection: { color, size },
+    title: `Field jacket — ${colorLabel}`,
+    description: DESCRIPTION,
+    price: { amount: color === "sand" ? 249 : 229, currency: "EUR" },
+    media: [shot(color === "sand" ? "d8c7a8" : "2b2b2b"), shot("c9d4f5")],
+    url: "https://example.com/jacket",
+    attributes: [
+      { name: "Material", value: "Water-repellent cotton" },
+      { name: "Fit", value: "Relaxed" },
+    ],
+  };
+}
+
+const PRODUCT: Product = {
+  id: "field-jacket",
+  options: [
+    {
+      id: "color",
+      label: "Color",
+      values: [
+        { id: "black", label: "Black", media: shot("2b2b2b") },
+        { id: "sand", label: "Sand", media: shot("d8c7a8") },
+      ],
+    },
+    {
+      id: "size",
+      label: "Size",
+      values: [
+        { id: "m", label: "M" },
+        { id: "l", label: "L" },
+      ],
+    },
+  ],
+  variants: [
+    jacket("fj-black-m", "black", "Black", "m"),
+    jacket("fj-black-l", "black", "Black", "l"),
+    jacket("fj-sand-m", "sand", "Sand", "m"),
+  ],
+  card: {
+    title: "Field jacket",
+    price: { amount: 229, currency: "EUR" },
+    media: [shot("2b2b2b")],
+    attributes: [],
+  },
+};
+
+export const Default = () => (
+  <DetailView product={PRODUCT} />
+);
+
+// Single-variant product: no picker, buyable immediately.
+const SIMPLE: Product = {
+  id: "tote",
+  options: [],
+  variants: [
+    {
+      id: "tote",
+      selection: {},
+      title: "Canvas tote",
+      description: "A sturdy everyday canvas tote.",
+      price: { amount: 39, currency: "EUR" },
+      media: [shot("e1e1e1")],
+      url: "https://example.com/tote",
+      attributes: [{ name: "Material", value: "Canvas" }],
+    },
+  ],
+  card: {
+    title: "Canvas tote",
+    price: { amount: 39, currency: "EUR" },
+    media: [shot("e1e1e1")],
+    attributes: [],
+  },
+};
+
+export const SingleVariant = () => (
+  <DetailView product={SIMPLE} />
+);

--- a/packages/create-skybridge/templates/ecom/src/views/carousel/detail/detail.stories.tsx
+++ b/packages/create-skybridge/templates/ecom/src/views/carousel/detail/detail.stories.tsx
@@ -5,6 +5,27 @@ function shot(fill: string) {
   return `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='400'%3E%3Crect width='400' height='400' fill='%23${fill}'/%3E%3Ccircle cx='200' cy='200' r='110' fill='%23ffffff' fill-opacity='0.5'/%3E%3C/svg%3E`;
 }
 
+// A long media set (primary shot + several accents) so the desktop thumbnail
+// rail is taller than the image and overflows past its bottom.
+const ACCENT_FILLS = [
+  "c9d4f5",
+  "f5d4c9",
+  "d4f5c9",
+  "f5f0c9",
+  "e0c9f5",
+  "c9f5f0",
+  "f5c9e0",
+  "d9d9d9",
+];
+
+function galleryMedia(primaryFill: string): string[] {
+  const media = [shot(primaryFill)];
+  for (const fill of ACCENT_FILLS) {
+    media.push(shot(fill));
+  }
+  return media;
+}
+
 const DESCRIPTION =
   "A relaxed-fit jacket in water-repellent cotton.\n\nDropped shoulders, a two-way zip, and ribbed cuffs. Fully lined, with two zip pockets at the front and one inside.";
 
@@ -22,7 +43,7 @@ function jacket(
     title: `Field jacket — ${colorLabel}`,
     description: DESCRIPTION,
     price: { amount: color === "sand" ? 249 : 229, currency: "EUR" },
-    media: [shot(color === "sand" ? "d8c7a8" : "2b2b2b"), shot("c9d4f5")],
+    media: galleryMedia(color === "sand" ? "d8c7a8" : "2b2b2b"),
     url: "https://example.com/jacket",
     attributes: [
       { name: "Material", value: "Water-repellent cotton" },

--- a/packages/create-skybridge/templates/ecom/src/views/carousel/detail/index.tsx
+++ b/packages/create-skybridge/templates/ecom/src/views/carousel/detail/index.tsx
@@ -1,0 +1,190 @@
+import { useEffect, useState } from "react";
+import { useOpenExternal, useSetOpenInAppUrl, useUser } from "skybridge/web";
+import { ExpandableText } from "../../../components/expandable-text";
+import { ImageGallery } from "../../../components/image-gallery";
+import { VariantPicker } from "../../../components/variant-picker";
+import { sprinkles, text } from "../../../design/tokens";
+import { type Labels, useLabels } from "../../../i18n";
+import { cx } from "../../../lib/cx";
+import { formatPrice } from "../../../lib/format";
+import {
+  initialSelection,
+  resolveVariant,
+  type Selection,
+} from "../../../lib/variants.js";
+import type { Product } from "../../../tools/render-carousel.js";
+import * as styles from "./detail.css";
+
+// Price to show: the resolved variant's price, else the range across variants
+// (or a single price when they agree), else the card price, else a fallback.
+function priceText(
+  product: Product,
+  variantPrice: Product["card"]["price"],
+  locale: string,
+  labels: Labels,
+): string {
+  if (variantPrice) {
+    return formatPrice(variantPrice, locale);
+  }
+  const amounts: number[] = [];
+  let currency = "";
+  for (const variant of product.variants) {
+    if (variant.price) {
+      amounts.push(variant.price.amount);
+      currency = variant.price.currency;
+    }
+  }
+  if (amounts.length > 0) {
+    const min = Math.min(...amounts);
+    const max = Math.max(...amounts);
+    if (min === max) {
+      return formatPrice({ amount: min, currency }, locale);
+    }
+    return `${formatPrice({ amount: min, currency }, locale)} – ${formatPrice({ amount: max, currency }, locale)}`;
+  }
+  if (product.card.price) {
+    return formatPrice(product.card.price, locale);
+  }
+  return labels.priceOnRequest;
+}
+
+// data-llm narrates the variant the user is currently looking at. The full
+// product spec (every variant) is pushed to view state by the carousel
+// orchestrator, so the model can answer beyond what is on screen; this stays
+// scoped to the visible selection.
+function grounding(
+  product: Product,
+  title: string,
+  price: string,
+  selection: Selection,
+  outOfStock: boolean,
+  labels: Labels,
+): string {
+  const parts = [`The user is viewing "${title}" (product id: ${product.id}).`];
+  const chosen: string[] = [];
+  for (const option of product.options) {
+    let label = "not selected";
+    const valueId = selection[option.id];
+    for (const value of option.values) {
+      if (value.id === valueId) {
+        label = value.label;
+        break;
+      }
+    }
+    chosen.push(`${option.label}: ${label}`);
+  }
+  if (chosen.length > 0) {
+    parts.push(`Selected — ${chosen.join(", ")}.`);
+  }
+  parts.push(`Price: ${price}.`);
+  if (outOfStock) {
+    parts.push(labels.outOfStock);
+  }
+  return parts.join(" ");
+}
+
+/**
+ * Product detail view, rendered fullscreen over the carousel (see the carousel
+ * orchestrator). Reads a single product from the payload already in `_meta`;
+ * does no fetch. Option choices resolve against the product's sparse variant
+ * list in-place (no remount).
+ */
+export function DetailView({ product }: { product: Product }) {
+  const { locale } = useUser();
+  const labels = useLabels();
+  const openExternal = useOpenExternal();
+  const setOpenInAppUrl = useSetOpenInAppUrl();
+  const [selection, setSelection] = useState<Selection>(() =>
+    initialSelection(product),
+  );
+
+  const variant = resolveVariant(product, selection);
+  // Fall back to the card for display fields until a variant resolves.
+  const displayTitle = variant?.title ?? product.card.title;
+  const description = variant?.description ?? product.card.description;
+  const media = variant?.media.length ? variant.media : product.card.media;
+  const attributes = variant?.attributes ?? product.card.attributes;
+  const outOfStock = variant?.outOfStock ?? product.card.outOfStock ?? false;
+  const url = variant?.url ?? product.card.url;
+
+  const price = priceText(product, variant?.price, locale, labels);
+  // Buy CTA is enabled only once a real, linkable variant is resolved.
+  const canBuy = variant != null && url != null;
+
+  // Point the host's fullscreen "Open in app" affordance at the selected
+  // variant's page. Apps-SDK only; MCP Apps hosts reject, so ignore that.
+  useEffect(() => {
+    if (url) {
+      setOpenInAppUrl(url).catch(() => {});
+    }
+  }, [url, setOpenInAppUrl]);
+
+  return (
+    <div
+      className={styles.detail}
+      data-llm={grounding(product, displayTitle, price, selection, outOfStock, labels)}
+    >
+      <div className={styles.grid}>
+        <div className={styles.galleryCell}>
+          {media.length > 0 ? (
+            <ImageGallery media={media} alt={displayTitle} />
+          ) : null}
+        </div>
+
+        <div className={styles.info}>
+          <h1 className={cx(text({ style: "headingS", weight: "medium" }), styles.title)}>
+            {displayTitle}
+          </h1>
+
+          <p className={cx(text({ style: "headingS" }), styles.price)}>{price}</p>
+
+          {outOfStock ? (
+            <p className={cx(text({ style: "bodyS" }), styles.oos)}>
+              {labels.outOfStock}
+            </p>
+          ) : null}
+
+          <VariantPicker
+            product={product}
+            selection={selection}
+            onChange={setSelection}
+          />
+
+          {description ? <ExpandableText>{description}</ExpandableText> : null}
+
+          <button
+            type="button"
+            className={cx(styles.cta, sprinkles({ mt: "3xs" }))}
+            disabled={!canBuy}
+            onClick={canBuy && url ? () => openExternal(url) : undefined}
+          >
+            {variant ? labels.viewOnSite : labels.selectOptions}
+          </button>
+
+          {/* Specs rendered as a simple table, after the CTA. This is the visual
+              treatment only — the full spec is already in view state for the
+              model (see the carousel orchestrator), so hiding the table never
+              hides specs from the assistant. @todo: group/collapse, restyle, or
+              drop the table entirely. */}
+          {attributes.length > 0 ? (
+            <section className={styles.specs}>
+              <h2 className={text({ style: "labelM", weight: "medium" })}>
+                {labels.specifications}
+              </h2>
+              {attributes.map((attribute) => (
+                <div key={attribute.name} className={styles.specRow}>
+                  <span className={cx(text({ style: "bodyS" }), styles.specName)}>
+                    {attribute.name}
+                  </span>
+                  <span className={cx(text({ style: "bodyS" }), styles.specValue)}>
+                    {attribute.value}
+                  </span>
+                </div>
+              ))}
+            </section>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/create-skybridge/templates/ecom/src/views/carousel/detail/index.tsx
+++ b/packages/create-skybridge/templates/ecom/src/views/carousel/detail/index.tsx
@@ -135,7 +135,13 @@ export function DetailView({ product }: { product: Product }) {
       <div className={styles.grid}>
         <div className={styles.galleryCell}>
           {media.length > 0 ? (
-            <ImageGallery media={media} alt={displayTitle} />
+            // Key on the media set so switching to a variant with different
+            // images remounts the gallery fresh (index reset to the first image).
+            <ImageGallery
+              key={media.join("|")}
+              media={media}
+              alt={displayTitle}
+            />
           ) : null}
         </div>
 

--- a/packages/create-skybridge/templates/ecom/src/views/carousel/detail/index.tsx
+++ b/packages/create-skybridge/templates/ecom/src/views/carousel/detail/index.tsx
@@ -108,8 +108,9 @@ export function DetailView({ product }: { product: Product }) {
   const url = variant?.url ?? product.card.url;
 
   const price = priceText(product, variant?.price, locale, labels);
-  // Buy CTA is enabled only once a real, linkable variant is resolved.
-  const canBuy = variant != null && url != null;
+  // Buy CTA is enabled only once a variant resolves and carries a real link
+  // (an empty url would leave the button enabled but dead).
+  const canBuy = variant != null && Boolean(url);
 
   // Point the host's fullscreen "Open in app" affordance at the selected
   // variant's page. Apps-SDK only; MCP Apps hosts reject, so ignore that.
@@ -122,7 +123,14 @@ export function DetailView({ product }: { product: Product }) {
   return (
     <div
       className={styles.detail}
-      data-llm={grounding(product, displayTitle, price, selection, outOfStock, labels)}
+      data-llm={grounding(
+        product,
+        displayTitle,
+        price,
+        selection,
+        outOfStock,
+        labels,
+      )}
     >
       <div className={styles.grid}>
         <div className={styles.galleryCell}>
@@ -132,11 +140,18 @@ export function DetailView({ product }: { product: Product }) {
         </div>
 
         <div className={styles.info}>
-          <h1 className={cx(text({ style: "headingS", weight: "medium" }), styles.title)}>
+          <h1
+            className={cx(
+              text({ style: "headingS", weight: "medium" }),
+              styles.title,
+            )}
+          >
             {displayTitle}
           </h1>
 
-          <p className={cx(text({ style: "headingS" }), styles.price)}>{price}</p>
+          <p className={cx(text({ style: "headingS" }), styles.price)}>
+            {price}
+          </p>
 
           {outOfStock ? (
             <p className={cx(text({ style: "bodyS" }), styles.oos)}>
@@ -173,10 +188,14 @@ export function DetailView({ product }: { product: Product }) {
               </h2>
               {attributes.map((attribute) => (
                 <div key={attribute.name} className={styles.specRow}>
-                  <span className={cx(text({ style: "bodyS" }), styles.specName)}>
+                  <span
+                    className={cx(text({ style: "bodyS" }), styles.specName)}
+                  >
                     {attribute.name}
                   </span>
-                  <span className={cx(text({ style: "bodyS" }), styles.specValue)}>
+                  <span
+                    className={cx(text({ style: "bodyS" }), styles.specValue)}
+                  >
                     {attribute.value}
                   </span>
                 </div>

--- a/packages/create-skybridge/templates/ecom/src/views/carousel/index.tsx
+++ b/packages/create-skybridge/templates/ecom/src/views/carousel/index.tsx
@@ -178,6 +178,10 @@ function Carousel() {
     selectedId != null
       ? products.find((product) => product.id === selectedId)
       : undefined;
+  // The detail actually renders only when we have a product to show. Everything
+  // that hides the carousel keys off this, so a stale id shows the carousel, not
+  // a blank page.
+  const detailProduct = showDetail ? selectedProduct : undefined;
 
   const cards: ReactNode[] = [];
   for (const [index, product] of products.entries()) {
@@ -187,7 +191,7 @@ function Carousel() {
         <ProductCard
           // Drop per-card grounding while the detail owns the screen.
           data-llm={
-            !showDetail && visibleIndices.includes(index)
+            !detailProduct && visibleIndices.includes(index)
               ? narrate(product, index)
               : ""
           }
@@ -212,19 +216,17 @@ function Carousel() {
     <ViewFrame>
       <div
         className={sprinkles({ p: "3xs" })}
-        style={{ display: showDetail ? "none" : undefined }}
+        style={{ display: detailProduct ? "none" : undefined }}
       >
         <ProductCarousel
           trackRef={trackRef}
           onVisibleChange={setVisibleIndices}
-          data-llm={showDetail ? "" : narration}
+          data-llm={detailProduct ? "" : narration}
         >
           {cards}
         </ProductCarousel>
       </div>
-      {showDetail && selectedProduct ? (
-        <DetailView product={selectedProduct} />
-      ) : null}
+      {detailProduct ? <DetailView product={detailProduct} /> : null}
     </ViewFrame>
   );
 }

--- a/packages/create-skybridge/templates/ecom/src/views/carousel/index.tsx
+++ b/packages/create-skybridge/templates/ecom/src/views/carousel/index.tsx
@@ -9,11 +9,11 @@ import {
 } from "react";
 import { useDisplayMode, useViewState } from "skybridge/web";
 import { EmptyState } from "../../components/empty-state";
-import * as cardStyles from "../../components/product-card.css";
 import {
   ProductCard,
   ProductCardSkeleton,
 } from "../../components/product-card";
+import * as cardStyles from "../../components/product-card.css";
 import { ProductCarousel } from "../../components/product-carousel";
 import { ViewFrame } from "../../components/view-frame";
 import { sprinkles } from "../../design/tokens";

--- a/packages/create-skybridge/templates/ecom/src/views/carousel/index.tsx
+++ b/packages/create-skybridge/templates/ecom/src/views/carousel/index.tsx
@@ -1,7 +1,15 @@
 import "../../index.css";
 
-import { type ReactNode, useState } from "react";
+import {
+  type ReactNode,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { useDisplayMode, useViewState } from "skybridge/web";
 import { EmptyState } from "../../components/empty-state";
+import * as cardStyles from "../../components/product-card.css";
 import {
   ProductCard,
   ProductCardSkeleton,
@@ -13,6 +21,8 @@ import { useToolInfo } from "../../helpers.js";
 import { useLabels } from "../../i18n";
 import { formatPrice } from "../../lib/format";
 import type { Product } from "../../tools/render-carousel.js";
+import type { Attribute, Price } from "../../types.js";
+import { DetailView } from "./detail";
 
 const SKELETON_COUNT = 4;
 
@@ -25,15 +35,117 @@ function narrate(product: Product, index: number): string {
   return `${index + 1}. ${card.title} (id: ${product.id})${price}${oos}`;
 }
 
+// View state, persisted on the host so an open detail survives a remount (e.g.
+// after a follow-up message). scrollLeft restores the carousel position on the
+// way back; spec is the full product spec (every variant) the model can answer
+// from while the detail is open.
+type VariantSpec = {
+  selection: Record<string, string>; // option label -> chosen value label
+  price?: Price;
+  available: boolean;
+  attributes: Attribute[];
+};
+type ProductSpec = { id: string; title: string; variants: VariantSpec[] };
+type ViewState = {
+  selectedId: string | null;
+  scrollLeft: number;
+  spec: ProductSpec | null;
+};
+
+// The complete spec of the open product — every variant, not just the visible
+// one — pushed to view state so the model can answer any detail question. The
+// on-screen variant is narrated separately (data-llm, in the detail view). Keep
+// it to a single product; a very large spec trips the view-state size warning.
+function buildProductSpec(product: Product): ProductSpec {
+  const variants: VariantSpec[] = [];
+  for (const variant of product.variants) {
+    const selection: Record<string, string> = {};
+    for (const option of product.options) {
+      const valueId = variant.selection[option.id];
+      if (!valueId) {
+        continue;
+      }
+      let label = valueId;
+      for (const value of option.values) {
+        if (value.id === valueId) {
+          label = value.label;
+          break;
+        }
+      }
+      selection[option.label] = label;
+    }
+    variants.push({
+      selection,
+      price: variant.price,
+      available: !variant.outOfStock,
+      attributes: variant.attributes,
+    });
+  }
+  return { id: product.id, title: product.card.title, variants };
+}
+
 /**
- * Carousel view for the `render-carousel` tool. Reads the full products from
- * `_meta` (via useToolInfo().responseMetadata) and renders one card each.
- * `structuredContent` is the model's grounding and is not used to render.
+ * Carousel view + product detail, in one view. The carousel is the inline
+ * surface; tapping a card opens the detail fullscreen over it (the carousel is
+ * hidden, not unmounted). Both read the full products from `_meta`; the detail
+ * needs no extra fetch.
  */
 function Carousel() {
   const { responseMetadata } = useToolInfo<"render-carousel">();
-  const [visibleIndices, setVisibleIndices] = useState<number[]>([]);
   const labels = useLabels();
+  const trackRef = useRef<HTMLElement>(null);
+  const [visibleIndices, setVisibleIndices] = useState<number[]>([]);
+  const [mode, setMode] = useDisplayMode();
+  const [nav, setNav] = useViewState<ViewState>({
+    selectedId: null,
+    scrollLeft: 0,
+    spec: null,
+  });
+  // True between requesting fullscreen and the host applying it, so the
+  // collapse-is-back effect below does not fire mid-transition.
+  const enteringRef = useRef(false);
+
+  const selectedId = nav.selectedId;
+  // The detail only mounts once the host is actually fullscreen: rendering the
+  // tall page inside the small inline frame would flash a cramped layout.
+  const showDetail = selectedId != null && mode === "fullscreen";
+
+  // A host-driven exit from fullscreen (the user used host chrome) means "back".
+  useEffect(() => {
+    if (mode === "fullscreen") {
+      enteringRef.current = false;
+      return;
+    }
+    if (selectedId != null && !enteringRef.current) {
+      setNav((prev) => ({ ...prev, selectedId: null, spec: null }));
+    }
+  }, [mode, selectedId, setNav]);
+
+  // Restore carousel scroll when back on the carousel. display:none resets
+  // scrollLeft, so re-apply once it is visible again (layout effect, not mount).
+  useLayoutEffect(() => {
+    if (!showDetail && trackRef.current) {
+      trackRef.current.scrollLeft = nav.scrollLeft;
+    }
+  }, [showDetail, nav.scrollLeft]);
+
+  function openProduct(id: string) {
+    enteringRef.current = true;
+    const list = responseMetadata?.products ?? [];
+    let spec: ProductSpec | null = null;
+    for (const product of list) {
+      if (product.id === id) {
+        spec = buildProductSpec(product);
+        break;
+      }
+    }
+    setNav({
+      selectedId: id,
+      scrollLeft: trackRef.current?.scrollLeft ?? 0,
+      spec,
+    });
+    setMode("fullscreen");
+  }
 
   // Tool still resolving: reserve the layout with skeleton cards.
   if (responseMetadata == null) {
@@ -50,7 +162,7 @@ function Carousel() {
     );
   }
 
-  const products = responseMetadata?.products ?? [];
+  const products = responseMetadata.products ?? [];
 
   if (products.length === 0) {
     return (
@@ -60,18 +172,37 @@ function Carousel() {
     );
   }
 
+  // Guard against a stale id (e.g. the model rendered a new carousel while a
+  // detail was open): fall back to the carousel rather than an empty page.
+  const selectedProduct =
+    selectedId != null
+      ? products.find((product) => product.id === selectedId)
+      : undefined;
+
   const cards: ReactNode[] = [];
   for (const [index, product] of products.entries()) {
     const { card } = product;
     cards.push(
-      <ProductCard
-        key={product.id}
-        data-llm={visibleIndices.includes(index) ? narrate(product, index) : ""}
-        title={card.title}
-        price={card.price}
-        media={card.media}
-        outOfStock={card.outOfStock}
-      />,
+      <div key={product.id} className={cardStyles.cardClickable}>
+        <ProductCard
+          // Drop per-card grounding while the detail owns the screen.
+          data-llm={
+            !showDetail && visibleIndices.includes(index)
+              ? narrate(product, index)
+              : ""
+          }
+          title={card.title}
+          price={card.price}
+          media={card.media}
+          outOfStock={card.outOfStock}
+        />
+        <button
+          type="button"
+          aria-label={card.title}
+          className={cardStyles.cardButton}
+          onClick={() => openProduct(product.id)}
+        />
+      </div>,
     );
   }
 
@@ -79,14 +210,21 @@ function Carousel() {
 
   return (
     <ViewFrame>
-      <div className={sprinkles({ p: "3xs" })}>
+      <div
+        className={sprinkles({ p: "3xs" })}
+        style={{ display: showDetail ? "none" : undefined }}
+      >
         <ProductCarousel
+          trackRef={trackRef}
           onVisibleChange={setVisibleIndices}
-          data-llm={narration}
+          data-llm={showDetail ? "" : narration}
         >
           {cards}
         </ProductCarousel>
       </div>
+      {showDetail && selectedProduct ? (
+        <DetailView product={selectedProduct} />
+      ) : null}
     </ViewFrame>
   );
 }

--- a/scripts/bump.js
+++ b/scripts/bump.js
@@ -92,6 +92,7 @@ for (const dirEntry of readdirSync(join(rootDir, "examples"), {
 const targets = [
   "packages/create-skybridge/templates/demo/package.json",
   "packages/create-skybridge/templates/blank/package.json",
+  "packages/create-skybridge/templates/ecom/package.json",
   ...exampleTargets,
 ];
 

--- a/skills/chatgpt-app-builder/references/ecommerce.md
+++ b/skills/chatgpt-app-builder/references/ecommerce.md
@@ -43,8 +43,11 @@ src/
     sprinkles.css.ts             atomic style props
     recipes/typography.css.ts    the `text` recipe
     tokens.ts                    barrel (single import door)
-  components/                  ViewFrame, ProductCard, ProductCarousel, EmptyState
-  views/carousel/              the render-carousel view (reads _meta, renders cards)
+  components/                  ViewFrame, ProductCard, ProductCarousel, EmptyState,
+                               ImageGallery, VariantPicker, Chip, ExpandableText
+  lib/                         format, cx, variants (resolve a selection to a variant)
+  views/carousel/              render-carousel view: carousel + product detail
+    detail/                      fullscreen product detail (display-mode switch)
 ```
 
 The template is `@todo`-driven: `grep -rn "@todo" src` lists every decision point. The subsections below (**Server**, **Design system**, **Components**) each own their markers: Server and Design system are independent; Components build on the Design system. Resolve every `@todo` and verify as you go. `{pm} run build` typechecks the whole tree at any point.
@@ -99,6 +102,7 @@ Takes the curated IDs and returns the products for the carousel. The full produc
 - [ ] `description`: adapt the wording and brand voice; the behavioral rules (order, no-repeat, accuracy) apply to any catalog.
 - [ ] `_meta`: the invoking and invoked status messages.
 - [ ] `view`: already wired to the `carousel` view (`view: { component: "carousel" }`); customize it in the Components subsection.
+- [ ] `view.csp`: add your image host to `resourceDomains` (so product images load) and the product site to `redirectDomains` (so the detail view's "view on site" link and the host "open in app" URL are allowed).
 
 ##### Mapping ids to products (`getProducts`)
 
@@ -199,3 +203,19 @@ All user-facing text is centralized in `src/i18n.ts`, shared across every compon
 - [ ] `product-card.tsx`: extra images from `media` (e.g. hover cross-fade to `media[1]`); extra fields from `attributes` (ratings, tags, badges).
 - [ ] `product-carousel.css.ts`: tuning knobs (`gap`, `CARDS_VISIBLE`, `CARDS_VISIBLE_COMPACT`, `COMPACT_MAX_WIDTH`).
 - [ ] Framing: the `FRAMED` flag boxes each card (`product-card.tsx`, includes its skeleton) or the whole strip (`product-carousel.tsx`). Both `false` for plain cards (default); set at most one to `true`, never both. If you enable one, tune the frame (padding, border, radius, shadow) in `product-card.css.ts` or `product-carousel.css.ts`.
+
+#### Product detail
+
+The fullscreen page a user opens by tapping a carousel card (`src/views/carousel/detail/`). It is not a second tool or view: the carousel orchestrator (`views/carousel/index.tsx`) switches display mode to `fullscreen` and renders the detail over the carousel (hidden, not unmounted). It reads the same `_meta` products, so opening a product and switching variants needs no fetch. Selection, carousel scroll, and the full product spec ride in `useViewState`, so an open detail survives a host remount.
+
+The building blocks live in `src/components/` (each previews in Ladle): `ImageGallery`, `VariantPicker` + `Chip`, `ExpandableText`. Variant logic is pure in `src/lib/variants.ts` (`resolveVariant`, `selectableValues`, `initialSelection`).
+
+Variant selection. `variants` is sparse, so contingency is derived, never ruled: `selectableValues` filters the list on the other axes' current choices, and the picker disables any value with no surviving variant. Selection is in-place (every axis is local state, no remount). The initial selection is the tapped variant (its id equals the opened product id), else the first variant, so a variant is always preselected and the buy CTA is live on open (it disables only if the resolved variant has no link).
+
+Grounding. The detail's `data-llm` narrates only the variant on screen. The full spec (every variant) is pushed to `useViewState` by the orchestrator, so the model can answer detail questions beyond what is visible; the on-screen spec table is a display choice, not the model's source.
+
+- [ ] `variant-picker`: chips are the default. For a long text-only axis (many sizes), swap the chip row for a native `<select>`; keep image chips for swatch axes (color, material). Promote an axis to a cross-product switch only if the catalog models it as separate products.
+- [ ] `image-gallery`: `THUMBNAIL_RAIL` adds a desktop thumbnail rail (off = swipe only); style the progress bar and, if enabled, the rail.
+- [ ] `detail.css.ts`: the two-column breakpoint, and whether the gallery is sticky on desktop.
+- [ ] CTA: `viewOnSite` deep-links to `variant.url ?? card.url` (`useOpenExternal`), and `setOpenInAppUrl` points the host "open in app" at the same URL. Needs the product site in the view CSP (above).
+- [ ] Specs: a table after the CTA. Group, restyle, or drop it (the full spec is already in view state for the model).


### PR DESCRIPTION
This adds the product detail page that opens when you tap a carousel card.

It's not a second tool or a second view. The detail is a display-mode switch inside the existing carousel view: tapping a card flips the widget to fullscreen and renders the detail over the carousel (hidden, not unmounted). It reads the same products already sitting in _meta, so opening a product and switching its variants does zero extra fetches. Selection, carousel scroll position, and the full product spec all live in useViewState, so an open detail survives a host remount and the carousel is right where you left it when you go back.

What's on the page:

- image gallery: native swipe / scroll-snap with chevrons and a progress bar. Off-by-default THUMBNAIL_RAIL flag adds a desktop thumbnail rail beside the image.
- variant picker: a chip row per axis. Contingency comes straight from the sparse variant list, so a combination that doesn't exist (a color that doesn't come in the picked size) is disabled, not hidden. A variant is preselected on open so the buy button is live right away.
- price (single or a from/to range), an expandable description, and a spec table.
- a view-on-site CTA that deep-links to the selected variant (useOpenExternal), plus setOpenInAppUrl so the host's open-in-app button points at the same page.

Model grounding: the detail's data-llm narrates only the variant you're looking at, while the full spec (every variant) is pushed to useViewState so the model can still answer detail questions beyond what's on screen, even if you drop the spec table.

Same skeleton approach as the rest of the template: opinionated defaults, every fork left as a @todo (variant control, the gallery rail, the two-column breakpoint, CTA and CSP, specs treatment). Each new component ships a Ladle story. The chatgpt-app-builder ecommerce reference gets a product-detail section and the CSP note.

<img width="1081" height="553" alt="image" src="https://github.com/user-attachments/assets/1fd92197-6639-4267-b49c-9f0bf30e213e" />