### PR TITLE
fix(create-skybridge): allow esbuild builds for pnpm scaffolds

### DIFF
--- a/packages/create-skybridge/src/index.test.ts
+++ b/packages/create-skybridge/src/index.test.ts
@@ -70,7 +70,7 @@ describe("create-skybridge", () => {
       path.join(process.cwd(), tempDirName, "project", "pnpm-workspace.yaml"),
       "utf-8",
     );
-    // onlyBuiltDependencies covers pnpm 10, allowBuilds covers pnpm 11+.
+    expect(workspaceRaw).toContain('packages:\n  - "."');
     expect(workspaceRaw).toContain("onlyBuiltDependencies:\n  - esbuild");
     expect(workspaceRaw).toContain("allowBuilds:\n  esbuild: true");
   });

--- a/packages/create-skybridge/src/index.test.ts
+++ b/packages/create-skybridge/src/index.test.ts
@@ -62,6 +62,30 @@ describe("create-skybridge", () => {
     ).rejects.toThrow();
   });
 
+  it("writes pnpm-workspace.yaml allowing esbuild builds when using pnpm", async () => {
+    const name = `${tempDirName}/project`;
+    await init([name, "--yes", "--skip-skills", "--pm", "pnpm"]);
+
+    const workspaceRaw = await fs.readFile(
+      path.join(process.cwd(), tempDirName, "project", "pnpm-workspace.yaml"),
+      "utf-8",
+    );
+    // onlyBuiltDependencies covers pnpm 10, allowBuilds covers pnpm 11+.
+    expect(workspaceRaw).toContain("onlyBuiltDependencies:\n  - esbuild");
+    expect(workspaceRaw).toContain("allowBuilds:\n  esbuild: true");
+  });
+
+  it("does not write pnpm-workspace.yaml for other package managers", async () => {
+    const name = `${tempDirName}/project`;
+    await init([name, "--yes", "--skip-skills", "--pm", "npm"]);
+
+    await expect(
+      fs.access(
+        path.join(process.cwd(), tempDirName, "project", "pnpm-workspace.yaml"),
+      ),
+    ).rejects.toThrow();
+  });
+
   it("sets package.json name to the project directory basename", async () => {
     const name = `${tempDirName}/my-app`;
     await init([name, "--yes", "--skip-skills"]);

--- a/packages/create-skybridge/src/index.ts
+++ b/packages/create-skybridge/src/index.ts
@@ -311,7 +311,18 @@ export async function init(args: string[] = process.argv.slice(2)) {
     pm = choice;
   }
 
-  // 8. Always install dependencies
+  // 8. pnpm ≥10 skips dependency build scripts unless allow-listed, and pnpm 11
+  // turns the skipped esbuild postinstall into a hard install error
+  // (ERR_PNPM_IGNORED_BUILDS). onlyBuiltDependencies is read by pnpm 10,
+  // allowBuilds by pnpm 11+; each version ignores the other's key.
+  if (pm === "pnpm") {
+    fs.writeFileSync(
+      path.join(root, "pnpm-workspace.yaml"),
+      "onlyBuiltDependencies:\n  - esbuild\nallowBuilds:\n  esbuild: true\n",
+    );
+  }
+
+  // 9. Always install dependencies
   Spinner.start(`Installing dependencies with ${pm}`);
   const { status, output } = await spawnAsync(pm, ["install"]);
   if (status === 0) {
@@ -322,7 +333,7 @@ export async function init(args: string[] = process.argv.slice(2)) {
     abort(`Try manually: cd ${targetDir} && ${pm} install`);
   }
 
-  // 9. Start dev server?
+  // 10. Start dev server?
   let start = false;
   if (argv.start) {
     start = true;

--- a/packages/create-skybridge/src/index.ts
+++ b/packages/create-skybridge/src/index.ts
@@ -311,14 +311,11 @@ export async function init(args: string[] = process.argv.slice(2)) {
     pm = choice;
   }
 
-  // 8. pnpm ≥10 skips dependency build scripts unless allow-listed, and pnpm 11
-  // turns the skipped esbuild postinstall into a hard install error
-  // (ERR_PNPM_IGNORED_BUILDS). onlyBuiltDependencies is read by pnpm 10,
-  // allowBuilds by pnpm 11+; each version ignores the other's key.
+  // 8. pnpm ≥10 fails installs unless esbuild's build script is allow-listed
   if (pm === "pnpm") {
     fs.writeFileSync(
       path.join(root, "pnpm-workspace.yaml"),
-      "onlyBuiltDependencies:\n  - esbuild\nallowBuilds:\n  esbuild: true\n",
+      'packages:\n  - "."\nonlyBuiltDependencies:\n  - esbuild\nallowBuilds:\n  esbuild: true\n',
     );
   }
 


### PR DESCRIPTION
## Summary

- Fresh `create-skybridge` scaffolds abort at the install step on pnpm ≥10: pnpm skips esbuild's postinstall unless allow-listed, and pnpm 11 turns that into a hard `ERR_PNPM_IGNORED_BUILDS` error. Same failure repeats on `pnpm dev`, which re-runs the install check.
- #760 fixed this for the monorepo's own `pnpm-workspace.yaml` but the scaffolded templates were left uncovered — this closes that gap.
- The create CLI now writes a `pnpm-workspace.yaml` into the project right before installing, only when the selected package manager is pnpm, so npm/yarn/bun/deno scaffolds are untouched:

```yaml
onlyBuiltDependencies:
  - esbuild
allowBuilds:
  esbuild: true
```

`onlyBuiltDependencies` is read by pnpm 10, `allowBuilds` by pnpm 11+; each version ignores the other's key.

Fixes #1029

## Notes

- The file also makes the scaffold its own pnpm workspace root. For a standalone project that's a no-op; it's arguably desirable isolation if someone scaffolds inside an existing monorepo, but flagging it for review.
- Existing projects scaffolded before this fix need the yaml added manually — the error message pnpm prints (`pnpm approve-builds`) also resolves it interactively.

## Verification

- `pnpm run test:unit` in `packages/create-skybridge` — 5 passed (2 new: pnpm scaffolds get the file with both keys, `--pm npm` scaffolds don't).
- `pnpm run test:format` (biome ci) — clean.
- Dual-key file verified against real installs of an esbuild-depending project: pnpm 10.18.3 and pnpm 11.15.1 both install cleanly and esbuild's binary is present.
- Repro of the original failure: `pnpm create skybridge@latest my-app --yes --pm pnpm` with pnpm 11.15.1 aborts as described in #1029.

🤖 Generated with [Claude Code](https://claude.com/claude-code)