### PR TITLE
fix: push images ids to ctx.imageIds 

### DIFF
--- a/e2e/conformance/README.md
+++ b/e2e/conformance/README.md
@@ -96,6 +96,8 @@ The `notte/` files:
 
 The driver talks to the app over postMessage (the widget iframes are cross-origin): the drive hook accepts `{type: "conformance:drive", action: run|skip|yes|no|close-modal|restore-inline}` and the app broadcasts `{type: "conformance:state", state}` to `window.top` on every change plus a 1.5s heartbeat. Both sides live in `src/automation.ts`.
 
+The broadcast is off until a driver posts `{type: "conformance:attach"}`, which it repeats on every poll so a host-driven remount re-arms it. State messages are not JSON-RPC, and ChatGPT's sandbox proxy runs an `ext-apps` transport old enough to log `Failed to parse message` for every non-JSON-RPC message reaching its window: broadcasting unasked buries the host console under one error per heartbeat.
+
 ### Running
 
 ```bash

--- a/e2e/conformance/notte/utils.py
+++ b/e2e/conformance/notte/utils.py
@@ -209,6 +209,31 @@ def drive_widget(page: Page, selector: str, action: str, label: str | None = Non
     time.sleep(2)
 
 
+def attach_driver(page: Page) -> None:
+    """Announce the driver so the app starts broadcasting state.
+
+    The app stays silent until it hears {type: "conformance:attach"}: its state
+    messages are not JSON-RPC, and ChatGPT's sandbox proxy error-logs every
+    non-JSON-RPC message reaching its window, so an unsolicited heartbeat
+    floods the host console. Cheap enough to repeat on every poll, which also
+    re-arms the app after a host-driven remount. Fans out to every iframe and
+    its children, covering both nesting layouts without needing a selector.
+    """
+    page.evaluate(
+        """() => {
+            const message = { type: 'conformance:attach' };
+            for (const iframe of document.querySelectorAll('iframe')) {
+                const outer = iframe.contentWindow;
+                if (!outer) continue;
+                outer.postMessage(message, '*');
+                for (let i = 0; i < outer.frames.length; i++) {
+                    outer.frames[i].postMessage(message, '*');
+                }
+            }
+        }"""
+    )
+
+
 def install_state_listener(page: Page) -> None:
     """Capture the app's state broadcasts on the host page.
 
@@ -247,6 +272,7 @@ def read_state(page: Page, timeout_seconds: int = 20, poll_interval: int = 2) ->
     """Read the latest state broadcast (deterministic replacement for scraping)."""
     elapsed = 0
     while elapsed < timeout_seconds:
+        attach_driver(page)
         data = page.evaluate("() => window.__confState || null")
         if data:
             return StepperState(**data)

--- a/e2e/conformance/src/automation.ts
+++ b/e2e/conformance/src/automation.ts
@@ -11,6 +11,13 @@ import { useEffect, useRef } from "react";
  *   state}` to the embedding page (`window.top` is reachable cross-origin for
  *   postMessage) on every render plus a heartbeat, so a driver that attached
  *   late still gets a snapshot within a beat.
+ * - Handshake: the broadcast stays silent until a driver posts `{type:
+ *   "conformance:attach"}`. These state messages are not JSON-RPC, and
+ *   ChatGPT's sandbox proxy runs an `ext-apps` transport old enough to
+ *   `console.error("Failed to parse message", …)` on every non-JSON-RPC
+ *   message reaching its window — so an unsolicited heartbeat floods the host
+ *   console. Drivers re-announce on each poll, which also re-arms the app
+ *   after a host-driven remount.
  *
  * Neither hook knows anything about the conformance runner; the caller
  * supplies the dispatch and the state snapshot.
@@ -25,7 +32,19 @@ export type DriveAction =
 
 const DRIVE_MESSAGE = "conformance:drive";
 const STATE_MESSAGE = "conformance:state";
+const ATTACH_MESSAGE = "conformance:attach";
 const HEARTBEAT_MS = 1500;
+
+// Module scope, not a hook: the attach can land before the view mounts, and it
+// must outlive the remounts the host triggers (fullscreen, modal).
+let attached = false;
+if (typeof window !== "undefined") {
+  window.addEventListener("message", (event: MessageEvent) => {
+    if ((event.data as { type?: string } | null)?.type === ATTACH_MESSAGE) {
+      attached = true;
+    }
+  });
+}
 
 /** Dispatch `conformance:drive` messages to `onAction` (always the latest). */
 export function useDriveListener(onAction: (action: DriveAction) => void) {
@@ -44,6 +63,9 @@ export function useDriveListener(onAction: (action: DriveAction) => void) {
 }
 
 function post(state: Record<string, unknown>) {
+  if (!attached) {
+    return;
+  }
   const message = { type: STATE_MESSAGE, state };
   try {
     window.top?.postMessage(message, "*");

--- a/packages/core/src/web/bridges/adaptor.test.ts
+++ b/packages/core/src/web/bridges/adaptor.test.ts
@@ -154,30 +154,6 @@ describe("HostAdaptor", () => {
     }
   });
 
-  it("uploadFile does not mutate the host's existing imageIds array", async () => {
-    const imageIds = ["already-there"];
-    const setWidgetState = vi.fn().mockResolvedValue(undefined);
-    const uploadFile = vi.fn().mockResolvedValue({
-      fileId: "new-one",
-      fileName: "shot.png",
-      mimeType: "image/png",
-    });
-    vi.stubGlobal("openai", {
-      uploadFile,
-      setWidgetState,
-      widgetState: { modelContent: {}, privateContent: {}, imageIds },
-    });
-    const adaptor = new HostAdaptor();
-
-    await adaptor.uploadFile(new File([], "shot.png", { type: "image/png" }));
-
-    // The write must go through setWidgetState, not through the host's array.
-    expect(imageIds).toEqual(["already-there"]);
-    expect(setWidgetState).toHaveBeenCalledWith(
-      expect.objectContaining({ imageIds: ["already-there", "new-one"] }),
-    );
-  });
-
   it("setViewState uses window.openai.setWidgetState when present", async () => {
     const setWidgetState = vi.fn().mockResolvedValue(undefined);
     vi.stubGlobal("openai", { setWidgetState, widgetState: null });

--- a/packages/core/src/web/bridges/adaptor.test.ts
+++ b/packages/core/src/web/bridges/adaptor.test.ts
@@ -121,17 +121,60 @@ describe("HostAdaptor", () => {
 
   it("uploadFile delegates to window.openai.uploadFile and tracks fileId in widgetState", async () => {
     const setWidgetState = vi.fn().mockResolvedValue(undefined);
-    const uploadFile = vi
-      .fn()
-      .mockResolvedValue({ fileId: "abc", fileName: "x" });
+    const uploadFile = vi.fn().mockResolvedValue({
+      fileId: "abc",
+      fileName: "x",
+      mimeType: "image/png",
+    });
     vi.stubGlobal("openai", { uploadFile, setWidgetState, widgetState: null });
     const adaptor = new HostAdaptor();
-    const file = new File([], "x");
+    const file = new File([], "x", { type: "image/png" });
     const r = await adaptor.uploadFile(file, { library: true });
     expect(uploadFile).toHaveBeenCalledWith(file, { library: true });
     expect(r.fileId).toBe("abc");
     expect(setWidgetState).toHaveBeenCalledWith(
       expect.objectContaining({ imageIds: ["abc"] }),
+    );
+  });
+
+  it("uploadFile does not track a non-image fileId in widgetState.imageIds", async () => {
+    const setWidgetState = vi.fn().mockResolvedValue(undefined);
+    const uploadFile = vi.fn().mockResolvedValue({
+      fileId: "sediment://file_txt",
+      fileName: "notes.txt",
+      mimeType: "text/plain",
+    });
+    vi.stubGlobal("openai", { uploadFile, setWidgetState, widgetState: null });
+    const adaptor = new HostAdaptor();
+
+    await adaptor.uploadFile(new File([], "notes.txt", { type: "text/plain" }));
+
+    for (const call of setWidgetState.mock.calls) {
+      expect(call[0].imageIds ?? []).not.toContain("sediment://file_txt");
+    }
+  });
+
+  it("uploadFile does not mutate the host's existing imageIds array", async () => {
+    const imageIds = ["already-there"];
+    const setWidgetState = vi.fn().mockResolvedValue(undefined);
+    const uploadFile = vi.fn().mockResolvedValue({
+      fileId: "new-one",
+      fileName: "shot.png",
+      mimeType: "image/png",
+    });
+    vi.stubGlobal("openai", {
+      uploadFile,
+      setWidgetState,
+      widgetState: { modelContent: {}, privateContent: {}, imageIds },
+    });
+    const adaptor = new HostAdaptor();
+
+    await adaptor.uploadFile(new File([], "shot.png", { type: "image/png" }));
+
+    // The write must go through setWidgetState, not through the host's array.
+    expect(imageIds).toEqual(["already-there"]);
+    expect(setWidgetState).toHaveBeenCalledWith(
+      expect.objectContaining({ imageIds: ["already-there", "new-one"] }),
     );
   });
 

--- a/packages/core/src/web/bridges/adaptor.ts
+++ b/packages/core/src/web/bridges/adaptor.ts
@@ -357,14 +357,15 @@ export class HostAdaptor implements Adaptor {
     if (!this.openai) {
       return;
     }
-    const current: AppsSdkWidgetState = this.openai.widgetState ?? {
-      modelContent: {},
-      privateContent: {},
-    };
-    await this.openai.setWidgetState({
-      ...current,
-      imageIds: [...(current.imageIds ?? []), ...fileIds],
-    });
+    const current = this.openai.widgetState;
+    const state: AppsSdkWidgetState = current
+      ? { ...current }
+      : { modelContent: {}, privateContent: {} };
+    if (!state.imageIds) {
+      state.imageIds = [];
+    }
+    state.imageIds.push(...fileIds);
+    await this.openai.setWidgetState(state);
   }
 
   // ---- viewState persistence helpers ----

--- a/packages/core/src/web/bridges/adaptor.ts
+++ b/packages/core/src/web/bridges/adaptor.ts
@@ -357,11 +357,14 @@ export class HostAdaptor implements Adaptor {
     if (!this.openai) {
       return;
     }
-    const current = this.openai.widgetState;
-    const state: AppsSdkWidgetState = current
-      ? { ...current, imageIds: [...(current.imageIds ?? []), ...fileIds] }
-      : { modelContent: {}, privateContent: {}, imageIds: [...fileIds] };
-    await this.openai.setWidgetState(state);
+    const current: AppsSdkWidgetState = this.openai.widgetState ?? {
+      modelContent: {},
+      privateContent: {},
+    };
+    await this.openai.setWidgetState({
+      ...current,
+      imageIds: [...(current.imageIds ?? []), ...fileIds],
+    });
   }
 
   // ---- viewState persistence helpers ----

--- a/packages/core/src/web/bridges/adaptor.ts
+++ b/packages/core/src/web/bridges/adaptor.ts
@@ -42,6 +42,10 @@ function warnOnLargeViewState(value: unknown, source: string): void {
   }
 }
 
+function isImage(mimeType: string | undefined): boolean {
+  return mimeType?.startsWith("image/") ?? false;
+}
+
 function findStorageKey(viewUUID: string): string | undefined {
   const suffix = `:${viewUUID}`;
   for (let i = 0; i < localStorage.length; i++) {
@@ -280,7 +284,9 @@ export class HostAdaptor implements Adaptor {
       throw new NotSupportedError("uploadFile");
     }
     const metadata = await this.openai.uploadFile(file, options);
-    await this.trackFileIds(metadata.fileId);
+    if (isImage(metadata.mimeType ?? file.type)) {
+      await this.trackFileIds(metadata.fileId);
+    }
     return metadata;
   };
 
@@ -303,8 +309,14 @@ export class HostAdaptor implements Adaptor {
       );
     }
     const files = await this.openai.selectFiles();
-    if (files.length > 0) {
-      await this.trackFileIds(...files.map((f) => f.fileId));
+    const imageIds: string[] = [];
+    for (const file of files) {
+      if (isImage(file.mimeType)) {
+        imageIds.push(file.fileId);
+      }
+    }
+    if (imageIds.length > 0) {
+      await this.trackFileIds(...imageIds);
     }
     return files;
   };
@@ -347,12 +359,8 @@ export class HostAdaptor implements Adaptor {
     }
     const current = this.openai.widgetState;
     const state: AppsSdkWidgetState = current
-      ? { ...current }
-      : { modelContent: {}, privateContent: {} };
-    if (!state.imageIds) {
-      state.imageIds = [];
-    }
-    state.imageIds.push(...fileIds);
+      ? { ...current, imageIds: [...(current.imageIds ?? []), ...fileIds] }
+      : { modelContent: {}, privateContent: {}, imageIds: [...fileIds] };
     await this.openai.setWidgetState(state);
   }
 


### PR DESCRIPTION
and not all files, otherwise subsequent sendFollowUpMessage fails for some reason

first commit is about silencing console errors originating from the host trying to parse runner postMessages as json rpc