### PR TITLE
feat(auth): type-safe AuthInfo.extra, owned by the verifier

### DIFF
--- a/docs/api-reference/custom-provider.mdx
+++ b/docs/api-reference/custom-provider.mdx
@@ -64,10 +64,10 @@ type CustomProviderOptions = {
 A `Promise` (discovery is a boot-time network call) for the `OAuthConfig` you pass to the [`oauth`](/api-reference/mcp-server#constructor) constructor option.
 
 ```ts
-type OAuthConfig = {
+type OAuthConfig<TExtra = Record<string, unknown>> = {
   baseUrl?: string;
   oauthMetadata: OAuthMetadata;
-  verify: { issuer: string; audience?: string; jwksUri?: string };
+  verifier: TokenVerifier<TExtra>;
   scopesSupported?: string[];
   requiredScopes?: string[];
 };
@@ -77,11 +77,13 @@ type OAuthConfig = {
 | --- | --- |
 | `baseUrl` | Echoes the `baseUrl` option. |
 | `oauthMetadata` | AS metadata served at `/.well-known/oauth-authorization-server`. |
-| `verify` | JWKS token-verification config. |
+| `verifier` | Checks each bearer token, and carries the claim type handlers receive. |
 | `scopesSupported` | Scopes advertised in protected-resource metadata. |
 | `requiredScopes` | Server-wide required-scope floor. |
 
-Build this object by hand only to wire an IdP whose metadata `customProvider` can't discover: supply `verify.issuer` and `verify.jwksUri` yourself and the [`oauth`](/api-reference/mcp-server#constructor) option mounts the same endpoints.
+`TExtra` is the claim shape the verifier resolves with, and the server reads it from here, so handlers get `extra.authInfo?.extra` typed without declaring anything. Pass it as a type argument to name claims your IdP sends: `customProvider<{ subject?: string; email?: string }>({ ... })`.
+
+Build this object by hand only to wire an IdP whose metadata `customProvider` can't discover. Supply the verifier yourself — `createJwksVerifier({ issuer, jwksUri })` for JWTs, or your own [`TokenVerifier`](/api-reference/verifier) for opaque tokens — and the [`oauth`](/api-reference/mcp-server#constructor) option mounts the same endpoints.
 
 <CardGroup cols={3}>
   <Card title="Connect an Identity Provider" icon="fingerprint" href="/guides/auth-providers">

--- a/docs/api-reference/custom-provider.mdx
+++ b/docs/api-reference/custom-provider.mdx
@@ -67,10 +67,9 @@ A `Promise` (discovery is a boot-time network call) for the `OAuthConfig` you pa
 type OAuthConfig<TExtra = Record<string, unknown>> = {
   baseUrl?: string;
   oauthMetadata: OAuthMetadata;
-  verifier: TokenVerifier<TExtra>;
   scopesSupported?: string[];
   requiredScopes?: string[];
-};
+} & ({ verifier: TokenVerifier<TExtra> } | { verify: JwksVerifyConfig });
 ```
 
 | Field | Description |
@@ -78,12 +77,13 @@ type OAuthConfig<TExtra = Record<string, unknown>> = {
 | `baseUrl` | Echoes the `baseUrl` option. |
 | `oauthMetadata` | AS metadata served at `/.well-known/oauth-authorization-server`. |
 | `verifier` | Checks each bearer token, and carries the claim type handlers receive. |
+| `verify` | Deprecated. JWKS parameters (`issuer`, `audience`, `jwksUri`) used to build the verifier; claims stay `Record<string, unknown>`. |
 | `scopesSupported` | Scopes advertised in protected-resource metadata. |
 | `requiredScopes` | Server-wide required-scope floor. |
 
 `TExtra` is the claim shape the verifier resolves with, and the server reads it from here, so handlers get `extra.authInfo?.extra` typed without declaring anything. Pass it as a type argument to name claims your IdP sends: `customProvider<{ subject?: string; email?: string }>({ ... })`.
 
-Build this object by hand only to wire an IdP whose metadata `customProvider` can't discover. Supply the verifier yourself — `createJwksVerifier({ issuer, jwksUri })` for JWTs, or your own [`TokenVerifier`](/api-reference/verifier) for opaque tokens — and the [`oauth`](/api-reference/mcp-server#constructor) option mounts the same endpoints.
+Build this object by hand only to wire an IdP whose metadata `customProvider` can't discover. Supply exactly one of the two: `verifier`, from `createJwksVerifier({ issuer, jwksUri })` for JWTs or your own [`TokenVerifier`](/api-reference/verifier) for opaque tokens, or the deprecated `verify` parameters. Either way the [`oauth`](/api-reference/mcp-server#constructor) option mounts the same endpoints.
 
 <CardGroup cols={3}>
   <Card title="Connect an Identity Provider" icon="fingerprint" href="/guides/auth-providers">

--- a/docs/api-reference/mcp-server.mdx
+++ b/docs/api-reference/mcp-server.mdx
@@ -75,6 +75,35 @@ server.registerTool(config, handler): this;
 
 Registers a tool, optionally bound to a view. See [registerTool](/api-reference/register-tool) for the full config and handler.
 
+### `withAuthExtra`
+
+```ts
+server.withAuthExtra<TExtra>(): McpServer;
+```
+
+Declares the shape of the verified token's `extra` claims. Nothing happens at runtime: the call exists only to carry the type, so tool [handlers](/api-reference/register-tool#handler) and [`mcpMiddleware`](#mcpmiddleware) read `extra.authInfo.extra` without casting.
+
+```ts
+type Claims = { subject?: string; email?: string };
+
+const server = new McpServer(
+  { name: "my-app", version: "1.0.0" },
+  {},
+  { oauth: await workosProvider({ domain, audience }) },
+)
+  .withAuthExtra<Claims>()
+  .registerTool({ name: "orders", inputSchema: {} }, (_args, extra) => {
+    const email = extra.authInfo?.extra?.email; // string | undefined
+    return { content: `Orders for ${email}` };
+  });
+```
+
+Chain it before `registerTool` so every handler sees the shape. Without it, `extra.authInfo.extra` stays `Record<string, unknown> | undefined`.
+
+<Warning>
+The declared shape is an assertion about what your verifier produces, not a runtime check. A claim your provider omits reads as `undefined` at runtime whatever the type says, so keep optional claims optional.
+</Warning>
+
 ### `use`
 
 ```ts

--- a/docs/api-reference/mcp-server.mdx
+++ b/docs/api-reference/mcp-server.mdx
@@ -47,20 +47,7 @@ type SkybridgeServerOptions = {
 
 `oauth` is an [`OAuthConfig`](/api-reference/custom-provider#returns), usually from [`customProvider`](/api-reference/custom-provider) or a branded provider. When set, it mounts the well-known OAuth metadata and bearer-token verification on `/mcp`.
 
-The config also carries the claim shape its verifier produces, and the server picks it up from there. Tool [handlers](/api-reference/register-tool#handler) and [`mcpMiddleware`](#mcpmiddleware) then read `extra.authInfo?.extra` with no cast:
-
-```ts
-const server = new McpServer(
-  { name: "my-app", version: "1.0.0" },
-  {},
-  { oauth: await workosProvider({ domain, audience }) },
-).registerTool({ name: "orders", inputSchema: {} }, (_args, extra) => {
-  const org = extra.authInfo?.extra?.org_id; // string | undefined
-  return { content: `Orders for ${org}` };
-});
-```
-
-Each provider ships the claims its own docs promise, and a type argument adds your own: `workosProvider<{ tenant: string }>({ ... })`. See [Type the Claims You Read](/build/auth#type-the-claims-you-read).
+The config also carries the claim shape its verifier produces, so handlers read `extra.authInfo?.extra` typed, with no declaration of their own. See [Type the Claims You Read](/build/auth#type-the-claims-you-read).
 
 `skills` set to `true` serves [Agent Skills over MCP](/guides/skills) from `src/skills` and declares the `io.modelcontextprotocol/skills` capability. See the [Skills guide](/guides/skills).
 

--- a/docs/api-reference/mcp-server.mdx
+++ b/docs/api-reference/mcp-server.mdx
@@ -47,6 +47,21 @@ type SkybridgeServerOptions = {
 
 `oauth` is an [`OAuthConfig`](/api-reference/custom-provider#returns), usually from [`customProvider`](/api-reference/custom-provider) or a branded provider. When set, it mounts the well-known OAuth metadata and bearer-token verification on `/mcp`.
 
+The config also carries the claim shape its verifier produces, and the server picks it up from there. Tool [handlers](/api-reference/register-tool#handler) and [`mcpMiddleware`](#mcpmiddleware) then read `extra.authInfo?.extra` with no cast:
+
+```ts
+const server = new McpServer(
+  { name: "my-app", version: "1.0.0" },
+  {},
+  { oauth: await workosProvider({ domain, audience }) },
+).registerTool({ name: "orders", inputSchema: {} }, (_args, extra) => {
+  const org = extra.authInfo?.extra?.org_id; // string | undefined
+  return { content: `Orders for ${org}` };
+});
+```
+
+Each provider ships the claims its own docs promise, and a type argument adds your own: `workosProvider<{ tenant: string }>({ ... })`. See [Type the Claims You Read](/build/auth#type-the-claims-you-read).
+
 `skills` set to `true` serves [Agent Skills over MCP](/guides/skills) from `src/skills` and declares the `io.modelcontextprotocol/skills` capability. See the [Skills guide](/guides/skills).
 
 <Info>
@@ -74,35 +89,6 @@ server.registerTool(config, handler): this;
 ```
 
 Registers a tool, optionally bound to a view. See [registerTool](/api-reference/register-tool) for the full config and handler.
-
-### `withAuthExtra`
-
-```ts
-server.withAuthExtra<TExtra>(): McpServer;
-```
-
-Declares the shape of the verified token's `extra` claims. Nothing happens at runtime: the call exists only to carry the type, so tool [handlers](/api-reference/register-tool#handler) and [`mcpMiddleware`](#mcpmiddleware) read `extra.authInfo.extra` without casting.
-
-```ts
-type Claims = { subject?: string; email?: string };
-
-const server = new McpServer(
-  { name: "my-app", version: "1.0.0" },
-  {},
-  { oauth: await workosProvider({ domain, audience }) },
-)
-  .withAuthExtra<Claims>()
-  .registerTool({ name: "orders", inputSchema: {} }, (_args, extra) => {
-    const email = extra.authInfo?.extra?.email; // string | undefined
-    return { content: `Orders for ${email}` };
-  });
-```
-
-Chain it before `registerTool` so every handler sees the shape. Without it, `extra.authInfo.extra` stays `Record<string, unknown> | undefined`.
-
-<Warning>
-The declared shape is an assertion about what your verifier produces, not a runtime check. A claim your provider omits reads as `undefined` at runtime whatever the type says, so keep optional claims optional.
-</Warning>
 
 ### `use`
 

--- a/docs/api-reference/register-tool.mdx
+++ b/docs/api-reference/register-tool.mdx
@@ -32,7 +32,7 @@ const server = new McpServer({ name: "shop", version: "1.0" }).registerTool(
     },
   },
   async ({ query, maxPrice }, { authInfo }) => {
-    const userId = authInfo.extra?.subject as string;
+    const userId = authInfo?.extra?.subject;
     const products = await search(query, { maxPrice, userId });
     return {
       content: `Found ${products.length} products for "${query}".`,
@@ -220,7 +220,7 @@ The request context.
 
 | Field | Purpose |
 | --- | --- |
-| `authInfo` | Validated token from an auth middleware: `clientId`, `scopes`, `extra`. |
+| `authInfo` | Validated token from an auth middleware: `clientId`, `scopes`, `extra`. The [provider](/guides/auth-providers) types the claims in `extra`. |
 | `requestInfo` | The HTTP request: headers and URL. |
 | `signal` | An `AbortSignal`, aborted when the call is cancelled. |
 | `_meta` | Client hints (below). |

--- a/docs/api-reference/verifier.mdx
+++ b/docs/api-reference/verifier.mdx
@@ -69,6 +69,18 @@ type AuthInfo = {
 | `expiresAt` | Expiry in unix seconds. Required: tokens with no expiration are rejected. |
 | `extra` | Anything else you want available to handlers, for example `sub` or `email`. |
 
+`extra` is an untyped bag by default. Pass the shape your verifier produces to type it, in the verifier and in every handler:
+
+```ts
+type Claims = { sub: string; email?: string };
+
+async function verifyAccessToken(token: string): Promise<AuthInfo<Claims>> {
+  // ...
+}
+```
+
+Handlers get the same shape once the server declares it with [`withAuthExtra`](/api-reference/mcp-server#withauthextra).
+
 <CardGroup cols={3}>
   <Card title="requireBearerAuth" icon="lock" href="/api-reference/require-bearer-auth">
     Require a token on every request

--- a/docs/api-reference/verifier.mdx
+++ b/docs/api-reference/verifier.mdx
@@ -47,6 +47,31 @@ The verifier's only required method.
 
 Do not check scopes here: the middleware enforces `requiredScopes` against `authInfo.scopes` and returns a 403 on a missing scope.
 
+## `createJwksVerifier`
+
+```ts
+createJwksVerifier<TExtra>(config: JwksVerifyConfig): JwksTokenVerifier<TExtra>;
+```
+
+Builds a verifier that validates JWTs against a remote JWKS. The [providers](/guides/auth-providers) use it internally; call it yourself when hand-building an [`OAuthConfig`](/api-reference/custom-provider#returns) for an IdP whose metadata discovery can't reach.
+
+```ts
+import { createJwksVerifier } from "skybridge/server";
+
+const verifier = createJwksVerifier<{ subject?: string; email?: string }>({
+  issuer: "https://auth.myshop.com",
+  audience: process.env.SERVER_URL,
+});
+```
+
+| Field | Description |
+| --- | --- |
+| `issuer` | Expected `iss`. Also derives the default JWKS URL. Required. |
+| `audience` | Expected `aud`. Omit to skip the audience check, for IdPs that bind none. |
+| `jwksUri` | Defaults to `${issuer}/.well-known/jwks.json`. |
+
+The returned verifier exposes the parameters it resolved as `verifier.config`, which is handy for checking what a provider derived from discovery. Verified claims land in `extra` with `sub` renamed to `subject`; `client_id`, `scope` and `exp` become `AuthInfo` fields instead, and the registered claims (`iss`, `aud`, `iat`, `nbf`, `jti`) stay in `extra`.
+
 ## `AuthInfo`
 
 What `verifyAccessToken` resolves with for a valid token.
@@ -67,19 +92,19 @@ type AuthInfo = {
 | `clientId` | The OAuth `client_id`, often the `azp` or `client_id` claim. |
 | `scopes` | The scopes granted, checked against `requiredScopes` and per-tool [`securitySchemes`](/api-reference/register-tool#securityschemes). |
 | `expiresAt` | Expiry in unix seconds. Required: tokens with no expiration are rejected. |
-| `extra` | Anything else you want available to handlers, for example `sub` or `email`. |
+| `extra` | Anything else you want available to handlers, for example `subject` or `email`. |
 
 `extra` is an untyped bag by default. Pass the shape your verifier produces to type it, in the verifier and in every handler:
 
 ```ts
-type Claims = { sub: string; email?: string };
+type Claims = { subject?: string; email?: string };
 
 async function verifyAccessToken(token: string): Promise<AuthInfo<Claims>> {
   // ...
 }
 ```
 
-Handlers get the same shape once the server declares it with [`withAuthExtra`](/api-reference/mcp-server#withauthextra).
+Handlers get the same shape automatically: the claim type travels with the verifier through [`OAuthConfig`](/api-reference/custom-provider#returns) into the server.
 
 <CardGroup cols={3}>
   <Card title="requireBearerAuth" icon="lock" href="/api-reference/require-bearer-auth">

--- a/docs/api-reference/verifier.mdx
+++ b/docs/api-reference/verifier.mdx
@@ -50,27 +50,12 @@ Do not check scopes here: the middleware enforces `requiredScopes` against `auth
 ## `createJwksVerifier`
 
 ```ts
-createJwksVerifier<TExtra>(config: JwksVerifyConfig): JwksTokenVerifier<TExtra>;
+createJwksVerifier<TExtra>(config: { issuer: string; audience?: string; jwksUri?: string }): TokenVerifier<TExtra>;
 ```
 
-Builds a verifier that validates JWTs against a remote JWKS. The [providers](/guides/auth-providers) use it internally; call it yourself when hand-building an [`OAuthConfig`](/api-reference/custom-provider#returns) for an IdP whose metadata discovery can't reach.
+Builds a verifier that validates JWTs against a remote JWKS. The [providers](/guides/auth-providers) use it internally; call it yourself when hand-building an [`OAuthConfig`](/api-reference/custom-provider#returns). `jwksUri` defaults to `${issuer}/.well-known/jwks.json`, and omitting `audience` skips the audience check, for IdPs that bind none.
 
-```ts
-import { createJwksVerifier } from "skybridge/server";
-
-const verifier = createJwksVerifier<{ subject?: string; email?: string }>({
-  issuer: "https://auth.myshop.com",
-  audience: process.env.SERVER_URL,
-});
-```
-
-| Field | Description |
-| --- | --- |
-| `issuer` | Expected `iss`. Also derives the default JWKS URL. Required. |
-| `audience` | Expected `aud`. Omit to skip the audience check, for IdPs that bind none. |
-| `jwksUri` | Defaults to `${issuer}/.well-known/jwks.json`. |
-
-The returned verifier exposes the parameters it resolved as `verifier.config`, which is handy for checking what a provider derived from discovery. Verified claims land in `extra` with `sub` renamed to `subject`; `client_id`, `scope` and `exp` become `AuthInfo` fields instead, and the registered claims (`iss`, `aud`, `iat`, `nbf`, `jti`) stay in `extra`.
+Verified claims land in `extra` with `sub` renamed to `subject`, while `client_id`, `scope` and `exp` become `AuthInfo` fields.
 
 ## `AuthInfo`
 
@@ -94,17 +79,7 @@ type AuthInfo = {
 | `expiresAt` | Expiry in unix seconds. Required: tokens with no expiration are rejected. |
 | `extra` | Anything else you want available to handlers, for example `subject` or `email`. |
 
-`extra` is an untyped bag by default. Pass the shape your verifier produces to type it, in the verifier and in every handler:
-
-```ts
-type Claims = { subject?: string; email?: string };
-
-async function verifyAccessToken(token: string): Promise<AuthInfo<Claims>> {
-  // ...
-}
-```
-
-Handlers get the same shape automatically: the claim type travels with the verifier through [`OAuthConfig`](/api-reference/custom-provider#returns) into the server.
+`extra` is an untyped bag by default. Pass the claims your verifier resolves with (`Promise<AuthInfo<Claims>>`) and handlers receive that shape, since the type travels with the verifier into the server.
 
 <CardGroup cols={3}>
   <Card title="requireBearerAuth" icon="lock" href="/api-reference/require-bearer-auth">

--- a/docs/build/auth.mdx
+++ b/docs/build/auth.mdx
@@ -152,6 +152,8 @@ const server = new McpServer({ name: "personal-shopper", version: "0.0.1" }, {})
 
 The shape is a claim about your verifier's output, not a runtime check, so type a claim the provider may omit as optional. Have `verifyAccessToken` return `Promise<AuthInfo<Claims>>` to keep both ends in sync.
 
+Check what your provider actually puts in an access token before declaring it. Identity claims you might expect are often absent: WorkOS AuthKit issues `sub`, `sid`, `org_id`, `role` and `permissions` but no `email`, and Clerk and Descope only carry one through a JWT template or a custom-claim action. Anything the token omits reads as `undefined`, whatever the type says.
+
 ## Mix Public and Authenticated Tools
 
 Serving both anonymous and signed-in callers from one server takes three changes to the fully authenticated setup.

--- a/docs/build/auth.mdx
+++ b/docs/build/auth.mdx
@@ -137,22 +137,41 @@ The validation body is provider-specific: [JWKS](https://datatracker.ietf.org/do
 
 ## Type the Claims You Read
 
-Whatever your verifier puts in `extra` reaches handlers as `authInfo.extra`, typed `Record<string, unknown>`, so every read needs a cast. Declare the shape once with [`withAuthExtra`](/api-reference/mcp-server#withauthextra) and the casts go away:
+Whatever the verifier puts in `extra` reaches handlers as `authInfo.extra`. The claim shape belongs to the verifier, so declaring it there is enough for every handler to see it.
 
-```ts server.ts highlight={3}
-type Claims = { sub: string; email?: string };
+On the [provider path](/guides/auth-providers) you get it for free. Each provider ships the claims its own documentation promises:
 
-const server = new McpServer({ name: "personal-shopper", version: "0.0.1" }, {})
-  .withAuthExtra<Claims>()
-  .use("/mcp", requireBearerAuth({ verifier: { verifyAccessToken } }))
-  .registerTool({ name: "orders", inputSchema: {} }, async (_args, extra) => ({
-    structuredContent: { orders: await fetchOrders(extra.authInfo?.extra?.sub) },
-  }));
+```ts server.ts
+const server = new McpServer(
+  { name: "personal-shopper", version: "0.0.1" },
+  {},
+  { oauth: await workosProvider({ domain, audience }) },
+).registerTool({ name: "orders", inputSchema: {} }, async (_args, extra) => ({
+  structuredContent: { orders: await fetchOrders(extra.authInfo?.extra?.org_id) },
+}));
 ```
 
-The shape is a claim about your verifier's output, not a runtime check, so type a claim the provider may omit as optional. Have `verifyAccessToken` return `Promise<AuthInfo<Claims>>` to keep both ends in sync.
+A type argument adds claims your tenant sends on top of the provider's, which is how you reach a custom claim:
 
-Check what your provider actually puts in an access token before declaring it. Identity claims you might expect are often absent: WorkOS AuthKit issues `sub`, `sid`, `org_id`, `role` and `permissions` but no `email`, and Clerk and Descope only carry one through a JWT template or a custom-claim action. Anything the token omits reads as `undefined`, whatever the type says.
+```ts
+oauth: await workosProvider<{ tenant: string }>({ domain, audience }),
+```
+
+Writing the verifier yourself? Type its return and pass it in the config; the shape flows the same way:
+
+```ts auth.ts
+type Claims = { subject?: string; email?: string };
+
+export const verifier: TokenVerifier<Claims> = {
+  async verifyAccessToken(token) {
+    // ...
+  },
+};
+```
+
+None of this is a runtime check: nothing rejects a token whose claims differ from the declared shape, so keep anything the IdP may omit optional.
+
+Check what your provider actually puts in an access token before declaring extra claims. Identity claims you might expect are usually absent: no provider ships `email` in an access token by default. WorkOS, Clerk, Descope and Stytch can add one through a JWT template or a claims action, while Auth0 requires a namespaced claim such as `"https://yourapp.example.com/email"`, since it silently drops non-namespaced ones.
 
 ## Mix Public and Authenticated Tools
 

--- a/docs/build/auth.mdx
+++ b/docs/build/auth.mdx
@@ -135,6 +135,23 @@ The validation body is provider-specific: [JWKS](https://datatracker.ietf.org/do
 
 {/* @todo: link to full auth provider reference */}
 
+## Type the Claims You Read
+
+Whatever your verifier puts in `extra` reaches handlers as `authInfo.extra`, typed `Record<string, unknown>`, so every read needs a cast. Declare the shape once with [`withAuthExtra`](/api-reference/mcp-server#withauthextra) and the casts go away:
+
+```ts server.ts highlight={3}
+type Claims = { sub: string; email?: string };
+
+const server = new McpServer({ name: "personal-shopper", version: "0.0.1" }, {})
+  .withAuthExtra<Claims>()
+  .use("/mcp", requireBearerAuth({ verifier: { verifyAccessToken } }))
+  .registerTool({ name: "orders", inputSchema: {} }, async (_args, extra) => ({
+    structuredContent: { orders: await fetchOrders(extra.authInfo?.extra?.sub) },
+  }));
+```
+
+The shape is a claim about your verifier's output, not a runtime check, so type a claim the provider may omit as optional. Have `verifyAccessToken` return `Promise<AuthInfo<Claims>>` to keep both ends in sync.
+
 ## Mix Public and Authenticated Tools
 
 Serving both anonymous and signed-in callers from one server takes three changes to the fully authenticated setup.

--- a/docs/build/auth.mdx
+++ b/docs/build/auth.mdx
@@ -137,41 +137,15 @@ The validation body is provider-specific: [JWKS](https://datatracker.ietf.org/do
 
 ## Type the Claims You Read
 
-Whatever the verifier puts in `extra` reaches handlers as `authInfo.extra`. The claim shape belongs to the verifier, so declaring it there is enough for every handler to see it.
-
-On the [provider path](/guides/auth-providers) you get it for free. Each provider ships the claims its own documentation promises:
+The claim shape belongs to the verifier, so handlers get it without declaring anything. On the [provider path](/guides/auth-providers) each provider ships the claims its own docs promise, and a type argument adds the ones your tenant sends:
 
 ```ts server.ts
-const server = new McpServer(
-  { name: "personal-shopper", version: "0.0.1" },
-  {},
-  { oauth: await workosProvider({ domain, audience }) },
-).registerTool({ name: "orders", inputSchema: {} }, async (_args, extra) => ({
-  structuredContent: { orders: await fetchOrders(extra.authInfo?.extra?.org_id) },
-}));
-```
-
-A type argument adds claims your tenant sends on top of the provider's, which is how you reach a custom claim:
-
-```ts
 oauth: await workosProvider<{ tenant: string }>({ domain, audience }),
 ```
 
-Writing the verifier yourself? Type its return and pass it in the config; the shape flows the same way:
+Writing the verifier yourself? Type it `TokenVerifier<Claims>` and the shape flows the same way.
 
-```ts auth.ts
-type Claims = { subject?: string; email?: string };
-
-export const verifier: TokenVerifier<Claims> = {
-  async verifyAccessToken(token) {
-    // ...
-  },
-};
-```
-
-None of this is a runtime check: nothing rejects a token whose claims differ from the declared shape, so keep anything the IdP may omit optional.
-
-Check what your provider actually puts in an access token before declaring extra claims. Identity claims you might expect are usually absent: no provider ships `email` in an access token by default. WorkOS, Clerk, Descope and Stytch can add one through a JWT template or a claims action, while Auth0 requires a namespaced claim such as `"https://yourapp.example.com/email"`, since it silently drops non-namespaced ones.
+None of this is checked at runtime, so keep anything the IdP may omit optional. No provider ships `email` in an access token by default: WorkOS, Clerk, Descope and Stytch can add one through a JWT template or claims action, and Auth0 needs a namespaced claim, since it drops non-namespaced ones.
 
 ## Mix Public and Authenticated Tools
 

--- a/examples/auth-auth0/src/server.ts
+++ b/examples/auth-auth0/src/server.ts
@@ -1,5 +1,5 @@
 import { intentMiddleware } from "@alpic-ai/insights";
-import { type AuthInfo, auth0Provider, McpServer } from "skybridge/server";
+import { auth0Provider, McpServer } from "skybridge/server";
 import * as z from "zod";
 import { searchCoffeeShops } from "./coffee-data.js";
 import { env } from "./env.js";
@@ -75,11 +75,9 @@ const server = new McpServer(
       },
     },
     async ({ query, minRating }, extra) => {
-      const auth = extra.authInfo as AuthInfo;
-
       try {
         const userInfoResponse = await fetch(`${AUTH0_BASE_URL}/userinfo`, {
-          headers: { Authorization: `Bearer ${auth.token}` },
+          headers: { Authorization: `Bearer ${extra.authInfo?.token}` },
         });
 
         const userInfo = userInfoResponse.ok
@@ -93,7 +91,7 @@ const server = new McpServer(
         const results = searchCoffeeShops({
           query,
           minRating,
-          userId: auth?.extra?.subject as string,
+          userId: extra.authInfo?.extra?.subject ?? "anonymous",
         });
 
         return {

--- a/examples/auth-authplane/src/server.ts
+++ b/examples/auth-authplane/src/server.ts
@@ -25,10 +25,6 @@ import { env } from "./env.js";
  * for byte.
  */
 
-type AuthplaneClaims = {
-  subject?: string;
-  email?: string;
-};
 
 const server = new McpServer(
   {
@@ -37,13 +33,12 @@ const server = new McpServer(
   },
   { capabilities: {} },
   {
-    oauth: await authplaneProvider({
+    oauth: await authplaneProvider<{ email?: string }>({
       issuer: env.AUTHPLANE_ISSUER,
       resource: env.SERVER_URL,
     }),
   },
 )
-  .withAuthExtra<AuthplaneClaims>()
   .mcpMiddleware(intentMiddleware())
   .registerTool(
     {

--- a/examples/auth-authplane/src/server.ts
+++ b/examples/auth-authplane/src/server.ts
@@ -1,5 +1,5 @@
 import { intentMiddleware } from "@alpic-ai/insights";
-import { type AuthInfo, authplaneProvider, McpServer } from "skybridge/server";
+import { authplaneProvider, McpServer } from "skybridge/server";
 import * as z from "zod";
 import { searchCoffeeShops } from "./coffee-data.js";
 import { env } from "./env.js";
@@ -25,6 +25,11 @@ import { env } from "./env.js";
  * for byte.
  */
 
+type AuthplaneClaims = {
+  subject?: string;
+  email?: string;
+};
+
 const server = new McpServer(
   {
     name: "auth-coffee",
@@ -38,6 +43,7 @@ const server = new McpServer(
     }),
   },
 )
+  .withAuthExtra<AuthplaneClaims>()
   .mcpMiddleware(intentMiddleware())
   .registerTool(
     {
@@ -75,21 +81,20 @@ const server = new McpServer(
       },
     },
     ({ query, minRating }, extra) => {
-      const auth = extra.authInfo as AuthInfo;
 
       // `sub` identifies the signed-in user and is what favourites key off.
       // Access tokens carry no profile claims, so there is no display name to
       // show — `email` is read in case a deployment maps one in, and the view
       // falls back to a neutral label when it is absent rather than rendering
       // a raw identifier.
-      const subject = auth.extra?.subject as string | undefined;
-      const email = auth.extra?.email as string | undefined;
+      const subject = extra.authInfo?.extra?.subject;
+      const email = extra.authInfo?.extra?.email;
       const userName = email?.split("@")[0];
 
       const results = searchCoffeeShops({
         query,
         minRating,
-        userId: subject ?? auth.clientId,
+        userId: subject ?? extra.authInfo?.clientId ?? "anonymous",
       });
 
       return {

--- a/examples/auth-clerk/src/server.ts
+++ b/examples/auth-clerk/src/server.ts
@@ -19,10 +19,6 @@ import { env } from "./env.js";
  * via JWKS). Clerk tokens carry no `aud`, so verification is issuer + JWKS only.
  */
 
-type ClerkClaims = {
-  subject?: string;
-  email?: string;
-};
 
 const server = new McpServer(
   {
@@ -36,7 +32,6 @@ const server = new McpServer(
     }),
   },
 )
-  .withAuthExtra<ClerkClaims>()
   .mcpMiddleware(intentMiddleware())
   .registerTool(
     {

--- a/examples/auth-clerk/src/server.ts
+++ b/examples/auth-clerk/src/server.ts
@@ -1,5 +1,5 @@
 import { intentMiddleware } from "@alpic-ai/insights";
-import { type AuthInfo, clerkProvider, McpServer } from "skybridge/server";
+import { clerkProvider, McpServer } from "skybridge/server";
 import * as z from "zod";
 import { searchCoffeeShops } from "./coffee-data.js";
 import { env } from "./env.js";
@@ -19,6 +19,11 @@ import { env } from "./env.js";
  * via JWKS). Clerk tokens carry no `aud`, so verification is issuer + JWKS only.
  */
 
+type ClerkClaims = {
+  subject?: string;
+  email?: string;
+};
+
 const server = new McpServer(
   {
     name: "auth-coffee",
@@ -31,6 +36,7 @@ const server = new McpServer(
     }),
   },
 )
+  .withAuthExtra<ClerkClaims>()
   .mcpMiddleware(intentMiddleware())
   .registerTool(
     {
@@ -68,15 +74,14 @@ const server = new McpServer(
       },
     },
     ({ query, minRating }, extra) => {
-      const auth = extra.authInfo as AuthInfo;
 
-      const email = auth.extra?.email as string | undefined;
-      const subject = auth.extra?.subject as string | undefined;
+      const email = extra.authInfo?.extra?.email;
+      const subject = extra.authInfo?.extra?.subject;
 
       const results = searchCoffeeShops({
         query,
         minRating,
-        userId: subject ?? auth.clientId,
+        userId: subject ?? extra.authInfo?.clientId ?? "anonymous",
       });
 
       const displayName = email?.split("@")[0] ?? subject ?? "User";

--- a/examples/auth-descope-alpic/src/server.ts
+++ b/examples/auth-descope-alpic/src/server.ts
@@ -1,5 +1,5 @@
 import { intentMiddleware } from "@alpic-ai/insights";
-import { type AuthInfo, customProvider, McpServer } from "skybridge/server";
+import { customProvider, McpServer } from "skybridge/server";
 import * as z from "zod";
 import { searchCoffeeShops } from "./coffee-data.js";
 import { env } from "./env.js";
@@ -36,6 +36,11 @@ function projectIdFromUrl(url: string): string {
 
 const projectId = projectIdFromUrl(env.DESCOPE_MCP_SERVER_URL);
 
+type DescopeClaims = {
+  subject?: string;
+  email?: string;
+};
+
 const server = new McpServer(
   {
     name: "auth-coffee",
@@ -50,6 +55,7 @@ const server = new McpServer(
     }),
   },
 )
+  .withAuthExtra<DescopeClaims>()
   .mcpMiddleware(intentMiddleware())
   .registerTool(
     {
@@ -87,15 +93,13 @@ const server = new McpServer(
       },
     },
     ({ query, minRating }, extra) => {
-      const auth = extra.authInfo as AuthInfo;
-
-      const email = auth.extra?.email as string | undefined;
-      const subject = auth.extra?.subject as string | undefined;
+      const email = extra.authInfo?.extra?.email;
+      const subject = extra.authInfo?.extra?.subject;
 
       const results = searchCoffeeShops({
         query,
         minRating,
-        userId: subject ?? auth.clientId,
+        userId: subject ?? extra.authInfo?.clientId ?? "anonymous",
       });
 
       const displayName = email?.split("@")[0] ?? subject ?? "User";

--- a/examples/auth-descope-alpic/src/server.ts
+++ b/examples/auth-descope-alpic/src/server.ts
@@ -36,10 +36,6 @@ function projectIdFromUrl(url: string): string {
 
 const projectId = projectIdFromUrl(env.DESCOPE_MCP_SERVER_URL);
 
-type DescopeClaims = {
-  subject?: string;
-  email?: string;
-};
 
 const server = new McpServer(
   {
@@ -48,14 +44,13 @@ const server = new McpServer(
   },
   { capabilities: {} },
   {
-    oauth: await customProvider({
+    oauth: await customProvider<{ subject?: string; email?: string }>({
       issuer: env.DESCOPE_MCP_SERVER_URL,
       audience: projectId,
       serverUrl: env.SERVER_URL,
     }),
   },
 )
-  .withAuthExtra<DescopeClaims>()
   .mcpMiddleware(intentMiddleware())
   .registerTool(
     {

--- a/examples/auth-descope/src/server.ts
+++ b/examples/auth-descope/src/server.ts
@@ -1,5 +1,5 @@
 import { intentMiddleware } from "@alpic-ai/insights";
-import { type AuthInfo, descopeProvider, McpServer } from "skybridge/server";
+import { descopeProvider, McpServer } from "skybridge/server";
 import * as z from "zod";
 import { searchCoffeeShops } from "./coffee-data.js";
 import { env } from "./env.js";
@@ -18,6 +18,11 @@ import { env } from "./env.js";
  * `aud` to [DCR client id, project id], not the server URL.
  */
 
+type DescopeClaims = {
+  subject?: string;
+  email?: string;
+};
+
 const server = new McpServer(
   {
     name: "auth-coffee",
@@ -30,6 +35,7 @@ const server = new McpServer(
     }),
   },
 )
+  .withAuthExtra<DescopeClaims>()
   .mcpMiddleware(intentMiddleware())
   .registerTool(
     {
@@ -67,15 +73,14 @@ const server = new McpServer(
       },
     },
     ({ query, minRating }, extra) => {
-      const auth = extra.authInfo as AuthInfo;
 
-      const email = auth.extra?.email as string | undefined;
-      const subject = auth.extra?.subject as string | undefined;
+      const email = extra.authInfo?.extra?.email;
+      const subject = extra.authInfo?.extra?.subject;
 
       const results = searchCoffeeShops({
         query,
         minRating,
-        userId: subject ?? auth.clientId,
+        userId: subject ?? extra.authInfo?.clientId ?? "anonymous",
       });
 
       const displayName = email?.split("@")[0] ?? subject ?? "User";

--- a/examples/auth-descope/src/server.ts
+++ b/examples/auth-descope/src/server.ts
@@ -18,10 +18,6 @@ import { env } from "./env.js";
  * `aud` to [DCR client id, project id], not the server URL.
  */
 
-type DescopeClaims = {
-  subject?: string;
-  email?: string;
-};
 
 const server = new McpServer(
   {
@@ -35,7 +31,6 @@ const server = new McpServer(
     }),
   },
 )
-  .withAuthExtra<DescopeClaims>()
   .mcpMiddleware(intentMiddleware())
   .registerTool(
     {

--- a/examples/auth-stytch/src/server.ts
+++ b/examples/auth-stytch/src/server.ts
@@ -22,10 +22,6 @@ import { env } from "./env.js";
  * advertises it as the authorization_endpoint.
  */
 
-type StytchClaims = {
-  subject?: string;
-  email?: string;
-};
 
 const server = new McpServer(
   {
@@ -40,7 +36,6 @@ const server = new McpServer(
     }),
   },
 )
-  .withAuthExtra<StytchClaims>()
   .mcpMiddleware(intentMiddleware())
   .registerTool(
     {

--- a/examples/auth-stytch/src/server.ts
+++ b/examples/auth-stytch/src/server.ts
@@ -1,5 +1,5 @@
 import { intentMiddleware } from "@alpic-ai/insights";
-import { type AuthInfo, McpServer, stytchProvider } from "skybridge/server";
+import { McpServer, stytchProvider } from "skybridge/server";
 import * as z from "zod";
 import { searchCoffeeShops } from "./coffee-data.js";
 import { env } from "./env.js";
@@ -22,6 +22,11 @@ import { env } from "./env.js";
  * advertises it as the authorization_endpoint.
  */
 
+type StytchClaims = {
+  subject?: string;
+  email?: string;
+};
+
 const server = new McpServer(
   {
     name: "auth-coffee",
@@ -35,6 +40,7 @@ const server = new McpServer(
     }),
   },
 )
+  .withAuthExtra<StytchClaims>()
   .mcpMiddleware(intentMiddleware())
   .registerTool(
     {
@@ -72,15 +78,14 @@ const server = new McpServer(
       },
     },
     ({ query, minRating }, extra) => {
-      const auth = extra.authInfo as AuthInfo;
 
-      const email = auth.extra?.email as string | undefined;
-      const subject = auth.extra?.subject as string | undefined;
+      const email = extra.authInfo?.extra?.email;
+      const subject = extra.authInfo?.extra?.subject;
 
       const results = searchCoffeeShops({
         query,
         minRating,
-        userId: auth.clientId,
+        userId: extra.authInfo?.clientId ?? "anonymous",
       });
 
       const displayName = email?.split("@")[0] ?? subject ?? "User";

--- a/examples/auth-workos/src/server.ts
+++ b/examples/auth-workos/src/server.ts
@@ -1,5 +1,5 @@
 import { intentMiddleware } from "@alpic-ai/insights";
-import { type AuthInfo, McpServer, workosProvider } from "skybridge/server";
+import { McpServer, workosProvider } from "skybridge/server";
 import * as z from "zod";
 import { searchCoffeeShops } from "./coffee-data.js";
 import { env } from "./env.js";
@@ -17,6 +17,11 @@ import { env } from "./env.js";
  * configured in the WorkOS dashboard — here, this server's public URL.
  */
 
+type AuthKitClaims = {
+  subject?: string;
+  email?: string;
+};
+
 const server = new McpServer(
   {
     name: "auth-coffee",
@@ -30,6 +35,7 @@ const server = new McpServer(
     }),
   },
 )
+  .withAuthExtra<AuthKitClaims>()
   .mcpMiddleware(intentMiddleware())
   .registerTool(
     {
@@ -67,15 +73,13 @@ const server = new McpServer(
       },
     },
     ({ query, minRating }, extra) => {
-      const auth = extra.authInfo as AuthInfo;
-
-      const email = auth.extra?.email as string | undefined;
-      const subject = auth.extra?.subject as string | undefined;
+      const email = extra.authInfo?.extra?.email;
+      const subject = extra.authInfo?.extra?.subject;
 
       const results = searchCoffeeShops({
         query,
         minRating,
-        userId: subject ?? auth.clientId,
+        userId: subject ?? extra.authInfo?.clientId ?? "anonymous",
       });
 
       const displayName = email?.split("@")[0] ?? subject ?? "User";

--- a/examples/auth-workos/src/server.ts
+++ b/examples/auth-workos/src/server.ts
@@ -17,10 +17,6 @@ import { env } from "./env.js";
  * configured in the WorkOS dashboard — here, this server's public URL.
  */
 
-type AuthKitClaims = {
-  subject?: string;
-  email?: string;
-};
 
 const server = new McpServer(
   {
@@ -35,7 +31,6 @@ const server = new McpServer(
     }),
   },
 )
-  .withAuthExtra<AuthKitClaims>()
   .mcpMiddleware(intentMiddleware())
   .registerTool(
     {

--- a/packages/core/src/server/auth-extra.test-d.ts
+++ b/packages/core/src/server/auth-extra.test-d.ts
@@ -1,14 +1,18 @@
 import { expectTypeOf, test } from "vitest";
 import { z } from "zod";
-import type { McpServer } from "./server.js";
+import { customProvider } from "./auth/providers/custom.js";
+import { workosProvider } from "./auth/providers/workos.js";
+import type { TokenVerifier } from "./auth.js";
+import { McpServer } from "./server.js";
 
-type Claims = { subject?: string; orgId: string };
+const workosOAuth = await workosProvider({ domain: "d", audience: "a" });
+const customOAuth = await workosProvider<{ tenant: string }>({
+  domain: "d",
+  audience: "a",
+});
 
-const server = null as unknown as McpServer;
-const typed = server.withAuthExtra<Claims>();
-
-test("default server keeps the SDK's untyped extra bag", () => {
-  server.registerTool(
+test("a server with no oauth keeps the untyped claim bag", () => {
+  new McpServer({ name: "t", version: "0" }).registerTool(
     { name: "plain", inputSchema: { q: z.string() } },
     (_args, extra) => {
       expectTypeOf(extra.authInfo?.extra).toEqualTypeOf<
@@ -19,39 +23,78 @@ test("default server keeps the SDK's untyped extra bag", () => {
   );
 });
 
-test("withAuthExtra types extra.authInfo.extra in tool handlers", () => {
-  typed.registerTool(
-    { name: "claims", inputSchema: { q: z.string() } },
-    (_args, extra) => {
-      expectTypeOf(extra.authInfo?.extra?.orgId).toEqualTypeOf<
+test("provider claims reach tool handlers", () => {
+  new McpServer({ name: "t", version: "0" }, {}, { oauth: workosOAuth })
+    .registerTool({ name: "a", inputSchema: {} }, (_args, extra) => {
+      expectTypeOf(extra.authInfo?.extra?.org_id).toEqualTypeOf<
         string | undefined
       >();
-      expectTypeOf(extra.authInfo?.extra?.subject).toEqualTypeOf<
-        string | undefined
+      expectTypeOf(extra.authInfo?.extra?.permissions).toEqualTypeOf<
+        string[] | undefined
       >();
-      // @ts-expect-error unknown claim
+      // @ts-expect-error not a WorkOS claim
       extra.authInfo?.extra?.nope;
-      return { content: "ok" };
-    },
-  );
-});
-
-test("the declared extra survives registerTool chaining", () => {
-  typed
-    .registerTool({ name: "a", inputSchema: {} }, () => ({ content: "a" }))
+      return { content: "a" };
+    })
     .registerTool({ name: "b", inputSchema: {} }, (_args, extra) => {
-      expectTypeOf(extra.authInfo?.extra?.orgId).toEqualTypeOf<
+      expectTypeOf(extra.authInfo?.extra?.sid).toEqualTypeOf<
         string | undefined
       >();
       return { content: "b" };
     });
 });
 
-test("withAuthExtra types extra.authInfo.extra in mcp middleware", () => {
-  typed.mcpMiddleware("tools/call", (_request, extra, next) => {
-    expectTypeOf(extra.authInfo?.extra?.orgId).toEqualTypeOf<
+test("registered claims survive the mapping into extra", () => {
+  new McpServer(
+    { name: "t", version: "0" },
+    {},
+    { oauth: workosOAuth },
+  ).registerTool({ name: "a", inputSchema: {} }, (_args, extra) => {
+    expectTypeOf(extra.authInfo?.extra?.iss).toEqualTypeOf<
       string | undefined
     >();
-    return next();
+    expectTypeOf(extra.authInfo?.extra?.iat).toEqualTypeOf<
+      number | undefined
+    >();
+    return { content: "a" };
   });
+});
+
+test("a hand-written verifier carries its own claims", async () => {
+  type Claims = { subject?: string; email?: string };
+  const verifier: TokenVerifier<Claims> = {
+    async verifyAccessToken(token) {
+      return { token, clientId: "c", scopes: [], expiresAt: 1, extra: {} };
+    },
+  };
+  const oauth = await customProvider({ issuer: "https://idp.example.com" });
+  new McpServer(
+    { name: "t", version: "0" },
+    {},
+    { oauth: { ...oauth, verifier } },
+  ).registerTool({ name: "a", inputSchema: {} }, (_args, extra) => {
+    expectTypeOf(extra.authInfo?.extra?.email).toEqualTypeOf<
+      string | undefined
+    >();
+    return { content: "a" };
+  });
+});
+
+test("a provider override adds claims without dropping the provider's", () => {
+  new McpServer({ name: "t", version: "0" }, {}, { oauth: customOAuth })
+    .registerTool({ name: "a", inputSchema: {} }, (_args, extra) => {
+      expectTypeOf(extra.authInfo?.extra?.tenant).toEqualTypeOf<
+        string | undefined
+      >();
+      expectTypeOf(extra.authInfo?.extra?.org_id).toEqualTypeOf<
+        string | undefined
+      >();
+      return { content: "a" };
+    })
+    .mcpMiddleware("tools/call", (_request, extra, next) => {
+      expectTypeOf(extra.authInfo?.extra?.tenant).toEqualTypeOf<
+        string | undefined
+      >();
+      return next();
+    });
 });

--- a/packages/core/src/server/auth-extra.test-d.ts
+++ b/packages/core/src/server/auth-extra.test-d.ts
@@ -1,0 +1,57 @@
+import { expectTypeOf, test } from "vitest";
+import { z } from "zod";
+import type { McpServer } from "./server.js";
+
+type Claims = { subject?: string; orgId: string };
+
+const server = null as unknown as McpServer;
+const typed = server.withAuthExtra<Claims>();
+
+test("default server keeps the SDK's untyped extra bag", () => {
+  server.registerTool(
+    { name: "plain", inputSchema: { q: z.string() } },
+    (_args, extra) => {
+      expectTypeOf(extra.authInfo?.extra).toEqualTypeOf<
+        Record<string, unknown> | undefined
+      >();
+      return { content: "ok" };
+    },
+  );
+});
+
+test("withAuthExtra types extra.authInfo.extra in tool handlers", () => {
+  typed.registerTool(
+    { name: "claims", inputSchema: { q: z.string() } },
+    (_args, extra) => {
+      expectTypeOf(extra.authInfo?.extra?.orgId).toEqualTypeOf<
+        string | undefined
+      >();
+      expectTypeOf(extra.authInfo?.extra?.subject).toEqualTypeOf<
+        string | undefined
+      >();
+      // @ts-expect-error unknown claim
+      extra.authInfo?.extra?.nope;
+      return { content: "ok" };
+    },
+  );
+});
+
+test("the declared extra survives registerTool chaining", () => {
+  typed
+    .registerTool({ name: "a", inputSchema: {} }, () => ({ content: "a" }))
+    .registerTool({ name: "b", inputSchema: {} }, (_args, extra) => {
+      expectTypeOf(extra.authInfo?.extra?.orgId).toEqualTypeOf<
+        string | undefined
+      >();
+      return { content: "b" };
+    });
+});
+
+test("withAuthExtra types extra.authInfo.extra in mcp middleware", () => {
+  typed.mcpMiddleware("tools/call", (_request, extra, next) => {
+    expectTypeOf(extra.authInfo?.extra?.orgId).toEqualTypeOf<
+      string | undefined
+    >();
+    return next();
+  });
+});

--- a/packages/core/src/server/auth-extra.test-d.ts
+++ b/packages/core/src/server/auth-extra.test-d.ts
@@ -1,5 +1,6 @@
 import { expectTypeOf, test } from "vitest";
 import { z } from "zod";
+import type { OAuthConfig } from "./auth/index.js";
 import { customProvider } from "./auth/providers/custom.js";
 import { workosProvider } from "./auth/providers/workos.js";
 import type { TokenVerifier } from "./auth.js";
@@ -67,17 +68,45 @@ test("a hand-written verifier carries its own claims", async () => {
       return { token, clientId: "c", scopes: [], expiresAt: 1, extra: {} };
     },
   };
-  const oauth = await customProvider({ issuer: "https://idp.example.com" });
+  const { oauthMetadata } = await customProvider({
+    issuer: "https://idp.example.com",
+  });
   new McpServer(
     { name: "t", version: "0" },
     {},
-    { oauth: { ...oauth, verifier } },
+    { oauth: { oauthMetadata, verifier } },
   ).registerTool({ name: "a", inputSchema: {} }, (_args, extra) => {
     expectTypeOf(extra.authInfo?.extra?.email).toEqualTypeOf<
       string | undefined
     >();
     return { content: "a" };
   });
+});
+
+test("the legacy verify config still works, with untyped claims", () => {
+  new McpServer(
+    { name: "t", version: "0" },
+    {},
+    {
+      oauth: {
+        oauthMetadata: workosOAuth.oauthMetadata,
+        verify: { issuer: "https://idp.example.com" },
+      },
+    },
+  ).registerTool({ name: "a", inputSchema: {} }, (_args, extra) => {
+    expectTypeOf(extra.authInfo?.extra).toEqualTypeOf<
+      Record<string, unknown> | undefined
+    >();
+    return { content: "a" };
+  });
+});
+
+test("a config must carry exactly one of verifier / verify", () => {
+  // @ts-expect-error one of verifier / verify is required
+  const neither: OAuthConfig = {
+    oauthMetadata: workosOAuth.oauthMetadata,
+  };
+  void neither;
 });
 
 test("a provider override adds claims without dropping the provider's", () => {

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -15,6 +15,9 @@ export {
   type AuthMetadataOptions,
   mcpAuthMetadataRouter,
 } from "@modelcontextprotocol/sdk/server/auth/router.js";
+/** Claims a verifier puts in `AuthInfo["extra"]`: any JSON-ish bag of them. */
+export type ExtraClaims = Record<string, unknown>;
+
 /**
  * A validated access token, as resolved by a
  * [verifier](https://docs.skybridge.tech/api-reference/verifier) and handed to
@@ -35,9 +38,10 @@ export {
  * }
  * ```
  */
-export type AuthInfo<
-  TExtra extends Record<string, unknown> = Record<string, unknown>,
-> = Omit<SdkAuthInfo, "extra"> & { extra?: TExtra };
+export type AuthInfo<TExtra extends ExtraClaims = ExtraClaims> = Omit<
+  SdkAuthInfo,
+  "extra"
+> & { extra?: TExtra };
 
 /**
  * Checks a bearer token and resolves the claims it carries. The type parameter
@@ -49,9 +53,7 @@ export type AuthInfo<
  *
  * @typeParam TExtra - Claims this verifier populates in `AuthInfo["extra"]`.
  */
-export type TokenVerifier<
-  TExtra extends Record<string, unknown> = Record<string, unknown>,
-> = {
+export type TokenVerifier<TExtra extends ExtraClaims = ExtraClaims> = {
   verifyAccessToken(token: string): Promise<AuthInfo<TExtra>>;
 };
 

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -2,6 +2,7 @@ import {
   type BearerAuthMiddlewareOptions,
   requireBearerAuth,
 } from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js";
+import type { AuthInfo as SdkAuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 
 import type { RequestHandler } from "express";
 
@@ -14,7 +15,29 @@ export {
   type AuthMetadataOptions,
   mcpAuthMetadataRouter,
 } from "@modelcontextprotocol/sdk/server/auth/router.js";
-export type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+/**
+ * A validated access token, as resolved by a
+ * [verifier](https://docs.skybridge.tech/api-reference/verifier) and handed to
+ * handlers on `extra.authInfo`.
+ *
+ * Unparameterized, `extra` stays the SDK's `Record<string, unknown>` bag. Pass
+ * the claims your verifier produces to type it, and declare the same shape on
+ * the server with {@link McpServer.withAuthExtra} so handlers see it too.
+ *
+ * @typeParam TExtra - Claims populated in `extra`. Makes `extra` required.
+ *
+ * @example
+ * ```ts
+ * type Claims = { sub: string; email?: string };
+ *
+ * async function verifyAccessToken(token: string): Promise<AuthInfo<Claims>> {
+ *   // ...
+ * }
+ * ```
+ */
+export type AuthInfo<
+  TExtra extends Record<string, unknown> = Record<string, unknown>,
+> = Omit<SdkAuthInfo, "extra"> & { extra?: TExtra };
 
 /**
  * Like `requireBearerAuth`, but lets requests through when no

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -20,15 +20,15 @@ export {
  * [verifier](https://docs.skybridge.tech/api-reference/verifier) and handed to
  * handlers on `extra.authInfo`.
  *
- * Unparameterized, `extra` stays the SDK's `Record<string, unknown>` bag. Pass
- * the claims your verifier produces to type it, and declare the same shape on
- * the server with {@link McpServer.withAuthExtra} so handlers see it too.
+ * Unparameterized, `extra` stays the SDK's `Record<string, unknown>` bag. The
+ * claims are owned by whoever verifies the token: parameterize the verifier and
+ * the shape flows through {@link OAuthConfig} to every handler.
  *
- * @typeParam TExtra - Claims populated in `extra`. Makes `extra` required.
+ * @typeParam TExtra - Claims populated in `extra`.
  *
  * @example
  * ```ts
- * type Claims = { sub: string; email?: string };
+ * type Claims = { subject?: string; email?: string };
  *
  * async function verifyAccessToken(token: string): Promise<AuthInfo<Claims>> {
  *   // ...
@@ -38,6 +38,22 @@ export {
 export type AuthInfo<
   TExtra extends Record<string, unknown> = Record<string, unknown>,
 > = Omit<SdkAuthInfo, "extra"> & { extra?: TExtra };
+
+/**
+ * Checks a bearer token and resolves the claims it carries. The type parameter
+ * is what makes `extra.authInfo.extra` typed downstream, so a verifier is the
+ * single source for the claim shape.
+ *
+ * Pass one to {@link requireBearerAuth} or {@link optionalBearerAuth} directly,
+ * or hand it to the `oauth` server option inside an {@link OAuthConfig}.
+ *
+ * @typeParam TExtra - Claims this verifier populates in `AuthInfo["extra"]`.
+ */
+export type TokenVerifier<
+  TExtra extends Record<string, unknown> = Record<string, unknown>,
+> = {
+  verifyAccessToken(token: string): Promise<AuthInfo<TExtra>>;
+};
 
 /**
  * Like `requireBearerAuth`, but lets requests through when no

--- a/packages/core/src/server/auth/index.ts
+++ b/packages/core/src/server/auth/index.ts
@@ -1,5 +1,5 @@
 import type { OAuthMetadata } from "@modelcontextprotocol/sdk/shared/auth.js";
-import type { TokenVerifier } from "../auth.js";
+import type { ExtraClaims, TokenVerifier } from "../auth.js";
 import type { JwksVerifyConfig } from "./verify.js";
 
 /**
@@ -12,9 +12,7 @@ import type { JwksVerifyConfig } from "./verify.js";
  *
  * @typeParam TExtra - Claims the verifier populates in `AuthInfo["extra"]`.
  */
-export type OAuthConfig<
-  TExtra extends Record<string, unknown> = Record<string, unknown>,
-> = {
+export type OAuthConfig<TExtra extends ExtraClaims = ExtraClaims> = {
   /**
    * Public URL of this server; sets `resourceServerUrl` and the
    * `resource_metadata` URL. When omitted, it is inferred per request from

--- a/packages/core/src/server/auth/index.ts
+++ b/packages/core/src/server/auth/index.ts
@@ -1,9 +1,11 @@
 import type { OAuthMetadata } from "@modelcontextprotocol/sdk/shared/auth.js";
 import type { TokenVerifier } from "../auth.js";
+import type { JwksVerifyConfig } from "./verify.js";
 
 /**
  * Resource-server OAuth config for `SkybridgeServerOptions.oauth`.
  *
+ * Supply either a `verifier` or the legacy `verify` parameters, never both.
  * `TExtra` comes from the `verifier` and flows on to tool handlers and
  * `mcpMiddleware`, so the claim shape is declared once by whoever checks the
  * token. The branded providers set it from the claims their IdP documents.
@@ -21,13 +23,28 @@ export type OAuthConfig<
   baseUrl?: string;
   /** AS metadata served at `/.well-known/oauth-authorization-server`. */
   oauthMetadata: OAuthMetadata;
-  /**
-   * Checks each bearer token. Build one with `createJwksVerifier` for a
-   * JWT-issuing IdP, or supply your own for opaque tokens.
-   */
-  verifier: TokenVerifier<TExtra>;
   /** Scopes advertised in protected-resource metadata. */
   scopesSupported?: string[];
   /** Server-wide required-scope floor. */
   requiredScopes?: string[];
-};
+} & (
+  | {
+      /**
+       * Checks each bearer token. Build one with `createJwksVerifier` for a
+       * JWT-issuing IdP, or supply your own for opaque tokens.
+       */
+      verifier: TokenVerifier<TExtra>;
+      verify?: never;
+    }
+  | {
+      /**
+       * JWKS verification parameters, used to build the verifier.
+       *
+       * @deprecated Pass `verifier: createJwksVerifier({ … })` instead, which
+       * also types the claims handlers receive. Claims stay
+       * `Record<string, unknown>` on this path.
+       */
+      verify: JwksVerifyConfig;
+      verifier?: never;
+    }
+);

--- a/packages/core/src/server/auth/index.ts
+++ b/packages/core/src/server/auth/index.ts
@@ -1,8 +1,18 @@
 import type { OAuthMetadata } from "@modelcontextprotocol/sdk/shared/auth.js";
-import type { JwksVerifyConfig } from "./verify.js";
+import type { TokenVerifier } from "../auth.js";
 
-/** Resource-server OAuth config for `SkybridgeServerOptions.oauth`. */
-export type OAuthConfig = {
+/**
+ * Resource-server OAuth config for `SkybridgeServerOptions.oauth`.
+ *
+ * `TExtra` comes from the `verifier` and flows on to tool handlers and
+ * `mcpMiddleware`, so the claim shape is declared once by whoever checks the
+ * token. The branded providers set it from the claims their IdP documents.
+ *
+ * @typeParam TExtra - Claims the verifier populates in `AuthInfo["extra"]`.
+ */
+export type OAuthConfig<
+  TExtra extends Record<string, unknown> = Record<string, unknown>,
+> = {
   /**
    * Public URL of this server; sets `resourceServerUrl` and the
    * `resource_metadata` URL. When omitted, it is inferred per request from
@@ -11,7 +21,11 @@ export type OAuthConfig = {
   baseUrl?: string;
   /** AS metadata served at `/.well-known/oauth-authorization-server`. */
   oauthMetadata: OAuthMetadata;
-  verify: JwksVerifyConfig;
+  /**
+   * Checks each bearer token. Build one with `createJwksVerifier` for a
+   * JWT-issuing IdP, or supply your own for opaque tokens.
+   */
+  verifier: TokenVerifier<TExtra>;
   /** Scopes advertised in protected-resource metadata. */
   scopesSupported?: string[];
   /** Server-wide required-scope floor. */

--- a/packages/core/src/server/auth/providers/auth0.test.ts
+++ b/packages/core/src/server/auth/providers/auth0.test.ts
@@ -1,11 +1,9 @@
 // @vitest-environment node
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { OAuthConfig } from "../index.js";
-import type { JwksTokenVerifier } from "../verify.js";
 import { auth0Provider } from "./auth0.js";
+import { lastJwksConfig as jwks } from "./verify-spy.js";
 
-const jwks = (config: OAuthConfig) =>
-  (config.verifier as JwksTokenVerifier).config;
+vi.mock("../verify.js", () => import("./verify-spy.js"));
 
 afterEach(() => vi.restoreAllMocks());
 
@@ -53,7 +51,7 @@ describe("auth0Provider", () => {
     // baseUrl left unset so the PRM resource resolves per request (Alpic-safe).
     expect(config.baseUrl).toBeUndefined();
     // token verification still uses Auth0 as issuer + the API audience.
-    expect(jwks(config).issuer).toBe(issuer);
-    expect(jwks(config).audience).toBe("https://api.example.com/");
+    expect(jwks().issuer).toBe(issuer);
+    expect(jwks().audience).toBe("https://api.example.com/");
   });
 });

--- a/packages/core/src/server/auth/providers/auth0.test.ts
+++ b/packages/core/src/server/auth/providers/auth0.test.ts
@@ -1,6 +1,11 @@
 // @vitest-environment node
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OAuthConfig } from "../index.js";
+import type { JwksTokenVerifier } from "../verify.js";
 import { auth0Provider } from "./auth0.js";
+
+const jwks = (config: OAuthConfig) =>
+  (config.verifier as JwksTokenVerifier).config;
 
 afterEach(() => vi.restoreAllMocks());
 
@@ -48,7 +53,7 @@ describe("auth0Provider", () => {
     // baseUrl left unset so the PRM resource resolves per request (Alpic-safe).
     expect(config.baseUrl).toBeUndefined();
     // token verification still uses Auth0 as issuer + the API audience.
-    expect(config.verify.issuer).toBe(issuer);
-    expect(config.verify.audience).toBe("https://api.example.com/");
+    expect(jwks(config).issuer).toBe(issuer);
+    expect(jwks(config).audience).toBe("https://api.example.com/");
   });
 });

--- a/packages/core/src/server/auth/providers/auth0.ts
+++ b/packages/core/src/server/auth/providers/auth0.ts
@@ -1,3 +1,4 @@
+import type { ExtraClaims } from "../../auth.js";
 import type { OAuthConfig } from "../index.js";
 import type { RegisteredClaims } from "../verify.js";
 import { type CustomProviderOptions, customProvider } from "./custom.js";
@@ -36,7 +37,7 @@ export type Auth0Claims = {
  * Auth0 (the token's real `iss`).
  */
 export async function auth0Provider<
-  TCustom extends Record<string, unknown> = Record<never, never>,
+  TCustom extends ExtraClaims = Record<never, never>,
 >(
   opts: { domain: string; audience: string; serverUrl: string } & Omit<
     CustomProviderOptions,

--- a/packages/core/src/server/auth/providers/auth0.ts
+++ b/packages/core/src/server/auth/providers/auth0.ts
@@ -14,8 +14,6 @@ import { toIssuerUrl } from "./shared.js";
  * @see https://auth0.com/docs/secure/tokens/json-web-tokens/create-custom-claims
  */
 export type Auth0Claims = {
-  /** The Auth0 user id (the token's `sub`). */
-  subject?: string;
   /** Authorized party: the client id the token was issued to. */
   azp?: string;
   /** Only when the API has RBAC and "Add Permissions in the Access Token" on. */

--- a/packages/core/src/server/auth/providers/auth0.ts
+++ b/packages/core/src/server/auth/providers/auth0.ts
@@ -1,6 +1,30 @@
 import type { OAuthConfig } from "../index.js";
+import type { RegisteredClaims } from "../verify.js";
 import { type CustomProviderOptions, customProvider } from "./custom.js";
 import { toIssuerUrl } from "./shared.js";
+
+/**
+ * Claims an Auth0 access token carries for a custom API audience. Auth0 puts no
+ * user attributes beyond the id in the token, so there is no `email`: call
+ * `/userinfo` for the profile. Custom claims must be namespaced (a bare `email`
+ * key is silently dropped), so add them through the type parameter under their
+ * full URI.
+ *
+ * @see https://auth0.com/docs/secure/tokens/access-tokens
+ * @see https://auth0.com/docs/secure/tokens/json-web-tokens/create-custom-claims
+ */
+export type Auth0Claims = {
+  /** The Auth0 user id (the token's `sub`). */
+  subject?: string;
+  /** Authorized party: the client id the token was issued to. */
+  azp?: string;
+  /** Only when the API has RBAC and "Add Permissions in the Access Token" on. */
+  permissions?: string[];
+  /** Organization id, when the tenant uses Organizations. */
+  org_id?: string;
+  /** Organization name, when the tenant uses Organizations. */
+  org_name?: string;
+};
 
 /**
  * OAuth provider for Auth0. `domain` is the tenant domain (e.g.
@@ -13,14 +37,16 @@ import { toIssuerUrl } from "./shared.js";
  * `authorization_endpoint`. The token's `aud` is the API; `verify.issuer` stays
  * Auth0 (the token's real `iss`).
  */
-export async function auth0Provider(
+export async function auth0Provider<
+  TCustom extends Record<string, unknown> = Record<never, never>,
+>(
   opts: { domain: string; audience: string; serverUrl: string } & Omit<
     CustomProviderOptions,
     "issuer" | "audience" | "baseUrl" | "serverUrl"
   >,
-): Promise<OAuthConfig> {
+): Promise<OAuthConfig<Auth0Claims & TCustom & RegisteredClaims>> {
   const { domain, audience, ...rest } = opts;
-  const config = await customProvider({
+  const config = await customProvider<Auth0Claims & TCustom>({
     issuer: toIssuerUrl(domain),
     audience,
     ...rest,

--- a/packages/core/src/server/auth/providers/authplane.test.ts
+++ b/packages/core/src/server/auth/providers/authplane.test.ts
@@ -1,11 +1,9 @@
 // @vitest-environment node
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { OAuthConfig } from "../index.js";
-import type { JwksTokenVerifier } from "../verify.js";
 import { authplaneProvider } from "./authplane.js";
+import { lastJwksConfig as jwks } from "./verify-spy.js";
 
-const jwks = (config: OAuthConfig) =>
-  (config.verifier as JwksTokenVerifier).config;
+vi.mock("../verify.js", () => import("./verify-spy.js"));
 
 afterEach(() => vi.restoreAllMocks());
 
@@ -49,9 +47,9 @@ describe("authplaneProvider", () => {
       resource: "https://coffee.example.com/mcp",
     });
 
-    expect(jwks(config).audience).toBe("https://coffee.example.com/mcp");
-    expect(jwks(config).issuer).toBe(ISSUER);
-    expect(jwks(config).jwksUri).toBe(`${ISSUER}/.well-known/jwks.json`);
+    expect(jwks().audience).toBe("https://coffee.example.com/mcp");
+    expect(jwks().issuer).toBe(ISSUER);
+    expect(jwks().jwksUri).toBe(`${ISSUER}/.well-known/jwks.json`);
     expect(config.baseUrl).toBe("https://coffee.example.com/mcp");
   });
 
@@ -67,7 +65,7 @@ describe("authplaneProvider", () => {
     const config = await authplaneProvider({ issuer: ISSUER, resource });
 
     expect(config.baseUrl).toBe(resource);
-    expect(jwks(config).audience).toBe(resource);
+    expect(jwks().audience).toBe(resource);
   });
 
   // The metadata router serialises the resource identifier through `URL` before
@@ -93,13 +91,13 @@ describe("authplaneProvider", () => {
   it("lets an explicit audience override the default", async () => {
     mockDiscovery({ [ISSUER]: ["checkout"] });
 
-    const config = await authplaneProvider({
+    await authplaneProvider({
       issuer: ISSUER,
       resource: "https://coffee.example.com/mcp",
       audience: "urn:acme:coffee",
     });
 
-    expect(jwks(config).audience).toBe("urn:acme:coffee");
+    expect(jwks().audience).toBe("urn:acme:coffee");
   });
 
   it.each([
@@ -132,25 +130,25 @@ describe("authplaneProvider", () => {
     // rather than rewriting the operator's value.
     mockDiscovery({ [ISSUER]: ["checkout"] });
 
-    const config = await authplaneProvider({
+    await authplaneProvider({
       issuer: `${ISSUER}/`,
       resource: "https://coffee.example.com/mcp",
     });
 
-    expect(jwks(config).issuer).toBe(ISSUER);
+    expect(jwks().issuer).toBe(ISSUER);
   });
 
   it("accepts a local http issuer for development", async () => {
     const local = "http://localhost:9000";
     mockDiscovery({ [local]: ["checkout"] });
 
-    const config = await authplaneProvider({
+    await authplaneProvider({
       issuer: local,
       resource: "http://localhost:3000/mcp",
     });
 
-    expect(jwks(config).issuer).toBe(local);
-    expect(jwks(config).audience).toBe("http://localhost:3000/mcp");
+    expect(jwks().issuer).toBe(local);
+    expect(jwks().audience).toBe("http://localhost:3000/mcp");
   });
 
   it("forwards scopes and the required-scope floor", async () => {

--- a/packages/core/src/server/auth/providers/authplane.test.ts
+++ b/packages/core/src/server/auth/providers/authplane.test.ts
@@ -1,6 +1,11 @@
 // @vitest-environment node
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OAuthConfig } from "../index.js";
+import type { JwksTokenVerifier } from "../verify.js";
 import { authplaneProvider } from "./authplane.js";
+
+const jwks = (config: OAuthConfig) =>
+  (config.verifier as JwksTokenVerifier).config;
 
 afterEach(() => vi.restoreAllMocks());
 
@@ -44,9 +49,9 @@ describe("authplaneProvider", () => {
       resource: "https://coffee.example.com/mcp",
     });
 
-    expect(config.verify.audience).toBe("https://coffee.example.com/mcp");
-    expect(config.verify.issuer).toBe(ISSUER);
-    expect(config.verify.jwksUri).toBe(`${ISSUER}/.well-known/jwks.json`);
+    expect(jwks(config).audience).toBe("https://coffee.example.com/mcp");
+    expect(jwks(config).issuer).toBe(ISSUER);
+    expect(jwks(config).jwksUri).toBe(`${ISSUER}/.well-known/jwks.json`);
     expect(config.baseUrl).toBe("https://coffee.example.com/mcp");
   });
 
@@ -62,7 +67,7 @@ describe("authplaneProvider", () => {
     const config = await authplaneProvider({ issuer: ISSUER, resource });
 
     expect(config.baseUrl).toBe(resource);
-    expect(config.verify.audience).toBe(resource);
+    expect(jwks(config).audience).toBe(resource);
   });
 
   // The metadata router serialises the resource identifier through `URL` before
@@ -94,7 +99,7 @@ describe("authplaneProvider", () => {
       audience: "urn:acme:coffee",
     });
 
-    expect(config.verify.audience).toBe("urn:acme:coffee");
+    expect(jwks(config).audience).toBe("urn:acme:coffee");
   });
 
   it.each([
@@ -132,7 +137,7 @@ describe("authplaneProvider", () => {
       resource: "https://coffee.example.com/mcp",
     });
 
-    expect(config.verify.issuer).toBe(ISSUER);
+    expect(jwks(config).issuer).toBe(ISSUER);
   });
 
   it("accepts a local http issuer for development", async () => {
@@ -144,8 +149,8 @@ describe("authplaneProvider", () => {
       resource: "http://localhost:3000/mcp",
     });
 
-    expect(config.verify.issuer).toBe(local);
-    expect(config.verify.audience).toBe("http://localhost:3000/mcp");
+    expect(jwks(config).issuer).toBe(local);
+    expect(jwks(config).audience).toBe("http://localhost:3000/mcp");
   });
 
   it("forwards scopes and the required-scope floor", async () => {

--- a/packages/core/src/server/auth/providers/authplane.ts
+++ b/packages/core/src/server/auth/providers/authplane.ts
@@ -2,18 +2,6 @@ import type { OAuthConfig } from "../index.js";
 import type { RegisteredClaims } from "../verify.js";
 import { type CustomProviderOptions, customProvider } from "./custom.js";
 
-/**
- * Claims an Authplane access token carries. It is an RFC 9068 `at+jwt` token, so
- * only the subject reaches `extra` once the standard fields are mapped onto
- * `AuthInfo`. Declare anything your deployment adds through the type parameter.
- *
- * @see https://datatracker.ietf.org/doc/html/rfc9068
- */
-export type AuthplaneClaims = {
-  /** The Authplane user id (the token's `sub`). */
-  subject?: string;
-};
-
 /** Options accepted by {@link authplaneProvider}. */
 export type AuthplaneProviderOptions = {
   /**
@@ -95,7 +83,7 @@ export function authplaneProvider<
   TCustom extends Record<string, unknown> = Record<never, never>,
 >(
   opts: AuthplaneProviderOptions,
-): Promise<OAuthConfig<AuthplaneClaims & TCustom & RegisteredClaims>> {
+): Promise<OAuthConfig<TCustom & RegisteredClaims>> {
   const { issuer, resource, audience, ...rest } = opts;
 
   parseIdentifier(issuer, "issuer");
@@ -114,7 +102,7 @@ export function authplaneProvider<
     );
   }
 
-  return customProvider<AuthplaneClaims & TCustom>({
+  return customProvider<TCustom>({
     issuer,
     audience: audience ?? resource,
     baseUrl: resource,

--- a/packages/core/src/server/auth/providers/authplane.ts
+++ b/packages/core/src/server/auth/providers/authplane.ts
@@ -1,3 +1,4 @@
+import type { ExtraClaims } from "../../auth.js";
 import type { OAuthConfig } from "../index.js";
 import type { RegisteredClaims } from "../verify.js";
 import { type CustomProviderOptions, customProvider } from "./custom.js";
@@ -80,7 +81,7 @@ function parseIdentifier(value: string, option: string): URL {
  * authorization server instead (see {@link customProvider}).
  */
 export function authplaneProvider<
-  TCustom extends Record<string, unknown> = Record<never, never>,
+  TCustom extends ExtraClaims = Record<never, never>,
 >(
   opts: AuthplaneProviderOptions,
 ): Promise<OAuthConfig<TCustom & RegisteredClaims>> {

--- a/packages/core/src/server/auth/providers/authplane.ts
+++ b/packages/core/src/server/auth/providers/authplane.ts
@@ -1,5 +1,18 @@
 import type { OAuthConfig } from "../index.js";
+import type { RegisteredClaims } from "../verify.js";
 import { type CustomProviderOptions, customProvider } from "./custom.js";
+
+/**
+ * Claims an Authplane access token carries. It is an RFC 9068 `at+jwt` token, so
+ * only the subject reaches `extra` once the standard fields are mapped onto
+ * `AuthInfo`. Declare anything your deployment adds through the type parameter.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc9068
+ */
+export type AuthplaneClaims = {
+  /** The Authplane user id (the token's `sub`). */
+  subject?: string;
+};
 
 /** Options accepted by {@link authplaneProvider}. */
 export type AuthplaneProviderOptions = {
@@ -78,9 +91,11 @@ function parseIdentifier(value: string, option: string): URL {
  * of the authorization path. Pass `serverUrl` to advertise this server as the
  * authorization server instead (see {@link customProvider}).
  */
-export function authplaneProvider(
+export function authplaneProvider<
+  TCustom extends Record<string, unknown> = Record<never, never>,
+>(
   opts: AuthplaneProviderOptions,
-): Promise<OAuthConfig> {
+): Promise<OAuthConfig<AuthplaneClaims & TCustom & RegisteredClaims>> {
   const { issuer, resource, audience, ...rest } = opts;
 
   parseIdentifier(issuer, "issuer");
@@ -99,7 +114,7 @@ export function authplaneProvider(
     );
   }
 
-  return customProvider({
+  return customProvider<AuthplaneClaims & TCustom>({
     issuer,
     audience: audience ?? resource,
     baseUrl: resource,

--- a/packages/core/src/server/auth/providers/clerk.test.ts
+++ b/packages/core/src/server/auth/providers/clerk.test.ts
@@ -1,6 +1,11 @@
 // @vitest-environment node
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OAuthConfig } from "../index.js";
+import type { JwksTokenVerifier } from "../verify.js";
 import { clerkProvider } from "./clerk.js";
+
+const jwks = (config: OAuthConfig) =>
+  (config.verifier as JwksTokenVerifier).config;
 
 afterEach(() => vi.restoreAllMocks());
 
@@ -31,7 +36,7 @@ describe("clerkProvider", () => {
       `${issuer}/.well-known/openid-configuration`,
       expect.anything(),
     );
-    expect(config.verify.issuer).toBe(issuer);
-    expect(config.verify.audience).toBeUndefined();
+    expect(jwks(config).issuer).toBe(issuer);
+    expect(jwks(config).audience).toBeUndefined();
   });
 });

--- a/packages/core/src/server/auth/providers/clerk.test.ts
+++ b/packages/core/src/server/auth/providers/clerk.test.ts
@@ -1,11 +1,9 @@
 // @vitest-environment node
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { OAuthConfig } from "../index.js";
-import type { JwksTokenVerifier } from "../verify.js";
 import { clerkProvider } from "./clerk.js";
+import { lastJwksConfig as jwks } from "./verify-spy.js";
 
-const jwks = (config: OAuthConfig) =>
-  (config.verifier as JwksTokenVerifier).config;
+vi.mock("../verify.js", () => import("./verify-spy.js"));
 
 afterEach(() => vi.restoreAllMocks());
 
@@ -30,13 +28,13 @@ describe("clerkProvider", () => {
       }),
     );
 
-    const config = await clerkProvider({ domain: "acme.clerk.accounts.dev" });
+    await clerkProvider({ domain: "acme.clerk.accounts.dev" });
 
     expect(fetchSpy).toHaveBeenCalledWith(
       `${issuer}/.well-known/openid-configuration`,
       expect.anything(),
     );
-    expect(jwks(config).issuer).toBe(issuer);
-    expect(jwks(config).audience).toBeUndefined();
+    expect(jwks().issuer).toBe(issuer);
+    expect(jwks().audience).toBeUndefined();
   });
 });

--- a/packages/core/src/server/auth/providers/clerk.ts
+++ b/packages/core/src/server/auth/providers/clerk.ts
@@ -1,6 +1,45 @@
 import type { OAuthConfig } from "../index.js";
+import type { RegisteredClaims } from "../verify.js";
 import { type CustomProviderOptions, customProvider } from "./custom.js";
 import { toIssuerUrl } from "./shared.js";
+
+/**
+ * Claims a Clerk session token (v2) carries. All optional: `o` and `act` appear
+ * only with organizations and impersonation, and `email` only when a JWT
+ * template adds it.
+ *
+ * @see https://clerk.com/docs/backend-requests/resources/session-tokens
+ * @see https://clerk.com/docs/backend-requests/jwt-templates
+ */
+export type ClerkClaims = {
+  /** The Clerk user id (the token's `sub`). */
+  subject?: string;
+  /** Session id. */
+  sid?: string;
+  /** Authorized party: the origin the token was issued to. */
+  azp?: string;
+  /** Session token version. */
+  v?: number;
+  /** Factor verification age, `[since-first-factor, since-second-factor]`. */
+  fva?: number[];
+  /** Active organization, when the user has one. */
+  o?: {
+    /** Organization id. */
+    id?: string;
+    /** Organization slug. */
+    slg?: string;
+    /** Role within the organization. */
+    rol?: string;
+    /** Permissions within the organization. */
+    per?: string;
+    /** Feature-permission map backing `per`. */
+    fpm?: string;
+  };
+  /** Actor, present while a user is being impersonated. */
+  act?: Record<string, unknown>;
+  /** Only when a JWT template adds it; not a default Clerk claim. */
+  email?: string;
+};
 
 /**
  * OAuth provider for Clerk. `domain` is the Frontend API URL (e.g.
@@ -11,9 +50,14 @@ import { toIssuerUrl } from "./shared.js";
  * Clerk access tokens carry no `aud` claim, so there is no `audience` option —
  * verification is issuer + JWKS only (matching Clerk's own `mcpAuthClerk`).
  */
-export function clerkProvider(
+export function clerkProvider<
+  TCustom extends Record<string, unknown> = Record<never, never>,
+>(
   opts: { domain: string } & Omit<CustomProviderOptions, "issuer" | "audience">,
-): Promise<OAuthConfig> {
+): Promise<OAuthConfig<ClerkClaims & TCustom & RegisteredClaims>> {
   const { domain, ...rest } = opts;
-  return customProvider({ issuer: toIssuerUrl(domain), ...rest });
+  return customProvider<ClerkClaims & TCustom>({
+    issuer: toIssuerUrl(domain),
+    ...rest,
+  });
 }

--- a/packages/core/src/server/auth/providers/clerk.ts
+++ b/packages/core/src/server/auth/providers/clerk.ts
@@ -12,8 +12,6 @@ import { toIssuerUrl } from "./shared.js";
  * @see https://clerk.com/docs/backend-requests/jwt-templates
  */
 export type ClerkClaims = {
-  /** The Clerk user id (the token's `sub`). */
-  subject?: string;
   /** Session id. */
   sid?: string;
   /** Authorized party: the origin the token was issued to. */

--- a/packages/core/src/server/auth/providers/clerk.ts
+++ b/packages/core/src/server/auth/providers/clerk.ts
@@ -1,3 +1,4 @@
+import type { ExtraClaims } from "../../auth.js";
 import type { OAuthConfig } from "../index.js";
 import type { RegisteredClaims } from "../verify.js";
 import { type CustomProviderOptions, customProvider } from "./custom.js";
@@ -49,7 +50,7 @@ export type ClerkClaims = {
  * verification is issuer + JWKS only (matching Clerk's own `mcpAuthClerk`).
  */
 export function clerkProvider<
-  TCustom extends Record<string, unknown> = Record<never, never>,
+  TCustom extends ExtraClaims = Record<never, never>,
 >(
   opts: { domain: string } & Omit<CustomProviderOptions, "issuer" | "audience">,
 ): Promise<OAuthConfig<ClerkClaims & TCustom & RegisteredClaims>> {

--- a/packages/core/src/server/auth/providers/custom.test.ts
+++ b/packages/core/src/server/auth/providers/custom.test.ts
@@ -1,7 +1,12 @@
 // @vitest-environment node
 import http from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OAuthConfig } from "../index.js";
+import type { JwksTokenVerifier } from "../verify.js";
 import { customProvider } from "./custom.js";
+
+const jwks = (config: OAuthConfig) =>
+  (config.verifier as JwksTokenVerifier).config;
 
 const servers: http.Server[] = [];
 afterEach(() => {
@@ -52,7 +57,7 @@ describe("customProvider", () => {
     });
 
     expect(config.baseUrl).toBe("https://app.example.test");
-    expect(config.verify).toEqual({
+    expect(jwks(config)).toEqual({
       issuer: base,
       audience: "my-api",
       jwksUri: `${base}/jwks`,
@@ -68,7 +73,7 @@ describe("customProvider", () => {
       audience: "a",
       metadataOverrides: { issuer: "https://evil.test" } as never,
     });
-    expect(config.verify.issuer).toBe(base);
+    expect(jwks(config).issuer).toBe(base);
     expect(config.oauthMetadata.issuer).toBe(base);
   });
 
@@ -79,14 +84,14 @@ describe("customProvider", () => {
       audience: "a",
       metadataOverrides: { jwks_uri: "https://evil.test/keys" } as never,
     });
-    expect(config.verify.jwksUri).toBe(`${base}/jwks`);
+    expect(jwks(config).jwksUri).toBe(`${base}/jwks`);
   });
 
   it("serves metadata without a registration_endpoint when the IdP has no DCR", async () => {
     const base = await serveDiscovery({ registration_endpoint: undefined });
     const config = await customProvider({ issuer: base, audience: "a" });
     expect(config.oauthMetadata.registration_endpoint).toBeUndefined();
-    expect(config.verify.issuer).toBe(base);
+    expect(jwks(config).issuer).toBe(base);
   });
 
   it("throws when discovery has no jwks_uri (token verification needs it)", async () => {
@@ -108,7 +113,7 @@ describe("customProvider", () => {
     expect(config.oauthMetadata.issuer).toBe("https://app.example.test");
     expect(config.oauthMetadata.scopes_supported).toEqual(["openid"]);
     // but the token's issuer is still verified against the IdP.
-    expect(config.verify.issuer).toBe(base);
+    expect(jwks(config).issuer).toBe(base);
   });
 
   it("authorizationServer supplies the advertised metadata and the verified issuer", async () => {
@@ -125,7 +130,7 @@ describe("customProvider", () => {
     expect(config.oauthMetadata.authorization_endpoint).toBe(`${as}/authorize`);
     expect(config.oauthMetadata.registration_endpoint).toBe(`${as}/register`);
     expect(config.scopesSupported).toEqual(["checkout"]);
-    expect(config.verify).toEqual({
+    expect(jwks(config)).toEqual({
       issuer: as,
       audience: "a",
       jwksUri: `${as}/jwks`,
@@ -147,7 +152,7 @@ describe("customProvider", () => {
     expect(config.oauthMetadata.authorization_endpoint).toBe(
       `${base}/authorize`,
     );
-    expect(config.verify.issuer).toBe(base);
+    expect(jwks(config).issuer).toBe(base);
     warn.mockRestore();
   });
 
@@ -162,7 +167,7 @@ describe("customProvider", () => {
     });
     expect(config.oauthMetadata.issuer).toBe("https://app.example.test");
     expect(config.oauthMetadata.token_endpoint).toBe(`${as}/token`);
-    expect(config.verify.issuer).toBe(as);
+    expect(jwks(config).issuer).toBe(as);
   });
 
   it("applies metadataOverrides over discovered values", async () => {

--- a/packages/core/src/server/auth/providers/custom.test.ts
+++ b/packages/core/src/server/auth/providers/custom.test.ts
@@ -1,12 +1,10 @@
 // @vitest-environment node
 import http from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { OAuthConfig } from "../index.js";
-import type { JwksTokenVerifier } from "../verify.js";
 import { customProvider } from "./custom.js";
+import { lastJwksConfig as jwks } from "./verify-spy.js";
 
-const jwks = (config: OAuthConfig) =>
-  (config.verifier as JwksTokenVerifier).config;
+vi.mock("../verify.js", () => import("./verify-spy.js"));
 
 const servers: http.Server[] = [];
 afterEach(() => {
@@ -57,7 +55,7 @@ describe("customProvider", () => {
     });
 
     expect(config.baseUrl).toBe("https://app.example.test");
-    expect(jwks(config)).toEqual({
+    expect(jwks()).toEqual({
       issuer: base,
       audience: "my-api",
       jwksUri: `${base}/jwks`,
@@ -73,25 +71,25 @@ describe("customProvider", () => {
       audience: "a",
       metadataOverrides: { issuer: "https://evil.test" } as never,
     });
-    expect(jwks(config).issuer).toBe(base);
+    expect(jwks().issuer).toBe(base);
     expect(config.oauthMetadata.issuer).toBe(base);
   });
 
   it("ignores a runtime jwks_uri override (keeps the discovered signing keys)", async () => {
     const base = await serveDiscovery();
-    const config = await customProvider({
+    await customProvider({
       issuer: base,
       audience: "a",
       metadataOverrides: { jwks_uri: "https://evil.test/keys" } as never,
     });
-    expect(jwks(config).jwksUri).toBe(`${base}/jwks`);
+    expect(jwks().jwksUri).toBe(`${base}/jwks`);
   });
 
   it("serves metadata without a registration_endpoint when the IdP has no DCR", async () => {
     const base = await serveDiscovery({ registration_endpoint: undefined });
     const config = await customProvider({ issuer: base, audience: "a" });
     expect(config.oauthMetadata.registration_endpoint).toBeUndefined();
-    expect(jwks(config).issuer).toBe(base);
+    expect(jwks().issuer).toBe(base);
   });
 
   it("throws when discovery has no jwks_uri (token verification needs it)", async () => {
@@ -113,7 +111,7 @@ describe("customProvider", () => {
     expect(config.oauthMetadata.issuer).toBe("https://app.example.test");
     expect(config.oauthMetadata.scopes_supported).toEqual(["openid"]);
     // but the token's issuer is still verified against the IdP.
-    expect(jwks(config).issuer).toBe(base);
+    expect(jwks().issuer).toBe(base);
   });
 
   it("authorizationServer supplies the advertised metadata and the verified issuer", async () => {
@@ -130,7 +128,7 @@ describe("customProvider", () => {
     expect(config.oauthMetadata.authorization_endpoint).toBe(`${as}/authorize`);
     expect(config.oauthMetadata.registration_endpoint).toBe(`${as}/register`);
     expect(config.scopesSupported).toEqual(["checkout"]);
-    expect(jwks(config)).toEqual({
+    expect(jwks()).toEqual({
       issuer: as,
       audience: "a",
       jwksUri: `${as}/jwks`,
@@ -152,7 +150,7 @@ describe("customProvider", () => {
     expect(config.oauthMetadata.authorization_endpoint).toBe(
       `${base}/authorize`,
     );
-    expect(jwks(config).issuer).toBe(base);
+    expect(jwks().issuer).toBe(base);
     warn.mockRestore();
   });
 
@@ -167,7 +165,7 @@ describe("customProvider", () => {
     });
     expect(config.oauthMetadata.issuer).toBe("https://app.example.test");
     expect(config.oauthMetadata.token_endpoint).toBe(`${as}/token`);
-    expect(jwks(config).issuer).toBe(as);
+    expect(jwks().issuer).toBe(as);
   });
 
   it("applies metadataOverrides over discovered values", async () => {

--- a/packages/core/src/server/auth/providers/custom.ts
+++ b/packages/core/src/server/auth/providers/custom.ts
@@ -1,4 +1,5 @@
 import type { OAuthMetadata } from "@modelcontextprotocol/sdk/shared/auth.js";
+import type { ExtraClaims } from "../../auth.js";
 import {
   type DiscoveredMetadata,
   discoverAuthorizationServer,
@@ -42,9 +43,7 @@ export type CustomProviderOptions = {
  * as `extra.authInfo.extra`. The branded providers pass their documented claims;
  * pass your own when wiring an IdP by hand.
  */
-export async function customProvider<
-  TExtra extends Record<string, unknown> = Record<string, unknown>,
->(
+export async function customProvider<TExtra extends ExtraClaims = ExtraClaims>(
   opts: CustomProviderOptions,
 ): Promise<OAuthConfig<TExtra & RegisteredClaims>> {
   const discovered = await discoverAuthorizationServer(opts.issuer);

--- a/packages/core/src/server/auth/providers/custom.ts
+++ b/packages/core/src/server/auth/providers/custom.ts
@@ -4,6 +4,7 @@ import {
   discoverAuthorizationServer,
 } from "../discovery.js";
 import type { OAuthConfig } from "../index.js";
+import { createJwksVerifier, type RegisteredClaims } from "../verify.js";
 
 /** Options accepted by {@link customProvider} and the branded providers. */
 export type CustomProviderOptions = {
@@ -34,10 +35,18 @@ export type CustomProviderOptions = {
   metadataOverrides?: Omit<Partial<OAuthMetadata>, "issuer">;
 };
 
-/** Builds a complete {@link OAuthConfig} from an IdP's OAuth discovery document. */
-export async function customProvider(
+/**
+ * Builds a complete {@link OAuthConfig} from an IdP's OAuth discovery document.
+ *
+ * @typeParam TExtra - Claims the IdP puts in the access token, reaching handlers
+ * as `extra.authInfo.extra`. The branded providers pass their documented claims;
+ * pass your own when wiring an IdP by hand.
+ */
+export async function customProvider<
+  TExtra extends Record<string, unknown> = Record<string, unknown>,
+>(
   opts: CustomProviderOptions,
-): Promise<OAuthConfig> {
+): Promise<OAuthConfig<TExtra & RegisteredClaims>> {
   const discovered = await discoverAuthorizationServer(opts.issuer);
 
   // JWKS verification needs a signing-key URL; without it the server can't verify
@@ -86,11 +95,11 @@ export async function customProvider(
   return {
     baseUrl: opts.baseUrl,
     oauthMetadata,
-    verify: {
+    verifier: createJwksVerifier<TExtra>({
       issuer: advertised.issuer,
       audience: opts.audience,
       jwksUri: advertised.jwks_uri ?? discovered.jwks_uri,
-    },
+    }),
     scopesSupported,
     requiredScopes: opts.requiredScopes,
   };

--- a/packages/core/src/server/auth/providers/descope.test.ts
+++ b/packages/core/src/server/auth/providers/descope.test.ts
@@ -1,6 +1,11 @@
 // @vitest-environment node
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OAuthConfig } from "../index.js";
+import type { JwksTokenVerifier } from "../verify.js";
 import { descopeProvider } from "./descope.js";
+
+const jwks = (config: OAuthConfig) =>
+  (config.verifier as JwksTokenVerifier).config;
 
 afterEach(() => vi.restoreAllMocks());
 
@@ -49,8 +54,8 @@ describe("descopeProvider", () => {
       `${PROJECT}/.well-known/openid-configuration`,
       expect.anything(),
     );
-    expect(config.verify.issuer).toBe(AGENTIC);
-    expect(config.verify.audience).toBe("P123");
+    expect(jwks(config).issuer).toBe(AGENTIC);
+    expect(jwks(config).audience).toBe("P123");
     expect(config.oauthMetadata.issuer).toBe(AGENTIC);
     expect(config.oauthMetadata.registration_endpoint).toBe(
       `${AGENTIC}/register`,
@@ -74,6 +79,6 @@ describe("descopeProvider", () => {
 
     const config = await descopeProvider({ url: AGENTIC, audience: "custom" });
 
-    expect(config.verify.audience).toBe("custom");
+    expect(jwks(config).audience).toBe("custom");
   });
 });

--- a/packages/core/src/server/auth/providers/descope.test.ts
+++ b/packages/core/src/server/auth/providers/descope.test.ts
@@ -1,11 +1,9 @@
 // @vitest-environment node
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { OAuthConfig } from "../index.js";
-import type { JwksTokenVerifier } from "../verify.js";
 import { descopeProvider } from "./descope.js";
+import { lastJwksConfig as jwks } from "./verify-spy.js";
 
-const jwks = (config: OAuthConfig) =>
-  (config.verifier as JwksTokenVerifier).config;
+vi.mock("../verify.js", () => import("./verify-spy.js"));
 
 afterEach(() => vi.restoreAllMocks());
 
@@ -54,8 +52,8 @@ describe("descopeProvider", () => {
       `${PROJECT}/.well-known/openid-configuration`,
       expect.anything(),
     );
-    expect(jwks(config).issuer).toBe(AGENTIC);
-    expect(jwks(config).audience).toBe("P123");
+    expect(jwks().issuer).toBe(AGENTIC);
+    expect(jwks().audience).toBe("P123");
     expect(config.oauthMetadata.issuer).toBe(AGENTIC);
     expect(config.oauthMetadata.registration_endpoint).toBe(
       `${AGENTIC}/register`,
@@ -77,8 +75,8 @@ describe("descopeProvider", () => {
   it("lets an explicit audience override the derived project id", async () => {
     mockDiscovery({ [PROJECT]: ["openid"], [AGENTIC]: ["checkout"] });
 
-    const config = await descopeProvider({ url: AGENTIC, audience: "custom" });
+    await descopeProvider({ url: AGENTIC, audience: "custom" });
 
-    expect(jwks(config).audience).toBe("custom");
+    expect(jwks().audience).toBe("custom");
   });
 });

--- a/packages/core/src/server/auth/providers/descope.ts
+++ b/packages/core/src/server/auth/providers/descope.ts
@@ -11,8 +11,6 @@ import { type CustomProviderOptions, customProvider } from "./custom.js";
  * @see https://docs.descope.com/management/token/jwt-templates
  */
 export type DescopeClaims = {
-  /** The Descope user id (the token's `sub`). */
-  subject?: string;
   /** Authentication methods used, e.g. `["otp"]`. */
   amr?: string[];
   /** Descope Resource Name: where the token is stored. */

--- a/packages/core/src/server/auth/providers/descope.ts
+++ b/packages/core/src/server/auth/providers/descope.ts
@@ -1,3 +1,4 @@
+import type { ExtraClaims } from "../../auth.js";
 import type { OAuthConfig } from "../index.js";
 import type { RegisteredClaims } from "../verify.js";
 import { type CustomProviderOptions, customProvider } from "./custom.js";
@@ -62,7 +63,7 @@ function projectIdFromUrl(url: string): string {
  * id, project id], not the server URL; pass `audience` to override.
  */
 export function descopeProvider<
-  TCustom extends Record<string, unknown> = Record<never, never>,
+  TCustom extends ExtraClaims = Record<never, never>,
 >(
   opts: { url: string } & Omit<CustomProviderOptions, "issuer">,
 ): Promise<OAuthConfig<DescopeClaims & TCustom & RegisteredClaims>> {

--- a/packages/core/src/server/auth/providers/descope.ts
+++ b/packages/core/src/server/auth/providers/descope.ts
@@ -1,5 +1,33 @@
 import type { OAuthConfig } from "../index.js";
+import type { RegisteredClaims } from "../verify.js";
 import { type CustomProviderOptions, customProvider } from "./custom.js";
+
+/**
+ * Claims a Descope session JWT carries. Roles and permissions are nested per
+ * tenant when the project uses tenants, and flat otherwise. `email` arrives only
+ * through a Custom Claims flow action or a JWT template.
+ *
+ * @see https://docs.descope.com/authorization/session-management
+ * @see https://docs.descope.com/management/token/jwt-templates
+ */
+export type DescopeClaims = {
+  /** The Descope user id (the token's `sub`). */
+  subject?: string;
+  /** Authentication methods used, e.g. `["otp"]`. */
+  amr?: string[];
+  /** Descope Resource Name: where the token is stored. */
+  drn?: string;
+  /** The user's active tenant. */
+  dct?: string;
+  /** Associated tenants, keyed by tenant id. */
+  tenants?: Record<string, { roles?: string[]; permissions?: string[] }>;
+  /** Roles, when the project has no tenants. */
+  roles?: string[];
+  /** Permissions, when the project has no tenants. */
+  permissions?: string[];
+  /** Only via a Custom Claims action or JWT template; not a default claim. */
+  email?: string;
+};
 
 /**
  * Turns the console's Discovery URL into the authorization server's base URL:
@@ -35,14 +63,16 @@ function projectIdFromUrl(url: string): string {
  * the **Project ID** derived from the URL — Descope binds `aud` to [DCR client
  * id, project id], not the server URL; pass `audience` to override.
  */
-export function descopeProvider(
+export function descopeProvider<
+  TCustom extends Record<string, unknown> = Record<never, never>,
+>(
   opts: { url: string } & Omit<CustomProviderOptions, "issuer">,
-): Promise<OAuthConfig> {
+): Promise<OAuthConfig<DescopeClaims & TCustom & RegisteredClaims>> {
   const { url, audience, ...rest } = opts;
   const asUrl = toAuthorizationServerUrl(url);
   const projectId = projectIdFromUrl(asUrl);
   const issuer = `${asUrl.slice(0, asUrl.indexOf("/agentic/"))}/${projectId}`;
-  return customProvider({
+  return customProvider<DescopeClaims & TCustom>({
     issuer,
     audience: audience ?? projectId,
     authorizationServer: asUrl,

--- a/packages/core/src/server/auth/providers/stytch.ts
+++ b/packages/core/src/server/auth/providers/stytch.ts
@@ -11,8 +11,6 @@ import { toIssuerUrl } from "./shared.js";
  * @see https://stytch.com/docs/api/connected-apps-create
  */
 export type StytchClaims = {
-  /** Id of the Stytch member or user that granted access (the token's `sub`). */
-  subject?: string;
   /** Only when the client's access-token template adds it. */
   email?: string;
 };

--- a/packages/core/src/server/auth/providers/stytch.ts
+++ b/packages/core/src/server/auth/providers/stytch.ts
@@ -1,6 +1,21 @@
 import type { OAuthConfig } from "../index.js";
+import type { RegisteredClaims } from "../verify.js";
 import { type CustomProviderOptions, customProvider } from "./custom.js";
 import { toIssuerUrl } from "./shared.js";
+
+/**
+ * Claims a Stytch Connected Apps access token carries. Beyond the subject,
+ * everything is project-configured through the client's access-token template.
+ *
+ * @see https://stytch.com/docs/api-reference/consumer/api/connected-apps/tokens/connected-app-access-token-object
+ * @see https://stytch.com/docs/api/connected-apps-create
+ */
+export type StytchClaims = {
+  /** Id of the Stytch member or user that granted access (the token's `sub`). */
+  subject?: string;
+  /** Only when the client's access-token template adds it. */
+  email?: string;
+};
 
 /**
  * OAuth provider for Stytch Connected Apps. `domain` is the project domain,
@@ -8,12 +23,17 @@ import { toIssuerUrl } from "./shared.js";
  * DCR enabled in the Stytch dashboard. `audience` is the Stytch Project ID
  * (the default token audience).
  */
-export function stytchProvider(
+export function stytchProvider<
+  TCustom extends Record<string, unknown> = Record<never, never>,
+>(
   opts: { domain: string; audience: string } & Omit<
     CustomProviderOptions,
     "issuer" | "audience"
   >,
-): Promise<OAuthConfig> {
+): Promise<OAuthConfig<StytchClaims & TCustom & RegisteredClaims>> {
   const { domain, ...rest } = opts;
-  return customProvider({ issuer: toIssuerUrl(domain), ...rest });
+  return customProvider<StytchClaims & TCustom>({
+    issuer: toIssuerUrl(domain),
+    ...rest,
+  });
 }

--- a/packages/core/src/server/auth/providers/stytch.ts
+++ b/packages/core/src/server/auth/providers/stytch.ts
@@ -1,3 +1,4 @@
+import type { ExtraClaims } from "../../auth.js";
 import type { OAuthConfig } from "../index.js";
 import type { RegisteredClaims } from "../verify.js";
 import { type CustomProviderOptions, customProvider } from "./custom.js";
@@ -22,7 +23,7 @@ export type StytchClaims = {
  * (the default token audience).
  */
 export function stytchProvider<
-  TCustom extends Record<string, unknown> = Record<never, never>,
+  TCustom extends ExtraClaims = Record<never, never>,
 >(
   opts: { domain: string; audience: string } & Omit<
     CustomProviderOptions,

--- a/packages/core/src/server/auth/providers/verify-spy.ts
+++ b/packages/core/src/server/auth/providers/verify-spy.ts
@@ -1,0 +1,24 @@
+import { vi } from "vitest";
+
+const actual =
+  await vi.importActual<typeof import("../verify.js")>("../verify.js");
+
+export const createJwksVerifier = vi.fn(actual.createJwksVerifier);
+
+/**
+ * The JWKS parameters a provider handed to `createJwksVerifier`: the issuer and
+ * JWKS URL it derived from discovery, and the audience it expects. Substitute
+ * this module for `../verify.js` to assert on them:
+ *
+ * ```ts
+ * vi.mock("../verify.js", () => import("./verify-spy.js"));
+ * import { lastJwksConfig as jwks } from "./verify-spy.js";
+ * ```
+ */
+export const lastJwksConfig = () => {
+  const call = createJwksVerifier.mock.lastCall;
+  if (!call) {
+    throw new Error("createJwksVerifier was not called");
+  }
+  return call[0];
+};

--- a/packages/core/src/server/auth/providers/workos.ts
+++ b/packages/core/src/server/auth/providers/workos.ts
@@ -12,8 +12,6 @@ import { toIssuerUrl } from "./shared.js";
  * @see https://workos.com/docs/authkit/jwt-templates
  */
 export type WorkosClaims = {
-  /** The WorkOS user id (the token's `sub`). */
-  subject?: string;
   /** Session id, used for signing out. */
   sid?: string;
   /** Organization selected at sign-in. */

--- a/packages/core/src/server/auth/providers/workos.ts
+++ b/packages/core/src/server/auth/providers/workos.ts
@@ -1,3 +1,4 @@
+import type { ExtraClaims } from "../../auth.js";
 import type { OAuthConfig } from "../index.js";
 import type { RegisteredClaims } from "../verify.js";
 import { type CustomProviderOptions, customProvider } from "./custom.js";
@@ -30,7 +31,7 @@ export type WorkosClaims = {
  * (Connect → Configuration). `audience` is the MCP server's Resource Indicator.
  */
 export function workosProvider<
-  TCustom extends Record<string, unknown> = Record<never, never>,
+  TCustom extends ExtraClaims = Record<never, never>,
 >(
   opts: { domain: string; audience: string } & Omit<
     CustomProviderOptions,

--- a/packages/core/src/server/auth/providers/workos.ts
+++ b/packages/core/src/server/auth/providers/workos.ts
@@ -1,18 +1,47 @@
 import type { OAuthConfig } from "../index.js";
+import type { RegisteredClaims } from "../verify.js";
 import { type CustomProviderOptions, customProvider } from "./custom.js";
 import { toIssuerUrl } from "./shared.js";
+
+/**
+ * Claims a WorkOS AuthKit access token carries. All optional: `org_id`, `role`
+ * and `permissions` appear only when an organization is selected at sign-in, and
+ * `email` only when a JWT template adds it.
+ *
+ * @see https://workos.com/docs/authkit/sessions/integrating-sessions/access-token
+ * @see https://workos.com/docs/authkit/jwt-templates
+ */
+export type WorkosClaims = {
+  /** The WorkOS user id (the token's `sub`). */
+  subject?: string;
+  /** Session id, used for signing out. */
+  sid?: string;
+  /** Organization selected at sign-in. */
+  org_id?: string;
+  /** Role of the selected organization membership. */
+  role?: string;
+  /** Permissions assigned to the role. */
+  permissions?: string[];
+  /** Only when a JWT template adds it; not a default AuthKit claim. */
+  email?: string;
+};
 
 /**
  * OAuth provider for WorkOS AuthKit. `domain` is the AuthKit domain, e.g.
  * `acme.authkit.app`. Requires DCR enabled in the WorkOS dashboard
  * (Connect → Configuration). `audience` is the MCP server's Resource Indicator.
  */
-export function workosProvider(
+export function workosProvider<
+  TCustom extends Record<string, unknown> = Record<never, never>,
+>(
   opts: { domain: string; audience: string } & Omit<
     CustomProviderOptions,
     "issuer" | "audience"
   >,
-): Promise<OAuthConfig> {
+): Promise<OAuthConfig<WorkosClaims & TCustom & RegisteredClaims>> {
   const { domain, ...rest } = opts;
-  return customProvider({ issuer: toIssuerUrl(domain), ...rest });
+  return customProvider<WorkosClaims & TCustom>({
+    issuer: toIssuerUrl(domain),
+    ...rest,
+  });
 }

--- a/packages/core/src/server/auth/setup.test.ts
+++ b/packages/core/src/server/auth/setup.test.ts
@@ -6,6 +6,7 @@ import type { RequestHandler } from "express";
 import * as jose from "jose";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { McpServer } from "../server.js";
+import { createJwksVerifier } from "./verify.js";
 
 vi.mock("@skybridge/devtools", () => ({
   devtoolsStaticServer: () =>
@@ -76,7 +77,11 @@ async function bootServer(
           token_endpoint: `${ISSUER}/token`,
           response_types_supported: ["code"],
         },
-        verify: { issuer: ISSUER, audience: AUDIENCE, jwksUri },
+        verifier: createJwksVerifier({
+          issuer: ISSUER,
+          audience: AUDIENCE,
+          jwksUri,
+        }),
         scopesSupported: ["openid", "email"],
         requiredScopes: ["openid"],
       },
@@ -229,7 +234,11 @@ async function bootMixedServer(jwksUri: string) {
           token_endpoint: `${ISSUER}/token`,
           response_types_supported: ["code"],
         },
-        verify: { issuer: ISSUER, audience: AUDIENCE, jwksUri },
+        verifier: createJwksVerifier({
+          issuer: ISSUER,
+          audience: AUDIENCE,
+          jwksUri,
+        }),
       },
     },
   )
@@ -476,7 +485,11 @@ async function bootScopedServer(jwksUri: string) {
           token_endpoint: `${ISSUER}/token`,
           response_types_supported: ["code"],
         },
-        verify: { issuer: ISSUER, audience: AUDIENCE, jwksUri },
+        verifier: createJwksVerifier({
+          issuer: ISSUER,
+          audience: AUDIENCE,
+          jwksUri,
+        }),
       },
     },
   ).registerTool(
@@ -608,7 +621,10 @@ describe("oauth config validation", () => {
           oauth: {
             baseUrl: "not-a-url",
             oauthMetadata: validMetadata,
-            verify: { issuer: ISSUER, audience: AUDIENCE },
+            verifier: createJwksVerifier({
+              issuer: ISSUER,
+              audience: AUDIENCE,
+            }),
           },
         }),
     ).toThrow(/baseUrl must be a valid absolute URL/);

--- a/packages/core/src/server/auth/setup.test.ts
+++ b/packages/core/src/server/auth/setup.test.ts
@@ -62,7 +62,10 @@ function signToken(key: CryptoKey, scope = "openid email") {
 
 async function bootServer(
   jwksUri: string,
-  { baseUrl = "https://app.example.test" }: { baseUrl?: string | null } = {},
+  {
+    baseUrl = "https://app.example.test",
+    legacyVerify = false,
+  }: { baseUrl?: string | null; legacyVerify?: boolean } = {},
 ) {
   const { createApp } = await import("../express.js");
   const server = new McpServer(
@@ -77,11 +80,15 @@ async function bootServer(
           token_endpoint: `${ISSUER}/token`,
           response_types_supported: ["code"],
         },
-        verifier: createJwksVerifier({
-          issuer: ISSUER,
-          audience: AUDIENCE,
-          jwksUri,
-        }),
+        ...(legacyVerify
+          ? { verify: { issuer: ISSUER, audience: AUDIENCE, jwksUri } }
+          : {
+              verifier: createJwksVerifier({
+                issuer: ISSUER,
+                audience: AUDIENCE,
+                jwksUri,
+              }),
+            }),
         scopesSupported: ["openid", "email"],
         requiredScopes: ["openid"],
       },
@@ -155,6 +162,26 @@ describe("setupOAuth wiring", () => {
     })) as unknown as {
       content: { type: string; text: string }[];
     };
+    expect(result.content[0]?.text).toBe("client-1");
+
+    await client.close();
+  });
+  it("builds the verifier from the legacy verify config", async () => {
+    const { privateKey, jwksUri } = await startJwks();
+    const base = await bootServer(jwksUri, { legacyVerify: true });
+    const token = await signToken(privateKey);
+
+    const client = new Client({ name: "test-client", version: "0.0.0" });
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`${base}/mcp`),
+      { requestInit: { headers: { Authorization: `Bearer ${token}` } } },
+    );
+    await client.connect(transport);
+
+    const result = (await client.callTool({
+      name: "whoami",
+      arguments: {},
+    })) as unknown as { content: { type: string; text: string }[] };
     expect(result.content[0]?.text).toBe("client-1");
 
     await client.close();

--- a/packages/core/src/server/auth/setup.ts
+++ b/packages/core/src/server/auth/setup.ts
@@ -19,7 +19,6 @@ import {
   securitySchemesAllowAnonymous,
   wwwAuthenticateHeader,
 } from "./security-schemes.js";
-import { createJwksVerifier } from "./verify.js";
 
 export type ResourceMetadataUrlResolver = (
   getHeader: (key: string) => string | undefined,
@@ -28,16 +27,16 @@ export type ResourceMetadataUrlResolver = (
 /** Mounts the well-known OAuth metadata and bearer auth on `/mcp`. */
 export function setupOAuth(
   app: Express,
-  config: OAuthConfig,
+  config: OAuthConfig<Record<string, unknown>>,
   schemesByTool: Map<string, SecurityScheme[] | undefined>,
 ): ResourceMetadataUrlResolver {
-  if (!config.verify?.issuer) {
-    throw new Error("oauth.verify requires an `issuer`");
+  if (!config.verifier) {
+    throw new Error("oauth requires a `verifier`");
   }
 
   const acceptsAnonymous = () =>
     [...schemesByTool.values()].some(securitySchemesAllowAnonymous);
-  const verifier = createJwksVerifier(config.verify);
+  const verifier = config.verifier;
   const bearer = (options: BearerAuthMiddlewareOptions): RequestHandler => {
     const required = requireBearerAuth(options);
     const optional = optionalBearerAuth(options);

--- a/packages/core/src/server/auth/setup.ts
+++ b/packages/core/src/server/auth/setup.ts
@@ -19,6 +19,7 @@ import {
   securitySchemesAllowAnonymous,
   wwwAuthenticateHeader,
 } from "./security-schemes.js";
+import { createJwksVerifier } from "./verify.js";
 
 export type ResourceMetadataUrlResolver = (
   getHeader: (key: string) => string | undefined,
@@ -30,13 +31,13 @@ export function setupOAuth(
   config: OAuthConfig<Record<string, unknown>>,
   schemesByTool: Map<string, SecurityScheme[] | undefined>,
 ): ResourceMetadataUrlResolver {
-  if (!config.verifier) {
+  if (!config.verifier && !config.verify) {
     throw new Error("oauth requires a `verifier`");
   }
 
   const acceptsAnonymous = () =>
     [...schemesByTool.values()].some(securitySchemesAllowAnonymous);
-  const verifier = config.verifier;
+  const verifier = config.verifier ?? createJwksVerifier(config.verify);
   const bearer = (options: BearerAuthMiddlewareOptions): RequestHandler => {
     const required = requireBearerAuth(options);
     const optional = optionalBearerAuth(options);

--- a/packages/core/src/server/auth/verify.test.ts
+++ b/packages/core/src/server/auth/verify.test.ts
@@ -122,23 +122,28 @@ describe("createJwksVerifier", () => {
       // jose: `missing required "aud" claim`
       "Token verification failed: missing required  aud  claim",
     ],
-  ])("keeps the message safe inside the challenge for %s", async (_, mint, expected) => {
-    const { privateKey, jwksUri } = await startJwks();
-    const verifier = createJwksVerifier({
-      issuer: ISSUER,
-      audience: AUDIENCE,
-      jwksUri,
-    });
+  ])(
+    "keeps the message safe inside the challenge for %s",
+    async (_, mint, expected) => {
+      const { privateKey, jwksUri } = await startJwks();
+      const verifier = createJwksVerifier({
+        issuer: ISSUER,
+        audience: AUDIENCE,
+        jwksUri,
+      });
 
-    const error = await verifier.verifyAccessToken(await mint(privateKey)).then(
-      () => undefined,
-      (e: Error) => e,
-    );
+      const error = await verifier
+        .verifyAccessToken(await mint(privateKey))
+        .then(
+          () => undefined,
+          (e: Error) => e,
+        );
 
-    expect(error?.message).toBe(expected);
-    // OAuth 2.1 §5.3.1: %x20-21 / %x23-5B / %x5D-7E and nothing else.
-    expect(error?.message).not.toMatch(/[^\x20-\x21\x23-\x5B\x5D-\x7E]/);
-  });
+      expect(error?.message).toBe(expected);
+      // OAuth 2.1 §5.3.1: %x20-21 / %x23-5B / %x5D-7E and nothing else.
+      expect(error?.message).not.toMatch(/[^\x20-\x21\x23-\x5B\x5D-\x7E]/);
+    },
+  );
 
   it("skips the aud check when no audience is configured (e.g. Clerk)", async () => {
     const { privateKey, jwksUri } = await startJwks();

--- a/packages/core/src/server/auth/verify.test.ts
+++ b/packages/core/src/server/auth/verify.test.ts
@@ -41,6 +41,12 @@ function sign(
     .sign(key);
 }
 
+it("rejects a config with no issuer", () => {
+  expect(() => createJwksVerifier({ issuer: "" })).toThrow(
+    /requires an `issuer`/,
+  );
+});
+
 describe("createJwksVerifier", () => {
   it("verifies a valid token and maps claims to AuthInfo", async () => {
     const { privateKey, jwksUri } = await startJwks();
@@ -116,28 +122,23 @@ describe("createJwksVerifier", () => {
       // jose: `missing required "aud" claim`
       "Token verification failed: missing required  aud  claim",
     ],
-  ])(
-    "keeps the message safe inside the challenge for %s",
-    async (_, mint, expected) => {
-      const { privateKey, jwksUri } = await startJwks();
-      const verifier = createJwksVerifier({
-        issuer: ISSUER,
-        audience: AUDIENCE,
-        jwksUri,
-      });
+  ])("keeps the message safe inside the challenge for %s", async (_, mint, expected) => {
+    const { privateKey, jwksUri } = await startJwks();
+    const verifier = createJwksVerifier({
+      issuer: ISSUER,
+      audience: AUDIENCE,
+      jwksUri,
+    });
 
-      const error = await verifier
-        .verifyAccessToken(await mint(privateKey))
-        .then(
-          () => undefined,
-          (e: Error) => e,
-        );
+    const error = await verifier.verifyAccessToken(await mint(privateKey)).then(
+      () => undefined,
+      (e: Error) => e,
+    );
 
-      expect(error?.message).toBe(expected);
-      // OAuth 2.1 §5.3.1: %x20-21 / %x23-5B / %x5D-7E and nothing else.
-      expect(error?.message).not.toMatch(/[^\x20-\x21\x23-\x5B\x5D-\x7E]/);
-    },
-  );
+    expect(error?.message).toBe(expected);
+    // OAuth 2.1 §5.3.1: %x20-21 / %x23-5B / %x5D-7E and nothing else.
+    expect(error?.message).not.toMatch(/[^\x20-\x21\x23-\x5B\x5D-\x7E]/);
+  });
 
   it("skips the aud check when no audience is configured (e.g. Clerk)", async () => {
     const { privateKey, jwksUri } = await startJwks();

--- a/packages/core/src/server/auth/verify.ts
+++ b/packages/core/src/server/auth/verify.ts
@@ -1,7 +1,6 @@
 import { InvalidTokenError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
-import type { OAuthTokenVerifier } from "@modelcontextprotocol/sdk/server/auth/provider.js";
-import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import * as jose from "jose";
+import type { AuthInfo, TokenVerifier } from "../auth.js";
 
 export type JwksVerifyConfig = {
   /** Expected `iss` claim. */
@@ -13,17 +12,63 @@ export type JwksVerifyConfig = {
   jwksUri?: string;
 };
 
-/** Builds an `OAuthTokenVerifier` validating JWTs against a remote JWKS. Internal, not exported. */
-export function createJwksVerifier(
-  config: JwksVerifyConfig,
-): OAuthTokenVerifier {
+/**
+ * Registered JWT claims a verified token always carries into `extra`, since only
+ * `client_id`, `scope`, `exp` and `sub` are lifted onto `AuthInfo` itself.
+ * Intersected into every claim shape a JWKS verifier resolves.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc7519#section-4.1
+ */
+export type RegisteredClaims = {
+  /** Issuer of the token. */
+  iss?: string;
+  /** Audience the token was minted for. */
+  aud?: string | string[];
+  /** Issued-at, in unix seconds. */
+  iat?: number;
+  /** Not-valid-before, in unix seconds. */
+  nbf?: number;
+  /** Unique token id. */
+  jti?: string;
+};
+
+/**
+ * A {@link TokenVerifier} backed by a remote JWKS, carrying the verification
+ * parameters it resolved. Read `config` to check what a provider derived from
+ * discovery: the issuer and JWKS URL are the trust anchor.
+ */
+export type JwksTokenVerifier<
+  TExtra extends Record<string, unknown> = Record<string, unknown>,
+> = TokenVerifier<TExtra> & { readonly config: Readonly<JwksVerifyConfig> };
+
+/**
+ * Builds a {@link TokenVerifier} that validates JWTs against a remote JWKS.
+ *
+ * `extra` receives the token's claims with `sub` renamed to `subject`, minus
+ * `client_id`, `scope` and `exp`, which map onto `AuthInfo` fields instead. Pass
+ * `TExtra` to declare what your IdP puts there; the branded providers do this
+ * for you. {@link RegisteredClaims} is always included, since those claims
+ * survive the mapping.
+ *
+ * @typeParam TExtra - Claims the verified token carries in `extra`. An
+ * assertion, not a runtime check: nothing rejects a token whose claims differ.
+ */
+export function createJwksVerifier<
+  TExtra extends Record<string, unknown> = Record<string, unknown>,
+>(config: JwksVerifyConfig): JwksTokenVerifier<TExtra & RegisteredClaims> {
+  if (!config.issuer) {
+    throw new Error("createJwksVerifier requires an `issuer`");
+  }
   const jwksUri =
     config.jwksUri ??
     `${config.issuer.replace(/\/$/, "")}/.well-known/jwks.json`;
   const jwks = jose.createRemoteJWKSet(new URL(jwksUri));
 
   return {
-    async verifyAccessToken(token: string): Promise<AuthInfo> {
+    config: { ...config, jwksUri },
+    async verifyAccessToken(
+      token: string,
+    ): Promise<AuthInfo<TExtra & RegisteredClaims>> {
       let payload: jose.JWTPayload;
       try {
         ({ payload } = await jose.jwtVerify(token, jwks, {
@@ -67,8 +112,9 @@ export function createJwksVerifier(
         clientId: client_id ?? "",
         scopes,
         expiresAt: exp,
-        extra: { subject: sub, ...rest },
-      } satisfies AuthInfo;
+        extra: { subject: sub, ...rest } as unknown as TExtra &
+          RegisteredClaims,
+      };
     },
   };
 }

--- a/packages/core/src/server/auth/verify.ts
+++ b/packages/core/src/server/auth/verify.ts
@@ -1,6 +1,6 @@
 import { InvalidTokenError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
 import * as jose from "jose";
-import type { AuthInfo, TokenVerifier } from "../auth.js";
+import type { AuthInfo, ExtraClaims, TokenVerifier } from "../auth.js";
 
 export type JwksVerifyConfig = {
   /** Expected `iss` claim. */
@@ -48,9 +48,9 @@ export type RegisteredClaims = {
  * @typeParam TExtra - Claims the verified token carries in `extra`. An
  * assertion, not a runtime check: nothing rejects a token whose claims differ.
  */
-export function createJwksVerifier<
-  TExtra extends Record<string, unknown> = Record<string, unknown>,
->(config: JwksVerifyConfig): TokenVerifier<TExtra & RegisteredClaims> {
+export function createJwksVerifier<TExtra extends ExtraClaims = ExtraClaims>(
+  config: JwksVerifyConfig,
+): TokenVerifier<TExtra & RegisteredClaims> {
   if (!config.issuer) {
     throw new Error("createJwksVerifier requires an `issuer`");
   }

--- a/packages/core/src/server/auth/verify.ts
+++ b/packages/core/src/server/auth/verify.ts
@@ -13,13 +13,17 @@ export type JwksVerifyConfig = {
 };
 
 /**
- * Registered JWT claims a verified token always carries into `extra`, since only
- * `client_id`, `scope`, `exp` and `sub` are lifted onto `AuthInfo` itself.
- * Intersected into every claim shape a JWKS verifier resolves.
+ * Claims a JWKS-verified token always carries into `extra`, whatever the IdP:
+ * `subject` (the renamed `sub`) plus the registered claims that survive the
+ * mapping. `client_id`, `scope` and `exp` do not appear here, since they become
+ * `AuthInfo` fields instead. Intersected into every claim shape a JWKS verifier
+ * resolves.
  *
  * @see https://datatracker.ietf.org/doc/html/rfc7519#section-4.1
  */
 export type RegisteredClaims = {
+  /** The token's `sub`, renamed on the way into `extra`. */
+  subject?: string;
   /** Issuer of the token. */
   iss?: string;
   /** Audience the token was minted for. */
@@ -31,15 +35,6 @@ export type RegisteredClaims = {
   /** Unique token id. */
   jti?: string;
 };
-
-/**
- * A {@link TokenVerifier} backed by a remote JWKS, carrying the verification
- * parameters it resolved. Read `config` to check what a provider derived from
- * discovery: the issuer and JWKS URL are the trust anchor.
- */
-export type JwksTokenVerifier<
-  TExtra extends Record<string, unknown> = Record<string, unknown>,
-> = TokenVerifier<TExtra> & { readonly config: Readonly<JwksVerifyConfig> };
 
 /**
  * Builds a {@link TokenVerifier} that validates JWTs against a remote JWKS.
@@ -55,7 +50,7 @@ export type JwksTokenVerifier<
  */
 export function createJwksVerifier<
   TExtra extends Record<string, unknown> = Record<string, unknown>,
->(config: JwksVerifyConfig): JwksTokenVerifier<TExtra & RegisteredClaims> {
+>(config: JwksVerifyConfig): TokenVerifier<TExtra & RegisteredClaims> {
   if (!config.issuer) {
     throw new Error("createJwksVerifier requires an `issuer`");
   }
@@ -65,7 +60,6 @@ export function createJwksVerifier<
   const jwks = jose.createRemoteJWKSet(new URL(jwksUri));
 
   return {
-    config: { ...config, jwksUri },
     async verifyAccessToken(
       token: string,
     ): Promise<AuthInfo<TExtra & RegisteredClaims>> {

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -1,9 +1,6 @@
 export type { OAuthConfig } from "./auth/index.js";
 export { type Auth0Claims, auth0Provider } from "./auth/providers/auth0.js";
-export {
-  type AuthplaneClaims,
-  authplaneProvider,
-} from "./auth/providers/authplane.js";
+export { authplaneProvider } from "./auth/providers/authplane.js";
 export { type ClerkClaims, clerkProvider } from "./auth/providers/clerk.js";
 export { customProvider } from "./auth/providers/custom.js";
 export {

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -1,11 +1,21 @@
 export type { OAuthConfig } from "./auth/index.js";
-export { auth0Provider } from "./auth/providers/auth0.js";
-export { authplaneProvider } from "./auth/providers/authplane.js";
-export { clerkProvider } from "./auth/providers/clerk.js";
+export { type Auth0Claims, auth0Provider } from "./auth/providers/auth0.js";
+export {
+  type AuthplaneClaims,
+  authplaneProvider,
+} from "./auth/providers/authplane.js";
+export { type ClerkClaims, clerkProvider } from "./auth/providers/clerk.js";
 export { customProvider } from "./auth/providers/custom.js";
-export { descopeProvider } from "./auth/providers/descope.js";
-export { stytchProvider } from "./auth/providers/stytch.js";
-export { workosProvider } from "./auth/providers/workos.js";
+export {
+  type DescopeClaims,
+  descopeProvider,
+} from "./auth/providers/descope.js";
+export { type StytchClaims, stytchProvider } from "./auth/providers/stytch.js";
+export { type WorkosClaims, workosProvider } from "./auth/providers/workos.js";
+export {
+  createJwksVerifier,
+  type JwksVerifyConfig,
+} from "./auth/verify.js";
 export {
   type AuthInfo,
   type AuthMetadataOptions,
@@ -14,6 +24,7 @@ export {
   mcpAuthMetadataRouter,
   optionalBearerAuth,
   requireBearerAuth,
+  type TokenVerifier,
 } from "./auth.js";
 export {
   audio,

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -17,6 +17,7 @@ export {
   type AuthInfo,
   type AuthMetadataOptions,
   type BearerAuthMiddlewareOptions,
+  type ExtraClaims,
   InvalidTokenError,
   mcpAuthMetadataRouter,
   optionalBearerAuth,

--- a/packages/core/src/server/middleware.ts
+++ b/packages/core/src/server/middleware.ts
@@ -21,11 +21,16 @@ import type {
   ServerRequest,
   ServerResult,
 } from "@modelcontextprotocol/sdk/types.js";
+import type { AuthInfo } from "./auth.js";
 
 /**
  * The `extra` context object provided by the MCP SDK to request handlers.
  */
-export type McpExtra = RequestHandlerExtra<ServerRequest, ServerNotification>;
+export type McpExtra<
+  TAuthExtra extends Record<string, unknown> = Record<string, unknown>,
+> = Omit<RequestHandlerExtra<ServerRequest, ServerNotification>, "authInfo"> & {
+  authInfo?: AuthInfo<TAuthExtra>;
+};
 
 /**
  * A single MCP middleware function following the onion model.
@@ -33,9 +38,11 @@ export type McpExtra = RequestHandlerExtra<ServerRequest, ServerNotification>;
  * For notifications, `extra` is `undefined` (SDK does not provide extra context)
  * and `next()` resolves to `undefined`.
  */
-export type McpMiddlewareFn = (
+export type McpMiddlewareFn<
+  TAuthExtra extends Record<string, unknown> = Record<string, unknown>,
+> = (
   request: { method: string; params: Record<string, unknown> },
-  extra: McpExtra | undefined,
+  extra: McpExtra<TAuthExtra> | undefined,
   next: () => Promise<unknown>,
 ) => Promise<unknown> | unknown;
 
@@ -64,11 +71,14 @@ export type McpRequestParams<M extends string> =
  * request methods, `undefined` for notification methods (the SDK does not
  * pass extra context for notifications).
  */
-export type McpExtraFor<M extends string> = M extends ClientRequest["method"]
-  ? McpExtra
+export type McpExtraFor<
+  M extends string,
+  TAuthExtra extends Record<string, unknown> = Record<string, unknown>,
+> = M extends ClientRequest["method"]
+  ? McpExtra<TAuthExtra>
   : M extends ClientNotification["method"]
     ? undefined
-    : McpExtra | undefined;
+    : McpExtra<TAuthExtra> | undefined;
 
 /** Maps each MCP request method to its SDK result type. */
 interface McpResultMap {
@@ -115,9 +125,12 @@ export type McpResultFor<M extends string> = M extends keyof McpResultMap
  * via {@link McpRequestParams}, `extra` via {@link McpExtraFor}, and the
  * resolved value of `next()` via {@link McpResultFor}.
  */
-export type McpTypedMiddlewareFn<M extends string> = (
+export type McpTypedMiddlewareFn<
+  M extends string,
+  TAuthExtra extends Record<string, unknown> = Record<string, unknown>,
+> = (
   request: { method: M; params: McpRequestParams<M> },
-  extra: McpExtraFor<M>,
+  extra: McpExtraFor<M, TAuthExtra>,
   next: () => Promise<McpResultFor<M>>,
 ) => Promise<unknown> | unknown;
 

--- a/packages/core/src/server/middleware.ts
+++ b/packages/core/src/server/middleware.ts
@@ -21,14 +21,15 @@ import type {
   ServerRequest,
   ServerResult,
 } from "@modelcontextprotocol/sdk/types.js";
-import type { AuthInfo } from "./auth.js";
+import type { AuthInfo, ExtraClaims } from "./auth.js";
 
 /**
  * The `extra` context object provided by the MCP SDK to request handlers.
  */
-export type McpExtra<
-  TAuthExtra extends Record<string, unknown> = Record<string, unknown>,
-> = Omit<RequestHandlerExtra<ServerRequest, ServerNotification>, "authInfo"> & {
+export type McpExtra<TAuthExtra extends ExtraClaims = ExtraClaims> = Omit<
+  RequestHandlerExtra<ServerRequest, ServerNotification>,
+  "authInfo"
+> & {
   authInfo?: AuthInfo<TAuthExtra>;
 };
 
@@ -38,9 +39,7 @@ export type McpExtra<
  * For notifications, `extra` is `undefined` (SDK does not provide extra context)
  * and `next()` resolves to `undefined`.
  */
-export type McpMiddlewareFn<
-  TAuthExtra extends Record<string, unknown> = Record<string, unknown>,
-> = (
+export type McpMiddlewareFn<TAuthExtra extends ExtraClaims = ExtraClaims> = (
   request: { method: string; params: Record<string, unknown> },
   extra: McpExtra<TAuthExtra> | undefined,
   next: () => Promise<unknown>,
@@ -73,7 +72,7 @@ export type McpRequestParams<M extends string> =
  */
 export type McpExtraFor<
   M extends string,
-  TAuthExtra extends Record<string, unknown> = Record<string, unknown>,
+  TAuthExtra extends ExtraClaims = ExtraClaims,
 > = M extends ClientRequest["method"]
   ? McpExtra<TAuthExtra>
   : M extends ClientNotification["method"]
@@ -127,7 +126,7 @@ export type McpResultFor<M extends string> = M extends keyof McpResultMap
  */
 export type McpTypedMiddlewareFn<
   M extends string,
-  TAuthExtra extends Record<string, unknown> = Record<string, unknown>,
+  TAuthExtra extends ExtraClaims = ExtraClaims,
 > = (
   request: { method: M; params: McpRequestParams<M> },
   extra: McpExtraFor<M, TAuthExtra>,

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -39,6 +39,7 @@ import {
   inBandChallengeResult,
 } from "./auth/security-schemes.js";
 import { type ResourceMetadataUrlResolver, setupOAuth } from "./auth/setup.js";
+import type { AuthInfo } from "./auth.js";
 import { createApp } from "./express.js";
 import { hostFromUserAgent } from "./host.js";
 import { createMiddlewareEntry } from "./metric.js";
@@ -353,10 +354,12 @@ type AddTool<
   TInput extends ZodRawShapeCompat,
   TOutput,
   TResponseMetadata = unknown,
+  TAuthExtra extends Record<string, unknown> = Record<string, unknown>,
 > = McpServer<
   TTools & {
     [K in TName]: ToolDef<ShapeOutput<TInput>, TOutput, TResponseMetadata>;
-  }
+  },
+  TAuthExtra
 >;
 
 interface ToolConfigBase<TInput extends ZodRawShapeCompat | AnySchema> {
@@ -421,19 +424,23 @@ export interface ClientHintsMeta {
   "openai/widgetSessionId"?: string;
 }
 
-type ToolHandlerExtra = Omit<
+type ToolHandlerExtra<
+  TAuthExtra extends Record<string, unknown> = Record<string, unknown>,
+> = Omit<
   RequestHandlerExtra<ServerRequest, ServerNotification>,
-  "_meta"
+  "_meta" | "authInfo"
 > & {
   _meta?: RequestMeta & ClientHintsMeta;
+  authInfo?: AuthInfo<TAuthExtra>;
 };
 
 type ToolHandler<
   TInput extends ZodRawShapeCompat,
   TReturn extends { content?: HandlerContent } = { content?: HandlerContent },
+  TAuthExtra extends Record<string, unknown> = Record<string, unknown>,
 > = (
   args: ShapeOutput<TInput>,
-  extra: ToolHandlerExtra,
+  extra: ToolHandlerExtra<TAuthExtra>,
 ) => TReturn | Promise<TReturn>;
 
 type ErrorMiddlewareConfig = {
@@ -583,6 +590,7 @@ function normalizeRegisterToolArgs(args: unknown[]): {
 
 export class McpServer<
   TTools extends Record<string, ToolDef> = Record<never, ToolDef>,
+  TAuthExtra extends Record<string, unknown> = Record<string, unknown>,
 > extends McpServerBaseOmitted {
   declare readonly $types: McpServerTypes<TTools>;
   /**
@@ -674,6 +682,42 @@ export class McpServer<
   }
 
   /**
+   * Declare the shape of the verified token's `extra` claims. Type-only: the
+   * call returns the same instance and does nothing at runtime, it only carries
+   * `TExtra` so tool handlers and {@link McpServer.mcpMiddleware} read
+   * `extra.authInfo.extra` without casting. Chain it before the tools that
+   * depend on it.
+   *
+   * The shape is an assertion about what your verifier puts in `extra`, never a
+   * runtime check. A claim the provider omits reads as `undefined` whatever the
+   * type says, so keep optional claims optional.
+   *
+   * @typeParam TExtra - Claims the verifier resolves with, mirroring the
+   * `AuthInfo<TExtra>` returned by `verifyAccessToken`. Declare it as a type
+   * alias; an `interface` needs `extends Record<string, unknown>` to satisfy the
+   * constraint.
+   *
+   * @example
+   * ```ts
+   * type Claims = { subject?: string; email?: string };
+   *
+   * const server = new McpServer(info, {}, { oauth })
+   *   .withAuthExtra<Claims>()
+   *   .registerTool({ name: "orders", inputSchema: {} }, (_args, extra) => ({
+   *     content: `Orders for ${extra.authInfo?.extra?.email}`,
+   *   }));
+   * ```
+   *
+   * @see https://docs.skybridge.tech/api-reference/mcp-server#withauthextra
+   */
+  withAuthExtra<TExtra extends Record<string, unknown>>(): McpServer<
+    TTools,
+    TExtra
+  > {
+    return this as unknown as McpServer<TTools, TExtra>;
+  }
+
+  /**
    * Register Express middleware on the underlying app. Mirrors `app.use` —
    * pass handlers directly or a path-prefixed handler list. Register before
    * {@link McpServer.run}; ordering matches Express.
@@ -727,13 +771,13 @@ export class McpServer<
   }
 
   /** Register MCP protocol-level middleware (catch-all). */
-  mcpMiddleware(handler: McpMiddlewareFn): this;
+  mcpMiddleware(handler: McpMiddlewareFn<TAuthExtra>): this;
   /** Register MCP protocol-level middleware for all requests (`extra` is `McpExtra`). */
   mcpMiddleware(
     filter: "request",
     handler: (
       request: { method: string; params: Record<string, unknown> },
-      extra: McpExtra,
+      extra: McpExtra<TAuthExtra>,
       next: () => Promise<ServerResult>,
     ) => Promise<unknown> | unknown,
   ): this;
@@ -752,7 +796,7 @@ export class McpServer<
    */
   mcpMiddleware<M extends McpMethodString>(
     filter: M,
-    handler: McpTypedMiddlewareFn<M>,
+    handler: McpTypedMiddlewareFn<M, TAuthExtra>,
   ): this;
   /**
    * Register MCP protocol-level middleware for a wildcard pattern (e.g. `"tools/*"`).
@@ -762,7 +806,7 @@ export class McpServer<
     filter: W,
     handler: (
       request: { method: string; params: Record<string, unknown> },
-      extra: McpExtraFor<W>,
+      extra: McpExtraFor<W, TAuthExtra>,
       next: () => Promise<McpResultFor<W>>,
     ) => Promise<unknown> | unknown,
   ): this;
@@ -771,9 +815,12 @@ export class McpServer<
    * Filter can be an exact method (`"tools/call"`), wildcard (`"tools/*"`),
    * category (`"request"` | `"notification"`), or an array of those.
    */
-  mcpMiddleware(filter: McpMiddlewareFilter, handler: McpMiddlewareFn): this;
   mcpMiddleware(
-    filterOrHandler: McpMiddlewareFilter | McpMiddlewareFn,
+    filter: McpMiddlewareFilter,
+    handler: McpMiddlewareFn<TAuthExtra>,
+  ): this;
+  mcpMiddleware(
+    filterOrHandler: McpMiddlewareFilter | McpMiddlewareFn<TAuthExtra>,
     // biome-ignore lint/suspicious/noExplicitAny: overloads narrow the handler type at call sites; implementation must accept all variants
     maybeHandler?: any,
   ): this {
@@ -788,7 +835,7 @@ export class McpServer<
     if (typeof filterOrHandler === "function") {
       this.mcpMiddlewareEntries.push({
         filter: null,
-        handler: filterOrHandler,
+        handler: filterOrHandler as McpMiddlewareFn,
       });
     } else if (handler) {
       this.mcpMiddlewareEntries.push({
@@ -1411,17 +1458,18 @@ export class McpServer<
     TReturn extends { content?: HandlerContent },
   >(
     config: ToolConfig<InputArgs> & { name: TName },
-    cb: ToolHandler<InputArgs, TReturn>,
+    cb: ToolHandler<InputArgs, TReturn, TAuthExtra>,
   ): AddTool<
     TTools,
     TName,
     InputArgs,
     ExtractStructuredContent<TReturn>,
-    ExtractMeta<TReturn>
+    ExtractMeta<TReturn>,
+    TAuthExtra
   >;
   registerTool<InputArgs extends ZodRawShapeCompat>(
     config: ToolConfig<InputArgs>,
-    cb: ToolHandler<InputArgs>,
+    cb: ToolHandler<InputArgs, { content?: HandlerContent }, TAuthExtra>,
   ): this;
   registerTool(...args: unknown[]): unknown {
     const baseFn = McpServerBase.prototype.registerTool as (

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -191,12 +191,20 @@ export type ToolAuth = {
  */
 export type JsonOptions = NonNullable<Parameters<typeof express.json>[0]>;
 
-/** Skybridge-specific server options, passed as the third `McpServer` constructor argument. */
-export interface SkybridgeServerOptions {
+/**
+ * Skybridge-specific server options, passed as the third `McpServer` constructor
+ * argument.
+ *
+ * @typeParam TAuthExtra - Claims the `oauth` verifier populates. Inferred from
+ * the config a provider returns, and carried on to tool handlers.
+ */
+export interface SkybridgeServerOptions<
+  TAuthExtra extends Record<string, unknown> = Record<string, unknown>,
+> {
   /** Options for the built-in `express.json()` middleware, e.g. `{ limit: "10mb" }`. */
   json?: JsonOptions;
   /** Resource-server OAuth config. When set, mounts well-known metadata and bearer auth on `/mcp`. */
-  oauth?: OAuthConfig;
+  oauth?: OAuthConfig<TAuthExtra>;
   /**
    * @experimental Serve Agent Skills from `src/skills` over MCP (SEP-2640).
    * API may change.
@@ -636,7 +644,7 @@ export class McpServer<
   constructor(
     serverInfo: Implementation,
     options?: ServerOptions,
-    skybridgeOptions?: SkybridgeServerOptions,
+    skybridgeOptions?: SkybridgeServerOptions<TAuthExtra>,
   ) {
     const mergedOptions = withSkillsCapability(options, skybridgeOptions);
     super(serverInfo, mergedOptions);
@@ -679,42 +687,6 @@ export class McpServer<
     }
 
     registerSkills(this, skills);
-  }
-
-  /**
-   * Declare the shape of the verified token's `extra` claims. Type-only: the
-   * call returns the same instance and does nothing at runtime, it only carries
-   * `TExtra` so tool handlers and {@link McpServer.mcpMiddleware} read
-   * `extra.authInfo.extra` without casting. Chain it before the tools that
-   * depend on it.
-   *
-   * The shape is an assertion about what your verifier puts in `extra`, never a
-   * runtime check. A claim the provider omits reads as `undefined` whatever the
-   * type says, so keep optional claims optional.
-   *
-   * @typeParam TExtra - Claims the verifier resolves with, mirroring the
-   * `AuthInfo<TExtra>` returned by `verifyAccessToken`. Declare it as a type
-   * alias; an `interface` needs `extends Record<string, unknown>` to satisfy the
-   * constraint.
-   *
-   * @example
-   * ```ts
-   * type Claims = { subject?: string; email?: string };
-   *
-   * const server = new McpServer(info, {}, { oauth })
-   *   .withAuthExtra<Claims>()
-   *   .registerTool({ name: "orders", inputSchema: {} }, (_args, extra) => ({
-   *     content: `Orders for ${extra.authInfo?.extra?.email}`,
-   *   }));
-   * ```
-   *
-   * @see https://docs.skybridge.tech/api-reference/mcp-server#withauthextra
-   */
-  withAuthExtra<TExtra extends Record<string, unknown>>(): McpServer<
-    TTools,
-    TExtra
-  > {
-    return this as unknown as McpServer<TTools, TExtra>;
   }
 
   /**

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -39,7 +39,7 @@ import {
   inBandChallengeResult,
 } from "./auth/security-schemes.js";
 import { type ResourceMetadataUrlResolver, setupOAuth } from "./auth/setup.js";
-import type { AuthInfo } from "./auth.js";
+import type { AuthInfo, ExtraClaims } from "./auth.js";
 import { createApp } from "./express.js";
 import { hostFromUserAgent } from "./host.js";
 import { createMiddlewareEntry } from "./metric.js";
@@ -199,7 +199,7 @@ export type JsonOptions = NonNullable<Parameters<typeof express.json>[0]>;
  * the config a provider returns, and carried on to tool handlers.
  */
 export interface SkybridgeServerOptions<
-  TAuthExtra extends Record<string, unknown> = Record<string, unknown>,
+  TAuthExtra extends ExtraClaims = ExtraClaims,
 > {
   /** Options for the built-in `express.json()` middleware, e.g. `{ limit: "10mb" }`. */
   json?: JsonOptions;
@@ -362,7 +362,7 @@ type AddTool<
   TInput extends ZodRawShapeCompat,
   TOutput,
   TResponseMetadata = unknown,
-  TAuthExtra extends Record<string, unknown> = Record<string, unknown>,
+  TAuthExtra extends ExtraClaims = ExtraClaims,
 > = McpServer<
   TTools & {
     [K in TName]: ToolDef<ShapeOutput<TInput>, TOutput, TResponseMetadata>;
@@ -432,9 +432,7 @@ export interface ClientHintsMeta {
   "openai/widgetSessionId"?: string;
 }
 
-type ToolHandlerExtra<
-  TAuthExtra extends Record<string, unknown> = Record<string, unknown>,
-> = Omit<
+type ToolHandlerExtra<TAuthExtra extends ExtraClaims = ExtraClaims> = Omit<
   RequestHandlerExtra<ServerRequest, ServerNotification>,
   "_meta" | "authInfo"
 > & {
@@ -445,7 +443,7 @@ type ToolHandlerExtra<
 type ToolHandler<
   TInput extends ZodRawShapeCompat,
   TReturn extends { content?: HandlerContent } = { content?: HandlerContent },
-  TAuthExtra extends Record<string, unknown> = Record<string, unknown>,
+  TAuthExtra extends ExtraClaims = ExtraClaims,
 > = (
   args: ShapeOutput<TInput>,
   extra: ToolHandlerExtra<TAuthExtra>,
@@ -598,7 +596,7 @@ function normalizeRegisterToolArgs(args: unknown[]): {
 
 export class McpServer<
   TTools extends Record<string, ToolDef> = Record<never, ToolDef>,
-  TAuthExtra extends Record<string, unknown> = Record<string, unknown>,
+  TAuthExtra extends ExtraClaims = ExtraClaims,
 > extends McpServerBaseOmitted {
   declare readonly $types: McpServerTypes<TTools>;
   /**

--- a/skills/chatgpt-app-builder/references/oauth.md
+++ b/skills/chatgpt-app-builder/references/oauth.md
@@ -99,11 +99,7 @@ server.registerTool(
 );
 ```
 
-For a claim the provider does not ship by default, name it on the provider. No provider puts `email` in an access token unless a JWT template or claims action adds it:
-
-```typescript
-oauth: await workosProvider<{ email?: string }>({ domain, audience }),
-```
+For a claim the provider does not ship by default, name it on the provider: `workosProvider<{ email?: string }>({ ... })`. No provider puts `email` in an access token unless a JWT template or claims action adds it.
 
 ## 4. Mixed auth: per-tool `auth`
 

--- a/skills/chatgpt-app-builder/references/oauth.md
+++ b/skills/chatgpt-app-builder/references/oauth.md
@@ -84,23 +84,25 @@ oauth: await customProvider({
 
 ## 3. Read auth in handlers
 
-`extra.authInfo` carries the verified token. Its `extra.subject` holds the `sub` claim; all other JWT claims (e.g. `email`) are spread alongside it.
+`extra.authInfo` carries the verified token. Its `extra.subject` holds the `sub` claim; all other JWT claims are spread alongside it, typed from the claims the provider documents, so no cast is needed.
 
 ```typescript
-import type { AuthInfo } from "skybridge/server";
-
 server.registerTool(
   { name: "get-orders", description: "Get user orders" },
   async (_input, extra) => {
-    const auth = extra.authInfo as AuthInfo;
-    const subject = auth.extra?.subject as string;
-    const orders = await fetchOrders(subject);
+    const orders = await fetchOrders(extra.authInfo?.extra?.subject);
     return {
       structuredContent: { orders },
       content: [{ type: "text", text: `Found ${orders.length} orders` }],
     };
   },
 );
+```
+
+For a claim the provider does not ship by default, name it on the provider. No provider puts `email` in an access token unless a JWT template or claims action adds it:
+
+```typescript
+oauth: await workosProvider<{ email?: string }>({ domain, audience }),
 ```
 
 ## 4. Mixed auth: per-tool `auth`


### PR DESCRIPTION
Closes #1016

## Summary

- `AuthInfo<TExtra>` types the `extra` claim bag; bare `AuthInfo` is unchanged.
- The claim type is owned by the verifier and flows outward: `createJwksVerifier` → `OAuthConfig<TExtra>` → `SkybridgeServerOptions<TExtra>` → inferred at `new McpServer(...)` → tool handlers and `mcpMiddleware`.
- Each branded provider ships the claims its docs promise, so `workosProvider()` alone types `extra.authInfo?.extra?.org_id`. Every field is optional, since claims are tenant-configurable.
- Override per provider to add your own: `workosProvider<{ tenant: string }>({ ... })` intersects with the provider's base, so IdP claims are never redeclared.
- Casts dropped from all 7 auth examples.
- `OAuthConfig` gains `verifier` (the built verifier, carrying the claim type) alongside the now-deprecated `verify` parameters. Exactly one is required, enforced by the type. A hand-built config keeps working on `verify`, with claims left as `Record<string, unknown>`.

Additive: `TAuthExtra` is a second generic with a default, so positional `McpServer<MyTools>` and plain `McpServer` annotations keep working.

## Alternatives Considered

**A server-level `withAuthExtra<Claims>()` carrier**, chained before the tools, in the style of Fastify's `withTypeProvider` and tRPC's `.context`. It covers every path, including a hand-written verifier mounted through `requireBearerAuth` with no `oauth` option at all. Rejected on Fred's review: a no-op call that exists only to carry a type is a lot of API surface, and it puts the declaration somewhere the verifier's actual return type cannot be checked against, so the two can silently diverge. Attaching the type to the verifier gives one source instead of two.

**Generic reordering (`new McpServer<Claims>(...)`).** Reads well and is what Hono and Kysely do. Rejected because it reorders `McpServer`'s type params, breaking positional `McpServer<MyTools>` users for a type-only feature.

**A zod claims schema on `oauth.verify`, inferred into the generic.** Would validate claims at the JWKS boundary rather than asserting them. Rejected because `extra` is not always JWT claims: a hand-written `verifyAccessToken` doing introspection or a DB lookup fills it too, and those apps have no `oauth.verify` to hang a schema on.

**Declaration merging on an `AuthExtra` interface**, as Passport does with `Express.User`. Smallest diff, but one global shape per app and no way to differ between two auth sources.

## Compatibility

One breaking change, and it only bites code reading the resolved JWKS parameters off a provider's result:

- A provider now returns `verifier`, not `verify`, so `(await workosProvider({ … })).verify.issuer` no longer compiles, and reads as `undefined` at runtime in JS. The issuer and JWKS URL are still what discovery resolved; nothing else about them changed. Hand-built configs are unaffected, since `verify` stays accepted as an input.

Two further type-level effects, both runtime-neutral:

- Reading a claim a provider does not declare now errors where it used to be `unknown` — for example `extra.authInfo?.extra?.my_claim` on a WorkOS-typed server. Name it on the provider (`workosProvider<{ my_claim: string }>({ ... })`), or keep casting through bare `AuthInfo`, which still compiles.
- Passing `TTools` explicitly (`new McpServer<MyTools>(...)`) falls back to the untyped claim bag: TypeScript has no partial type-argument inference, so naming the first generic drops inference of the second. Leave `TTools` inferred.

Everything else is unchanged, verified against `main`: no export removed, bare `AuthInfo` interchangeable with the SDK's in both directions, bare `OAuthConfig`, bare `McpServer`, positional `McpServer<MyTools>`, `InferTools`/`$types`, a no-`oauth` server's untyped claim bag, and the `extra.authInfo as AuthInfo` pattern all still compile. Runtime verification and `extra` contents are identical.

## Notes

- Still an assertion, not a runtime check: nothing validates that a token carries the declared claims. What changes is that the type has a single owner.
- Provider defaults are drawn from each provider's own docs and linked in TSDoc. No provider ships `email` in an access token; where a JWT template or claims action can add it, it is typed optional. Auth0 is excluded because non-namespaced custom claims on an API-audience access token are silently dropped there.
- `RegisteredClaims` (`iss`, `aud`, `iat`, `nbf`, `jti`) is intersected into every JWKS-verified shape, since those claims survive the mapping into `extra` and code reading them would otherwise stop compiling.
- Writing the verifier by hand still works: type it `TokenVerifier<Claims>` and put it in the config, and the shape flows the same way. Only the middleware-only path (`requireBearerAuth` with no `oauth` option) gets nothing, since there is no config for the type to travel through.
- Spreading a provider config to swap its verifier (`{ ...config, verifier }`) no longer type-checks, since the union forbids carrying both fields. Build the config explicitly instead.
