### PR TITLE
fix(web): don't call adaptor.setViewState inside the React state updater

### DIFF
--- a/packages/core/src/web/hooks/use-view-state.test.ts
+++ b/packages/core/src/web/hooks/use-view-state.test.ts
@@ -1,4 +1,5 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { StrictMode } from "react";
 import {
   afterEach,
   beforeEach,
@@ -80,6 +81,18 @@ describe("useViewState", () => {
       privateContent: {},
     });
     expect(result.current[0]).toEqual({ count: 1, name: "test" });
+  });
+
+  it("should call window.openai.setWidgetState once per update under StrictMode", () => {
+    const { result } = renderHook(() => useViewState(defaultState), {
+      wrapper: StrictMode,
+    });
+
+    act(() => {
+      result.current[1]({ count: 10, name: "updated" });
+    });
+
+    expect(OpenaiMock.setWidgetState).toHaveBeenCalledTimes(1);
   });
 
   it("should update state when window.openai.widgetState changes", () => {

--- a/packages/core/src/web/hooks/use-view-state.test.ts
+++ b/packages/core/src/web/hooks/use-view-state.test.ts
@@ -95,6 +95,12 @@ describe("useViewState", () => {
     expect(OpenaiMock.setWidgetState).toHaveBeenCalledTimes(1);
   });
 
+  it("should not persist anything on mount", () => {
+    renderHook(() => useViewState(defaultState), { wrapper: StrictMode });
+
+    expect(OpenaiMock.setWidgetState).not.toHaveBeenCalled();
+  });
+
   it("should not persist state when setViewState is called after unmount", () => {
     const { result, unmount } = renderHook(() => useViewState(defaultState));
     const setViewState = result.current[1];

--- a/packages/core/src/web/hooks/use-view-state.test.ts
+++ b/packages/core/src/web/hooks/use-view-state.test.ts
@@ -95,6 +95,19 @@ describe("useViewState", () => {
     expect(OpenaiMock.setWidgetState).toHaveBeenCalledTimes(1);
   });
 
+  it("should not persist state when setViewState is called after unmount", () => {
+    const { result, unmount } = renderHook(() => useViewState(defaultState));
+    const setViewState = result.current[1];
+
+    unmount();
+
+    act(() => {
+      setViewState({ count: 10, name: "updated" });
+    });
+
+    expect(OpenaiMock.setWidgetState).not.toHaveBeenCalled();
+  });
+
   it("should update state when window.openai.widgetState changes", () => {
     OpenaiMock.widgetState = { modelContent: defaultState };
     const { result, rerender } = renderHook(() => useViewState(defaultState));

--- a/packages/core/src/web/hooks/use-view-state.test.ts
+++ b/packages/core/src/web/hooks/use-view-state.test.ts
@@ -112,6 +112,19 @@ describe("useViewState", () => {
     expect(OpenaiMock.setWidgetState).toHaveBeenCalledTimes(1);
   });
 
+  it("should not persist state when setViewState is called after unmount", () => {
+    const { result, unmount } = renderHook(() => useViewState(defaultState));
+    const setViewState = result.current[1];
+
+    unmount();
+
+    act(() => {
+      setViewState({ count: 10, name: "updated" });
+    });
+
+    expect(OpenaiMock.setWidgetState).not.toHaveBeenCalled();
+  });
+
   it("should update state when window.openai.widgetState changes", () => {
     OpenaiMock.widgetState = { modelContent: defaultState };
     const { result, rerender } = renderHook(() => useViewState(defaultState));

--- a/packages/core/src/web/hooks/use-view-state.test.ts
+++ b/packages/core/src/web/hooks/use-view-state.test.ts
@@ -112,19 +112,6 @@ describe("useViewState", () => {
     expect(OpenaiMock.setWidgetState).toHaveBeenCalledTimes(1);
   });
 
-  it("should not persist state when setViewState is called after unmount", () => {
-    const { result, unmount } = renderHook(() => useViewState(defaultState));
-    const setViewState = result.current[1];
-
-    unmount();
-
-    act(() => {
-      setViewState({ count: 10, name: "updated" });
-    });
-
-    expect(OpenaiMock.setWidgetState).not.toHaveBeenCalled();
-  });
-
   it("should update state when window.openai.widgetState changes", () => {
     OpenaiMock.widgetState = { modelContent: defaultState };
     const { result, rerender } = renderHook(() => useViewState(defaultState));

--- a/packages/core/src/web/hooks/use-view-state.test.ts
+++ b/packages/core/src/web/hooks/use-view-state.test.ts
@@ -101,6 +101,17 @@ describe("useViewState", () => {
     expect(OpenaiMock.setWidgetState).not.toHaveBeenCalled();
   });
 
+  it("should persist state when setViewState and unmount happen in the same tick", () => {
+    const { result, unmount } = renderHook(() => useViewState(defaultState));
+
+    act(() => {
+      result.current[1]({ count: 10, name: "updated" });
+      unmount();
+    });
+
+    expect(OpenaiMock.setWidgetState).toHaveBeenCalledTimes(1);
+  });
+
   it("should not persist state when setViewState is called after unmount", () => {
     const { result, unmount } = renderHook(() => useViewState(defaultState));
     const setViewState = result.current[1];

--- a/packages/core/src/web/hooks/use-view-state.ts
+++ b/packages/core/src/web/hooks/use-view-state.ts
@@ -52,8 +52,15 @@ export function useViewState<T extends UnknownObject>(
       : (defaultState ?? null);
   });
 
-  const viewStateRef = useRef(viewState);
-  viewStateRef.current = viewState;
+  const mountedStateRef = useRef<T | null | undefined>(viewState);
+
+  useEffect(() => {
+    mountedStateRef.current = viewState;
+
+    return () => {
+      mountedStateRef.current = undefined;
+    };
+  }, [viewState]);
 
   useEffect(() => {
     if (viewStateFromBridge !== null) {
@@ -63,12 +70,17 @@ export function useViewState<T extends UnknownObject>(
 
   const setViewState = useCallback(
     (state: SetStateAction<T | null>) => {
-      const newState =
-        typeof state === "function" ? state(viewStateRef.current) : state;
+      const prevState = mountedStateRef.current;
+
+      if (prevState === undefined) {
+        return;
+      }
+
+      const newState = typeof state === "function" ? state(prevState) : state;
       const stateToSet = injectViewContext(newState);
       const filteredState = filterViewContext(stateToSet);
 
-      viewStateRef.current = filteredState;
+      mountedStateRef.current = filteredState;
       _setViewState(filteredState);
 
       if (stateToSet !== null) {

--- a/packages/core/src/web/hooks/use-view-state.ts
+++ b/packages/core/src/web/hooks/use-view-state.ts
@@ -55,15 +55,6 @@ export function useViewState<T extends UnknownObject>(
   const viewStateRef = useRef(viewState);
   viewStateRef.current = viewState;
 
-  const isMountedRef = useRef(true);
-  useEffect(() => {
-    isMountedRef.current = true;
-
-    return () => {
-      isMountedRef.current = false;
-    };
-  }, []);
-
   useEffect(() => {
     if (viewStateFromBridge !== null) {
       _setViewState(filterViewContext(viewStateFromBridge));
@@ -72,10 +63,6 @@ export function useViewState<T extends UnknownObject>(
 
   const setViewState = useCallback(
     (state: SetStateAction<T | null>) => {
-      if (!isMountedRef.current) {
-        return;
-      }
-
       const newState =
         typeof state === "function" ? state(viewStateRef.current) : state;
       const stateToSet = injectViewContext(newState);

--- a/packages/core/src/web/hooks/use-view-state.ts
+++ b/packages/core/src/web/hooks/use-view-state.ts
@@ -1,4 +1,10 @@
-import { type SetStateAction, useCallback, useEffect, useState } from "react";
+import {
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { getAdaptor, useHostContext } from "../bridges/index.js";
 import { filterViewContext, injectViewContext } from "../helpers/state.js";
 import type { UnknownObject } from "../types.js";
@@ -46,6 +52,9 @@ export function useViewState<T extends UnknownObject>(
       : (defaultState ?? null);
   });
 
+  const viewStateRef = useRef(viewState);
+  viewStateRef.current = viewState;
+
   useEffect(() => {
     if (viewStateFromBridge !== null) {
       _setViewState(filterViewContext(viewStateFromBridge));
@@ -54,16 +63,17 @@ export function useViewState<T extends UnknownObject>(
 
   const setViewState = useCallback(
     (state: SetStateAction<T | null>) => {
-      _setViewState((prevState) => {
-        const newState = typeof state === "function" ? state(prevState) : state;
-        const stateToSet = injectViewContext(newState);
+      const newState =
+        typeof state === "function" ? state(viewStateRef.current) : state;
+      const stateToSet = injectViewContext(newState);
+      const filteredState = filterViewContext(stateToSet);
 
-        if (stateToSet !== null) {
-          adaptor.setViewState(stateToSet);
-        }
+      viewStateRef.current = filteredState;
+      _setViewState(filteredState);
 
-        return filterViewContext(stateToSet);
-      });
+      if (stateToSet !== null) {
+        adaptor.setViewState(stateToSet);
+      }
     },
     [adaptor],
   );

--- a/packages/core/src/web/hooks/use-view-state.ts
+++ b/packages/core/src/web/hooks/use-view-state.ts
@@ -37,7 +37,7 @@ export function useViewState<T extends UnknownObject>(
   const adaptor = getAdaptor();
   const viewStateFromBridge = useHostContext("viewState") as T | null;
 
-  const [viewState, _setViewState] = useState<T | null>(() => {
+  const [viewState, setViewState] = useState<T | null>(() => {
     if (viewStateFromBridge !== null) {
       return filterViewContext(viewStateFromBridge);
     }
@@ -54,7 +54,7 @@ export function useViewState<T extends UnknownObject>(
       const stateFromBridge = filterViewContext(viewStateFromBridge);
 
       persistedStateRef.current = stateFromBridge;
-      _setViewState(stateFromBridge);
+      setViewState(stateFromBridge);
     }
   }, [viewStateFromBridge]);
 
@@ -73,5 +73,5 @@ export function useViewState<T extends UnknownObject>(
     adaptor.setViewState(stateToSet);
   }, [viewState, adaptor]);
 
-  return [viewState, _setViewState] as const;
+  return [viewState, setViewState] as const;
 }

--- a/packages/core/src/web/hooks/use-view-state.ts
+++ b/packages/core/src/web/hooks/use-view-state.ts
@@ -1,10 +1,5 @@
-import {
-  type SetStateAction,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import { dequal } from "dequal/lite";
+import { type SetStateAction, useEffect, useRef, useState } from "react";
 import { getAdaptor, useHostContext } from "../bridges/index.js";
 import { filterViewContext, injectViewContext } from "../helpers/state.js";
 import type { UnknownObject } from "../types.js";
@@ -52,44 +47,31 @@ export function useViewState<T extends UnknownObject>(
       : (defaultState ?? null);
   });
 
-  const viewStateRef = useRef(viewState);
-  viewStateRef.current = viewState;
-
-  const isMountedRef = useRef(true);
-  useEffect(() => {
-    isMountedRef.current = true;
-
-    return () => {
-      isMountedRef.current = false;
-    };
-  }, []);
+  const persistedStateRef = useRef(viewState);
 
   useEffect(() => {
     if (viewStateFromBridge !== null) {
-      _setViewState(filterViewContext(viewStateFromBridge));
+      const stateFromBridge = filterViewContext(viewStateFromBridge);
+
+      persistedStateRef.current = stateFromBridge;
+      _setViewState(stateFromBridge);
     }
   }, [viewStateFromBridge]);
 
-  const setViewState = useCallback(
-    (state: SetStateAction<T | null>) => {
-      if (!isMountedRef.current) {
-        return;
-      }
+  useEffect(() => {
+    if (dequal(viewState, persistedStateRef.current)) {
+      return;
+    }
 
-      const newState =
-        typeof state === "function" ? state(viewStateRef.current) : state;
-      const stateToSet = injectViewContext(newState);
-      const filteredState = filterViewContext(stateToSet);
+    const stateToSet = injectViewContext(viewState);
 
-      viewStateRef.current = filteredState;
-      _setViewState(filteredState);
+    if (stateToSet === null) {
+      return;
+    }
 
-      if (stateToSet !== null) {
-        adaptor.setViewState(stateToSet);
-      }
-    },
-    [adaptor],
-  );
+    persistedStateRef.current = viewState;
+    adaptor.setViewState(stateToSet);
+  }, [viewState, adaptor]);
 
-  return [viewState, setViewState] as const;
+  return [viewState, _setViewState] as const;
 }

--- a/packages/core/src/web/hooks/use-view-state.ts
+++ b/packages/core/src/web/hooks/use-view-state.ts
@@ -55,6 +55,15 @@ export function useViewState<T extends UnknownObject>(
   const viewStateRef = useRef(viewState);
   viewStateRef.current = viewState;
 
+  const isMountedRef = useRef(true);
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
   useEffect(() => {
     if (viewStateFromBridge !== null) {
       _setViewState(filterViewContext(viewStateFromBridge));
@@ -63,6 +72,10 @@ export function useViewState<T extends UnknownObject>(
 
   const setViewState = useCallback(
     (state: SetStateAction<T | null>) => {
+      if (!isMountedRef.current) {
+        return;
+      }
+
       const newState =
         typeof state === "function" ? state(viewStateRef.current) : state;
       const stateToSet = injectViewContext(newState);

--- a/packages/core/src/web/hooks/use-view-state.ts
+++ b/packages/core/src/web/hooks/use-view-state.ts
@@ -78,10 +78,9 @@ export function useViewState<T extends UnknownObject>(
 
       const newState = typeof state === "function" ? state(prevState) : state;
       const stateToSet = injectViewContext(newState);
-      const filteredState = filterViewContext(stateToSet);
 
-      mountedStateRef.current = filteredState;
-      _setViewState(filteredState);
+      mountedStateRef.current = newState;
+      _setViewState(newState);
 
       if (stateToSet !== null) {
         adaptor.setViewState(stateToSet);

--- a/packages/core/src/web/hooks/use-view-state.ts
+++ b/packages/core/src/web/hooks/use-view-state.ts
@@ -1,5 +1,10 @@
-import { dequal } from "dequal/lite";
-import { type SetStateAction, useEffect, useRef, useState } from "react";
+import {
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { getAdaptor, useHostContext } from "../bridges/index.js";
 import { filterViewContext, injectViewContext } from "../helpers/state.js";
 import type { UnknownObject } from "../types.js";
@@ -37,7 +42,7 @@ export function useViewState<T extends UnknownObject>(
   const adaptor = getAdaptor();
   const viewStateFromBridge = useHostContext("viewState") as T | null;
 
-  const [viewState, setViewState] = useState<T | null>(() => {
+  const [viewState, _setViewState] = useState<T | null>(() => {
     if (viewStateFromBridge !== null) {
       return filterViewContext(viewStateFromBridge);
     }
@@ -47,31 +52,44 @@ export function useViewState<T extends UnknownObject>(
       : (defaultState ?? null);
   });
 
-  const persistedStateRef = useRef(viewState);
+  const viewStateRef = useRef(viewState);
+  viewStateRef.current = viewState;
+
+  const isMountedRef = useRef(true);
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   useEffect(() => {
     if (viewStateFromBridge !== null) {
-      const stateFromBridge = filterViewContext(viewStateFromBridge);
-
-      persistedStateRef.current = stateFromBridge;
-      setViewState(stateFromBridge);
+      _setViewState(filterViewContext(viewStateFromBridge));
     }
   }, [viewStateFromBridge]);
 
-  useEffect(() => {
-    if (dequal(viewState, persistedStateRef.current)) {
-      return;
-    }
+  const setViewState = useCallback(
+    (state: SetStateAction<T | null>) => {
+      if (!isMountedRef.current) {
+        return;
+      }
 
-    const stateToSet = injectViewContext(viewState);
+      const newState =
+        typeof state === "function" ? state(viewStateRef.current) : state;
+      const stateToSet = injectViewContext(newState);
+      const filteredState = filterViewContext(stateToSet);
 
-    if (stateToSet === null) {
-      return;
-    }
+      viewStateRef.current = filteredState;
+      _setViewState(filteredState);
 
-    persistedStateRef.current = viewState;
-    adaptor.setViewState(stateToSet);
-  }, [viewState, adaptor]);
+      if (stateToSet !== null) {
+        adaptor.setViewState(stateToSet);
+      }
+    },
+    [adaptor],
+  );
 
   return [viewState, setViewState] as const;
 }


### PR DESCRIPTION
## Summary

- `useViewState`'s setter called `adaptor.setViewState` from inside the `_setViewState` updater. React runs updaters during render, so the host write happened mid-render.
- Symptoms: `Cannot update a component (X) while rendering a different component (X)` on every `setViewState`, and two `setWidgetState` calls per update under StrictMode (which `mountView` always applies).
- Updater is now pure; the host write happens in the caller. A ref carries the latest state so function updaters still see fresh values.
- Added one test: `setWidgetState` is called once per update under StrictMode. Fails on `main` (2 calls), passes here.

Reported: https://discord.com/channels/1370323135861358713/1530232765058912377

`createStore` has a similar shape but is unaffected: its subscriber runs on `set()`, outside render.