### PR TITLE
Fix/devtools preview host surface

### DIFF
--- a/packages/devtools/e2e/tests/preview-surface.spec.ts
+++ b/packages/devtools/e2e/tests/preview-surface.spec.ts
@@ -1,0 +1,92 @@
+import { expect, type Locator, test } from "@playwright/test";
+
+// Issue #841: the preview surface (the area behind the rendered view) must
+// darken with the dark theme in every display mode, and the grid must stay
+// visible. Colours come from the centralized @theme tokens in index.css:
+//   light: --color-background #ffffff → rgb(255, 255, 255)
+//   dark:  --color-background #071718 → rgb(7, 23, 24)
+const LIGHT_SURFACE = "rgb(255, 255, 255)";
+const DARK_SURFACE = "rgb(7, 23, 24)";
+const LIGHT_GRID = "#e3eaea";
+const DARK_GRID = "#1f4449";
+
+test.describe("preview surface (issue #841)", () => {
+  // The preview container: the div wrapping the view iframe, whose background
+  // is `var(--preview-surface)`. Selected via its iframe child so it stays
+  // stable regardless of layout classes.
+  let container: Locator;
+  // The scrollable region behind the container that carries `data-theme` and
+  // the grid CSS variables.
+  let previewRegion: Locator;
+  // The view-options toolbar form holding the display-mode radios and the
+  // theme checkbox (all sr-only inputs wrapped in visible labels).
+  let toolbar: Locator;
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+
+    // Run the echo-card widget so a view iframe renders.
+    const echoCard = page.locator('[data-tool-name="echo-card"]');
+    await echoCard.locator('[data-slot="accordion-trigger"]').click();
+    await echoCard.getByLabel("message").fill("test");
+    await echoCard.getByRole("button", { name: /^run$/i }).click();
+
+    // View compilation by Vite can be slow under the full suite.
+    const iframe = page.frameLocator('iframe[title="html-preview"]');
+    await expect(iframe.getByText("test")).toBeVisible({ timeout: 45_000 });
+
+    container = page.locator('div:has(> iframe[title="html-preview"])');
+    previewRegion = page.locator(".preview-region");
+    toolbar = page.locator('form[toolname="devtools_set_view_options"]');
+  });
+
+  // Display-mode buttons are radios (values fullscreen | pip | inline) hidden
+  // inside visible labels; click the label to select the mode.
+  const setDisplayMode = (mode: string) =>
+    toolbar.locator(`label:has(input[value="${mode}"])`).click();
+
+  // The theme toggle is a checkbox (name="darkTheme") hidden inside a visible
+  // label; clicking the label flips light ⇄ dark.
+  const toggleTheme = () =>
+    toolbar.locator('label:has(input[name="darkTheme"])').click();
+
+  test("fullscreen: surface darkens with dark theme", async () => {
+    // Fullscreen desktop is the default display mode.
+    await expect(container).toHaveCSS("background-color", LIGHT_SURFACE);
+
+    await toggleTheme();
+
+    await expect(container).toHaveCSS("background-color", DARK_SURFACE);
+  });
+
+  test("inline: surface darkens with dark theme", async () => {
+    await setDisplayMode("inline");
+    await expect(container).toHaveCSS("background-color", LIGHT_SURFACE);
+
+    await toggleTheme();
+
+    await expect(container).toHaveCSS("background-color", DARK_SURFACE);
+  });
+
+  test("pip: surface darkens with dark theme", async () => {
+    await setDisplayMode("pip");
+    await expect(container).toHaveCSS("background-color", LIGHT_SURFACE);
+
+    await toggleTheme();
+
+    await expect(container).toHaveCSS("background-color", DARK_SURFACE);
+  });
+
+  test("grid: color stays visible and changes in dark theme", async () => {
+    const gridColor = () =>
+      previewRegion.evaluate((el) =>
+        getComputedStyle(el).getPropertyValue("--preview-region-grid").trim(),
+      );
+
+    await expect.poll(gridColor).toBe(LIGHT_GRID);
+
+    await toggleTheme();
+
+    await expect.poll(gridColor).toBe(DARK_GRID);
+  });
+});

--- a/packages/devtools/src/components/layout/tool-panel/view/index.tsx
+++ b/packages/devtools/src/components/layout/tool-panel/view/index.tsx
@@ -206,7 +206,7 @@ export const View = () => {
       ref={containerRef}
       className={cn(
         "relative transition-[width] duration-150 ease-out",
-        isFullscreenDesktop ? "h-full w-full bg-background" : "mx-auto",
+        isFullscreenDesktop ? "h-full w-full" : "mx-auto",
       )}
       style={{
         width: isFullscreenDesktop ? undefined : width,
@@ -216,6 +216,7 @@ export const View = () => {
             ? `${isPip ? Math.min(contentHeight, PIP_MAX_HEIGHT_PX) : contentHeight}px`
             : "auto",
         opacity: mounted ? 1 : 0,
+        background: "var(--preview-surface)",
       }}
     >
       <iframe

--- a/packages/devtools/src/index.css
+++ b/packages/devtools/src/index.css
@@ -5,6 +5,7 @@
 @source "../node_modules/@alpic-ai/ui/src/**/*.{ts,tsx}";
 
 @theme {
+  --color-background: #ffffff;
   --color-border: #e3eaea;
   --color-light-gray: #f9fafa;
   --color-light-gray-foreground: #707e7e;
@@ -16,8 +17,10 @@
   --color-cta-accent: #e90060;
 }
 
-.dark {
-  --color-border: #162828;
+.dark,
+[data-theme="dark"] {
+  --color-background: #071718;
+  --color-border: #1f4449;
   --color-light-gray: #162828;
 
   --color-primary: #89f0ec;
@@ -28,6 +31,7 @@
 
 .preview-region {
   /* Figma “bg-secondary-subtle” / “border-tertiary” → @alpic-ai/ui @theme color tokens */
+  --preview-surface: var(--color-background);
   --preview-region-bg: var(--color-light-gray);
   --preview-region-grid: var(--color-border);
   background-color: var(--preview-region-bg);

--- a/packages/devtools/src/index.css
+++ b/packages/devtools/src/index.css
@@ -20,7 +20,7 @@
 .dark,
 [data-theme="dark"] {
   --color-background: #071718;
-  --color-border: #1f4449;
+  --color-border: #162828;
   --color-light-gray: #162828;
 
   --color-primary: #89f0ec;
@@ -64,4 +64,10 @@
     16px 16px,
     16px 16px;
   background-position: 0 0;
+}
+
+.preview-region.dark,
+.preview-region[data-theme="dark"] {
+  /* Keep the grid visible against the dark surface without recolouring global borders. */
+  --preview-region-grid: #1f4449;
 }


### PR DESCRIPTION
## Why
Closes #841

The dark mode toggle in devtools had no visual effect because
index.css was not using the dark-theme CSS variables.

## What
- Applied dark-theme CSS variables for background and grid colors
  in the preview component
- Background color is now driven by `--preview-surface` which
  resolves to the correct `--color-background` value based on
  the active theme

The dark-theme colors were chosen without existing specs — happy
to adjust if needed.

## Testing
- Verified dark mode works across all screen modes (full, pip, inline)
- Added test case for grid color correctness in dark mode

## Screenshots
Before → After

<img width="1914" height="938" alt="chess_before" src="https://github.com/user-attachments/assets/f7758164-796c-4316-98e4-927a4f03e82f" />

<img width="1908" height="977" alt="chess_after" src="https://github.com/user-attachments/assets/d13e53ce-02f4-4987-a2eb-ae70c9408ee2" />

