### PR TITLE
fix(web): only resolve asset URLs at runtime in JS, keep CSS urls relative

### DIFF
--- a/packages/core/src/web/plugin/plugin.ts
+++ b/packages/core/src/web/plugin/plugin.ts
@@ -1,5 +1,6 @@
 import { isAbsolute, relative, resolve } from "node:path";
 import type { Plugin, ViteDevServer } from "vite";
+import { renderBuiltAssetUrl } from "./render-built-url.js";
 import {
   assertUniqueViewNames,
   type DiscoveredView,
@@ -131,11 +132,8 @@ export function skybridge(options?: SkybridgePluginOptions): Plugin {
           include: ["react", "react-dom/client", "react/jsx-runtime"],
         },
         experimental: {
-          renderBuiltUrl: (filename) => {
-            return {
-              runtime: `window.skybridge.serverUrl + "/assets/${filename}"`,
-            };
-          },
+          renderBuiltUrl: (filename, { hostType }) =>
+            renderBuiltAssetUrl(filename, hostType),
         },
       };
     },

--- a/packages/core/src/web/plugin/render-built-url.test.ts
+++ b/packages/core/src/web/plugin/render-built-url.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { renderBuiltAssetUrl } from "./render-built-url.js";
+
+describe("renderBuiltAssetUrl", () => {
+  it("resolves JS asset URLs at runtime so they follow the server origin", () => {
+    expect(renderBuiltAssetUrl("assets/logo.png", "js")).toEqual({
+      runtime: 'window.skybridge.serverUrl + "/assets/assets/logo.png"',
+    });
+  });
+
+  it("falls back to relative URLs outside JS, where Vite can't evaluate a runtime expression", () => {
+    expect(renderBuiltAssetUrl("assets/logo.png", "css")).toEqual({
+      relative: true,
+    });
+    expect(renderBuiltAssetUrl("assets/logo.png", "html")).toEqual({
+      relative: true,
+    });
+  });
+});

--- a/packages/core/src/web/plugin/render-built-url.ts
+++ b/packages/core/src/web/plugin/render-built-url.ts
@@ -1,0 +1,13 @@
+export type AssetHostType = "js" | "css" | "html";
+
+export function renderBuiltAssetUrl(
+  filename: string,
+  hostType: AssetHostType,
+): { runtime: string } | { relative: true } {
+  if (hostType !== "js") {
+    return { relative: true };
+  }
+  return {
+    runtime: `window.skybridge.serverUrl + "/assets/${filename}"`,
+  };
+}


### PR DESCRIPTION
Closes #1018.

## Summary

`renderBuiltUrl` returned the `{ runtime }` form for every built asset URL. Vite only supports it where there's a JS scope to evaluate the expression in, so `vite:css-post` threw and the build failed for any view whose CSS contains a `url()` pointing at a non-inlined asset (`@font-face`, `background-image`, …).

Non-JS host types now get `{ relative: true }`; JS keeps the runtime rewrite that #658 added for tunnels.

## Why relative is tunnel-safe

The stylesheet is itself loaded absolutely from the tunnel — `production.hbs` emits `<link href="{{serverUrl}}/assets/{{styleFile}}">`. A relative `url()` inside it resolves against that already-tunneled URL. With `base: "/assets"`, `outDir: "dist/assets"` and `cssCodeSplit: false`, the single stylesheet and the asset it references land in the same directory, so the result is byte-identical to what the runtime expression produced. JS is the only place the rewrite is actually needed, since a module has no reliable base.

`hostType: "html"` folds into the same branch: `input` is built solely from virtual view entries, and view HTML is server-rendered from `production.hbs` at request time, so Vite never emits HTML here.

## Contents

| | |
|---|---|
| `render-built-url.ts` | the resolution rule, extracted so it's testable without reaching through the Vite hook (`plugin.ts` is the public `skybridge/vite` entry) |
| `render-built-url.test.ts` | 2 tests — runtime in JS, relative elsewhere |

## Verification

Reproduced on `main` with the issue's repro, adapted to `examples/everything` — appending a `background-image: url("./views/tabs/image-tab/skybridge.jpg")` to `src/index.css` fails the build with the reported `vite:css-post` error. The asset has to exceed `assetsInlineLimit`; below 4 kB Vite inlines it as base64 and the bug doesn't trigger.

With the fix, that same build succeeds, emits `url(./skybridge-HoFq6PTZ.jpg)` in the CSS, and JS still emits `skybridge.serverUrl + "/assets/assets/skybridge-HoFq6PTZ.jpg"`.

`pnpm test` (398 tests, biome clean) and `pnpm build` pass from the root.
