### PR TITLE
feat(landing): track install copies, docs CTAs and GitHub clicks in GA

### DIFF
--- a/landing/app/components/hero.tsx
+++ b/landing/app/components/hero.tsx
@@ -25,6 +25,8 @@ export function InstallRow({ cmd, label }: InstallRowProps) {
     <button
       type="button"
       className="sb-install"
+      data-ga="copy_install_command"
+      data-ga-label={cmd}
       aria-label={label ? `${label} copy ${cmd}` : `Copy ${cmd}`}
       onClick={onCopy}
     >
@@ -114,6 +116,8 @@ export function Hero() {
                 <a
                   className="sb-btn sb-btn-primary sb-btn-lg"
                   href="https://docs.skybridge.tech"
+                  data-ga="cta_click"
+                  data-ga-label="hero_read_docs"
                   style={{ borderColor: "rgb(166, 244, 241)" }}
                 >
                   Read the docs

--- a/landing/app/components/hero.tsx
+++ b/landing/app/components/hero.tsx
@@ -8,16 +8,6 @@ const LONGEST_HOST = HOSTS.reduce((longest, host) =>
   longest.length >= host.length ? longest : host,
 );
 
-declare global {
-  interface Window {
-    gtag?: (
-      command: string,
-      event: string,
-      params?: Record<string, unknown>,
-    ) => void;
-  }
-}
-
 type InstallRowProps = {
   cmd: string;
   label?: string;

--- a/landing/app/components/hero.tsx
+++ b/landing/app/components/hero.tsx
@@ -27,11 +27,14 @@ export function InstallRow({ cmd, label }: InstallRowProps) {
   const [copied, setCopied] = useState(false);
   const onCopy = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
-    navigator.clipboard?.writeText(cmd).then(() => {
-      window.gtag?.("event", "copy_install_command", { label: cmd });
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    });
+    navigator.clipboard?.writeText(cmd).then(
+      () => {
+        window.gtag?.("event", "copy_install_command", { label: cmd });
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      },
+      () => {},
+    );
   };
   return (
     <button

--- a/landing/app/components/hero.tsx
+++ b/landing/app/components/hero.tsx
@@ -29,7 +29,7 @@ export function InstallRow({ cmd, label }: InstallRowProps) {
     event.preventDefault();
     navigator.clipboard?.writeText(cmd).then(
       () => {
-        window.gtag?.("event", "copy_install_command", { label: cmd });
+        window.gtag?.("event", "lp_copy_install_command", { label: cmd });
         setCopied(true);
         setTimeout(() => setCopied(false), 1500);
       },
@@ -129,7 +129,7 @@ export function Hero() {
                 <a
                   className="sb-btn sb-btn-primary sb-btn-lg"
                   href="https://docs.skybridge.tech"
-                  data-ga="cta_click"
+                  data-ga="lp_cta_click"
                   data-ga-label="hero_read_docs"
                   style={{ borderColor: "rgb(166, 244, 241)" }}
                 >

--- a/landing/app/components/hero.tsx
+++ b/landing/app/components/hero.tsx
@@ -8,6 +8,16 @@ const LONGEST_HOST = HOSTS.reduce((longest, host) =>
   longest.length >= host.length ? longest : host,
 );
 
+declare global {
+  interface Window {
+    gtag?: (
+      command: string,
+      event: string,
+      params?: Record<string, unknown>,
+    ) => void;
+  }
+}
+
 type InstallRowProps = {
   cmd: string;
   label?: string;
@@ -17,16 +27,16 @@ export function InstallRow({ cmd, label }: InstallRowProps) {
   const [copied, setCopied] = useState(false);
   const onCopy = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
-    navigator.clipboard?.writeText(cmd);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
+    navigator.clipboard?.writeText(cmd).then(() => {
+      window.gtag?.("event", "copy_install_command", { label: cmd });
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
   };
   return (
     <button
       type="button"
       className="sb-install"
-      data-ga="copy_install_command"
-      data-ga-label={cmd}
       aria-label={label ? `${label} copy ${cmd}` : `Copy ${cmd}`}
       onClick={onCopy}
     >

--- a/landing/app/components/site-nav.tsx
+++ b/landing/app/components/site-nav.tsx
@@ -73,6 +73,8 @@ export async function SiteNav() {
             href="https://github.com/alpic-ai/skybridge"
             target="_blank"
             rel="noopener noreferrer"
+            data-ga="github_click"
+            data-ga-label="nav_stars"
           >
             <Icon name="github" size={13} />
             <span className="sb-star-count">{stars}</span>
@@ -82,6 +84,8 @@ export async function SiteNav() {
             href="https://docs.skybridge.tech"
             target="_blank"
             rel="noreferrer"
+            data-ga="cta_click"
+            data-ga-label="nav_get_started"
           >
             Get started
             <Icon name="arrow" size={12} stroke={2} />

--- a/landing/app/components/site-nav.tsx
+++ b/landing/app/components/site-nav.tsx
@@ -73,7 +73,7 @@ export async function SiteNav() {
             href="https://github.com/alpic-ai/skybridge"
             target="_blank"
             rel="noopener noreferrer"
-            data-ga="github_click"
+            data-ga="lp_github_click"
             data-ga-label="nav_stars"
           >
             <Icon name="github" size={13} />
@@ -84,7 +84,7 @@ export async function SiteNav() {
             href="https://docs.skybridge.tech"
             target="_blank"
             rel="noreferrer"
-            data-ga="cta_click"
+            data-ga="lp_cta_click"
             data-ga-label="nav_get_started"
           >
             Get started

--- a/landing/app/components/trust-final.tsx
+++ b/landing/app/components/trust-final.tsx
@@ -65,6 +65,8 @@ export function FinalCtaSection() {
           <a
             className="sb-btn sb-btn-primary sb-btn-lg"
             href="https://docs.skybridge.tech"
+            data-ga="cta_click"
+            data-ga-label="final_read_docs"
           >
             Read the docs
             <Icon name="arrow" size={15} stroke={2} />
@@ -74,6 +76,8 @@ export function FinalCtaSection() {
             href="https://github.com/alpic-ai/skybridge"
             target="_blank"
             rel="noopener noreferrer"
+            data-ga="github_click"
+            data-ga-label="final_star"
             style={{ borderRadius: "10px", borderColor: "rgb(106, 177, 177)" }}
           >
             <Icon name="github" size={14} />

--- a/landing/app/components/trust-final.tsx
+++ b/landing/app/components/trust-final.tsx
@@ -65,7 +65,7 @@ export function FinalCtaSection() {
           <a
             className="sb-btn sb-btn-primary sb-btn-lg"
             href="https://docs.skybridge.tech"
-            data-ga="cta_click"
+            data-ga="lp_cta_click"
             data-ga-label="final_read_docs"
           >
             Read the docs
@@ -76,7 +76,7 @@ export function FinalCtaSection() {
             href="https://github.com/alpic-ai/skybridge"
             target="_blank"
             rel="noopener noreferrer"
-            data-ga="github_click"
+            data-ga="lp_github_click"
             data-ga-label="final_star"
             style={{ borderRadius: "10px", borderColor: "rgb(106, 177, 177)" }}
           >

--- a/landing/app/layout.tsx
+++ b/landing/app/layout.tsx
@@ -99,6 +99,10 @@ export default function RootLayout({
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
             gtag('config', 'G-0W0ZMXTSDZ');
+            document.addEventListener('click', function (event) {
+              var el = event.target && event.target.closest && event.target.closest('[data-ga]');
+              if (el) gtag('event', el.dataset.ga, { label: el.dataset.gaLabel });
+            });
           `}
         </Script>
         <script

--- a/landing/app/layout.tsx
+++ b/landing/app/layout.tsx
@@ -97,6 +97,7 @@ export default function RootLayout({
           {`
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
+            window['ga-disable-G-0W0ZMXTSDZ'] = /^(localhost|127\\.0\\.0\\.1|\\[::1\\])$/.test(location.hostname);
             gtag('js', new Date());
             gtag('config', 'G-0W0ZMXTSDZ');
             document.addEventListener('click', function (event) {

--- a/landing/global.d.ts
+++ b/landing/global.d.ts
@@ -1,0 +1,7 @@
+interface Window {
+  gtag?: (
+    command: string,
+    event: string,
+    params?: Record<string, unknown>,
+  ) => void;
+}


### PR DESCRIPTION
## Summary

- One delegated click listener in the existing gtag inline script, dispatching on `data-ga` / `data-ga-label` attributes
- `copy_install_command` on install-command copy (also fires on /showcase, same component)
- `cta_click` on the three docs.skybridge.tech CTAs (nav, hero, final)
- `github_click` on the two GitHub buttons (nav stars, final star)

Verified in a browser: all 5 elements push the expected `dataLayer` entries.

Follow-up in GA4 (marketing, not code): mark the three events as key events, register `label` as an event-scoped custom dimension.

Out of scope: footer GitHub/Contributing links, "News / OpenAI blog" banner.

Closes SKY-528