### PR TITLE
fix(build): allow extending esbuild externals via skybridge({ serverExternal })

### DIFF
--- a/docs/api-reference/cli.mdx
+++ b/docs/api-reference/cli.mdx
@@ -89,6 +89,26 @@ deno run -A npm:skybridge/skybridge build
 
 The output lands in `dist/`, ready for the `deploy` script or `skybridge start`.
 
+### Excluding packages from the server bundle
+
+The build's last step bundles your server into a single deployable function with esbuild. Bundling means every reachable dependency has to be resolved, including ones your code never runs.
+
+Some packages break that step. A common case is a logger with an optional native dependency, like [bunyan](https://github.com/trentm/node-bunyan), which does `require('dtrace-provider')` inside a `try/catch`. You never use DTrace, but esbuild still tries to resolve it and fails on the native binding.
+
+List those packages in the Vite plugin's `serverExternal` to leave them out of the bundle:
+
+```ts vite.config.ts
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { skybridge } from "skybridge/vite";
+
+export default defineConfig({
+  plugins: [react(), skybridge({ serverExternal: ["dtrace-provider"] })],
+});
+```
+
+An external package stays a plain `import` in the output, resolved from `node_modules` at runtime. Only list packages your server doesn't need at runtime, or that your deployment target installs itself.
+
 ## `start`
 
 Run the production server from the build output. Run `skybridge build` first.

--- a/packages/core/src/cli/build-helpers.test.ts
+++ b/packages/core/src/cli/build-helpers.test.ts
@@ -159,6 +159,28 @@ describe("emitVercelBuildOutput", () => {
     ).toContain("bundled view");
   });
 
+  it("leaves serverExternal packages unbundled", async () => {
+    const root = mkTmp();
+    mkdirSync(path.join(root, "dist"), { recursive: true });
+    // Unresolvable from the tmp root, so esbuild fails the build unless the
+    // package is marked external (bunyan → optional `dtrace-provider`).
+    writeFileSync(
+      path.join(root, "dist", "__entry.js"),
+      'import "dtrace-provider";\nexport default null;\n',
+    );
+
+    await expect(emitVercelBuildOutput(root)).rejects.toThrow(
+      /Could not resolve "dtrace-provider"/,
+    );
+    await emitVercelBuildOutput(root, ["dtrace-provider"]);
+
+    const bundle = readFileSync(
+      path.join(root, ".vercel", "output", "functions", "mcp.func", "index.js"),
+      "utf-8",
+    );
+    expect(bundle).toContain('import "dtrace-provider"');
+  });
+
   it("emits static assets directory when dist/assets is missing", async () => {
     const root = mkTmp();
     mkdirSync(path.join(root, "dist"), { recursive: true });

--- a/packages/core/src/cli/build-helpers.ts
+++ b/packages/core/src/cli/build-helpers.ts
@@ -84,7 +84,10 @@ export const VERCEL_VC_CONFIG: unknown = {
 // directly would skip that priming and 500 on view resource reads when the
 // function falls back to `readFileSync('dist/assets/.vite/manifest.json')`
 // (Vercel functions don't ship `dist/`).
-export async function emitVercelBuildOutput(root: string): Promise<void> {
+export async function emitVercelBuildOutput(
+  root: string,
+  serverExternal: string[] = [],
+): Promise<void> {
   const outputDir = path.join(root, ".vercel", "output");
   const funcDir = path.join(
     outputDir,
@@ -108,7 +111,12 @@ export async function emitVercelBuildOutput(root: string): Promise<void> {
     define: { "process.env.NODE_ENV": '"production"' },
     // Dev-only deps reachable from re-exports; safe to leave unresolved since
     // the code paths that touch them are eliminated by the NODE_ENV define.
-    external: ["vite", "@skybridge/devtools"],
+    // `serverExternal` comes from the vite plugin, for deps esbuild can't
+    // resolve or load (e.g. optional native modules pulled in transitively).
+    external: ["vite", "@skybridge/devtools", ...serverExternal],
+    // Native addons can't be inlined into the bundle; copy them next to the
+    // function and rewrite the require path to point at the copy.
+    loader: { ".node": "file" },
     banner: {
       // ESM bundles miss CJS interop globals that some deps reach for.
       js: "import{createRequire}from'node:module';const require=createRequire(import.meta.url);",

--- a/packages/core/src/cli/build-steps.ts
+++ b/packages/core/src/cli/build-steps.ts
@@ -12,13 +12,13 @@ import {
   emitVercelBuildOutput,
   ensureAssetsDir,
 } from "./build-helpers.js";
-import { resolveViewsDir } from "./resolve-views-dir.js";
+import { resolveSkybridgeConfig } from "./resolve-skybridge-config.js";
 import type { CommandStep } from "./use-execute-steps.js";
 
 export async function getCommandSteps(
   root = process.cwd(),
 ): Promise<CommandStep[]> {
-  const viewsDir = await resolveViewsDir(root);
+  const { viewsDir, serverExternal } = await resolveSkybridgeConfig(root);
   const rawDir = viewsDir ?? "src/views";
   const resolvedDir = isAbsolute(rawDir) ? rawDir : resolve(root, rawDir);
   // Non-throwing pre-check: duplicate view names are validated in the
@@ -101,7 +101,7 @@ export async function getCommandSteps(
     },
     {
       label: "Emitting Vercel build output",
-      run: () => emitVercelBuildOutput(root),
+      run: () => emitVercelBuildOutput(root, serverExternal),
     },
   );
 

--- a/packages/core/src/cli/resolve-skybridge-config.ts
+++ b/packages/core/src/cli/resolve-skybridge-config.ts
@@ -1,6 +1,11 @@
-export async function resolveViewsDir(
+export interface SkybridgeConfig {
+  viewsDir?: string;
+  serverExternal?: string[];
+}
+
+export async function resolveSkybridgeConfig(
   root: string,
-): Promise<string | undefined> {
+): Promise<SkybridgeConfig> {
   const { loadConfigFromFile } = await import("vite");
   const loaded = await loadConfigFromFile(
     { command: "build", mode: "production" },
@@ -10,10 +15,10 @@ export async function resolveViewsDir(
 
   const isPluginCandidate = (
     value: unknown,
-  ): value is { name?: string; api?: { viewsDir?: string } } =>
+  ): value is { name?: string; api?: SkybridgeConfig } =>
     typeof value === "object" && value !== null;
 
-  const plugins: Array<{ name?: string; api?: { viewsDir?: string } }> = [];
+  const plugins: Array<{ name?: string; api?: SkybridgeConfig }> = [];
   const walk = (value: unknown) => {
     if (Array.isArray(value)) {
       value.forEach(walk);
@@ -22,5 +27,6 @@ export async function resolveViewsDir(
     }
   };
   walk(loaded?.config.plugins ?? []);
-  return plugins.find((p) => p.name === "skybridge")?.api?.viewsDir;
+  const api = plugins.find((p) => p.name === "skybridge")?.api;
+  return { viewsDir: api?.viewsDir, serverExternal: api?.serverExternal };
 }

--- a/packages/core/src/commands/dev.tsx
+++ b/packages/core/src/commands/dev.tsx
@@ -2,7 +2,7 @@ import { Command, Flags } from "@oclif/core";
 import { Box, render, Text } from "ink";
 import { resolvePort } from "../cli/detect-port.js";
 import { Header } from "../cli/header.js";
-import { resolveViewsDir } from "../cli/resolve-views-dir.js";
+import { resolveSkybridgeConfig } from "../cli/resolve-skybridge-config.js";
 import { runPlain } from "../cli/run-plain.js";
 import { startTunnelControlServer } from "../cli/tunnel-control-server.js";
 import { useMessages } from "../cli/use-messages.js";
@@ -52,7 +52,7 @@ export default class Dev extends Command {
     // and the dev UI reports phantom TS errors forever.
     const root = process.cwd();
     try {
-      scanAndWriteViewsDts(root, await resolveViewsDir(root));
+      scanAndWriteViewsDts(root, (await resolveSkybridgeConfig(root)).viewsDir);
     } catch {
       // Best-effort: if the scan fails (e.g. broken vite config, duplicate
       // view names) tsc may show phantom errors, but the dev server should

--- a/packages/core/src/web/plugin/plugin.ts
+++ b/packages/core/src/web/plugin/plugin.ts
@@ -17,6 +17,12 @@ const VIRTUAL_MODULE_PREFIX = "\0skybridge:view:";
 export interface SkybridgePluginOptions {
   /** Directory scanned for view modules. Defaults to `"src/views"`. */
   viewsDir?: string;
+  /**
+   * Package names to leave unbundled when `skybridge build` bundles the server
+   * for deployment. Use it for dependencies esbuild can't resolve or load —
+   * typically optional native modules pulled in by a transitive dependency.
+   */
+  serverExternal?: string[];
 }
 
 function buildVirtualEntry(viewFilePath: string): string {
@@ -72,8 +78,9 @@ export function skybridge(options?: SkybridgePluginOptions): Plugin {
   return {
     name: "skybridge",
     enforce: "pre",
-    // Read by `skybridge build` to resolve viewsDir before `tsc -b` runs.
-    api: { viewsDir: rawViewsDir },
+    // Read by `skybridge build` to resolve viewsDir before `tsc -b` runs, and
+    // to feed esbuild's external list when bundling the server.
+    api: { viewsDir: rawViewsDir, serverExternal: options?.serverExternal },
 
     config(config) {
       projectRoot = config.root || process.cwd();


### PR DESCRIPTION
[Slack discussion](https://alpicworkspace.slack.com/archives/C0B2D771DQV/p1785149256035349)

## Summary

- `skybridge build` bundles the server with esbuild, so every reachable dependency must resolve, even ones the server never runs. The external list was hardcoded to `["vite", "@skybridge/devtools"]` with no way to extend it, and the Vercel step is unconditional, so it can't be skipped either.
- Adds a `serverExternal` option to the `skybridge` Vite plugin, exposed via `api` and read by `skybridge build`, same wiring as the existing `viewsDir`.
- Sets `loader: { ".node": "file" }` on the esbuild call. Native addons can't be inlined, so today any native dependency in the tree fails the build and no `external` entry helps.
- `resolveViewsDir` becomes `resolveSkybridgeConfig`, returning the whole plugin api instead of a single field.

```ts
// vite.config.ts
skybridge({ serverExternal: ["dtrace-provider"] })
```

Reported by a user migrating to 1.3.0: bunyan does `require('dtrace-provider' + '')` in a `try/catch`, esbuild constant-folds the concatenation and fails on the native binding. Present since at least v1.1.0.

## Architecture Notes

`vite.config.ts` is the escape hatch's home rather than an env var or a new `package.json` field, because it is already the config file the build loads. Auto-externalizing anything esbuild can't resolve was rejected: it would turn a genuinely missing dependency into a runtime crash instead of a build error.

Docs updated in `api-reference/cli.mdx` under `build`.