### PR TITLE
feat(core): expose thrown tool errors to MCP middleware via getToolError

### DIFF
--- a/docs/api-reference/mcp-server.mdx
+++ b/docs/api-reference/mcp-server.mdx
@@ -117,6 +117,29 @@ server.mcpMiddleware("request", (request, extra, next) => {
 });
 ```
 
+### `getToolError`
+
+```ts
+import { getToolError } from "skybridge/server";
+
+getToolError(extra: McpExtra | undefined): unknown;
+```
+
+The MCP SDK catches whatever a tool handler throws and turns it into an `isError` tool result, so `await next()` resolves normally and the middleware never sees the failure. `getToolError` returns the error the tool handler threw during the current request, with its stack and `cause` intact. It lives on `extra`, which is never serialized to the client.
+
+```ts
+server.mcpMiddleware("tools/call", async (request, extra, next) => {
+  const result = await next();
+  const error = getToolError(extra);
+  if (error) {
+    Sentry.captureException(error);
+  }
+  return result;
+});
+```
+
+A tool failure is a valid MCP response, so [`useOnError`](#useonerror) never runs for it — report tool errors from `mcpMiddleware`, and keep `useOnError` for transport-level failures. Errors raised by the SDK itself — unknown tool, input or output schema validation — never reach your handler and are not reported here.
+
 ### `run`
 
 ```ts

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -39,6 +39,7 @@ export type {
   McpTypedMiddlewareFn,
   McpWildcard,
 } from "./middleware.js";
+export { getToolError } from "./middleware.js";
 export type {
   HandlerContent,
   JsonOptions,

--- a/packages/core/src/server/middleware.test.ts
+++ b/packages/core/src/server/middleware.test.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import {
   buildMiddlewareChain,
   getHandlerMaps,
+  getToolError,
   type McpExtra,
   type McpMiddlewareEntry,
   type McpMiddlewareFn,
@@ -561,6 +562,57 @@ describe("McpServer.mcpMiddleware()", () => {
     const result = await client.callTool({ name: "t1" });
     expect(result.content).toEqual([{ type: "text", text: "short-circuited" }]);
     expect(handlerCalled).not.toHaveBeenCalled();
+
+    await client.close();
+    await server.close();
+  });
+
+  it("exposes a thrown tool error to middleware via getToolError", async () => {
+    const schemaError = new Error("boom with schema");
+    const schemalessError = new Error("boom without schema");
+    let captured: unknown;
+
+    const server = new McpServer({ name: "test", version: "1.0.0" });
+
+    server.registerTool(
+      {
+        name: "withSchema",
+        description: "withSchema",
+        inputSchema: { name: z.string() },
+      },
+      () => {
+        throw schemaError;
+      },
+    );
+    server.registerTool(
+      { name: "withoutSchema", description: "withoutSchema" },
+      () => {
+        throw schemalessError;
+      },
+    );
+
+    server.mcpMiddleware("tools/call", async (_request, extra, next) => {
+      const result = await next();
+      captured = getToolError(extra);
+      return result;
+    });
+
+    const client = createClient();
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    const withSchema = await client.callTool({
+      name: "withSchema",
+      arguments: { name: "World" },
+    });
+    expect(withSchema.isError).toBe(true);
+    expect(captured).toBe(schemaError);
+
+    const withoutSchema = await client.callTool({ name: "withoutSchema" });
+    expect(withoutSchema.isError).toBe(true);
+    expect(captured).toBe(schemalessError);
 
     await client.close();
     await server.close();

--- a/packages/core/src/server/middleware.ts
+++ b/packages/core/src/server/middleware.ts
@@ -39,6 +39,48 @@ export type McpMiddlewareFn = (
   next: () => Promise<unknown>,
 ) => Promise<unknown> | unknown;
 
+const TOOL_ERROR = Symbol.for("skybridge.toolError");
+
+function toolErrorSlot(
+  extra: McpExtra | undefined,
+): Record<symbol, unknown> | undefined {
+  return extra as unknown as Record<symbol, unknown> | undefined;
+}
+
+export function captureToolError(
+  extra: McpExtra | undefined,
+  error: unknown,
+): void {
+  const slot = toolErrorSlot(extra);
+  if (slot) {
+    slot[TOOL_ERROR] = error;
+  }
+}
+
+/**
+ * Retrieve the error a tool handler threw during this request, if any.
+ *
+ * The MCP SDK catches anything a tool handler throws and turns it into an
+ * `isError` tool result, so `await next()` in middleware resolves normally and
+ * the original `Error` — stack, `cause` — is lost. Skybridge stores it on
+ * `extra` (never serialized to the client) so observability middleware can
+ * report it:
+ *
+ * ```ts
+ * server.mcpMiddleware("tools/call", async (request, extra, next) => {
+ *   const result = await next();
+ *   const error = getToolError(extra);
+ *   if (error) {
+ *     Sentry.captureException(error);
+ *   }
+ *   return result;
+ * });
+ * ```
+ */
+export function getToolError(extra: McpExtra | undefined): unknown {
+  return toolErrorSlot(extra)?.[TOOL_ERROR];
+}
+
 /**
  * MCP methods the server handles (incoming from client).
  */

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -53,7 +53,11 @@ import type {
   McpTypedMiddlewareFn,
   McpWildcard,
 } from "./middleware.js";
-import { buildMiddlewareChain, getHandlerMaps } from "./middleware.js";
+import {
+  buildMiddlewareChain,
+  captureToolError,
+  getHandlerMaps,
+} from "./middleware.js";
 import { resolveServerOrigin } from "./requestOrigin.js";
 import {
   discoverSkills,
@@ -1285,13 +1289,14 @@ export class McpServer<
     }: { attachViewUUID: boolean; securitySchemes?: SecurityScheme[] },
   ): ToolHandler<InputArgs> {
     return async (args, extra) => {
+      const toolExtra = extra ?? (args as unknown as McpExtra);
       if (this.oauthEnabled) {
         const failure = evaluateSecuritySchemes(
           securitySchemes,
-          extra.authInfo,
+          toolExtra?.authInfo,
         );
         if (failure) {
-          const headers = extra?.requestInfo?.headers ?? {};
+          const headers = toolExtra?.requestInfo?.headers ?? {};
           const header = (key: string) => {
             const value = headers[key];
             return Array.isArray(value) ? value[0] : value;
@@ -1302,7 +1307,13 @@ export class McpServer<
           );
         }
       }
-      const result = await cb(args, extra);
+      let result: Awaited<ReturnType<typeof cb>>;
+      try {
+        result = await cb(args, extra);
+      } catch (error) {
+        captureToolError(toolExtra, error);
+        throw error;
+      }
       return {
         ...result,
         content: normalizeContent(result.content),


### PR DESCRIPTION
## Summary

- The MCP SDK catches whatever a tool handler throws and returns an `isError` result, so `await next()` in `mcpMiddleware` resolves normally and the original `Error` is lost (#1017).
- Skybridge's tool wrapper now stashes the thrown error on the per-request `extra` and rethrows, so client behaviour is unchanged.
- New `getToolError(extra)` export returns it, with stack and `cause` intact.
- Also fixes a latent crash: the SDK calls schema-less tool handlers as `handler(extra)`, so `extra.authInfo` threw on an oauth server with a schema-less tool.

```ts
server.mcpMiddleware("tools/call", async (request, extra, next) => {
  const result = await next();
  const error = getToolError(extra);
  if (error) {
    Sentry.captureException(error);
  }
  return result;
});
```

Errors the SDK raises itself (unknown tool, schema validation) never reach the handler and are out of scope.

## Alternatives Considered

- **Error details on the result's `_meta`** (the issue's suggestion) — Attach message, stack, and cause to the `isError` result so middleware reads them back off the result. The result is the JSON-RPC payload, so every field on `_meta` is serialized to the host: ChatGPT and any other client would receive our stack traces and internal paths on every tool failure. Keeping the error on `extra` gives middleware the same data, and `extra` never crosses the wire.

  ```ts
  return { isError: true, content, _meta: { error: { stack, cause } } };
  ```

- **Re-throw past the SDK** — Let the error propagate out of the request handler so outer middleware sees a rejected promise. A throw at that level turns the response into a JSON-RPC protocol error, so clients stop receiving the `isError` tool result they get today, and hosts that render tool errors in the conversation would show a transport failure instead. Stashing and rethrowing inside the SDK's own try/catch leaves the response byte-identical.

- **Request-scoped map keyed by `extra.requestId`** — Store errors in a module-level `Map` instead of on `extra`. It survives the SDK shallow-copying `extra`, which is the one case the stash misses, but that copy only happens for task handlers (`registerToolTask`) and skybridge never registers those. In exchange the map needs its own eviction on every exit path, since a missed delete leaks the error object for the process lifetime. The stash is collected with the request.

  ```ts
  const errors = new Map<RequestId, unknown>();
  ```

Closes #1017