### PR TITLE
fix(1018): only rewrite asset URLs at runtime for JS, not CSS

### DIFF
--- a/packages/core/src/web/plugin/plugin-build.test.ts
+++ b/packages/core/src/web/plugin/plugin-build.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { build } from "vite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { skybridge } from "./plugin.js";
+
+/**
+ * Full `vite build` over a fixture whose stylesheet contains a `url()`. The
+ * unit test pins the `renderBuiltUrl` contract; this one proves Vite actually
+ * accepts what the plugin returns.
+ */
+describe("skybridge plugin build", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "skybridge-build-"));
+    mkdirSync(join(root, "views"), { recursive: true });
+    mkdirSync(join(root, "src"), { recursive: true });
+
+    writeFileSync(join(root, "src/demo.woff2"), Buffer.alloc(64, 1));
+    writeFileSync(
+      join(root, "src/styles.css"),
+      [
+        "@font-face {",
+        '  font-family: "Demo";',
+        '  src: url("./demo.woff2") format("woff2");',
+        "}",
+      ].join("\n"),
+    );
+    writeFileSync(join(root, "src/entry.js"), `import "./styles.css";\n`);
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("builds a view stylesheet that references a font", async () => {
+    const result = await build({
+      root,
+      logLevel: "silent",
+      plugins: [skybridge({ viewsDir: join(root, "views") })],
+      build: {
+        // Force the font to be emitted as a file rather than inlined, so the
+        // stylesheet actually carries a `url()`.
+        assetsInlineLimit: 0,
+        rollupOptions: { input: { entry: join(root, "src/entry.js") } },
+      },
+    });
+
+    const outputs = (Array.isArray(result) ? result : [result]).flatMap(
+      (bundle) => ("output" in bundle ? bundle.output : []),
+    );
+    const css = outputs.find(
+      (chunk) => chunk.type === "asset" && chunk.fileName.endsWith(".css"),
+    );
+    if (css?.type !== "asset") {
+      throw new Error("no CSS asset was emitted");
+    }
+
+    // The font resolves relative to the stylesheet, which the server hands out
+    // from `${serverUrl}/assets/` — no runtime expression, which CSS can't run.
+    expect(String(css.source)).toMatch(/url\(\.\/demo-[\w-]+\.woff2\)/);
+    expect(String(css.source)).not.toContain("window.skybridge");
+  });
+});

--- a/packages/core/src/web/plugin/plugin.test.ts
+++ b/packages/core/src/web/plugin/plugin.test.ts
@@ -1,0 +1,81 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { UserConfig } from "vite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { skybridge } from "./plugin.js";
+
+type RenderBuiltUrl = NonNullable<
+  NonNullable<UserConfig["experimental"]>["renderBuiltUrl"]
+>;
+
+function getRenderBuiltUrl(root: string): RenderBuiltUrl {
+  const plugin = skybridge({ viewsDir: join(root, "views") });
+  const hook = plugin.config;
+  if (!hook) {
+    throw new Error("plugin.config is not defined");
+  }
+  const handler = typeof hook === "function" ? hook : hook.handler;
+  const config = handler.call(
+    // biome-ignore lint/suspicious/noExplicitAny: vitest harness for plugin hook
+    {} as any,
+    { root },
+    { command: "build", mode: "production" },
+  ) as UserConfig;
+
+  const renderBuiltUrl = config.experimental?.renderBuiltUrl;
+  if (!renderBuiltUrl) {
+    throw new Error("experimental.renderBuiltUrl is not defined");
+  }
+  return renderBuiltUrl;
+}
+
+describe("skybridge plugin renderBuiltUrl", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "skybridge-plugin-"));
+    mkdirSync(join(root, "views"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  // Assets referenced from JS can't use `import.meta.url`: views render in a
+  // host sandbox iframe (web-sandbox.oaiusercontent.com), so the module origin
+  // doesn't point back at the Skybridge server. They have to be resolved at
+  // runtime against `window.skybridge.serverUrl` instead.
+  it("resolves JS asset references against window.skybridge.serverUrl", () => {
+    const renderBuiltUrl = getRenderBuiltUrl(root);
+
+    expect(
+      renderBuiltUrl("assets/logo-BXtQ8kd2.png", {
+        hostId: "assets/view-CwF9pQ1a.js",
+        hostType: "js",
+        type: "asset",
+        ssr: false,
+      }),
+    ).toEqual({
+      runtime: `window.skybridge.serverUrl + "/assets/assets/logo-BXtQ8kd2.png"`,
+    });
+  });
+
+  // Reproducer for the CSS build failure: Vite has nowhere to evaluate a
+  // runtime expression inside a stylesheet, so `{ runtime }` makes
+  // `vite:css-post` throw for any `url()` in CSS. It isn't needed either — the
+  // stylesheet is served from `${serverUrl}/assets/…`, and a relative `url()`
+  // resolves against the stylesheet's own URL, tunnel origin included.
+  it("resolves CSS asset references relatively", () => {
+    const renderBuiltUrl = getRenderBuiltUrl(root);
+
+    expect(
+      renderBuiltUrl("assets/demo-0IQFxQqs.woff2", {
+        hostId: "assets/style-DmQ2xY7b.css",
+        hostType: "css",
+        type: "asset",
+        ssr: false,
+      }),
+    ).toEqual({ relative: true });
+  });
+});

--- a/packages/core/src/web/plugin/plugin.ts
+++ b/packages/core/src/web/plugin/plugin.ts
@@ -131,10 +131,21 @@ export function skybridge(options?: SkybridgePluginOptions): Plugin {
           include: ["react", "react-dom/client", "react/jsx-runtime"],
         },
         experimental: {
-          renderBuiltUrl: (filename) => {
-            return {
-              runtime: `window.skybridge.serverUrl + "/assets/${filename}"`,
-            };
+          renderBuiltUrl: (filename, { hostType }) => {
+            // Views render inside a host sandbox iframe, so `import.meta.url`
+            // points at the sandbox domain rather than the Skybridge server.
+            // JS asset references have to be resolved at runtime against
+            // `window.skybridge.serverUrl` so they follow tunnels too.
+            if (hostType === "js") {
+              return {
+                runtime: `window.skybridge.serverUrl + "/assets/${filename}"`,
+              };
+            }
+            // CSS has nowhere to evaluate a runtime expression — `vite:css-post`
+            // throws on one. It doesn't need it either: the stylesheet is served
+            // from `${serverUrl}/assets/…` and a relative `url()` resolves
+            // against the stylesheet's own URL, tunnel origin included.
+            return { relative: true };
           },
         },
       };


### PR DESCRIPTION
Fix for #1018

`renderBuiltUrl` rewrote every built asset URL into a runtime JS expression. Vite has nowhere to evaluate that inside a stylesheet, so `vite:css-post` throws and the build fails outright for any view whose CSS contains a `url()` — a `@font-face`, a background image, anything a component library ships:

    [plugin vite:css-post]
    Error: { runtime: "window.skybridge.serverUrl + "/assets/assets/demo-0IQFxQqs.woff2"" }
    is not supported for assets in css files: assets/demo-0IQFxQqs.woff2

Narrow the rewrite to `hostType === "js"`, per Vite's documented `renderBuiltUrl` example, and fall back to `{ relative: true }`.

The runtime rewrite (#658) is still required for JS: views render in a host sandbox iframe, so `import.meta.url` points at the sandbox domain rather than the Skybridge server and can't follow a tunnel. That doesn't apply to CSS — a `url()` resolves against the stylesheet's own URL, and the stylesheet is already served from `${serverUrl}/assets/…`, so the tunnel origin is inherited automatically. This also brings the build path in line with the dev-server transform, which has excluded CSS since #697.