### PR TITLE
feat(docs): add webmcp devtools setup

### DIFF
--- a/docs/guides/skills.mdx
+++ b/docs/guides/skills.mdx
@@ -1,17 +1,17 @@
 ---
 title: "Serve Skills over MCP"
 description: "Ship Agent Skills alongside your server"
-sidebarTitle: "Skills"
-icon: "book-sparkles"
+sidebarTitle: "Skills Over MCP"
+icon: "book-open-text"
 ---
 
 <Info>
-Skills over MCP tracks [SEP-2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640), which is still under review. This feature is **experimental** and may change with the spec. Most hosts do not yet support it, so skills you serve today may go unused until they adopt the standard.
+Skills over MCP tracks [SEP-2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640), still under review. The feature is **experimental** and may change with the spec. Few hosts support it yet, so skills you serve today may go unused until they adopt the standard.
 </Info>
 
-A [tool](/build/tools) description tells an agent *what* a tool does. A **skill** tells it *how* to orchestrate a workflow — a directory of instructions (`SKILL.md` plus supporting files) that the host loads into context on demand. Skybridge serves skills as MCP resources under the `skill://` scheme, following the [Agent Skills](https://agentskills.io/) format, so any host that adopts the standard can discover and read them.
+A [tool](/build/tools) description tells the model *what* a tool does. A **skill** tells it *how* to run a workflow: a directory of instructions (`SKILL.md` plus supporting files) the host loads into context on demand.
 
-## Enable skills
+## Enable Skills
 
 Drop your skills under `src/skills/`, one directory per skill, and turn the option on:
 
@@ -26,12 +26,12 @@ const server = new McpServer(
 ```
 src/skills/
   refunds/
-    SKILL.md            # required — frontmatter + instructions
+    SKILL.md            # required: frontmatter + instructions
     templates/
       email.md          # supporting files, read on demand
 ```
 
-Each `SKILL.md` begins with YAML frontmatter whose `name` matches its directory:
+Each `SKILL.md` opens with YAML frontmatter whose `name` matches its directory:
 
 ```md src/skills/refunds/SKILL.md
 ---
@@ -43,23 +43,29 @@ description: Process customer refund requests per company policy.
 2. ...
 ```
 
-That is all. Skybridge validates every skill at build and dev startup (a bad `name`, missing `description`, or name/directory mismatch fails loudly), then exposes:
+Skybridge validates every skill at build and dev startup: a bad `name`, a missing `description`, or a name that mismatches its directory fails loudly. Each valid skill is then served at `skill://<name>/SKILL.md`, with its supporting files alongside.
 
-- `skill://refunds/SKILL.md` and each supporting file as MCP resources.
-- `skill://index.json`, the discovery index (each entry carries the skill's `url`, a `sha256` digest, and its frontmatter verbatim).
-- the `io.modelcontextprotocol/skills` capability, so hosts know to look.
+<Info>
+Skills are markdown files only: `SKILL.md` and any supporting `.md` files are served as `text/markdown`, other formats and symlinks are ignored.
+</Info>
 
-Skills are markdown-only for now: `SKILL.md` and any supporting `.md` files are served as `text/markdown`. Files of other formats, and symlinks, are ignored.
+## How Hosts Use Skills
 
-## How hosts use them
+Hosts don't inject skills on their own. To put one in front of the model, reference its URI from a tool description or a tool result, for example *"see `skill://refunds/SKILL.md`"*. The host pulls in the full instructions only when they're relevant.
 
-Skills are **pull-based**: the server never pushes them. A host reads `skill://index.json`, surfaces each skill's `name` and `description`, and lets the model read the full `SKILL.md` only when it's relevant ([progressive disclosure](https://agentskills.io/specification#progressive-disclosure)). To point the model at a skill, reference its URI from a tool description or a tool result, e.g. *"see `skill://refunds/SKILL.md`"*.
+<Info>
+A skill is a set of instructions a model may or may not act on: it does not bypass the model's system directives or guardrails.
+</Info>
 
-<Warning>
-Skill content is untrusted model input, not a trusted instruction. Hosts treat it as a prompt-injection surface and never grant it higher authority or execute code from it.
-</Warning>
-
-## Lifecycle
-
-- **Dev** — editing a skill under `src/skills/` triggers a dev-server restart that re-discovers it.
-- **Build / production** — `skybridge build` snapshots your skills into the bundle. They are served from memory at runtime, never read from disk, so the feature works on every deploy target including filesystem-less ones (Cloudflare Workers) and bundled functions (Vercel).
+## Go Further
+<Columns cols={3}>
+    <Card title="Register Tools" icon="wrench" href="/build/tools">
+        Define what humans and agents can do
+    </Card>
+    <Card title="UX Design" icon="sparkles" href="/guides/ux">
+        Account for what makes an MCP App different
+    </Card>
+    <Card title="Deploy" icon="rocket" href="/ship">
+        Ship your server to any host
+    </Card>
+</Columns>

--- a/docs/test/devtools.mdx
+++ b/docs/test/devtools.mdx
@@ -104,7 +104,7 @@ DevTools exposes its actions as [WebMCP](https://github.com/webmachinelearning/w
     </Tabs>
   </Step>
   <Step title="Start DevTools">
-    Run `npm run dev` and open the DevTools URL (`http://localhost:3000/`).
+    Run `npm run dev` and open the DevTools URL printed in the terminal.
   </Step>
   <Step title="Prompt your agent">
     <Prompt description="`Open my app in DevTools, run a tool, and check the view renders`" actions={["copy", "cursor"]}>

--- a/docs/test/devtools.mdx
+++ b/docs/test/devtools.mdx
@@ -48,6 +48,77 @@ Select a tool in the sidebar and DevTools gives you the full exchange:
 - **View preview**: the rendered [View](/build/view), with live controls to switch [display mode](/api-reference/use-display-mode#displaymode), theme, locale, and device type; the preview updates immediately.
 - **Call logs**: every runtime API call the view makes (`setViewState`, `callTool`, `requestDisplayMode`) with its arguments and responses.
 
+## Drive DevTools from a Coding Agent
+
+DevTools exposes its actions as [WebMCP](https://github.com/webmachinelearning/webmcp) tools, so a coding agent that drives your browser runs them directly. The agent connects through [chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp), an MCP server that discovers and calls a page's WebMCP tools. On the DevTools page it can:
+
+- **Run any registered tool** and render its view in the preview.
+- **Read the rendered view** by screenshotting the preview, then drive it as a real page.
+- **Switch the preview controls**: display mode, theme, locale, and device.
+
+### Set It Up
+
+<Steps>
+  <Step title="Add chrome-devtools-mcp to your agent">
+    Register the MCP server with the WebMCP flag, forwarding the browser feature flag to the Chrome it launches.
+
+    <Tabs>
+      <Tab title="Claude Code">
+        ```bash
+        claude mcp add chrome-devtools --scope user -- \
+          npx chrome-devtools-mcp@latest \
+          --categoryExperimentalWebmcp=true \
+          --chrome-arg=--enable-features=WebMCP,DevToolsWebMCPSupport
+        ```
+      </Tab>
+      <Tab title="Codex">
+        ```bash
+        codex mcp add chrome-devtools -- \
+          npx chrome-devtools-mcp@latest \
+          --categoryExperimentalWebmcp=true \
+          --chrome-arg=--enable-features=WebMCP,DevToolsWebMCPSupport
+        ```
+      </Tab>
+      <Tab title="Cursor">
+        [![Add to Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=chrome-devtools&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsImNocm9tZS1kZXZ0b29scy1tY3BAbGF0ZXN0IiwiLS1jYXRlZ29yeUV4cGVyaW1lbnRhbFdlYm1jcD10cnVlIiwiLS1jaHJvbWUtYXJnPS0tZW5hYmxlLWZlYXR1cmVzPVdlYk1DUCxEZXZUb29sc1dlYk1DUFN1cHBvcnQiXX0=)
+      </Tab>
+      <Tab title="Others">
+        See the [client configuration guide](https://github.com/ChromeDevTools/chrome-devtools-mcp#mcp-client-configuration), or add this to your MCP config:
+
+        ```json mcp.json
+        {
+          "mcpServers": {
+            "chrome-devtools": {
+              "command": "npx",
+              "args": [
+                "-y",
+                "chrome-devtools-mcp@latest",
+                "--categoryExperimentalWebmcp=true",
+                "--chrome-arg=--enable-features=WebMCP,DevToolsWebMCPSupport"
+              ]
+            }
+          }
+        }
+        ```
+      </Tab>
+    </Tabs>
+  </Step>
+  <Step title="Start DevTools">
+    Run `npm run dev` and open the DevTools URL (`http://localhost:3000/`).
+  </Step>
+  <Step title="Prompt your agent">
+    <Prompt description="`Open my app in DevTools, run a tool, and check the view renders`" actions={["copy", "cursor"]}>
+    Open the app in DevTools with chrome-devtools-mcp, list its WebMCP tools, call one with sample input, and screenshot the preview to check the view renders.
+    </Prompt>
+  </Step>
+</Steps>
+
+Your agent now closes its own loop: it edits a view, runs the tool, reads the rendered result, and fixes what is wrong.
+
+<Info>
+    WebMCP is experimental and supported Chrome version 149 or newer.
+</Info>
+
 ## Authenticated Servers
 
 When your server [requires OAuth](/build/auth), DevTools registers itself through Dynamic Client Registration on first connect and walks the full PKCE flow as a public client. A server that needs a pre-registered client or a different grant type won't connect from DevTools.


### PR DESCRIPTION
and fixes the skills over mcp one to match house style: icon, unequivocal title, format (em dashes), tone of voice, not discussing internals, go further cards.