### PR TITLE
feat(e2e): add alpic playground

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        host: [chatgpt, claude]
+        host: [chatgpt, claude, alpic]
     steps:
       - uses: actions/checkout@v7
 

--- a/e2e/conformance/README.md
+++ b/e2e/conformance/README.md
@@ -130,6 +130,13 @@ The scheduled GitHub Actions workflow lives at `.github/workflows/conformance.ym
 - A full run takes several minutes (fifteen tests, waits between actions, the 60s `useRegisterViewTool` timeout, and the follow-up verification can wait up to 2 minutes for the host to commit the turn). Over Notte, real clicks cost ~7s each on top (CDP round-trip), so budget ~15 minutes per host.
 - `useOpenExternal` is gated on both hosts now that each pops an observable "Open link" confirmation dialog the driver accepts. (It used to be un-gated over `--mode notte`, when ChatGPT opened a new tab that never surfaced to Playwright over Notte's CDP.) `UNVERIFIABLE_BY_MODE` in `conformance.py` is the seam for re-excluding any hook that becomes unobservable in a given mode; excluded hooks are recorded under `not_gated` in `results.json`.
 
+## Known host issues
+
+Host bugs surfaced by the runs, not problems with this app:
+
+- **Alpic playground**: opening the view as a modal (`useRequestModal`) breaks view-side tool registration (`useRegisterViewTool`) — the modal remounts the view, and the re-registration doesn't take.
+- **ChatGPT**: `useRequestModal` is broken — the view blurs but no modal appears. (This is why its baseline verdict is `unsupported`.)
+
 ## Resources
 
 - [Skybridge Documentation](https://docs.skybridge.tech/)

--- a/e2e/conformance/README.md
+++ b/e2e/conformance/README.md
@@ -71,11 +71,11 @@ notte/                   # Automated runs on real hosts (see E2E below)
 
 ## E2E
 
-`notte/conformance.py` runs the app end-to-end on a real host (ChatGPT or Claude), acting as the human tester: it presses Run/Close on the action tests and answers the Yes/No confirmations by verifying the side effects from outside the widget (modal overlay, new tab, follow-up message, host permission dialog). No LLM is involved (no scrape, no agent).
+`notte/conformance.py` runs the app end-to-end on a real host (ChatGPT, Claude, or the Alpic playground), acting as the human tester: it presses Run/Close on the action tests and answers the Yes/No confirmations by verifying the side effects from outside the widget (modal overlay, new tab, follow-up message, host permission dialog). No LLM is involved (no scrape, no agent).
 
 It's one plain [Playwright](https://playwright.dev) (sync) script, driven by [`uv`](https://docs.astral.sh/uv/) (inline script deps, no separate install). Two flags:
 
-- `--host chatgpt|claude`: which host to drive.
+- `--host chatgpt|claude|alpic`: which host to drive. `alpic` is the Skybridge "try this server" playground at `<server>/try`, which renders views inline in a chat; it needs no app connection and no login (the playground is already scoped to this server, and the page is public).
 - `--mode local|notte`: the browser backend. `local` is a persistent Chrome profile on your machine (`notte/.profiles/local`, gitignored) that you log into once by hand; `notte` connects to a [Notte](https://notte.cc) cloud browser over Chrome DevTools Protocol, which is what CI uses (no display needed, and the login persists in the Notte profile).
 
 The driver presses the widget's real buttons (Playwright reaches across the host's cross-origin iframes) and only falls back to the postMessage drive protocol when a button isn't reachable. Real clicks matter: ChatGPT gates the follow-up and open-external effects behind a genuine user gesture, which postMessage can't supply.
@@ -87,9 +87,11 @@ The `notte/` files:
 | `conformance.py`        | Entry point: the stepper loop, browser backends, baseline gate, and CLI       |
 | `chatgpt.py`            | ChatGPT host adapter (prompt, chrome, follow-up check, open-link dialog)       |
 | `claude.py`             | Claude host adapter (prompt, cookie banner, follow-up check, permission dialogs) |
+| `alpic.py`              | Alpic playground adapter (plain prompt, follow-up by reply count, window.open + host-dialog modal) |
 | `utils.py`              | Shared result models, `HostConfig`, and host-agnostic widget/overlay helpers   |
 | `chatgpt_expected.json` | Expected verdict per hook on ChatGPT: the CI baseline                          |
 | `claude_expected.json`  | Expected verdict per hook on Claude                                            |
+| `alpic_expected.json`   | Expected verdict per hook on the Alpic playground                             |
 | `create-profile.ts`     | Creates/reopens a Notte profile so you can log into the host account           |
 
 The driver talks to the app over postMessage (the widget iframes are cross-origin): the drive hook accepts `{type: "conformance:drive", action: run|skip|yes|no|close-modal|restore-inline}` and the app broadcasts `{type: "conformance:state", state}` to `window.top` on every change plus a 1.5s heartbeat. Both sides live in `src/automation.ts`.
@@ -99,6 +101,7 @@ The driver talks to the app over postMessage (the widget iframes are cross-origi
 ```bash
 uv run notte/conformance.py --host chatgpt --mode local            # local Chrome, logged-in profile
 uv run notte/conformance.py --host claude  --mode local
+uv run notte/conformance.py --host alpic   --mode local            # the /try playground, no login needed
 uv run notte/conformance.py --host chatgpt --mode notte            # Notte cloud browser (profile id from .env)
 pnpm notte:run --host claude --mode notte                          # same, via the npm script
 ```
@@ -109,7 +112,7 @@ Host quirks the driver handles: both hosts gate `openExternal` (and Claude also 
 
 ### Setup
 
-The app must be connected in the host account the profile is logged into:
+The `alpic` host needs none of this setup: the `/try` playground is public and already bound to this server, so skip straight to running it. Steps 1 and 2 below apply only to the ChatGPT and Claude hosts, which must be connected in the host account the profile is logged into:
 
 0. **Environment**: `cp .env.example .env` and fill in `NOTTE_API_KEY` and `NOTTE_PROFILE_ID`. `conformance.py` loads `.env` itself; `pnpm notte:profile` loads it via Node. CI passes real env vars instead; flags always override.
 1. **Connect the app** from any browser logged into the target account (connectors are account-level): enable developer mode, then connect the deployed conformance server as an app named `Conformance`. Both ChatGPT and Claude need the connection on their respective accounts.

--- a/e2e/conformance/notte/alpic.py
+++ b/e2e/conformance/notte/alpic.py
@@ -1,0 +1,114 @@
+"""Alpic playground host adapter: the Skybridge "try this server" playground
+at <server>/try (https://conformance.skybridge.tech/try), which renders MCP
+Apps views inline in a chat.
+
+Thinner than the chat hosts: the playground is already bound to this server's
+tools, so there's no app to connect and no account to log into. The prompt is
+plain (no @mention, no app-name resolution), and only two effects surface
+differently from ChatGPT/Claude:
+
+  - openExternal is forwarded to a top-page window.open (no permission dialog,
+    no tab the driver can track), recorded by install_state_listener.
+  - requestModal opens the view as a host dialog (role="dialog" with a "Close"
+    control) rather than a native OS dialog.
+"""
+
+import time
+
+from playwright.sync_api import Page
+
+from utils import (
+    PAGE_LOAD_TIMEOUT_MS,
+    HostConfig,
+    click_top_page_button,
+    host_modal_present,
+)
+
+
+def send_prompt_alpic(page: Page, app_name: str) -> None:
+    """Type into the playground composer and send.
+
+    The composer is a plain <textarea>; a single Enter sends. No mention
+    picker and no app to pick (the playground is already scoped to this
+    server), so the model just calls the `conformance` tool and the view
+    renders inline.
+    """
+    composer = page.locator("textarea").first
+    composer.click(timeout=PAGE_LOAD_TIMEOUT_MS)
+    composer.fill(f"run {app_name}")
+    time.sleep(1)
+    page.keyboard.press("Enter")
+
+
+def hide_sidebar_alpic(page: Page) -> None:
+    """No-op: the playground's thin icon rail doesn't overlap the widget."""
+    return
+
+
+def dismiss_modal_alpic(page: Page) -> None:
+    """No-op: the playground has no cookie/consent banner to clear."""
+    return
+
+
+def check_follow_up_alpic(page: Page, timeout_seconds: int = 120, poll_interval: int = 4) -> bool:
+    """Detect the follow-up by the reply it triggers.
+
+    The playground doesn't render the programmatic follow-up as a visible user
+    bubble (so there's no marker text to scrape, unlike Claude) — it only shows
+    the model's reply. Every run has exactly one assistant turn before this
+    test (the response to the "run" prompt), so a second assistant message is
+    the follow-up landing. Assistant turns carry data-role="assistant".
+    """
+    js = '() => document.querySelectorAll(\'[data-role="assistant"]\').length'
+    elapsed = 0
+    while elapsed < timeout_seconds:
+        if page.evaluate(js) >= 2:
+            return True
+        time.sleep(poll_interval)
+        elapsed += poll_interval
+    return False
+
+
+def accept_native_dialog_alpic(page: Page, hook: str) -> bool | None:
+    """Verify the effects the playground surfaces in the top page.
+
+    Called right after Run:
+      - openExternal: the playground forwards it to window.open (recorded by
+        install_state_listener); a docs.skybridge URL among the calls confirms
+        the host opened the link. window.open fires synchronously during Run,
+        but poll briefly to absorb the drive round-trip.
+      - requestModal: the view opens as a host dialog. Count it supported (like
+        Claude) and click its Close so the backdrop can't block later tests.
+      - download: no host dialog; the app detects the no-op itself (return None
+        so the generic path leaves the app's own unsupported verdict).
+    """
+    hook_lc = hook.lower()
+    if "openexternal" in hook_lc:
+        for _ in range(6):
+            opens = page.evaluate("() => window.__externalOpens || []")
+            if any("docs.skybridge" in url for url in opens):
+                return True
+            time.sleep(1)
+        return False
+    if "requestmodal" in hook_lc:
+        for _ in range(6):
+            if host_modal_present(page):
+                click_top_page_button(page, "Close")
+                return True
+            time.sleep(1)
+        return False
+    return None
+
+
+ALPIC = HostConfig(
+    name="alpic",
+    url="https://conformance.skybridge.tech/try",
+    # The playground renders MCP Apps views in a sandboxed iframe served at
+    # <server>/try/mcp-app-sandbox/index.html.
+    widget_iframe_selector='iframe[src*="mcp-app-sandbox"]',
+    send_prompt=send_prompt_alpic,
+    hide_sidebar=hide_sidebar_alpic,
+    dismiss_modal=dismiss_modal_alpic,
+    check_follow_up=check_follow_up_alpic,
+    accept_native_dialog=accept_native_dialog_alpic,
+)

--- a/e2e/conformance/notte/alpic_expected.json
+++ b/e2e/conformance/notte/alpic_expected.json
@@ -1,0 +1,17 @@
+{
+  "useToolInfo": "supported",
+  "useLayout": "supported",
+  "useUser": "supported",
+  "useViewState": "supported",
+  "useCallTool": "supported",
+  "useSetOpenInAppUrl": "supported",
+  "useDisplayMode": "supported",
+  "useRequestSize": "unsupported",
+  "useRequestModal": "supported",
+  "useOpenExternal": "supported",
+  "useDownload": "unsupported",
+  "useFiles": "unsupported",
+  "useSendFollowUpMessage": "supported",
+  "useRegisterViewTool": "unsupported",
+  "useRequestClose": "unsupported"
+}

--- a/e2e/conformance/notte/conformance.py
+++ b/e2e/conformance/notte/conformance.py
@@ -51,6 +51,7 @@ from dotenv import load_dotenv
 from playwright.sync_api import BrowserContext, Page, sync_playwright
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
+from alpic import ALPIC
 from chatgpt import CHATGPT
 from claude import CLAUDE
 from utils import (
@@ -71,7 +72,11 @@ from utils import (
     widget_present,
 )
 
-HOSTS: dict[str, HostConfig] = {CHATGPT.name: CHATGPT, CLAUDE.name: CLAUDE}
+HOSTS: dict[str, HostConfig] = {
+    CHATGPT.name: CHATGPT,
+    CLAUDE.name: CLAUDE,
+    ALPIC.name: ALPIC,
+}
 
 
 # ── Answering confirmations ──────────────────────────────────────────

--- a/e2e/conformance/notte/utils.py
+++ b/e2e/conformance/notte/utils.py
@@ -216,6 +216,12 @@ def install_state_listener(page: Page) -> None:
     every change plus a 1.5s heartbeat; stash the latest payload (a real
     object now, no JSON-string round trip needed) in a window variable that
     read_state polls. Zero LLM involved.
+
+    Also record window.open calls: the Alpic playground routes openExternal to
+    a top-page window.open (no permission dialog, no tab the driver can track),
+    so its adapter reads window.__externalOpens to verify the link opened. The
+    chat hosts pop a native dialog instead and never touch this, so recording
+    is a harmless no-op there.
     """
     page.evaluate(
         """() => {
@@ -226,6 +232,12 @@ def install_state_listener(page: Page) -> None:
                     window.__confState = event.data.state;
                 }
             });
+            window.__externalOpens = window.__externalOpens || [];
+            const nativeOpen = window.open;
+            window.open = function (url, ...rest) {
+                try { window.__externalOpens.push(String(url || '')); } catch (e) {}
+                return nativeOpen ? nativeOpen.apply(this, [url, ...rest]) : null;
+            };
             return 'installed';
         }"""
     )


### PR DESCRIPTION
this adds an `alpic` adapter in `notte/alpic.py`, wired into `HOSTS`, the ci matrix, and `alpic_expected.json`. it detects the follow-up by the assistant-reply count going one to two, closes the host dialog `useRequestModal` opens, and reads `useOpenExternal` off a `window.open` recorder added to `utils.py` (a no-op for the chat hosts). the runs also turned up two host bugs, now under known issues.