### PR TITLE
fix(descope): advertise the agentic AS's own discovery document

### DIFF
--- a/packages/core/src/server/auth/providers/custom.test.ts
+++ b/packages/core/src/server/auth/providers/custom.test.ts
@@ -1,10 +1,14 @@
 // @vitest-environment node
 import http from "node:http";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { customProvider } from "./custom.js";
 
-let server: http.Server | undefined;
-afterEach(() => server?.close());
+const servers: http.Server[] = [];
+afterEach(() => {
+  for (const srv of servers.splice(0)) {
+    srv.close();
+  }
+});
 
 function doc(origin: string, extra: Record<string, unknown> = {}) {
   return {
@@ -31,7 +35,7 @@ async function serveDiscovery(extra: Record<string, unknown> = {}) {
     res.end(JSON.stringify(doc(origin, extra)));
   });
   await new Promise<void>((resolve) => srv.listen(0, resolve));
-  server = srv;
+  servers.push(srv);
   origin = `http://localhost:${(srv.address() as { port: number }).port}`;
   return origin;
 }
@@ -107,29 +111,58 @@ describe("customProvider", () => {
     expect(config.verify.issuer).toBe(base);
   });
 
-  it("authorizationServer advertises a distinct AS, keeping the discovered issuer for verification", async () => {
+  it("authorizationServer supplies the advertised metadata and the verified issuer", async () => {
     const base = await serveDiscovery();
+    const as = await serveDiscovery({ scopes_supported: ["checkout"] });
+
     const config = await customProvider({
       issuer: base,
       audience: "a",
-      authorizationServer: "https://as.example.test/agentic/P1/MS1/",
+      authorizationServer: `${as}/`,
     });
-    expect(config.oauthMetadata.issuer).toBe(
-      "https://as.example.test/agentic/P1/MS1",
+
+    expect(config.oauthMetadata.issuer).toBe(as);
+    expect(config.oauthMetadata.authorization_endpoint).toBe(`${as}/authorize`);
+    expect(config.oauthMetadata.registration_endpoint).toBe(`${as}/register`);
+    expect(config.scopesSupported).toEqual(["checkout"]);
+    expect(config.verify).toEqual({
+      issuer: as,
+      audience: "a",
+      jwksUri: `${as}/jwks`,
+    });
+  });
+
+  it("falls back to the issuer's metadata when the authorizationServer is undiscoverable", async () => {
+    const base = await serveDiscovery();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const config = await customProvider({
+      issuer: base,
+      audience: "a",
+      authorizationServer: `${base}/agentic/P1/MS1`,
+    });
+
+    expect(warn).toHaveBeenCalledOnce();
+    expect(config.oauthMetadata.issuer).toBe(`${base}/agentic/P1/MS1`);
+    expect(config.oauthMetadata.authorization_endpoint).toBe(
+      `${base}/authorize`,
     );
     expect(config.verify.issuer).toBe(base);
+    warn.mockRestore();
   });
 
   it("serverUrl takes precedence over authorizationServer", async () => {
     const base = await serveDiscovery();
+    const as = await serveDiscovery();
     const config = await customProvider({
       issuer: base,
       audience: "a",
       serverUrl: "https://app.example.test/",
-      authorizationServer: "https://as.example.test/agentic/P1/MS1",
+      authorizationServer: as,
     });
     expect(config.oauthMetadata.issuer).toBe("https://app.example.test");
-    expect(config.verify.issuer).toBe(base);
+    expect(config.oauthMetadata.token_endpoint).toBe(`${as}/token`);
+    expect(config.verify.issuer).toBe(as);
   });
 
   it("applies metadataOverrides over discovered values", async () => {

--- a/packages/core/src/server/auth/providers/custom.ts
+++ b/packages/core/src/server/auth/providers/custom.ts
@@ -22,9 +22,11 @@ export type CustomProviderOptions = {
    * stays the IdP (the token's real `iss`). */
   serverUrl?: string;
   /** Advertise this URL as the authorization server (served AS metadata `issuer`
-   * and PRM `authorization_servers`) while `verify.issuer` stays the IdP's `iss`.
-   * Use when DCR/authorize/token live at a different URL than the token issuer
-   * (e.g. Descope's agentic URL vs. its base-project issuer). `serverUrl` wins if
+   * and PRM `authorization_servers`). Its own discovery document supplies the
+   * advertised endpoints, DCR registration, scopes and the `iss` tokens are
+   * verified against; only `jwks_uri` still comes from `issuer`'s document. Use
+   * when DCR/authorize/token live at a different URL than the discovery issuer
+   * (e.g. Descope's agentic URL vs. its base-project URL). `serverUrl` wins if
    * both are set. */
   authorizationServer?: string;
   scopes?: string[];
@@ -54,12 +56,22 @@ export async function customProvider(
     jwks_uri: _jwks,
     ...overrides
   }: Partial<DiscoveredMetadata> = opts.metadataOverrides ?? {};
-  const base: DiscoveredMetadata = { ...discovered, ...overrides };
+  let advertised = discovered;
+  if (opts.authorizationServer) {
+    try {
+      advertised = await discoverAuthorizationServer(opts.authorizationServer);
+    } catch (err) {
+      console.warn(
+        `OAuth discovery failed for authorizationServer ${opts.authorizationServer}; advertising ${opts.issuer} metadata instead: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+  const base: DiscoveredMetadata = { ...advertised, ...overrides };
   const scopesSupported = opts.scopes ?? base.scopes_supported;
 
-  // serverUrl (skybridge-as-AS) or authorizationServer (a distinct AS URL)
-  // override the advertised issuer (and keep the served scopes in sync). The
-  // verifier still trusts the IdP's `iss`. serverUrl wins when both are set.
+  // serverUrl (skybridge-as-AS) overrides the advertised issuer, keeping the
+  // IdP as the token issuer. authorizationServer re-asserts its own URL so a
+  // failed AS discovery still points clients at the AS. serverUrl wins.
   const advertisedIssuer =
     opts.serverUrl?.replace(/\/$/, "") ??
     opts.authorizationServer?.replace(/\/$/, "");
@@ -75,9 +87,9 @@ export async function customProvider(
     baseUrl: opts.baseUrl,
     oauthMetadata,
     verify: {
-      issuer: discovered.issuer,
+      issuer: advertised.issuer,
       audience: opts.audience,
-      jwksUri: discovered.jwks_uri,
+      jwksUri: advertised.jwks_uri ?? discovered.jwks_uri,
     },
     scopesSupported,
     requiredScopes: opts.requiredScopes,

--- a/packages/core/src/server/auth/providers/descope.test.ts
+++ b/packages/core/src/server/auth/providers/descope.test.ts
@@ -4,49 +4,75 @@ import { descopeProvider } from "./descope.js";
 
 afterEach(() => vi.restoreAllMocks());
 
-function discoveryDoc(issuer: string) {
+function discoveryDoc(issuer: string, scopes: string[]) {
   return {
     issuer,
     authorization_endpoint: `${issuer}/authorize`,
     token_endpoint: `${issuer}/token`,
     registration_endpoint: `${issuer}/register`,
     response_types_supported: ["code"],
-    scopes_supported: ["openid"],
+    scopes_supported: scopes,
     jwks_uri: `${issuer}/.well-known/jwks.json`,
   };
 }
 
-function mockDiscovery(issuer: string) {
-  return vi.spyOn(globalThis, "fetch").mockImplementation(
-    async () =>
-      new Response(JSON.stringify(discoveryDoc(issuer)), {
+const PROJECT = "https://api.descope.com/v1/apps/P123";
+const AGENTIC = "https://api.descope.com/v1/apps/agentic/P123/MS456";
+
+function mockDiscovery(docs: Record<string, string[]>) {
+  return vi
+    .spyOn(globalThis, "fetch")
+    .mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      const entry = Object.entries(docs).find(
+        ([issuer]) => url === `${issuer}/.well-known/openid-configuration`,
+      );
+      if (entry === undefined) {
+        return new Response(null, { status: 404 });
+      }
+      return new Response(JSON.stringify(discoveryDoc(...entry)), {
         headers: { "content-type": "application/json" },
-      }),
-  );
+      });
+    });
 }
 
 describe("descopeProvider", () => {
-  it("builds the base-project issuer and audience (project id) from the MCP Server URL", async () => {
-    const url = "https://api.descope.com/v1/apps/agentic/P123/MS456";
-    const base = "https://api.descope.com/v1/apps/P123";
-    const fetchSpy = mockDiscovery(base);
+  it("verifies against the agentic issuer it advertises", async () => {
+    const fetchSpy = mockDiscovery({
+      [PROJECT]: ["openid", "profile", "email", "phone"],
+      [AGENTIC]: ["checkout"],
+    });
 
-    const config = await descopeProvider({ url });
+    const config = await descopeProvider({ url: AGENTIC });
 
     expect(fetchSpy).toHaveBeenCalledWith(
-      `${base}/.well-known/openid-configuration`,
+      `${PROJECT}/.well-known/openid-configuration`,
       expect.anything(),
     );
-    expect(config.verify.issuer).toBe(base);
+    expect(config.verify.issuer).toBe(AGENTIC);
     expect(config.verify.audience).toBe("P123");
-    expect(config.oauthMetadata.issuer).toBe(url);
+    expect(config.oauthMetadata.issuer).toBe(AGENTIC);
+    expect(config.oauthMetadata.registration_endpoint).toBe(
+      `${AGENTIC}/register`,
+    );
+    expect(config.scopesSupported).toEqual(["checkout"]);
+  });
+
+  it("accepts a URL carrying the well-known suffix", async () => {
+    mockDiscovery({ [PROJECT]: ["openid"], [AGENTIC]: ["checkout"] });
+
+    const config = await descopeProvider({
+      url: `${AGENTIC}/.well-known/openid-configuration`,
+    });
+
+    expect(config.oauthMetadata.issuer).toBe(AGENTIC);
+    expect(config.scopesSupported).toEqual(["checkout"]);
   });
 
   it("lets an explicit audience override the derived project id", async () => {
-    const url = "https://api.descope.com/v1/apps/agentic/P123/MS456";
-    mockDiscovery("https://api.descope.com/v1/apps/P123");
+    mockDiscovery({ [PROJECT]: ["openid"], [AGENTIC]: ["checkout"] });
 
-    const config = await descopeProvider({ url, audience: "custom" });
+    const config = await descopeProvider({ url: AGENTIC, audience: "custom" });
 
     expect(config.verify.audience).toBe("custom");
   });

--- a/packages/core/src/server/auth/providers/descope.ts
+++ b/packages/core/src/server/auth/providers/descope.ts
@@ -2,6 +2,15 @@ import type { OAuthConfig } from "../index.js";
 import { type CustomProviderOptions, customProvider } from "./custom.js";
 
 /**
+ * Turns the console's Discovery URL into the authorization server's base URL:
+ * drops a `/.well-known/openid-configuration` (or `oauth-authorization-server`)
+ * suffix, since discovery appends that path itself, and any trailing slash.
+ */
+function toAuthorizationServerUrl(discoveryUrl: string): string {
+  return discoveryUrl.replace(/\/\.well-known\/[^?#]*$/, "").replace(/\/$/, "");
+}
+
+/**
  * Derives the Descope Project ID from an MCP Server URL
  * (`…/agentic/<projectId>/<mcpServerId>`). Descope binds the token `aud` to the
  * project id, so it doubles as the audience.
@@ -30,12 +39,13 @@ export function descopeProvider(
   opts: { url: string } & Omit<CustomProviderOptions, "issuer">,
 ): Promise<OAuthConfig> {
   const { url, audience, ...rest } = opts;
-  const projectId = projectIdFromUrl(url);
-  const issuer = `${url.slice(0, url.indexOf("/agentic/"))}/${projectId}`;
+  const asUrl = toAuthorizationServerUrl(url);
+  const projectId = projectIdFromUrl(asUrl);
+  const issuer = `${asUrl.slice(0, asUrl.indexOf("/agentic/"))}/${projectId}`;
   return customProvider({
     issuer,
     audience: audience ?? projectId,
-    authorizationServer: url,
+    authorizationServer: asUrl,
     ...rest,
   });
 }


### PR DESCRIPTION
### Summary

- Descope servers advertised the base project's scopes (`openid profile email phone`), so clients hit `invalid_scope` on `/authorize`.
- `authorizationServer` now discovers its own metadata instead of only renaming the advertised issuer.
- Served endpoints, DCR registration and scopes come from the agentic AS; token verification still uses the project issuer.
- `descopeProvider` tolerates a `url` carrying a `/.well-known/…` suffix.

### Architecture Notes

- **Split sources** — `verify` stays on the token's `iss`; everything client-facing comes from the AS the client is sent to.
- **Boot resilience** — unreachable AS discovery warns and falls back to the issuer document rather than failing startup.