### PR TITLE
fix(auth): keep verifier messages safe inside the WWW-Authenticate challenge

### DIFF
--- a/packages/core/src/server/auth/verify.test.ts
+++ b/packages/core/src/server/auth/verify.test.ts
@@ -83,6 +83,62 @@ describe("createJwksVerifier", () => {
     );
   });
 
+  // jose quotes claim names — `"exp" claim timestamp check failed`, `unexpected
+  // "aud" claim value`. Those quotes would close `error_description="…"` early,
+  // dropping the `resource_metadata` that MCP clients start discovery from.
+  it.each([
+    [
+      "an expired token",
+      (key: CryptoKey) => sign(key, {}, { expiresAt: "-1h" }),
+      // jose: `"exp" claim timestamp check failed`
+      "Token verification failed: exp  claim timestamp check failed",
+    ],
+    [
+      "a token issued for another resource",
+      (key: CryptoKey) => sign(key, {}, { audience: "api://other" }),
+      // jose: `unexpected "aud" claim value`
+      "Token verification failed: unexpected  aud  claim value",
+    ],
+    [
+      "a token from another issuer",
+      (key: CryptoKey) => sign(key, {}, { issuer: "https://other.test" }),
+      // jose: `unexpected "iss" claim value`
+      "Token verification failed: unexpected  iss  claim value",
+    ],
+    [
+      "a token carrying no aud claim",
+      (key: CryptoKey) =>
+        new jose.SignJWT({})
+          .setProtectedHeader({ alg: "RS256", kid: "test-key" })
+          .setIssuer(ISSUER)
+          .setExpirationTime("1h")
+          .sign(key),
+      // jose: `missing required "aud" claim`
+      "Token verification failed: missing required  aud  claim",
+    ],
+  ])(
+    "keeps the message safe inside the challenge for %s",
+    async (_, mint, expected) => {
+      const { privateKey, jwksUri } = await startJwks();
+      const verifier = createJwksVerifier({
+        issuer: ISSUER,
+        audience: AUDIENCE,
+        jwksUri,
+      });
+
+      const error = await verifier
+        .verifyAccessToken(await mint(privateKey))
+        .then(
+          () => undefined,
+          (e: Error) => e,
+        );
+
+      expect(error?.message).toBe(expected);
+      // OAuth 2.1 §5.3.1: %x20-21 / %x23-5B / %x5D-7E and nothing else.
+      expect(error?.message).not.toMatch(/[^\x20-\x21\x23-\x5B\x5D-\x7E]/);
+    },
+  );
+
   it("skips the aud check when no audience is configured (e.g. Clerk)", async () => {
     const { privateKey, jwksUri } = await startJwks();
     const verifier = createJwksVerifier({ issuer: ISSUER, jwksUri });

--- a/packages/core/src/server/auth/verify.ts
+++ b/packages/core/src/server/auth/verify.ts
@@ -33,7 +33,17 @@ export function createJwksVerifier(
         }));
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        throw new InvalidTokenError(`Token verification failed: ${message}`);
+        // This reaches the `error_description` of a `WWW-Authenticate`
+        // challenge, whose value must not include characters outside
+        // %x20-21 / %x23-5B / %x5D-7E (OAuth 2.1 §5.3.1, RFC 6750 §3). jose
+        // quotes claim names in its messages, and a quote would end the
+        // parameter early, dropping the `resource_metadata` that follows it.
+        // Each run becomes a space rather than being dropped, so removing one
+        // never runs two words together.
+        const safe = message
+          .replace(/[^\x20-\x21\x23-\x5B\x5D-\x7E]+/g, " ")
+          .trim();
+        throw new InvalidTokenError(`Token verification failed: ${safe}`);
       }
 
       const { client_id, scope, exp, sub, ...rest } = payload as Record<


### PR DESCRIPTION
`createJwksVerifier` interpolates the underlying JOSE error into `InvalidTokenError`, and `requireBearerAuth` places that message in the `error_description` parameter of the `WWW-Authenticate` challenge. JOSE quotes claim names in its messages, so the parameter closes early and everything after it — including `resource_metadata` — is left unparseable.

OAuth 2.1 §5.3.1 (RFC 6750 §3) requires `error` and `error_description` values to contain no characters outside `%x20-21 / %x23-5B / %x5D-7E`, and defines no escaping mechanism for them, so the constraint has to be met by the value itself.

Four of the conditions a resource server sees routinely produce a message carrying quotes:

| condition | JOSE message |
|---|---|
| token expired | `"exp" claim timestamp check failed` |
| `aud` does not match | `unexpected "aud" claim value` |
| `iss` does not match | `unexpected "iss" claim value` |
| no `aud` claim | `missing required "aud" claim` |

Expiry is the notable one — it happens on a timer in a healthy deployment, and the challenge that tells the client where to re-authenticate is the one truncated.

## Contents

| | |
|---|---|
| `packages/core/src/server/auth/verify.ts` | constrain the message to the permitted set |
| `packages/core/src/server/auth/verify.test.ts` | 4 tests |

## Behaviour

Each run of disallowed octets becomes one space rather than being dropped, so removing a character never runs two words together.

`Token verification failed: "exp" claim timestamp check failed` becomes `Token verification failed: exp  claim timestamp check failed`.

## Verification

`@skybridge/core`: 400 tests across 54 files pass, `biome ci` clean across 169 files.

The four cases sign real tokens against a live JWKS and assert the complete message. All four fail against `main` on exact-string equality.
