### PR TITLE
feat(web): apply host styles via skybridge({ hostStyles }) opt-in

### DIFF
--- a/docs/api-reference/use-layout.mdx
+++ b/docs/api-reference/use-layout.mdx
@@ -53,6 +53,10 @@ theme: Theme;
 
 The host's active color theme, `"light"` or `"dark"`. Mirror it in the view's styling for a native feel. It updates when the user toggles the host theme.
 
+<Tip>
+To match the host automatically, without branching on `theme` yourself, enable [host styles](/build/view#match-the-host-styles): Skybridge then applies the host's theme, palette, and fonts to your view as CSS variables.
+</Tip>
+
 ### `maxHeight`
 
 ```tsx

--- a/docs/build/view.mdx
+++ b/docs/build/view.mdx
@@ -68,7 +68,7 @@ server
 ```
 </CodeGroup>
 
-The sections below walk through it: the component itself, reading the tool, calling tools back, the typed helpers binding views to the server, and opening the sandbox to external domains.
+The sections below walk through it: the component itself, reading the tool, calling tools back, the typed helpers binding views to the server, matching the host's styles, and opening the sandbox to external domains.
 
 ## The Component
 
@@ -169,6 +169,53 @@ export const { useToolInfo, useCallTool } = generateHelpers<AppType>();
 Import `useToolInfo` and `useCallTool` from `helpers.ts` everywhere, and you get autocomplete on tool names, plus typed inputs, outputs, and metadata on both hooks.
 
 Type-safe hooks are generated using [generateHelpers](/api-reference/generate-helpers).
+
+## Match the Host Styles
+
+A view feels native when it borrows the host's own look: its palette, typography, and light or dark theme. On the [MCP Apps](/fundamentals/mcp-apps) runtime, hosts like Claude can hand your view a set of design tokens for exactly this. Opt in with the `hostStyles` option on the Vite plugin:
+
+```ts vite.config.ts highlight={7}
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { skybridge } from "skybridge/vite";
+
+export default defineConfig({
+  plugins: [react(), skybridge({ hostStyles: true })],
+});
+```
+
+With it on, Skybridge applies whatever the host provides, and keeps it in sync when the user toggles their theme:
+
+- **CSS variables** on `:root`, a standardized set you reference with `var(…)`, covering colors (`--color-background-primary`, `--color-text-primary`, `--color-border-primary`, and `info` / `danger` / `success` / `warning` variants), typography (`--font-sans`, `--font-mono`, `--font-weight-medium`, `--font-text-md-size`…), radii (`--border-radius-sm` … `--border-radius-full`), and shadows (`--shadow-sm` … `--shadow-lg`).
+- **`color-scheme`** on the document, so the host's `light-dark()` color values resolve to the right branch and native controls (scrollbars, form fields) match the theme.
+- **Fonts** the host ships, injected so `var(--font-sans)` renders in the host's typeface.
+
+```tsx views/carousel.tsx
+export default function ProductCard({ product }) {
+  return (
+    <div
+      style={{
+        background: "var(--color-background-primary)",
+        color: "var(--color-text-primary)",
+        border: "1px solid var(--color-border-primary)",
+        borderRadius: "var(--border-radius-lg)",
+        boxShadow: "var(--shadow-md)",
+        fontFamily: "var(--font-sans)",
+      }}
+    >
+      {product.name}
+    </div>
+  );
+}
+```
+
+<Note>
+`hostStyles` is **off by default**. Turning it on lets the host set those variables on `:root` and flip `color-scheme`, restyling your view. Because the variables are applied inline on the document root, a `:root { --color-text-primary: … }` of your own is **overridden** by the host's value; scope your overrides below the root (on a wrapper element) if you need them to win. Opt in once your view is ready to inherit the host's styling.
+</Note>
+
+<Info>
+Host styles are an MCP Apps feature. Under the ChatGPT [Apps SDK](/fundamentals/apps-sdk) runtime the host sends no tokens, so the option is a no-op there, and not every MCP host provides a full set. Read the current theme directly with [`useLayout`](/api-reference/use-layout#theme) when you need to branch in code.
+</Info>
 
 ## Open the Sandbox
 

--- a/packages/core/src/web/bridges/mcp-app/bridge.test.ts
+++ b/packages/core/src/web/bridges/mcp-app/bridge.test.ts
@@ -1,4 +1,6 @@
+import { act } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MockResizeObserver } from "../../hooks/test/utils.js";
 import { McpAppBridge } from "./bridge.js";
 
 describe("McpAppBridge.getInstance", () => {
@@ -14,5 +16,101 @@ describe("McpAppBridge.getInstance", () => {
   it("instantiates regardless of injected hostType", () => {
     vi.stubGlobal("skybridge", { hostType: "apps-sdk" });
     expect(() => McpAppBridge.getInstance()).not.toThrow();
+  });
+});
+
+/** Reply to `ui/initialize` with the given host context so `connect()` resolves. */
+function installHostMock(hostContext: Record<string, unknown>) {
+  vi.stubGlobal("parent", {
+    postMessage: vi.fn((message: { id?: number; method?: string }) => {
+      if (message.method === "ui/initialize" && message.id !== undefined) {
+        act(() => {
+          window.dispatchEvent(
+            new MessageEvent("message", {
+              source: window.parent,
+              data: {
+                jsonrpc: "2.0",
+                id: message.id,
+                result: {
+                  protocolVersion: "2025-06-18",
+                  hostInfo: { name: "test-host", version: "1.0.0" },
+                  hostCapabilities: {},
+                  hostContext,
+                },
+              },
+            }),
+          );
+        });
+      }
+    }),
+  });
+}
+
+describe("McpAppBridge host styles", () => {
+  beforeEach(() => {
+    vi.stubGlobal("skybridge", { hostType: "mcp-app" });
+    vi.stubGlobal("ResizeObserver", MockResizeObserver);
+    McpAppBridge.resetInstance();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    McpAppBridge.resetInstance();
+    const root = document.documentElement;
+    root.removeAttribute("data-theme");
+    root.style.colorScheme = "";
+    root.style.removeProperty("--color-background-primary");
+    document.getElementById("__mcp-host-fonts")?.remove();
+  });
+
+  it("applies theme, style variables and fonts from the initial host context when enabled", async () => {
+    installHostMock({
+      theme: "dark",
+      styles: {
+        variables: {
+          "--color-background-primary": "light-dark(#ffffff, #1a1a1a)",
+        },
+        css: { fonts: "@font-face{font-family:Test;src:url(x)}" },
+      },
+    });
+
+    await McpAppBridge.getInstance({ applyHostStyles: true }).getApp();
+
+    const root = document.documentElement;
+    expect(root.getAttribute("data-theme")).toBe("dark");
+    expect(root.style.colorScheme).toBe("dark");
+    expect(root.style.getPropertyValue("--color-background-primary")).toBe(
+      "light-dark(#ffffff, #1a1a1a)",
+    );
+    expect(document.getElementById("__mcp-host-fonts")?.textContent).toContain(
+      "@font-face",
+    );
+  });
+
+  it("leaves the document untouched by default even when the host sends styles", async () => {
+    installHostMock({
+      theme: "dark",
+      styles: {
+        variables: {
+          "--color-background-primary": "light-dark(#ffffff, #1a1a1a)",
+        },
+        css: { fonts: "@font-face{font-family:Test;src:url(x)}" },
+      },
+    });
+
+    await McpAppBridge.getInstance().getApp();
+
+    const root = document.documentElement;
+    expect(root.getAttribute("data-theme")).toBeNull();
+    expect(root.style.getPropertyValue("--color-background-primary")).toBe("");
+    expect(document.getElementById("__mcp-host-fonts")).toBeNull();
+  });
+
+  it("leaves the document untouched when enabled but the host provides no styles", async () => {
+    installHostMock({});
+
+    await McpAppBridge.getInstance({ applyHostStyles: true }).getApp();
+
+    expect(document.documentElement.getAttribute("data-theme")).toBeNull();
+    expect(document.getElementById("__mcp-host-fonts")).toBeNull();
   });
 });

--- a/packages/core/src/web/bridges/mcp-app/bridge.ts
+++ b/packages/core/src/web/bridges/mcp-app/bridge.ts
@@ -1,4 +1,9 @@
-import { App } from "@modelcontextprotocol/ext-apps";
+import {
+  App,
+  applyDocumentTheme,
+  applyHostFonts,
+  applyHostStyleVariables,
+} from "@modelcontextprotocol/ext-apps";
 import {
   type Implementation,
   ListToolsRequestSchema,
@@ -51,8 +56,10 @@ export class McpAppBridge implements Bridge<McpAppContext> {
   private listeners = new Map<McpAppContextKey, Set<() => void>>();
   private app: App;
   private connectPromise: Promise<void>;
+  private applyStylesEnabled: boolean;
 
-  constructor(options: { appInfo: Implementation }) {
+  constructor(options: { appInfo: Implementation; applyHostStyles?: boolean }) {
+    this.applyStylesEnabled = options.applyHostStyles ?? false;
     this.app = new App(options.appInfo, { tools: { listChanged: true } });
 
     this.app.setRequestHandler(ListToolsRequestSchema, async () => ({
@@ -126,7 +133,7 @@ export class McpAppBridge implements Bridge<McpAppContext> {
   }
 
   public static getInstance(
-    options?: Partial<{ appInfo: Implementation }>,
+    options?: Partial<{ appInfo: Implementation; applyHostStyles: boolean }>,
   ): McpAppBridge {
     if (McpAppBridge.instance && options) {
       console.warn(
@@ -259,7 +266,23 @@ export class McpAppBridge implements Bridge<McpAppContext> {
     });
   }
 
+  private applyHostStyles(context: Partial<McpAppContext>) {
+    if (!this.applyStylesEnabled || typeof document === "undefined") {
+      return;
+    }
+    if (context.theme) {
+      applyDocumentTheme(context.theme);
+    }
+    if (context.styles?.variables) {
+      applyHostStyleVariables(context.styles.variables);
+    }
+    if (context.styles?.css?.fonts) {
+      applyHostFonts(context.styles.css.fonts);
+    }
+  }
+
   private updateContext(context: Partial<McpAppContext>) {
+    this.applyHostStyles(context);
     this.context = { ...this.context, ...context };
     for (const key of Object.keys(context)) {
       this.emit(key);

--- a/packages/core/src/web/mount-view.ts
+++ b/packages/core/src/web/mount-view.ts
@@ -6,6 +6,18 @@ import { installOpenAILoggingProxy } from "./proxy.js";
 
 let rootInstance: Root | null = null;
 
+/** Options for {@link mountView}. */
+export type MountViewOptions = {
+  /**
+   * Apply the host's theme, CSS variables and fonts to the view automatically
+   * (MCP Apps runtime only). Off by default: enabling it lets the host restyle
+   * the view — including flipping `color-scheme` — so opt in once the view is
+   * ready to inherit host styling. No-op under the ChatGPT Apps SDK runtime.
+   * Usually set via the `skybridge({ hostStyles: true })` Vite plugin option.
+   */
+  hostStyles?: boolean;
+};
+
 /**
  * Mount a view's root React component into `#root`. Each view file's entry
  * point should call this exactly once.
@@ -25,7 +37,10 @@ let rootInstance: Root | null = null;
  * mountView(<App />);
  * ```
  */
-export const mountView = (component: React.ReactNode) => {
+export const mountView = (
+  component: React.ReactNode,
+  options?: MountViewOptions,
+) => {
   const rootElement = document.getElementById("root");
   if (!rootElement) {
     throw new Error("Root element not found");
@@ -44,6 +59,10 @@ export const mountView = (component: React.ReactNode) => {
   (async () => {
     let app = component;
     if (hostType === "mcp-app") {
+      const { McpAppBridge } = await import("./bridges/mcp-app/bridge.js");
+      McpAppBridge.getInstance({
+        applyHostStyles: options?.hostStyles ?? false,
+      });
       const { ModalProvider } = await import("./components/modal-provider.js");
       app = createElement(ModalProvider, null, component);
     }

--- a/packages/core/src/web/plugin/plugin.ts
+++ b/packages/core/src/web/plugin/plugin.ts
@@ -23,15 +23,24 @@ export interface SkybridgePluginOptions {
    * typically optional native modules pulled in by a transitive dependency.
    */
   serverExternal?: string[];
+  /**
+   * Apply the host's theme, CSS variables and fonts to your views
+   * automatically (MCP Apps runtime only). Off by default: enabling it lets the
+   * host restyle your views — including flipping `color-scheme`, which changes
+   * native control/scrollbar/background defaults — so opt in once your views
+   * are ready to inherit host styling. No-op under the ChatGPT Apps SDK runtime.
+   */
+  hostStyles?: boolean;
 }
 
-function buildVirtualEntry(viewFilePath: string): string {
+function buildVirtualEntry(viewFilePath: string, hostStyles: boolean): string {
   const normalized = viewFilePath.replace(/\\/g, "/");
+  const mountOptions = hostStyles ? ", { hostStyles: true }" : "";
   return [
     `import { mountView } from "skybridge/web";`,
     `import Component from "${normalized}";`,
     `import { createElement } from "react";`,
-    `mountView(createElement(Component));`,
+    `mountView(createElement(Component)${mountOptions});`,
   ].join("\n");
 }
 
@@ -155,7 +164,7 @@ export function skybridge(options?: SkybridgePluginOptions): Plugin {
         const name = id.slice(VIRTUAL_MODULE_PREFIX.length);
         const view = viewMap.get(name);
         if (view) {
-          return buildVirtualEntry(view.filePath);
+          return buildVirtualEntry(view.filePath, options?.hostStyles ?? false);
         }
       }
       return null;

--- a/skills/chatgpt-app-builder/references/ui-guidelines.md
+++ b/skills/chatgpt-app-builder/references/ui-guidelines.md
@@ -153,6 +153,8 @@ function Container({ children }) {
 }
 ```
 
+To match the host automatically instead of branching on `theme`, enable host styles with `skybridge({ hostStyles: true })` in `vite.config.ts` (MCP Apps only; no-op under the ChatGPT Apps SDK). Skybridge then applies the host's theme, palette, and fonts as CSS variables on `:root` — reference them with `var(--color-background-primary)`, `var(--color-text-primary)`, `var(--font-sans)`, `var(--border-radius-lg)`, etc. It is off by default because enabling it lets the host override same-named `:root` variables and flip `color-scheme`.
+
 ## Adapting to User
 
 Use `useUser` to read user context.


### PR DESCRIPTION
## What

On the **MCP Apps** runtime, hosts (Claude, etc.) can hand a view a set of design tokens — theme, CSS variables, and fonts — via `hostContext.styles`. Skybridge received them but dropped them on the floor. This wires them onto the view, behind an opt-in flag.

Enable it on the Vite plugin:

```ts
skybridge({ hostStyles: true })
```

With it on, Skybridge applies (and keeps in sync on theme toggle):
- **CSS variables** on `:root` — the standardized set (`--color-*`, `--font-*`, `--border-radius-*`, `--shadow-*`), referenced with `var(…)`
- **`color-scheme`** on the document, so the host's `light-dark()` values resolve and native controls match
- **Host fonts**, injected so `var(--font-sans)` renders in the host typeface

Reuses the ext-apps helpers (`applyDocumentTheme` / `applyHostStyleVariables` / `applyHostFonts`) — no reimplementation.

## Why opt-in / default off

Turning it on lets the host set variables on `:root` and flip `color-scheme`, which restyles the view. Since the variables are applied inline on the document root, an app's own `:root { --color-… }` gets overridden. Default off means no existing app is silently restyled; enabling it is a deliberate one-liner.

No-op under the ChatGPT Apps SDK runtime (it sends no tokens).

## How it's wired

`skybridge({ hostStyles })` → generated `mountView(component, { hostStyles })` → `McpAppBridge.getInstance({ applyHostStyles })` → gated apply inside the bridge's `updateContext` (covers the initial connect snapshot and live `host-context-changed` updates).

## Changes

- **plugin**: `SkybridgePluginOptions.hostStyles`, forwarded into the generated entry
- **mountView**: `MountViewOptions.hostStyles`, seeds the bridge before render
- **McpAppBridge**: `applyStylesEnabled` gate; idempotent apply
- **tests**: applies when enabled / untouched by default even when host sends styles / untouched when enabled but host sends nothing
- **docs**: "Match the Host Styles" section in `build/view`, `useLayout` theme tip
- **skills**: host-styles note in the shared `ui-guidelines` reference

## Tracking

Addresses the `styles` (80 CSS variables) context-property gap tracked in #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)