### PR TITLE
feat(web): add useHostInfo hook to identify the rendering host

### DIFF
--- a/docs/api-reference/overview.mdx
+++ b/docs/api-reference/overview.mdx
@@ -26,6 +26,7 @@ Every Skybridge export. Server APIs run in your MCP server and work with any hos
 | [`useDisplayMode`](/api-reference/use-display-mode) | Read and request inline, pip, or fullscreen. | <Compat compact alpic chatgpt claude goose /> |
 | [`useDownload`](/api-reference/use-download) | Save files to the user's device. | <Compat compact claude /> |
 | [`useFiles`](/api-reference/use-files) | Upload and pick host-managed files. | <Compat compact chatgpt /> |
+| [`useHostInfo`](/api-reference/use-host-info) | Identify which host is rendering the view. | <Compat compact alpic claude cursor goose /> |
 | [`useLayout`](/api-reference/use-layout) | Read theme, max height, and safe-area insets. | <Compat compact alpic chatgpt claude cursor goose /> |
 | [`useOpenExternal`](/api-reference/use-open-external) | Open a URL outside the view iframe. | <Compat compact alpic chatgpt claude cursor goose /> |
 | [`useRegisterViewTool`](/api-reference/use-register-view-tool) | Expose a tool that runs inside the view. | <Compat compact alpic /> |

--- a/docs/api-reference/use-host-info.mdx
+++ b/docs/api-reference/use-host-info.mdx
@@ -1,0 +1,81 @@
+---
+title: useHostInfo
+description: "Identify which host is rendering the view"
+---
+
+import { Compat } from "/components/compat.jsx";
+
+<Compat alpic claude cursor goose />
+
+The same [view](/build/view) runs inside every host — Claude, Cursor, Goose, and others. `useHostInfo` reports which one, taken from the MCP Apps `ui/initialize` handshake, so the view can adapt copy, shortcuts, or layout to the host it's rendering in. It runs only on MCP Apps hosts; the name is normalized to a [`Host`](#host) slug when recognized, otherwise passed through as a raw string.
+
+## Example
+
+An empty state suggests the next action using the wording that fits the host.
+
+```tsx highlight={4}
+import { useHostInfo } from "skybridge/web";
+
+function EmptyState() {
+  const { name } = useHostInfo();
+  const hint =
+    name === "claude"
+      ? "Ask Claude to add your first item."
+      : "Send a message to add your first item.";
+
+  return <p className="empty">{hint}</p>;
+}
+```
+
+## Returns
+
+### `name`
+
+```tsx
+name: Host | (string & {}) | undefined;
+```
+
+The host's reported name. It resolves to a [`Host`](#host) slug for recognized hosts, a raw string for hosts not yet mapped, and `undefined` until the handshake completes — the view renders first and re-renders once the host responds. The `(string & {})` keeps the known slugs in autocomplete while still accepting any string.
+
+### `version`
+
+```tsx
+version: string | undefined;
+```
+
+The host's version string, or `undefined` until the handshake completes.
+
+## Host
+
+The recognized hosts, as normalized slugs. An unrecognized host surfaces its raw reported name instead.
+
+```tsx
+type Host =
+  | "chatgpt"
+  | "claude"
+  | "cursor"
+  | "goose"
+  | "mistral-vibe"
+  | "alpic";
+```
+
+| Slug | Reported `hostInfo.name` |
+| --- | --- |
+| `chatgpt` | `chatgpt` |
+| `claude` | `Claude` |
+| `cursor` | `Cursor` |
+| `goose` | `MCP-UI Host` |
+| `mistral-vibe` | `Le Chat` |
+| `alpic` | `alpic-playground` |
+
+<CardGroup cols={3}>
+  <Card title="useUser" icon="user" href="/api-reference/use-user">
+    Read the host's locale and device capabilities
+  </Card>
+  <Card title="useMcpAppContext" icon="plug" href="/api-reference/use-mcp-app-context">
+    Read a raw MCP Apps context value by key
+  </Card>
+  <Card title="Design for the Host" icon="sparkles" href="/guides/ux">
+    Adapt the view to the host it runs in
+  </Card>
+</CardGroup>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -133,6 +133,7 @@
               "api-reference/use-display-mode",
               "api-reference/use-download",
               "api-reference/use-files",
+              "api-reference/use-host-info",
               "api-reference/use-layout",
               "api-reference/use-open-external",
               "api-reference/use-register-view-tool",

--- a/packages/core/src/web/bridges/mcp-app/bridge.ts
+++ b/packages/core/src/web/bridges/mcp-app/bridge.ts
@@ -47,6 +47,7 @@ export class McpAppBridge implements Bridge<McpAppContext> {
     toolInput: null,
     toolCancelled: null,
     toolResult: null,
+    hostInfo: null,
   };
   private listeners = new Map<McpAppContextKey, Set<() => void>>();
   private app: App;
@@ -86,9 +87,10 @@ export class McpAppBridge implements Bridge<McpAppContext> {
     try {
       await this.app.connect();
       const hostContext = this.app.getHostContext();
-      if (hostContext) {
-        this.updateContext(hostContext);
-      }
+      this.updateContext({
+        ...hostContext,
+        hostInfo: this.app.getHostVersion() ?? null,
+      });
     } catch (err) {
       console.error(err);
     }

--- a/packages/core/src/web/bridges/mcp-app/types.ts
+++ b/packages/core/src/web/bridges/mcp-app/types.ts
@@ -4,6 +4,7 @@ import type {
   McpUiToolInputNotification,
   McpUiToolResultNotification,
 } from "@modelcontextprotocol/ext-apps";
+import type { Implementation } from "@modelcontextprotocol/sdk/types.js";
 
 export type McpToolState = {
   toolInput: NonNullable<
@@ -11,6 +12,7 @@ export type McpToolState = {
   > | null;
   toolResult: McpUiToolResultNotification["params"] | null;
   toolCancelled: McpUiToolCancelledNotification["params"] | null;
+  hostInfo: Implementation | null;
 };
 
 export type McpAppContext = McpUiHostContext & McpToolState;

--- a/packages/core/src/web/hooks/index.ts
+++ b/packages/core/src/web/hooks/index.ts
@@ -8,6 +8,7 @@ export {
 export { useDisplayMode } from "./use-display-mode.js";
 export { type DownloadFn, useDownload } from "./use-download.js";
 export { useFiles } from "./use-files.js";
+export { type Host, type HostInfo, useHostInfo } from "./use-host-info.js";
 export { type LayoutState, useLayout } from "./use-layout.js";
 export { type OpenExternalFn, useOpenExternal } from "./use-open-external.js";
 export { useRegisterViewTool } from "./use-register-view-tool.js";

--- a/packages/core/src/web/hooks/test/utils.ts
+++ b/packages/core/src/web/hooks/test/utils.ts
@@ -21,6 +21,7 @@ const DEFAULT_CONTEXT: McpUiHostContext = {};
 export type McpAppHostMockOptions = {
   hostCapabilities?: McpUiHostCapabilities;
   downloadFileResult?: McpUiDownloadFileResult;
+  hostInfo?: McpUiInitializeResult["hostInfo"];
 };
 
 export const getMcpAppHostPostMessageMock = (
@@ -32,7 +33,7 @@ export const getMcpAppHostPostMessageMock = (
       case "ui/initialize": {
         const result: McpUiInitializeResult = {
           protocolVersion: "2025-06-18",
-          hostInfo: { name: "test-host", version: "1.0.0" },
+          hostInfo: options.hostInfo ?? { name: "test-host", version: "1.0.0" },
           hostCapabilities: options.hostCapabilities ?? {},
           hostContext: initialContext,
         };

--- a/packages/core/src/web/hooks/use-host-info.test.ts
+++ b/packages/core/src/web/hooks/use-host-info.test.ts
@@ -1,0 +1,71 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HostAdaptor } from "../bridges/adaptor.js";
+import { McpAppBridge } from "../bridges/mcp-app/bridge.js";
+import {
+  getMcpAppHostPostMessageMock,
+  MockResizeObserver,
+} from "./test/utils.js";
+import { type Host, useHostInfo } from "./use-host-info.js";
+
+const stubHost = (hostInfo?: { name: string; version: string }) => {
+  vi.stubGlobal("parent", {
+    postMessage: getMcpAppHostPostMessageMock({}, { hostInfo }),
+  });
+};
+
+describe("useHostInfo", () => {
+  beforeEach(() => {
+    HostAdaptor.resetInstance();
+    McpAppBridge.resetInstance();
+    vi.stubGlobal("openai", undefined);
+    vi.stubGlobal("skybridge", { hostType: "mcp-app" });
+    vi.stubGlobal("ResizeObserver", MockResizeObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetAllMocks();
+    McpAppBridge.resetInstance();
+    HostAdaptor.resetInstance();
+  });
+
+  it("is undefined before the handshake resolves, then populated after", async () => {
+    stubHost({ name: "Claude", version: "1.2.3" });
+    const { result } = renderHook(() => useHostInfo());
+
+    expect(result.current.name).toBeUndefined();
+    expect(result.current.version).toBeUndefined();
+
+    await waitFor(() => {
+      expect(result.current.name).toBe("claude");
+      expect(result.current.version).toBe("1.2.3");
+    });
+  });
+
+  it.each<[string, Host]>([
+    ["chatgpt", "chatgpt"],
+    ["Claude", "claude"],
+    ["Cursor", "cursor"],
+    ["MCP-UI Host", "goose"],
+    ["Le Chat", "mistral-vibe"],
+    ["alpic-playground", "alpic"],
+  ])("normalizes reported name %j to slug %j", async (reported, slug) => {
+    stubHost({ name: reported, version: "1.0.0" });
+    const { result } = renderHook(() => useHostInfo());
+
+    await waitFor(() => {
+      expect(result.current.name).toBe(slug);
+    });
+  });
+
+  it("preserves an unrecognized reported name as-is", async () => {
+    stubHost({ name: "Some Future Host", version: "9.9.9" });
+    const { result } = renderHook(() => useHostInfo());
+
+    await waitFor(() => {
+      expect(result.current.name).toBe("Some Future Host");
+      expect(result.current.version).toBe("9.9.9");
+    });
+  });
+});

--- a/packages/core/src/web/hooks/use-host-info.ts
+++ b/packages/core/src/web/hooks/use-host-info.ts
@@ -1,0 +1,50 @@
+import { useMcpAppContext } from "../bridges/index.js";
+
+/**
+ * Known host applications, as normalized slugs. Unrecognized hosts surface
+ * their raw `hostInfo.name` string instead.
+ */
+export type Host =
+  | "chatgpt"
+  | "claude"
+  | "cursor"
+  | "goose"
+  | "mistral-vibe"
+  | "alpic";
+
+const HOST_BY_REPORTED_NAME: Record<string, Host> = {
+  chatgpt: "chatgpt",
+  Claude: "claude",
+  Cursor: "cursor",
+  "MCP-UI Host": "goose",
+  "Le Chat": "mistral-vibe",
+  "alpic-playground": "alpic",
+};
+
+export type HostInfo = {
+  name: Host | (string & {}) | undefined;
+  version: string | undefined;
+};
+
+/**
+ * Identity of the host application rendering the view, from the MCP Apps
+ * `ui/initialize` handshake. `name` is normalized to a {@link Host} slug when
+ * recognized, otherwise the raw string; both fields are `undefined` until the
+ * handshake resolves (the view renders first and re-renders once it lands).
+ *
+ * @example
+ * ```tsx
+ * const { name } = useHostInfo();
+ * if (name === "claude") return <ClaudeLayout />;
+ * ```
+ */
+export function useHostInfo(): HostInfo {
+  const hostInfo = useMcpAppContext("hostInfo");
+  const name = hostInfo?.name;
+
+  return {
+    name:
+      name !== undefined ? (HOST_BY_REPORTED_NAME[name] ?? name) : undefined,
+    version: hostInfo?.version,
+  };
+}


### PR DESCRIPTION
Closes #909.

## What

Adds a `useHostInfo` hook so a view can tell which host it's rendering in (Claude, Cursor, Goose, …) and adapt copy, shortcuts, or layout accordingly.

```tsx
import { useHostInfo } from "skybridge/web";

const { name, version } = useHostInfo();
if (name === "claude") return <ClaudeLayout />;
```

The value is sourced from the MCP Apps `ui/initialize` handshake (`hostInfo`), which ext-apps already receives but Skybridge was dropping. `name` is normalized to a `Host` slug when recognized, and passes through the raw string otherwise.

## How

- `bridges/mcp-app/types.ts` — add `hostInfo: Implementation | null` to the bridge context
- `bridges/mcp-app/bridge.ts` — populate it in `connect()` via `app.getHostVersion()`
- `hooks/use-host-info.ts` — the hook, the `Host` slug union, and the raw-name→slug map; exported from `skybridge/web`
- docs: new `api-reference/use-host-info` page, nav entry, and overview-matrix row

## Design notes (vs the proposal in #909)

The issue sketched a `useHost` returning `{ name: "chatgpt" | "claude" | ... | "other" }`. This PR keeps that capability and the lowercase-slug shape, with a few deliberate refinements:

1. **`useHostInfo` returning `{ name, version }`** instead of `useHost` returning only `name`. It mirrors the MCP `Implementation` type the data actually comes from, and `version` is free once we're reading `hostInfo` — useful for host-version gating.
2. **Sourced from `hostInfo` (the `ui/initialize` handshake), not `userAgent`/`window.openai` sniffing.** The issue noted `window.openai` isn't ChatGPT-exclusive; `hostInfo.name` is the protocol's own, unambiguous host identity, so there's no false-positive heuristic to maintain.
3. **`Host` is a string-literal union of slugs** (`"chatgpt" | "claude" | "cursor" | "goose" | "mistral-vibe" | "alpic"`), and we translate the raw reported names (`"Claude"`, `"MCP-UI Host"`, `"Le Chat"`, …) to those slugs in one lookup map. `name === "claude"` narrows with full autocomplete and no import. Unknown hosts keep their raw string rather than collapsing to `"other"`, so callers can still read them — the type is `Host | (string & {}) | undefined`, which surfaces the known slugs in autocomplete while accepting any string.

Because the name arrives asynchronously from the handshake, this has to be a hook (not a `Platform`-style constant): `name`/`version` are `undefined` on first render and populate on the re-render once the host responds.

Happy to adjust naming/slugs — flagging that #909 has volunteers, so shout if there's a parallel attempt to reconcile with.