### PR TITLE
fix(cli): report a port fallback when PORT is invalid and 3000 is taken

### DIFF
--- a/packages/core/src/cli/detect-port.test.ts
+++ b/packages/core/src/cli/detect-port.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { busyPorts } = vi.hoisted(() => ({ busyPorts: new Set<number>() }));
+
+vi.mock("node:net", () => {
+  const createServer = () => {
+    const handlers: Record<string, () => void> = {};
+    const server = {
+      once(event: string, cb: () => void) {
+        handlers[event] = cb;
+        return server;
+      },
+      listen(port: number) {
+        queueMicrotask(() => {
+          if (busyPorts.has(port)) {
+            handlers.error?.();
+          } else {
+            handlers.listening?.();
+          }
+        });
+        return server;
+      },
+      close(cb?: () => void) {
+        cb?.();
+        return server;
+      },
+    };
+    return server;
+  };
+  return { default: { createServer } };
+});
+
+import { resolvePort } from "./detect-port.js";
+
+const originalPort = process.env.PORT;
+
+describe("resolvePort", () => {
+  beforeEach(() => {
+    busyPorts.clear();
+    delete process.env.PORT;
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalPort === undefined) {
+      delete process.env.PORT;
+    } else {
+      process.env.PORT = originalPort;
+    }
+  });
+
+  it("uses the --port flag as-is", async () => {
+    await expect(resolvePort(4000)).resolves.toEqual({
+      port: 4000,
+      fallback: false,
+    });
+  });
+
+  it("uses a valid PORT env var as-is", async () => {
+    process.env.PORT = "5000";
+    await expect(resolvePort()).resolves.toEqual({
+      port: 5000,
+      fallback: false,
+    });
+  });
+
+  it("reports a fallback when the default port is taken", async () => {
+    busyPorts.add(3000);
+    await expect(resolvePort()).resolves.toEqual({
+      port: 3001,
+      fallback: true,
+    });
+  });
+
+  it("warns and uses the default when PORT is invalid", async () => {
+    process.env.PORT = "not-a-port";
+    const result = await resolvePort();
+    expect(result.port).toBe(3000);
+    expect(result.fallback).toBe(false);
+    expect(result.envWarning).toContain("not-a-port");
+  });
+
+  it("reports a fallback when PORT is invalid and the default is taken", async () => {
+    // Regression: this branch hard-coded `fallback: false`, so the CLI printed
+    // "Running on ..." instead of "3000 in use, running on ..." even though it
+    // had moved off the default port.
+    process.env.PORT = "not-a-port";
+    busyPorts.add(3000);
+    const result = await resolvePort();
+    expect(result.port).toBe(3001);
+    expect(result.fallback).toBe(true);
+    expect(result.envWarning).toContain("not-a-port");
+  });
+});

--- a/packages/core/src/cli/detect-port.ts
+++ b/packages/core/src/cli/detect-port.ts
@@ -14,9 +14,12 @@ export async function resolvePort(flagPort?: number) {
     if (Number.isInteger(parsed) && parsed > 0) {
       return { port: parsed, fallback: false };
     }
+    const detected = await detectAvailablePort(DEFAULT_PORT);
     return {
-      port: await detectAvailablePort(DEFAULT_PORT),
-      fallback: false,
+      port: detected,
+      // The default can still be taken, in which case this is a fallback just
+      // like the branch below - otherwise the CLI omits the "3000 in use" note.
+      fallback: detected !== DEFAULT_PORT,
       envWarning: `Invalid PORT="${rawEnv}", ignoring and using default`,
     };
   }


### PR DESCRIPTION
`resolvePort` hard-codes `fallback: false` on the invalid-`PORT` branch, even though that branch calls `detectAvailablePort` and can land on a different port.

## Problem

```ts
if (rawEnv) {
  const parsed = Number(rawEnv)
  if (Number.isInteger(parsed) && parsed > 0) { ... }
  return {
    port: await detectAvailablePort(DEFAULT_PORT),
    fallback: false,   // <- even if 3000 was taken
    envWarning: `Invalid PORT="${rawEnv}", ...`,
  }
}
```

The CLI uses `fallback` to choose the message it prints:

- `commands/dev.tsx` — `"3000 in use, running on "` vs `"Running on "`
- `cli/run-plain.ts` — same distinction

So when `PORT` is invalid **and** 3000 is already taken, the server correctly moves to 3001 but the user is told plain `"Running on ..."` and never learns the default port was busy. The branch below it already computes this correctly (`fallback: port !== DEFAULT_PORT`).

## Fix

Compute the flag the same way the default branch does.

## Tests

`detect-port.ts` had no tests; added `detect-port.test.ts` covering the `--port` flag, a valid `PORT`, a taken default, an invalid `PORT`, and the regression (invalid `PORT` + taken default). I verified the regression test fails against the previous code and passes with the fix. `node:net` is mocked so port availability is deterministic.

Biome is clean. Note: the 3 failures in `build-steps.test.ts` on my checkout are pre-existing and reproduce on a clean tree (an artifact of installing with `--ignore-scripts`), unrelated to this change.