### PR TITLE
feat(examples): add docs-qa

### DIFF
--- a/examples/docs-qa/.env.example
+++ b/examples/docs-qa/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=

--- a/examples/docs-qa/.gitignore
+++ b/examples/docs-qa/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+.env*
+.DS_store
+*.tsbuildinfo
+.skybridge/
+.vercel/

--- a/examples/docs-qa/README.md
+++ b/examples/docs-qa/README.md
@@ -1,0 +1,137 @@
+# Docs Q&A Example
+
+An example MCP app built with [Skybridge](https://docs.skybridge.tech/home): retrieval-augmented Q&A over the Skybridge documentation, with a cited-answer view where every claim links back to the exact docs passage it came from.
+
+## What This Example Showcases
+
+- **Server-Side RAG Pipeline**: The MCP server ingests the live docs (fetch → chunk by section → embed), retrieves the passages most similar to the question, and generates an answer constrained to those passages
+- **Cited Answers**: Every claim in the answer carries a `[n]` citation rendered as an interactive chip; clicking it opens the exact source passage the claim came from
+- **Source-Passage Previews**: Each source expands to show the retrieved docs passage, its similarity score, and a deep link into [docs.skybridge.tech](https://docs.skybridge.tech) via [useOpenExternal()](https://docs.skybridge.tech/api-reference/use-open-external)
+- **Follow-Up Questions from the Widget**: An input inside the view calls the same tool again using [useCallTool()](https://docs.skybridge.tech/api-reference/use-call-tool)
+- **Model/View Data Separation**: The compact cited answer goes to the model via `structuredContent`, while the full passage texts ship view-only in `_meta` so the model's context isn't flooded with raw docs ([registerTool return](https://docs.skybridge.tech/api-reference/register-tool#return))
+- **Dynamic LLM Context with `data-llm`**: The view narrates which source the user is reading via the [data-llm](https://docs.skybridge.tech/api-reference/data-llm) attribute, so follow-ups like "tell me more about this one" resolve correctly
+- **Tool Info Access**: The view reads the mounting tool call's output and metadata via [useToolInfo()](https://docs.skybridge.tech/api-reference/use-tool-info)
+- **Theme Support**: Adapts to the host's light/dark theme via [useLayout()](https://docs.skybridge.tech/api-reference/use-layout)
+- **Hot Module Replacement**: [Live reloading](https://docs.skybridge.tech/concepts/fast-iteration#hmr-with-vite-plugin) of widget components during development
+- **Local DevTools**: [DevTools](https://docs.skybridge.tech/test/devtools) at `http://localhost:3000` for local testing
+
+## How It Works
+
+```
+question ──► embed ──► cosine top-k over doc chunks ──► answer model ──► cited answer
+                          ▲                                                  │
+llms.txt + per-page .md ──┘ (fetched & chunked at first use, cached 1h)      ▼
+                                                    view: answer + [n] chips + passage previews
+```
+
+1. **Ingest** (`src/rag/corpus.ts`): the docs site publishes an index of every page at [`/llms.txt`](https://docs.skybridge.tech/llms.txt) and each page as raw markdown at `<page-url>.md`. The server fetches all pages and splits them into per-section chunks that remember their page, heading, and deep-link anchor.
+2. **Index** (`src/rag/retrieval.ts`): each chunk is embedded (prefixed with its page › section breadcrumb for context) with `text-embedding-3-small`. The index is built lazily on the first question and cached in memory for an hour.
+3. **Retrieve**: the question is embedded and the top 5 chunks by cosine similarity are selected.
+4. **Generate** (`src/rag/answer.ts`): an answer model writes a short answer constrained to the retrieved passages, citing them inline as `[1]`, `[2]`, …
+5. **Render** (`src/views/ask-docs.tsx`): the view shows the answer with clickable citation chips, expandable source-passage previews, and a follow-up input.
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js 24+
+- **OpenAI API key** (see step 2 below)
+
+### Local Development
+
+#### 1. Install
+
+```bash
+npm install
+# or
+yarn install
+# or
+pnpm install
+# or
+bun install
+```
+
+#### 2. Set up your OpenAI API key
+
+This example uses the OpenAI API for embeddings and answer generation:
+
+1. Create an API key on the [OpenAI platform](https://platform.openai.com/api-keys).
+2. Create a `.env` file in the project root with your key. See `.env.example` for the format.
+
+Optional environment overrides:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `OPENAI_ANSWER_MODEL` | `gpt-5-mini` | Model that writes the cited answer |
+| `OPENAI_EMBEDDING_MODEL` | `text-embedding-3-small` | Model used to embed chunks and questions |
+| `OPENAI_BASE_URL` | `https://api.openai.com/v1` | Point at a compatible proxy or gateway |
+
+#### 3. Start your local server
+
+```bash
+npm run dev
+# or
+yarn dev
+# or
+pnpm dev
+# or
+bun dev
+```
+
+This command starts:
+
+- Your MCP server at `http://localhost:3000/mcp`.
+- Skybridge DevTools UI at `http://localhost:3000/`.
+
+Try asking: _"How do I call a tool from a view?"_ or _"What does data-llm do?"_
+
+The first question triggers the docs ingestion and embedding, so it takes a few extra seconds; later questions reuse the cached index.
+
+#### 4. Project structure
+
+```
+├── src/
+│   ├── server.ts          # MCP server: the ask-docs tool
+│   ├── env.ts             # Loads .env
+│   ├── helpers.ts         # Typed hooks inferred from the server
+│   ├── index.css          # Global styles
+│   ├── rag/
+│   │   ├── corpus.ts      # Fetch llms.txt + page markdown, chunk by section
+│   │   ├── retrieval.ts   # Embedding index + cosine top-k search
+│   │   ├── answer.ts      # Cited answer generation
+│   │   └── openai.ts      # Minimal fetch-based OpenAI client
+│   └── views/
+│       └── ask-docs.tsx   # Cited answer + source previews + follow-up input
+├── .env.example           # OpenAI API key template
+├── alpic.json             # Deployment config
+└── package.json
+```
+
+### Testing your App
+
+You can test your App locally by using our DevTools UI on `http://localhost:3000` while running the dev command.
+
+To test your app with other MCP Clients like ChatGPT, Claude or VSCode, see [Testing Your App](https://docs.skybridge.tech/quickstart/test-your-app).
+
+## Adapting This Example to Your Own Docs
+
+The pipeline is corpus-agnostic: any Mintlify-hosted docs expose the same `llms.txt` + per-page `.md` endpoints, so pointing `DOCS_INDEX_URL` in `src/rag/corpus.ts` at another docs site is usually enough. For other corpora, replace `loadCorpus()` with anything that returns `DocChunk`s (markdown files on disk, a CMS export, a sitemap crawl…) and the retrieval, generation, and view layers keep working unchanged.
+
+## Deploy to Production
+
+Skybridge is infrastructure vendor agnostic, and your app can be deployed on any cloud platform supporting MCP.
+
+The simplest way to deploy your App in minutes is [Alpic](https://alpic.ai/).
+
+1. Create an account on [Alpic platform](https://app.alpic.ai/).
+2. Connect your GitHub repository to automatically deploy at each commit.
+3. Use your remote App URL to connect it to MCP Clients, or use the Alpic Playground to easily test your App.
+
+[![Deploy it on Alpic](https://assets.alpic.ai/button.svg)](https://app.alpic.ai/new/clone?repositoryUrl=https://github.com/alpic-ai/skybridge&rootDir=examples/docs-qa)
+
+## Resources
+
+- [Skybridge Documentation](https://docs.skybridge.tech/)
+- [Apps SDK Documentation](https://developers.openai.com/apps-sdk)
+- [Model Context Protocol Documentation](https://modelcontextprotocol.io/)
+- [Alpic Documentation](https://docs.alpic.ai/)

--- a/examples/docs-qa/alpic.json
+++ b/examples/docs-qa/alpic.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://assets.alpic.ai/alpic.json"
+}

--- a/examples/docs-qa/package.json
+++ b/examples/docs-qa/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "skybridge-docs-qa-example",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Skybridge Docs Q&A Example",
+  "type": "module",
+  "scripts": {
+    "dev": "skybridge dev",
+    "dev:tunnel": "skybridge dev --tunnel",
+    "build": "skybridge build",
+    "start": "skybridge start",
+    "deploy": "alpic deploy --non-interactive"
+  },
+  "dependencies": {
+    "@alpic-ai/ui": "^1.122.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "lucide-react": "^1.14.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "skybridge": "^1.1.1",
+    "tw-animate-css": "^1.4.0",
+    "vite": "^8.1.5",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@skybridge/devtools": "^1.1.0",
+    "@tailwindcss/vite": "^4.2.4",
+    "@types/node": "^24.12.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.1",
+    "alpic": "^1.104.1",
+    "tailwindcss": "^4.2.4",
+    "tsx": "^4.21.0",
+    "typescript": "^6.0.2"
+  },
+  "engines": {
+    "node": ">=24.14.1"
+  }
+}

--- a/examples/docs-qa/src/env.ts
+++ b/examples/docs-qa/src/env.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { parseEnv } from "node:util";
+
+try {
+  Object.assign(
+    process.env,
+    parseEnv(readFileSync(resolve(process.cwd(), ".env"), "utf8")),
+  );
+} catch {
+  // no env file
+}

--- a/examples/docs-qa/src/helpers.ts
+++ b/examples/docs-qa/src/helpers.ts
@@ -1,0 +1,4 @@
+import { generateHelpers } from "skybridge/web";
+import type { AppType } from "./server.js";
+
+export const { useCallTool, useToolInfo } = generateHelpers<AppType>();

--- a/examples/docs-qa/src/index.css
+++ b/examples/docs-qa/src/index.css
@@ -1,0 +1,5 @@
+@import "tailwindcss";
+@import "tw-animate-css";
+@import "@alpic-ai/ui/theme";
+
+@source "../node_modules/@alpic-ai/ui/src";

--- a/examples/docs-qa/src/rag/answer.ts
+++ b/examples/docs-qa/src/rag/answer.ts
@@ -1,0 +1,36 @@
+import { complete } from "./openai.js";
+import type { RetrievedChunk } from "./retrieval.js";
+
+const SYSTEM_PROMPT = `You answer questions about Skybridge, a fullstack TypeScript framework for building ChatGPT and MCP Apps.
+
+Rules:
+- Use ONLY the numbered documentation passages provided. Never answer from prior knowledge.
+- Put a citation like [1] (or [2][3] for several) immediately after every claim, matching the passage numbers.
+- If the passages do not answer the question, say so in one sentence and name the passage closest to the topic.
+- Write plain prose: no headings, no bullet lists, no code blocks. Wrap identifiers like \`registerTool\` in backticks.
+- Keep the answer under 150 words.`;
+
+// Enough context to answer from, small enough to keep the request fast.
+const MAX_PASSAGE_CHARS = 1500;
+
+function formatPassage(retrieved: RetrievedChunk, id: number): string {
+  const { chunk } = retrieved;
+  const breadcrumb = chunk.section
+    ? `${chunk.pageTitle} › ${chunk.section}`
+    : chunk.pageTitle;
+  return `[${id}] ${breadcrumb}\n${chunk.text.slice(0, MAX_PASSAGE_CHARS)}`;
+}
+
+/** Generate a cited answer from the retrieved passages. */
+export async function generateAnswer(
+  question: string,
+  retrieved: RetrievedChunk[],
+): Promise<string> {
+  const passages = retrieved
+    .map((item, index) => formatPassage(item, index + 1))
+    .join("\n\n");
+  return complete(
+    SYSTEM_PROMPT,
+    `Question: ${question}\n\nPassages:\n\n${passages}`,
+  );
+}

--- a/examples/docs-qa/src/rag/corpus.ts
+++ b/examples/docs-qa/src/rag/corpus.ts
@@ -1,0 +1,155 @@
+// The corpus is the live Skybridge documentation. Mintlify serves an index of
+// every page at /llms.txt and each page as raw markdown at <page-url>.md, so
+// we ingest at runtime instead of shipping a stale snapshot of the docs.
+const DOCS_INDEX_URL = "https://docs.skybridge.tech/llms.txt";
+
+export type DocChunk = {
+  /** Position in the corpus; stable for one index build. */
+  id: number;
+  pageTitle: string;
+  /** H2 section heading, or null for a page's intro. */
+  section: string | null;
+  /** Deep link to the section on docs.skybridge.tech. */
+  url: string;
+  text: string;
+};
+
+type DocPage = {
+  title: string;
+  /** Human-facing page URL (no .md). */
+  url: string;
+  markdownUrl: string;
+};
+
+// Sections longer than this get split on paragraph boundaries so each
+// embedding stays focused on one idea.
+const MAX_CHUNK_CHARS = 2000;
+// Post-cleanup fragments shorter than this are navigation noise, not content.
+const MIN_CHUNK_CHARS = 80;
+
+function parseIndex(llmsTxt: string): DocPage[] {
+  const pages: DocPage[] = [];
+  for (const line of llmsTxt.split("\n")) {
+    const match = line.match(/^- \[(.+?)\]\((https:\/\/[^)\s]+?)\.md\)/);
+    if (match) {
+      pages.push({
+        title: match[1],
+        url: match[2],
+        markdownUrl: `${match[2]}.md`,
+      });
+    }
+  }
+  return pages;
+}
+
+/** Mintlify heading anchors: lowercased, punctuation dropped, spaces dashed. */
+function anchorFor(heading: string): string {
+  return heading
+    .toLowerCase()
+    .replace(/`/g, "")
+    .replace(/[^a-z0-9\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-");
+}
+
+// Raw page markdown embeds Mintlify components (cards, frames, callouts).
+// Cards and frames are navigation chrome; callouts carry real prose, so they
+// are unwrapped rather than dropped.
+function cleanMarkdown(markdown: string): string {
+  return markdown
+    .replace(/<CardGroup[\s\S]*?<\/CardGroup>/g, "")
+    .replace(/<Card[\s\S]*?<\/Card>/g, "")
+    .replace(/<Frame[\s\S]*?<\/Frame>/g, "")
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, "")
+    .replace(/^\s*<\/?[A-Z][a-zA-Z]*[^>]*>\s*$/gm, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function splitLongSection(text: string): string[] {
+  if (text.length <= MAX_CHUNK_CHARS) {
+    return [text];
+  }
+  const pieces: string[] = [];
+  let current = "";
+  for (const paragraph of text.split("\n\n")) {
+    if (current && current.length + paragraph.length + 2 > MAX_CHUNK_CHARS) {
+      pieces.push(current);
+      current = paragraph;
+    } else {
+      current = current ? `${current}\n\n${paragraph}` : paragraph;
+    }
+  }
+  if (current) {
+    pieces.push(current);
+  }
+  return pieces;
+}
+
+function chunkPage(page: DocPage, markdown: string): Omit<DocChunk, "id">[] {
+  // Drop the "Documentation Index" preamble Mintlify prepends before the H1.
+  const h1Start = markdown.search(/^# /m);
+  const body = h1Start === -1 ? markdown : markdown.slice(h1Start);
+
+  const pageTitle = body.match(/^# (.+)$/m)?.[1].trim() ?? page.title;
+  const afterTitle = body.replace(/^# .+$/m, "");
+
+  const chunks: Omit<DocChunk, "id">[] = [];
+  const sections = afterTitle.split(/^## /m);
+
+  // sections[0] is the page intro; the rest each start with their heading line.
+  for (const [index, raw] of sections.entries()) {
+    let section: string | null = null;
+    let content = raw;
+    if (index > 0) {
+      const newline = raw.indexOf("\n");
+      section = (newline === -1 ? raw : raw.slice(0, newline)).trim();
+      content = newline === -1 ? "" : raw.slice(newline + 1);
+    }
+    const cleaned = cleanMarkdown(content);
+    if (cleaned.length < MIN_CHUNK_CHARS) {
+      continue;
+    }
+    const url = section ? `${page.url}#${anchorFor(section)}` : page.url;
+    for (const text of splitLongSection(cleaned)) {
+      // Splitting can leave a stub tail (a stray closing line, a link);
+      // embedding those only adds noise to retrieval.
+      if (text.length >= MIN_CHUNK_CHARS) {
+        chunks.push({ pageTitle, section, url, text });
+      }
+    }
+  }
+  return chunks;
+}
+
+/** Fetch every docs page and chunk it by section. */
+export async function loadCorpus(): Promise<DocChunk[]> {
+  const indexResponse = await fetch(DOCS_INDEX_URL);
+  if (!indexResponse.ok) {
+    throw new Error(
+      `Failed to fetch docs index (HTTP ${indexResponse.status})`,
+    );
+  }
+  const pages = parseIndex(await indexResponse.text());
+  if (pages.length === 0) {
+    throw new Error("Docs index is empty; llms.txt format may have changed");
+  }
+
+  const results = await Promise.allSettled(
+    pages.map(async (page) => {
+      const response = await fetch(page.markdownUrl);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      return chunkPage(page, await response.text());
+    }),
+  );
+
+  const chunks = results
+    .filter((result) => result.status === "fulfilled")
+    .flatMap((result) => result.value);
+  if (chunks.length === 0) {
+    throw new Error("Could not load any documentation pages");
+  }
+  return chunks.map((chunk, id) => ({ ...chunk, id }));
+}

--- a/examples/docs-qa/src/rag/openai.ts
+++ b/examples/docs-qa/src/rag/openai.ts
@@ -1,0 +1,70 @@
+// Minimal OpenAI REST client. Two endpoints are enough for the whole RAG
+// loop, so we call them with fetch instead of pulling in an SDK.
+const BASE_URL = process.env.OPENAI_BASE_URL ?? "https://api.openai.com/v1";
+const EMBEDDING_MODEL =
+  process.env.OPENAI_EMBEDDING_MODEL ?? "text-embedding-3-small";
+const ANSWER_MODEL = process.env.OPENAI_ANSWER_MODEL ?? "gpt-5-mini";
+
+// The embeddings endpoint caps inputs per request; stay well under it.
+const EMBEDDING_BATCH_SIZE = 128;
+
+function apiKey(): string {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) {
+    throw new Error(
+      "OPENAI_API_KEY is not set. Copy .env.example to .env and add your key.",
+    );
+  }
+  return key;
+}
+
+async function post<T>(path: string, body: unknown): Promise<T> {
+  const response = await fetch(`${BASE_URL}${path}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey()}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    throw new Error(
+      `OpenAI ${path} failed (HTTP ${response.status})${detail ? `: ${detail.slice(0, 200)}` : ""}`,
+    );
+  }
+  return (await response.json()) as T;
+}
+
+/** Embed a list of texts, preserving input order. */
+export async function embed(texts: string[]): Promise<number[][]> {
+  const vectors: number[][] = [];
+  for (let i = 0; i < texts.length; i += EMBEDDING_BATCH_SIZE) {
+    const batch = texts.slice(i, i + EMBEDDING_BATCH_SIZE);
+    const result = await post<{
+      data: Array<{ index: number; embedding: number[] }>;
+    }>("/embeddings", { model: EMBEDDING_MODEL, input: batch });
+    for (const item of result.data) {
+      vectors[i + item.index] = item.embedding;
+    }
+  }
+  return vectors;
+}
+
+/** One-shot chat completion; returns the assistant message text. */
+export async function complete(system: string, user: string): Promise<string> {
+  const result = await post<{
+    choices: Array<{ message: { content: string | null } }>;
+  }>("/chat/completions", {
+    model: ANSWER_MODEL,
+    messages: [
+      { role: "system", content: system },
+      { role: "user", content: user },
+    ],
+  });
+  const content = result.choices[0]?.message.content;
+  if (!content) {
+    throw new Error("OpenAI returned an empty completion");
+  }
+  return content.trim();
+}

--- a/examples/docs-qa/src/rag/retrieval.ts
+++ b/examples/docs-qa/src/rag/retrieval.ts
@@ -1,0 +1,76 @@
+import { type DocChunk, loadCorpus } from "./corpus.js";
+import { embed } from "./openai.js";
+
+type IndexedChunk = DocChunk & { vector: number[] };
+
+export type RetrievedChunk = { chunk: DocChunk; score: number };
+
+// Re-ingest the docs periodically so a long-running server picks up edits.
+const INDEX_TTL_MS = 60 * 60 * 1000;
+
+let cache: { promise: Promise<IndexedChunk[]>; builtAt: number } | null = null;
+
+// Embedding a section under its page + heading breadcrumb disambiguates
+// passages that read alike out of context (e.g. multiple "Parameters"
+// sections).
+function embeddingInput(chunk: DocChunk): string {
+  const breadcrumb = chunk.section
+    ? `${chunk.pageTitle} › ${chunk.section}`
+    : chunk.pageTitle;
+  return `${breadcrumb}\n\n${chunk.text}`;
+}
+
+async function buildIndex(): Promise<IndexedChunk[]> {
+  const chunks = await loadCorpus();
+  const vectors = await embed(chunks.map(embeddingInput));
+  return chunks.map((chunk, i) => ({ ...chunk, vector: vectors[i] }));
+}
+
+function getIndex(): Promise<IndexedChunk[]> {
+  if (!cache || Date.now() - cache.builtAt > INDEX_TTL_MS) {
+    const promise = buildIndex();
+    cache = { promise, builtAt: Date.now() };
+    // A transient failure (network, rate limit) must not poison the cache.
+    promise.catch(() => {
+      if (cache?.promise === promise) {
+        cache = null;
+      }
+    });
+  }
+  return cache.promise;
+}
+
+function cosineSimilarity(a: number[], b: number[]): number {
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  const denominator = Math.sqrt(normA) * Math.sqrt(normB);
+  return denominator === 0 ? 0 : dot / denominator;
+}
+
+/** Return the top-k documentation chunks most similar to the question. */
+export async function searchDocs(
+  question: string,
+  k: number,
+): Promise<RetrievedChunk[]> {
+  const [index, [questionVector]] = await Promise.all([
+    getIndex(),
+    embed([question]),
+  ]);
+  return index
+    .map((chunk) => ({
+      chunk,
+      score: cosineSimilarity(questionVector, chunk.vector),
+    }))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, k)
+    .map(({ chunk: { vector: _vector, ...chunk }, score }) => ({
+      chunk,
+      score,
+    }));
+}

--- a/examples/docs-qa/src/server.ts
+++ b/examples/docs-qa/src/server.ts
@@ -1,0 +1,114 @@
+import "./env.js";
+import { McpServer, text } from "skybridge/server";
+import { z } from "zod";
+import { generateAnswer } from "./rag/answer.js";
+import { searchDocs } from "./rag/retrieval.js";
+
+// How many passages back each answer. Enough for cross-page questions while
+// keeping every citation reviewable at a glance.
+const RETRIEVAL_TOP_K = 5;
+
+const server = new McpServer(
+  {
+    name: "docs-qa",
+    version: "0.0.1",
+  },
+  { capabilities: {} },
+).registerTool(
+  {
+    name: "ask-docs",
+    description:
+      "Answer questions about Skybridge (the TypeScript framework for building ChatGPT and MCP Apps) from its official documentation. Retrieves the most relevant docs passages and returns an answer where every claim carries a [n] citation the user can inspect. Use it whenever the user asks how Skybridge works, what an API does, or how to build, test, or deploy a Skybridge app.",
+    inputSchema: {
+      question: z
+        .string()
+        .describe(
+          "The question to answer from the Skybridge docs, e.g. 'How do I call a tool from a view?'",
+        ),
+    },
+    outputSchema: {
+      question: z.string().describe("The question that was asked."),
+      answer: z
+        .string()
+        .optional()
+        .describe("Answer with [n] markers citing the sources."),
+      sources: z
+        .array(
+          z.object({
+            id: z.number().describe("Citation number used in the answer."),
+            title: z.string().describe("Documentation page title."),
+            section: z
+              .string()
+              .nullable()
+              .describe("Section heading, or null for a page intro."),
+            url: z.string().describe("Deep link to the cited section."),
+          }),
+        )
+        .optional(),
+      error: z
+        .string()
+        .optional()
+        .describe("Why the question could not be answered."),
+    },
+    annotations: {
+      readOnlyHint: true,
+      openWorldHint: true,
+      destructiveHint: false,
+    },
+    _meta: {
+      "openai/widgetAccessible": true,
+      "openai/toolInvocation/invoking": "Searching the Skybridge docs…",
+      "openai/toolInvocation/invoked": "Answer ready.",
+    },
+    view: {
+      component: "ask-docs",
+      description:
+        "Cited answer from the Skybridge docs, with clickable source-passage previews.",
+    },
+  },
+  async ({ question }) => {
+    try {
+      const retrieved = await searchDocs(question, RETRIEVAL_TOP_K);
+      const answer = await generateAnswer(question, retrieved);
+
+      const sources = retrieved.map(({ chunk }, index) => ({
+        id: index + 1,
+        title: chunk.pageTitle,
+        section: chunk.section,
+        url: chunk.url,
+      }));
+      const sourceLines = sources
+        .map(
+          (source) =>
+            `[${source.id}] ${source.title}${source.section ? ` › ${source.section}` : ""} — ${source.url}`,
+        )
+        .join("\n");
+
+      return {
+        _meta: {
+          // Full passages are for the view's preview panel only; the model
+          // already gets the answer, so don't flood it with raw docs text.
+          passages: retrieved.map(({ chunk, score }, index) => ({
+            id: index + 1,
+            text: chunk.text,
+            score: Math.round(score * 1000) / 1000,
+          })),
+        },
+        structuredContent: { question, answer, sources },
+        content: [text(`${answer}\n\nSources:\n${sourceLines}`)],
+        isError: false,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return {
+        structuredContent: { question, error: message },
+        content: [text(`Could not answer from the docs: ${message}`)],
+        isError: true,
+      };
+    }
+  },
+);
+
+export default await server.run();
+
+export type AppType = typeof server;

--- a/examples/docs-qa/src/views/ask-docs.tsx
+++ b/examples/docs-qa/src/views/ask-docs.tsx
@@ -1,0 +1,353 @@
+import "@/index.css";
+
+import { ErrorAlert } from "@alpic-ai/ui/components/alert";
+import { Button } from "@alpic-ai/ui/components/button";
+import {
+  BookOpen,
+  ChevronDown,
+  ExternalLink,
+  LoaderCircle,
+  Search,
+} from "lucide-react";
+import { type FormEvent, type ReactNode, useState } from "react";
+import { useLayout, useOpenExternal } from "skybridge/web";
+import { useCallTool, useToolInfo } from "../helpers.js";
+
+type Source = {
+  id: number;
+  title: string;
+  section: string | null;
+  url: string;
+};
+
+type Passage = { id: number; text: string; score: number };
+
+// The answer is plain prose with two kinds of inline islands: [n] citations
+// and `code` identifiers. Tokenizing on both lets citations render as
+// interactive chips. Each token keeps its character offset as a stable key.
+type Token =
+  | { type: "text"; value: string; offset: number }
+  | { type: "code"; value: string; offset: number }
+  | { type: "cite"; id: number; offset: number };
+
+function tokenizeAnswer(answer: string): Token[] {
+  const tokens: Token[] = [];
+  let last = 0;
+  for (const match of answer.matchAll(/\[(\d+)\]|`([^`\n]+)`/g)) {
+    if (match.index > last) {
+      tokens.push({
+        type: "text",
+        value: answer.slice(last, match.index),
+        offset: last,
+      });
+    }
+    if (match[1] === undefined) {
+      tokens.push({ type: "code", value: match[2], offset: match.index });
+    } else {
+      tokens.push({ type: "cite", id: Number(match[1]), offset: match.index });
+    }
+    last = match.index + match[0].length;
+  }
+  if (last < answer.length) {
+    tokens.push({ type: "text", value: answer.slice(last), offset: last });
+  }
+  return tokens;
+}
+
+function breadcrumbFor(source: Source): string {
+  return source.section ? `${source.title} › ${source.section}` : source.title;
+}
+
+function WidgetShell({
+  theme,
+  narration,
+  children,
+}: {
+  theme: string | undefined;
+  narration: string;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className={`${theme === "dark" ? "dark" : ""} bg-background text-foreground p-4`}
+    >
+      <div className="flex flex-col gap-3" data-llm={narration}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function CitationChip({
+  id,
+  isSelected,
+  onClick,
+}: {
+  id: number;
+  isSelected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={`Show source ${id}`}
+      className={`mx-0.5 inline-flex size-4 -translate-y-1 items-center justify-center rounded-full align-middle text-[10px] font-semibold transition-colors ${
+        isSelected
+          ? "bg-primary text-primary-foreground"
+          : "bg-muted text-muted-foreground [@media(hover:hover)]:hover:bg-primary/15 [@media(hover:hover)]:hover:text-primary"
+      }`}
+    >
+      {id}
+    </button>
+  );
+}
+
+function Answer({
+  answer,
+  selectedSource,
+  onSelectSource,
+}: {
+  answer: string;
+  selectedSource: number | null;
+  onSelectSource: (id: number) => void;
+}) {
+  return (
+    <p className="type-text-sm leading-relaxed">
+      {tokenizeAnswer(answer).map((token) => {
+        const key = `${token.type}-${token.offset}`;
+        if (token.type === "cite") {
+          return (
+            <CitationChip
+              key={key}
+              id={token.id}
+              isSelected={selectedSource === token.id}
+              onClick={() => onSelectSource(token.id)}
+            />
+          );
+        }
+        if (token.type === "code") {
+          return (
+            <code
+              key={key}
+              className="rounded bg-muted px-1 py-0.5 font-mono type-text-xs"
+            >
+              {token.value}
+            </code>
+          );
+        }
+        return <span key={key}>{token.value}</span>;
+      })}
+    </p>
+  );
+}
+
+function SourceCard({
+  source,
+  passage,
+  isOpen,
+  onToggle,
+  onOpenDocs,
+}: {
+  source: Source;
+  passage: Passage | undefined;
+  isOpen: boolean;
+  onToggle: () => void;
+  onOpenDocs: () => void;
+}) {
+  return (
+    <li
+      className="rounded-lg border border-border"
+      data-llm={
+        isOpen ? `Reading source [${source.id}] ${breadcrumbFor(source)}` : ""
+      }
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-center gap-2 p-2 text-left [@media(hover:hover)]:hover:bg-muted/40"
+      >
+        <span className="inline-flex size-4 shrink-0 items-center justify-center rounded-full bg-muted text-[10px] font-semibold text-muted-foreground">
+          {source.id}
+        </span>
+        <span className="min-w-0 flex-1 truncate type-text-xs font-medium">
+          {breadcrumbFor(source)}
+        </span>
+        <ChevronDown
+          className={`size-3.5 shrink-0 text-muted-foreground transition-transform ${isOpen ? "rotate-180" : ""}`}
+        />
+      </button>
+      {isOpen && (
+        <div className="flex flex-col gap-2 border-t border-border p-2">
+          <p className="max-h-40 overflow-y-auto whitespace-pre-wrap type-text-xs text-muted-foreground">
+            {passage?.text ?? "Passage preview unavailable."}
+          </p>
+          <div className="flex items-center justify-between gap-2">
+            {passage && (
+              <span className="type-text-xs text-muted-foreground">
+                similarity {passage.score.toFixed(2)}
+              </span>
+            )}
+            <Button
+              variant="secondary"
+              className="w-fit"
+              icon={<ExternalLink />}
+              onClick={onOpenDocs}
+            >
+              Open in docs
+            </Button>
+          </div>
+        </div>
+      )}
+    </li>
+  );
+}
+
+function FollowUp({
+  disabled,
+  onAsk,
+}: {
+  disabled: boolean;
+  onAsk: (question: string) => void;
+}) {
+  const [draft, setDraft] = useState("");
+
+  function submit(event: FormEvent) {
+    event.preventDefault();
+    const question = draft.trim();
+    if (question && !disabled) {
+      onAsk(question);
+      setDraft("");
+    }
+  }
+
+  return (
+    <form onSubmit={submit} className="flex items-center gap-2">
+      <input
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+        placeholder="Ask a follow-up about Skybridge…"
+        className="min-w-0 flex-1 rounded-lg border border-border bg-background px-3 py-1.5 type-text-sm outline-none transition-colors focus:border-primary"
+      />
+      <Button
+        variant="secondary"
+        className="w-fit shrink-0"
+        icon={<Search />}
+        disabled={disabled || draft.trim() === ""}
+      >
+        Ask
+      </Button>
+    </form>
+  );
+}
+
+function Searching({ question }: { question: string | null }) {
+  return (
+    <div className="flex min-h-24 flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-border p-4 text-center">
+      <LoaderCircle className="size-6 animate-spin text-muted-foreground" />
+      <p className="type-text-sm text-muted-foreground">
+        Searching the Skybridge docs…
+      </p>
+      {question && (
+        <p className="max-w-full truncate type-text-xs text-muted-foreground">
+          “{question}”
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default function AskDocs() {
+  const { theme } = useLayout();
+  const openExternal = useOpenExternal();
+  const {
+    output,
+    responseMetadata,
+    isPending: isHostPending,
+  } = useToolInfo<"ask-docs">();
+  const {
+    callTool,
+    data,
+    error: callError,
+    isPending: isCalling,
+  } = useCallTool("ask-docs");
+
+  const [pendingQuestion, setPendingQuestion] = useState<string | null>(null);
+  const [selectedSource, setSelectedSource] = useState<number | null>(null);
+
+  // A follow-up asked from the widget wins over the result it mounted with.
+  const result = data?.structuredContent ?? output;
+  // `meta` is untyped on call results, so narrow it before use.
+  const rawPassages = data?.meta?.passages ?? responseMetadata?.passages;
+  const passages = Array.isArray(rawPassages) ? (rawPassages as Passage[]) : [];
+  const sources = result?.sources ?? [];
+
+  const busy = isHostPending || isCalling || pendingQuestion !== null;
+  const errorMessage = callError
+    ? callError instanceof Error
+      ? callError.message
+      : "The docs lookup failed."
+    : result?.error;
+
+  function ask(question: string) {
+    setSelectedSource(null);
+    setPendingQuestion(question);
+    callTool({ question }, { onSettled: () => setPendingQuestion(null) });
+  }
+
+  function toggleSource(id: number) {
+    setSelectedSource((current) => (current === id ? null : id));
+  }
+
+  const narration = busy
+    ? "Searching the Skybridge docs"
+    : result?.answer
+      ? `Showing a cited answer to "${result.question}" with ${sources.length} sources`
+      : "Waiting for a question about the Skybridge docs";
+
+  return (
+    <WidgetShell theme={theme} narration={narration}>
+      {busy ? (
+        <Searching question={pendingQuestion} />
+      ) : (
+        <>
+          {errorMessage && (
+            <ErrorAlert description={errorMessage} className="max-w-full" />
+          )}
+          {!errorMessage && result?.answer && (
+            <>
+              <Answer
+                answer={result.answer}
+                selectedSource={selectedSource}
+                onSelectSource={toggleSource}
+              />
+              {sources.length > 0 && (
+                <div className="flex flex-col gap-1.5">
+                  <p className="flex items-center gap-1.5 type-text-xs font-medium text-muted-foreground">
+                    <BookOpen className="size-3.5" />
+                    Sources
+                  </p>
+                  <ul className="flex max-h-56 list-none flex-col gap-1.5 overflow-y-auto">
+                    {sources.map((source) => (
+                      <SourceCard
+                        key={source.id}
+                        source={source}
+                        passage={passages.find(
+                          (passage) => passage.id === source.id,
+                        )}
+                        isOpen={selectedSource === source.id}
+                        onToggle={() => toggleSource(source.id)}
+                        onOpenDocs={() => openExternal(source.url)}
+                      />
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </>
+          )}
+        </>
+      )}
+      <FollowUp disabled={busy} onAsk={ask} />
+    </WidgetShell>
+  );
+}

--- a/examples/docs-qa/tsconfig.json
+++ b/examples/docs-qa/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "skybridge/tsconfig",
+
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+
+  "include": ["src", ".skybridge/**/*.d.ts"]
+}

--- a/examples/docs-qa/vite.config.ts
+++ b/examples/docs-qa/vite.config.ts
@@ -1,0 +1,20 @@
+import path from "node:path";
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { skybridge } from "skybridge/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  server: {
+    forwardConsole: {
+      unhandledErrors: true,
+      logLevels: ["error"],
+    },
+  },
+  plugins: [skybridge(), react(), tailwindcss()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -764,6 +764,67 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  examples/docs-qa:
+    dependencies:
+      '@alpic-ai/ui':
+        specifier: ^1.122.0
+        version: 1.157.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(lucide-react@1.25.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.75.0(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)(sonner@2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(tailwindcss@4.3.3)(tw-animate-css@1.4.0)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
+      lucide-react:
+        specifier: ^1.14.0
+        version: 1.25.0(react@19.2.7)
+      react:
+        specifier: ^19.2.4
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.7(react@19.2.7)
+      skybridge:
+        specifier: workspace:*
+        version: link:../../packages/core
+      tw-animate-css:
+        specifier: ^1.4.0
+        version: 1.4.0
+      vite:
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.1)(yaml@2.9.0)
+      zod:
+        specifier: ^4.3.6
+        version: 4.4.3
+    devDependencies:
+      '@skybridge/devtools':
+        specifier: ^1.1.0
+        version: 1.2.7(arktype@2.1.27)(typescript@6.0.3)
+      '@tailwindcss/vite':
+        specifier: ^4.2.4
+        version: 4.3.3(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.1)(yaml@2.9.0))
+      '@types/node':
+        specifier: ^24.12.0
+        version: 24.13.3
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.1
+        version: 6.0.3(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.1)(yaml@2.9.0))
+      alpic:
+        specifier: ^1.104.1
+        version: 1.157.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(arktype@2.1.27)(rxjs@7.8.2)(typescript@6.0.3)
+      tailwindcss:
+        specifier: ^4.2.4
+        version: 4.3.3
+      tsx:
+        specifier: ^4.21.0
+        version: 4.23.1
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.3
+
   examples/ecom-carousel:
     dependencies:
       '@alpic-ai/insights':
@@ -3546,19 +3607,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-avatar@1.2.3':
-    resolution: {integrity: sha512-peavtnApRB1tABx42tHw+rPU83GSg5tXicMYO/Xi1/lqNcRsF6jkr6L7Njo7gj4q/xtDRDKBkqJvbMtoOMYWtA==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-avatar@1.2.4':
     resolution: {integrity: sha512-u4Sz6ajq2WobGMqbsNXnFI/3JP/o7TUBkEmQ4BRUYofPDQawdO3WWYy5907c9VgOFX+ETjKI3VxnnrKYAF7Pmg==}
     peerDependencies:
@@ -4215,19 +4263,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-popover@1.1.20':
-    resolution: {integrity: sha512-/PYqbsyuDkNj+IxMcRx71qNt6GelnuNulMwdCV7AtFEhUyK6XkbwreEN6CCLydMeTiDozBV4uv5aF5d12dDH7w==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-popover@1.1.21':
     resolution: {integrity: sha512-+AJ7P5oRcFqFtv7MaCD8fOuK3l5qQBAMdWEOnUOYd3JfHOeIUe7TnHHSSP15CtWwH4KrotyDCTzodOIoONh8vw==}
     peerDependencies:
@@ -4555,19 +4590,6 @@ packages:
 
   '@radix-ui/react-scroll-area@1.2.13':
     resolution: {integrity: sha512-7tncSubo2G0UY1e8rk+72qe3XRzrGnOLtZQ1PL1KoBfRUNX0NrJT5akb+0kfwSCc3gVR4wdHqyhAQBDpDNOwDw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-scroll-area@1.2.15':
-    resolution: {integrity: sha512-JVBHNfTBbGd9hhq/xZZOgmVnBCXhLs8PJJ8vMzgwI0pLZNsKckW9pkoqHyxokUCt1hoxbwDNvF9DItEeZsG68g==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -6245,9 +6267,6 @@ packages:
       ajv:
         optional: true
 
-  ajv@8.18.0:
-    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
-
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
@@ -7427,9 +7446,6 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
-
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
@@ -7872,10 +7888,6 @@ packages:
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
-    engines: {node: '>=0.10.0'}
-
-  iconv-lite@0.7.0:
-    resolution: {integrity: sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==}
     engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.1:
@@ -11325,21 +11337,21 @@ snapshots:
   '@alpic-ai/ui@1.157.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(lucide-react@1.25.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.75.0(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)(sonner@2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(tailwindcss@4.3.3)(tw-animate-css@1.4.0)':
     dependencies:
       '@radix-ui/react-accordion': 1.2.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-avatar': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-checkbox': 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-collapsible': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-dialog': 1.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-dropdown-menu': 2.1.21(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-label': 2.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-popover': 1.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-radio-group': 1.4.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-scroll-area': 1.2.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-select': 2.3.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-separator': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-switch': 1.3.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-tabs': 1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-toggle-group': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-avatar': 1.2.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-checkbox': 1.3.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-collapsible': 1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-dialog': 1.1.21(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-dropdown-menu': 2.1.22(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-label': 2.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-popover': 1.1.21(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-radio-group': 1.4.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-scroll-area': 1.2.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-select': 2.3.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-separator': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-switch': 1.3.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-tabs': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-toggle-group': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-tooltip': 1.2.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       class-variance-authority: 0.7.1
       clsx: 2.1.1
@@ -12773,8 +12785,8 @@ snapshots:
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.11(hono@4.12.8)
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
       cors: 2.8.6
       cross-spawn: 7.0.6
@@ -12795,8 +12807,8 @@ snapshots:
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.11(hono@4.12.8)
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
       cors: 2.8.6
       cross-spawn: 7.0.6
@@ -13341,20 +13353,6 @@ snapshots:
   '@radix-ui/react-avatar@1.2.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-avatar@1.2.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.6
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.17)(react@19.2.7)
@@ -14140,29 +14138,6 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@radix-ui/react-popover@1.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.6
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-dismissable-layer': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-focus-scope': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-popper': 1.3.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-portal': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-presence': 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.17)(react@19.2.7)
-      aria-hidden: 1.2.6
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
   '@radix-ui/react-popover@1.1.21(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
@@ -14576,23 +14551,6 @@ snapshots:
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-scroll-area@1.2.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/number': 1.1.2
-      '@radix-ui/primitive': 1.1.6
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-presence': 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
@@ -16506,20 +16464,9 @@ snapshots:
     optionalDependencies:
       ajv: 8.20.0
 
-  ajv-formats@3.0.1(ajv@8.18.0):
-    optionalDependencies:
-      ajv: 8.18.0
-
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
-
-  ajv@8.18.0:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
@@ -16850,8 +16797,8 @@ snapshots:
       bytes: 3.1.2
       content-type: 1.0.5
       debug: 4.4.3(supports-color@5.5.0)
-      http-errors: 2.0.0
-      iconv-lite: 0.7.0
+      http-errors: 2.0.1
+      iconv-lite: 0.7.1
       on-finished: 2.4.1
       qs: 6.15.0
       raw-body: 3.0.2
@@ -17879,8 +17826,6 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.0: {}
-
   fast-uri@3.1.2: {}
 
   fast-uri@4.1.1: {}
@@ -18465,10 +18410,6 @@ snapshots:
   ico-endec@0.1.6: {}
 
   iconv-lite@0.4.24:
-    dependencies:
-      safer-buffer: 2.1.2
-
-  iconv-lite@0.7.0:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -21245,7 +21186,7 @@ snapshots:
       escape-html: 1.0.3
       etag: 1.8.1
       fresh: 2.0.0
-      http-errors: 2.0.0
+      http-errors: 2.0.1
       mime-types: 3.0.1
       ms: 2.1.3
       on-finished: 2.4.1


### PR DESCRIPTION
## What

Adds a new example, `examples/docs-qa`: retrieval-augmented Q&A over the Skybridge documentation with a cited-answer view. Among the existing examples there's no retrieval/RAG one — this fills that gap, as discussed with Fred over email.

- **Server** (`src/server.ts` + `src/rag/`): one `ask-docs` tool. Ingests the live docs at first use (the docs site publishes `/llms.txt` plus per-page raw markdown), chunks by section with deep-link anchors, embeds server-side (`text-embedding-3-small`), retrieves top-5 by cosine similarity, and generates an answer constrained to the retrieved passages with inline `[n]` citations (`gpt-5-mini` by default, overridable via env).
- **View** (`src/views/ask-docs.tsx`): renders the answer with clickable `[n]` citation chips; each expands the exact source passage with its similarity score and an "Open in docs" deep link via `useOpenExternal`. Follow-up questions from inside the widget re-call the tool via `useCallTool`, and `data-llm` narrates which source the user is reading.
- **Model/view data separation**: the compact answer + source list go to the model via `structuredContent`; the full passage texts ship view-only in `_meta`, so the model's context isn't flooded with raw docs.

## Why this shape

- **Live ingestion instead of a committed snapshot**: no stale corpus in the repo, and the pipeline doubles as a template for any Mintlify-hosted docs — the README has an "Adapting This Example to Your Own Docs" section.
- **Plain-fetch OpenAI client** (two endpoints), no SDK dependency; embedding/answer models and base URL are overridable via env.

## Testing

- `pnpm build` and `pnpm test` pass from the root; biome clean.
- Ingestion verified against the live docs: 81 pages → ~380 section chunks with working deep-link anchors.
- Full pipeline exercised end-to-end in DevTools against a mocked OpenAI backend — retrieval ranks the expected pages (e.g. `useCallTool`/`useToolInfo` for "How do I call a tool from a view?"), and follow-up questions reuse the cached index.

Requires an `OPENAI_API_KEY` (see `.env.example` / README). Happy to also add a docs `examples/` page + showcase entry if you'd like it listed — kept the PR scoped to `examples/` to match prior example PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)