### PR TITLE
feat(core): implement skills/list and skills/get per current SEP-2640

### DIFF
--- a/docs/guides/skills.mdx
+++ b/docs/guides/skills.mdx
@@ -45,6 +45,8 @@ description: Process customer refund requests per company policy.
 
 Skybridge validates every skill at build and dev startup: a bad `name`, a missing `description`, or a name that mismatches its directory fails loudly. Each valid skill is then served at `skill://<name>/SKILL.md`, with its supporting files alongside.
 
+Hosts discover skills through the `skills/list` method, which returns each skill's URI, its verbatim frontmatter, and the complete file set with per-file SHA-256 digests; `skills/get` returns the same entry for a single skill by URI. This is the surface [ChatGPT's skill importer](https://developers.openai.com/plugins/build/mcp-server#import-skills-from-the-mcp-server) consumes when you submit your app.
+
 <Info>
 Skills are markdown files only: `SKILL.md` and any supporting `.md` files are served as `text/markdown`, other formats and symlinks are ignored.
 </Info>

--- a/packages/core/src/cli/build-helpers.test.ts
+++ b/packages/core/src/cli/build-helpers.test.ts
@@ -65,7 +65,7 @@ describe("emitSkillsModule", () => {
     const skills = JSON.parse(literal);
     expect(skills).toHaveLength(1);
     expect(skills[0]).toMatchObject({
-      name: "refunds",
+      uri: "skill://refunds/SKILL.md",
       frontmatter: { name: "refunds", description: "Process refunds" },
     });
     expect(skills[0].resources).toHaveLength(1);

--- a/packages/core/src/cli/build-helpers.test.ts
+++ b/packages/core/src/cli/build-helpers.test.ts
@@ -68,7 +68,9 @@ describe("emitSkillsModule", () => {
       name: "refunds",
       frontmatter: { name: "refunds", description: "Process refunds" },
     });
-    expect(skills[0].digest).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(skills[0].resources).toHaveLength(1);
+    expect(skills[0].resources[0].uri).toBe("skill://refunds/SKILL.md");
+    expect(skills[0].resources[0].digest).toMatch(/^sha256:[a-f0-9]{64}$/);
   });
 
   it("emits an empty array when the skills directory is absent", () => {

--- a/packages/core/src/server/skills-integration.test.ts
+++ b/packages/core/src/server/skills-integration.test.ts
@@ -47,10 +47,10 @@ describe("skills server option", () => {
     expect(extensionsOf(server)?.["io.modelcontextprotocol/skills"]).toEqual({
       directoryRead: true,
     });
-    // Resources are keyed by URI: the skill's SKILL.md plus the discovery
-    // index. Locks that the primed manifest was consumed and wired up.
+    // Resources are keyed by URI. Locks that the primed manifest was
+    // consumed and wired up.
     expect(registeredResourceNames(server)).toEqual(
-      expect.arrayContaining(["skill://demo/SKILL.md", "skill://index.json"]),
+      expect.arrayContaining(["skill://demo/SKILL.md"]),
     );
   });
 
@@ -61,7 +61,9 @@ describe("skills server option", () => {
     expect(
       extensionsOf(server)?.["io.modelcontextprotocol/skills"],
     ).toBeUndefined();
-    expect(registeredResourceNames(server)).not.toContain("skill://index.json");
+    expect(registeredResourceNames(server)).not.toContain(
+      "skill://demo/SKILL.md",
+    );
   });
 
   it("serves skills through the stateless transport (capability + reads)", async () => {
@@ -85,11 +87,6 @@ describe("skills server option", () => {
         "io.modelcontextprotocol/skills"
       ],
     ).toEqual({ directoryRead: true });
-
-    const index = await client.readResource({ uri: "skill://index.json" });
-    expect((index.contents[0] as { text?: string }).text).toContain(
-      "skill://demo/SKILL.md",
-    );
 
     const skill = await client.readResource({ uri: "skill://demo/SKILL.md" });
     expect((skill.contents[0] as { text?: string }).text).toBe("# Demo");

--- a/packages/core/src/server/skills-integration.test.ts
+++ b/packages/core/src/server/skills-integration.test.ts
@@ -1,6 +1,7 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 import {
   __setSkillsManifest,
   McpServer,
@@ -92,6 +93,28 @@ describe("skills server option", () => {
 
     const skill = await client.readResource({ uri: "skill://demo/SKILL.md" });
     expect((skill.contents[0] as { text?: string }).text).toBe("# Demo");
+
+    const SkillEntrySchema = z.object({
+      uri: z.string(),
+      frontmatter: z.record(z.string(), z.unknown()),
+      resources: z.array(z.object({ uri: z.string(), digest: z.string() })),
+    });
+
+    const list = await client.request(
+      { method: "skills/list", params: {} },
+      z.object({ skills: z.array(SkillEntrySchema) }),
+    );
+    expect(list.skills).toHaveLength(1);
+    expect(list.skills[0]?.uri).toBe("skill://demo/SKILL.md");
+    expect(list.skills[0]?.resources[0]?.digest).toMatch(
+      /^sha256:[a-f0-9]{64}$/,
+    );
+
+    const got = await client.request(
+      { method: "skills/get", params: { uri: "skill://demo/SKILL.md" } },
+      z.object({ skill: SkillEntrySchema }),
+    );
+    expect(got.skill).toEqual(list.skills[0]);
 
     await client.close();
     await server.close();

--- a/packages/core/src/server/skills-integration.test.ts
+++ b/packages/core/src/server/skills-integration.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { describe, expect, it, vi } from "vitest";
@@ -12,8 +13,13 @@ const MANIFEST: SkillsManifest = [
   {
     name: "demo",
     frontmatter: { name: "demo", description: "A demo skill" },
-    digest: "sha256:deadbeef",
-    files: { "SKILL.md": "# Demo" },
+    resources: [
+      {
+        uri: "skill://demo/SKILL.md",
+        digest: `sha256:${createHash("sha256").update("# Demo", "utf8").digest("hex")}`,
+        content: "# Demo",
+      },
+    ],
   },
 ];
 

--- a/packages/core/src/server/skills-integration.test.ts
+++ b/packages/core/src/server/skills-integration.test.ts
@@ -11,7 +11,7 @@ import {
 
 const MANIFEST: SkillsManifest = [
   {
-    name: "demo",
+    uri: "skill://demo/SKILL.md",
     frontmatter: { name: "demo", description: "A demo skill" },
     resources: [
       {

--- a/packages/core/src/server/skills.test.ts
+++ b/packages/core/src/server/skills.test.ts
@@ -25,10 +25,14 @@ function mkSkillDir(files: Record<string, string>): string {
 const FM = (name: string, description: string) =>
   `---\nname: ${name}\ndescription: ${description}\n---\n`;
 
+const digestOf = (content: string) =>
+  `sha256:${createHash("sha256").update(content, "utf8").digest("hex")}`;
+
 describe("discoverSkills", () => {
-  it("discovers a skill with frontmatter, digest, and supporting files", () => {
+  it("discovers a skill with frontmatter and per-file resources", () => {
+    const skillMd = `${FM("git-workflow", "Team git conventions")}Body`;
     const dir = mkSkillDir({
-      "git-workflow/SKILL.md": `${FM("git-workflow", "Team git conventions")}Body`,
+      "git-workflow/SKILL.md": skillMd,
       "git-workflow/references/GUIDE.md": "# Guide",
     });
     const [skill, ...rest] = discoverSkills(dir);
@@ -38,10 +42,17 @@ describe("discoverSkills", () => {
       name: "git-workflow",
       description: "Team git conventions",
     });
-    expect(skill?.digest).toMatch(/^sha256:[a-f0-9]{64}$/);
-    expect(Object.keys(skill?.files ?? {}).sort()).toEqual([
-      "SKILL.md",
-      "references/GUIDE.md",
+    expect(skill?.resources).toEqual([
+      {
+        uri: "skill://git-workflow/SKILL.md",
+        digest: digestOf(skillMd),
+        content: skillMd,
+      },
+      {
+        uri: "skill://git-workflow/references/GUIDE.md",
+        digest: digestOf("# Guide"),
+        content: "# Guide",
+      },
     ]);
   });
 
@@ -119,11 +130,18 @@ describe("registerSkills", () => {
     {
       name: "refunds",
       frontmatter: { name: "refunds", description: "Process refunds" },
-      digest: "sha256:abc",
-      files: {
-        "SKILL.md": "# Refunds",
-        "templates/email.md": "Hi",
-      },
+      resources: [
+        {
+          uri: "skill://refunds/SKILL.md",
+          digest: digestOf("# Refunds"),
+          content: "# Refunds",
+        },
+        {
+          uri: "skill://refunds/templates/email.md",
+          digest: digestOf("Hi"),
+          content: "Hi",
+        },
+      ],
     },
   ];
 
@@ -199,9 +217,6 @@ describe("registerSkills", () => {
     });
   });
 
-  const digestOf = (content: string) =>
-    `sha256:${createHash("sha256").update(content, "utf8").digest("hex")}`;
-
   it("lists entries with complete per-file resources via skills/list", () => {
     const { server, handlers } = fakeRegistrar();
     // biome-ignore lint/suspicious/noExplicitAny: structural test double
@@ -254,8 +269,8 @@ describe("discoverSkills symlink safety", () => {
     symlinkSync(join(outside, "secret.md"), join(dir, "demo", "leak.md"));
     symlinkSync(outside, join(dir, "demo", "escape"));
 
-    const files = discoverSkills(dir)[0]?.files ?? {};
-    expect(Object.keys(files).sort()).toEqual(["SKILL.md", "real.md"]);
+    const uris = discoverSkills(dir)[0]?.resources.map((r) => r.uri) ?? [];
+    expect(uris).toEqual(["skill://demo/SKILL.md", "skill://demo/real.md"]);
   });
 
   it("ignores non-markdown supporting files", () => {
@@ -265,7 +280,7 @@ describe("discoverSkills symlink safety", () => {
       "demo/data.json": "{}",
       "demo/scripts/run.py": "print(1)",
     });
-    const files = discoverSkills(dir)[0]?.files ?? {};
-    expect(Object.keys(files).sort()).toEqual(["SKILL.md", "notes.md"]);
+    const uris = discoverSkills(dir)[0]?.resources.map((r) => r.uri) ?? [];
+    expect(uris).toEqual(["skill://demo/SKILL.md", "skill://demo/notes.md"]);
   });
 });

--- a/packages/core/src/server/skills.test.ts
+++ b/packages/core/src/server/skills.test.ts
@@ -37,7 +37,7 @@ describe("discoverSkills", () => {
     });
     const [skill, ...rest] = discoverSkills(dir);
     expect(rest).toHaveLength(0);
-    expect(skill?.name).toBe("git-workflow");
+    expect(skill?.uri).toBe("skill://git-workflow/SKILL.md");
     expect(skill?.frontmatter).toMatchObject({
       name: "git-workflow",
       description: "Team git conventions",
@@ -128,7 +128,7 @@ describe("skillUriToRelPath", () => {
 describe("registerSkills", () => {
   const manifest: Skill[] = [
     {
-      name: "refunds",
+      uri: "skill://refunds/SKILL.md",
       frontmatter: { name: "refunds", description: "Process refunds" },
       resources: [
         {

--- a/packages/core/src/server/skills.test.ts
+++ b/packages/core/src/server/skills.test.ts
@@ -8,7 +8,6 @@ import { describe, expect, it, vi } from "vitest";
 import {
   discoverSkills,
   registerSkills,
-  SKILL_INDEX_URI,
   type Skill,
   skillUriToRelPath,
 } from "./skills.js";
@@ -153,25 +152,6 @@ describe("registerSkills", () => {
     };
     return { server, resources, handlers };
   }
-
-  it("builds an index.json with url, digest, and verbatim frontmatter", () => {
-    const { server, resources } = fakeRegistrar();
-    // biome-ignore lint/suspicious/noExplicitAny: structural test double
-    registerSkills(server as any, manifest);
-    const index = resources.get("skill-index");
-    const result = index?.cb(new URL(SKILL_INDEX_URI)) as {
-      contents: { text: string }[];
-    };
-    expect(JSON.parse(result.contents[0]?.text ?? "")).toEqual({
-      skills: [
-        {
-          url: "skill://refunds/SKILL.md",
-          digest: "sha256:abc",
-          frontmatter: { name: "refunds", description: "Process refunds" },
-        },
-      ],
-    });
-  });
 
   it("serves supporting files through the template resource", () => {
     const { server, resources } = fakeRegistrar();

--- a/packages/core/src/server/skills.test.ts
+++ b/packages/core/src/server/skills.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { createHash } from "node:crypto";
 import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -132,7 +133,7 @@ describe("registerSkills", () => {
       string,
       { uri: unknown; cb: (...args: unknown[]) => unknown }
     >();
-    let dirHandler: ((req: unknown) => unknown) | undefined;
+    const handlers = new Map<string, (req: unknown) => unknown>();
     const server = {
       registerResource: vi.fn(
         (name: string, uri: unknown, _cfg: unknown, cb: unknown) => {
@@ -143,12 +144,14 @@ describe("registerSkills", () => {
         },
       ),
       server: {
-        setRequestHandler: vi.fn((_schema: unknown, handler: unknown) => {
-          dirHandler = handler as (req: unknown) => unknown;
+        setRequestHandler: vi.fn((schema: unknown, handler: unknown) => {
+          const method = (schema as { shape: { method: { value: string } } })
+            .shape.method.value;
+          handlers.set(method, handler as (req: unknown) => unknown);
         }),
       },
     };
-    return { server, resources, getDirHandler: () => dirHandler };
+    return { server, resources, handlers };
   }
 
   it("builds an index.json with url, digest, and verbatim frontmatter", () => {
@@ -185,7 +188,7 @@ describe("registerSkills", () => {
     const on = fakeRegistrar();
     // biome-ignore lint/suspicious/noExplicitAny: structural test double
     registerSkills(on.server as any, manifest);
-    const result = on.getDirHandler()?.({
+    const result = on.handlers.get("resources/directory/read")?.({
       params: { uri: "skill://refunds/templates" },
     }) as { resources: { uri: string; name: string; mimeType: string }[] };
     expect(result.resources).toEqual([
@@ -198,10 +201,10 @@ describe("registerSkills", () => {
   });
 
   it("lists a skill root and marks subdirectories as inode/directory", () => {
-    const { server, getDirHandler } = fakeRegistrar();
+    const { server, handlers } = fakeRegistrar();
     // biome-ignore lint/suspicious/noExplicitAny: structural test double
     registerSkills(server as any, manifest);
-    const result = getDirHandler()?.({
+    const result = handlers.get("resources/directory/read")?.({
       params: { uri: "skill://refunds" },
     }) as { resources: { name: string; mimeType: string }[] };
     expect(result.resources).toContainEqual({
@@ -214,6 +217,49 @@ describe("registerSkills", () => {
       name: "SKILL.md",
       mimeType: "text/markdown",
     });
+  });
+
+  const digestOf = (content: string) =>
+    `sha256:${createHash("sha256").update(content, "utf8").digest("hex")}`;
+
+  it("lists entries with complete per-file resources via skills/list", () => {
+    const { server, handlers } = fakeRegistrar();
+    // biome-ignore lint/suspicious/noExplicitAny: structural test double
+    registerSkills(server as any, manifest);
+    const result = handlers.get("skills/list")?.({ params: {} });
+    expect(result).toEqual({
+      skills: [
+        {
+          uri: "skill://refunds/SKILL.md",
+          frontmatter: { name: "refunds", description: "Process refunds" },
+          resources: [
+            { uri: "skill://refunds/SKILL.md", digest: digestOf("# Refunds") },
+            {
+              uri: "skill://refunds/templates/email.md",
+              digest: digestOf("Hi"),
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("returns a single entry via skills/get and rejects non-skill URIs", () => {
+    const { server, handlers } = fakeRegistrar();
+    // biome-ignore lint/suspicious/noExplicitAny: structural test double
+    registerSkills(server as any, manifest);
+    const get = handlers.get("skills/get");
+    const result = get?.({
+      params: { uri: "skill://refunds/SKILL.md" },
+    }) as { skill: { uri: string; resources: unknown[] } };
+    expect(result.skill.uri).toBe("skill://refunds/SKILL.md");
+    expect(result.skill.resources).toHaveLength(2);
+    expect(() =>
+      get?.({ params: { uri: "skill://unknown/SKILL.md" } }),
+    ).toThrow(/Unknown skill/);
+    expect(() =>
+      get?.({ params: { uri: "skill://refunds/templates/email.md" } }),
+    ).toThrow(/Unknown skill/);
   });
 });
 

--- a/packages/core/src/server/skills.ts
+++ b/packages/core/src/server/skills.ts
@@ -181,6 +181,31 @@ const DirectoryReadRequestSchema = z.object({
   params: z.object({ uri: z.string(), cursor: z.string().optional() }),
 });
 
+const SkillsListRequestSchema = z.object({
+  method: z.literal("skills/list"),
+  params: z.object({ cursor: z.string().optional() }).optional(),
+});
+
+const SkillsGetRequestSchema = z.object({
+  method: z.literal("skills/get"),
+  params: z.object({ uri: z.string() }),
+});
+
+const toSkillEntry = (skill: Skill) => ({
+  uri: `skill://${skill.name}/SKILL.md`,
+  frontmatter: skill.frontmatter,
+  resources: Object.entries(skill.files)
+    .sort(
+      ([a], [b]) =>
+        Number(b === "SKILL.md") - Number(a === "SKILL.md") ||
+        a.localeCompare(b),
+    )
+    .map(([path, content]) => ({
+      uri: `skill://${skill.name}/${path}`,
+      digest: sha256(content),
+    })),
+});
+
 export function registerSkills(
   server: SkillRegistrar,
   manifest: SkillsManifest,
@@ -240,6 +265,26 @@ export function registerSkills(
       ],
     }),
   );
+
+  const entryByName = new Map(
+    manifest.map((skill) => [skill.name, toSkillEntry(skill)]),
+  );
+
+  server.server.setRequestHandler(SkillsListRequestSchema, () => ({
+    skills: [...entryByName.values()],
+  }));
+
+  server.server.setRequestHandler(SkillsGetRequestSchema, ({ params }) => {
+    const { name, relPath } = skillUriToRelPath(params.uri);
+    const entry = relPath === "SKILL.md" ? entryByName.get(name) : undefined;
+    if (!entry) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Unknown skill: ${params.uri}`,
+      );
+    }
+    return { skill: entry };
+  });
 
   server.server.setRequestHandler(DirectoryReadRequestSchema, ({ params }) => {
     const { name, relPath } = skillUriToRelPath(params.uri);

--- a/packages/core/src/server/skills.ts
+++ b/packages/core/src/server/skills.ts
@@ -37,8 +37,8 @@ export interface SkillResource {
 }
 
 export interface Skill {
-  name: string;
-  frontmatter: Record<string, unknown>;
+  uri: string;
+  frontmatter: { name: string; description: string } & Record<string, unknown>;
   resources: SkillResource[];
 }
 
@@ -125,7 +125,7 @@ export function discoverSkills(dir: string): SkillsManifest {
       }));
 
     skills.push({
-      name: entry.name,
+      uri: `skill://${entry.name}/SKILL.md`,
       frontmatter: parsed.data,
       resources,
     });
@@ -154,7 +154,7 @@ function listDir(
   relPath: string,
 ): { name: string; mimeType: string }[] | null {
   const prefix = relPath === "" ? "" : `${relPath}/`;
-  const base = `skill://${skill.name}/`;
+  const base = skill.uri.slice(0, -"SKILL.md".length);
   const children = new Map<string, string>();
   let matched = relPath === "";
   for (const filePath of skill.resources.map((resource) =>
@@ -210,7 +210,7 @@ const SkillsGetRequestSchema = z.object({
 });
 
 const toWireEntry = (skill: Skill) => ({
-  uri: `skill://${skill.name}/SKILL.md`,
+  uri: skill.uri,
   frontmatter: skill.frontmatter,
   resources: skill.resources.map(({ uri, digest }) => ({ uri, digest })),
 });
@@ -219,13 +219,11 @@ export function registerSkills(
   server: SkillRegistrar,
   manifest: SkillsManifest,
 ): void {
-  const byName = new Map(manifest.map((s) => [s.name, s]));
-  const serveFile = (name: string, relPath: string, href: string) => {
-    const text = byName
-      .get(name)
-      ?.resources.find(
-        (resource) => resource.uri === `skill://${name}/${relPath}`,
-      )?.content;
+  const byUri = new Map(manifest.map((skill) => [skill.uri, skill]));
+  const serveFile = (skillUri: string, fileUri: string, href: string) => {
+    const text = byUri
+      .get(skillUri)
+      ?.resources.find((resource) => resource.uri === fileUri)?.content;
     if (text === undefined) {
       throw new McpError(ErrorCode.InvalidParams, `Not found: ${href}`);
     }
@@ -236,13 +234,13 @@ export function registerSkills(
 
   for (const skill of manifest) {
     server.registerResource(
-      skill.name,
-      `skill://${skill.name}/SKILL.md`,
+      skill.frontmatter.name,
+      skill.uri,
       {
-        description: String(skill.frontmatter.description),
+        description: skill.frontmatter.description,
         mimeType: "text/markdown",
       },
-      (readUri) => serveFile(skill.name, "SKILL.md", readUri.href),
+      (readUri) => serveFile(skill.uri, skill.uri, readUri.href),
     );
   }
 
@@ -254,7 +252,11 @@ export function registerSkills(
     {},
     (readUri) => {
       const { name, relPath } = skillUriToRelPath(readUri.href);
-      return serveFile(name, relPath, readUri.href);
+      return serveFile(
+        `skill://${name}/SKILL.md`,
+        `skill://${name}/${relPath}`,
+        readUri.href,
+      );
     },
   );
 
@@ -263,8 +265,7 @@ export function registerSkills(
   }));
 
   server.server.setRequestHandler(SkillsGetRequestSchema, ({ params }) => {
-    const { name, relPath } = skillUriToRelPath(params.uri);
-    const skill = relPath === "SKILL.md" ? byName.get(name) : undefined;
+    const skill = byUri.get(params.uri);
     if (!skill) {
       throw new McpError(
         ErrorCode.InvalidParams,
@@ -276,7 +277,7 @@ export function registerSkills(
 
   server.server.setRequestHandler(DirectoryReadRequestSchema, ({ params }) => {
     const { name, relPath } = skillUriToRelPath(params.uri);
-    const skill = byName.get(name);
+    const skill = byUri.get(`skill://${name}/SKILL.md`);
     const entries = skill ? listDir(skill, relPath) : null;
     if (!entries) {
       throw new McpError(

--- a/packages/core/src/server/skills.ts
+++ b/packages/core/src/server/skills.ts
@@ -30,11 +30,16 @@ const SkillFrontmatterSchema = z
   })
   .loose();
 
+export interface SkillResource {
+  uri: string;
+  digest: string;
+  content: string;
+}
+
 export interface Skill {
   name: string;
   frontmatter: Record<string, unknown>;
-  digest: string;
-  files: Record<string, string>;
+  resources: SkillResource[];
 }
 
 export type SkillsManifest = Skill[];
@@ -107,11 +112,22 @@ export function discoverSkills(dir: string): SkillsManifest {
       );
     }
 
+    const resources = Object.entries(files)
+      .sort(
+        ([a], [b]) =>
+          Number(b === "SKILL.md") - Number(a === "SKILL.md") ||
+          a.localeCompare(b),
+      )
+      .map(([relPath, content]) => ({
+        uri: `skill://${entry.name}/${relPath}`,
+        digest: sha256(content),
+        content,
+      }));
+
     skills.push({
       name: entry.name,
       frontmatter: parsed.data,
-      digest: sha256(skillMd),
-      files,
+      resources,
     });
   }
   return skills;
@@ -138,9 +154,12 @@ function listDir(
   relPath: string,
 ): { name: string; mimeType: string }[] | null {
   const prefix = relPath === "" ? "" : `${relPath}/`;
+  const base = `skill://${skill.name}/`;
   const children = new Map<string, string>();
   let matched = relPath === "";
-  for (const filePath of Object.keys(skill.files)) {
+  for (const filePath of skill.resources.map((resource) =>
+    resource.uri.slice(base.length),
+  )) {
     if (!filePath.startsWith(prefix)) {
       continue;
     }
@@ -190,19 +209,10 @@ const SkillsGetRequestSchema = z.object({
   params: z.object({ uri: z.string() }),
 });
 
-const toSkillEntry = (skill: Skill) => ({
+const toWireEntry = (skill: Skill) => ({
   uri: `skill://${skill.name}/SKILL.md`,
   frontmatter: skill.frontmatter,
-  resources: Object.entries(skill.files)
-    .sort(
-      ([a], [b]) =>
-        Number(b === "SKILL.md") - Number(a === "SKILL.md") ||
-        a.localeCompare(b),
-    )
-    .map(([path, content]) => ({
-      uri: `skill://${skill.name}/${path}`,
-      digest: sha256(content),
-    })),
+  resources: skill.resources.map(({ uri, digest }) => ({ uri, digest })),
 });
 
 export function registerSkills(
@@ -211,7 +221,11 @@ export function registerSkills(
 ): void {
   const byName = new Map(manifest.map((s) => [s.name, s]));
   const serveFile = (name: string, relPath: string, href: string) => {
-    const text = byName.get(name)?.files[relPath];
+    const text = byName
+      .get(name)
+      ?.resources.find(
+        (resource) => resource.uri === `skill://${name}/${relPath}`,
+      )?.content;
     if (text === undefined) {
       throw new McpError(ErrorCode.InvalidParams, `Not found: ${href}`);
     }
@@ -244,24 +258,20 @@ export function registerSkills(
     },
   );
 
-  const entryByName = new Map(
-    manifest.map((skill) => [skill.name, toSkillEntry(skill)]),
-  );
-
   server.server.setRequestHandler(SkillsListRequestSchema, () => ({
-    skills: [...entryByName.values()],
+    skills: manifest.map(toWireEntry),
   }));
 
   server.server.setRequestHandler(SkillsGetRequestSchema, ({ params }) => {
     const { name, relPath } = skillUriToRelPath(params.uri);
-    const entry = relPath === "SKILL.md" ? entryByName.get(name) : undefined;
-    if (!entry) {
+    const skill = relPath === "SKILL.md" ? byName.get(name) : undefined;
+    if (!skill) {
       throw new McpError(
         ErrorCode.InvalidParams,
         `Unknown skill: ${params.uri}`,
       );
     }
-    return { skill: entry };
+    return { skill: toWireEntry(skill) };
   });
 
   server.server.setRequestHandler(DirectoryReadRequestSchema, ({ params }) => {

--- a/packages/core/src/server/skills.ts
+++ b/packages/core/src/server/skills.ts
@@ -13,7 +13,6 @@ import { parse as parseYaml } from "yaml";
 import { z } from "zod";
 
 export const SKILLS_EXTENSION_KEY = "io.modelcontextprotocol/skills";
-export const SKILL_INDEX_URI = "skill://index.json";
 
 const SKILL_NAME_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
@@ -243,27 +242,6 @@ export function registerSkills(
       const { name, relPath } = skillUriToRelPath(readUri.href);
       return serveFile(name, relPath, readUri.href);
     },
-  );
-
-  server.registerResource(
-    "skill-index",
-    SKILL_INDEX_URI,
-    { mimeType: "application/json" },
-    () => ({
-      contents: [
-        {
-          uri: SKILL_INDEX_URI,
-          mimeType: "application/json",
-          text: JSON.stringify({
-            skills: manifest.map((skill) => ({
-              url: `skill://${skill.name}/SKILL.md`,
-              digest: skill.digest,
-              frontmatter: skill.frontmatter,
-            })),
-          }),
-        },
-      ],
-    }),
   );
 
   const entryByName = new Map(


### PR DESCRIPTION
Closes #1035

## Why

Skybridge's skills-over-MCP implementation tracks the pre-July-13 draft of [SEP-2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640): a `skill://index.json` resource with a single SKILL.md digest per skill, plus `resources/directory/read`. The SEP has since replaced the index with two mandatory methods — `9b9d299a` (index.json → `skills/list`), `d7490ecd` (add `skills/get`), `cff984c3` (per-file `resources` digests) — and the current revision states that declaring the `io.modelcontextprotocol/skills` extension commits the server to both. Skybridge declares the extension but returned `-32601` for both methods, which breaks [ChatGPT's skill importer](https://developers.openai.com/plugins/build/mcp-server#import-skills-from-the-mcp-server) at its discovery step (it consumes a static subset of the current SEP revision, entering through `skills/list`).

## What

- `skills/list`: returns all entries in one page as `{uri, frontmatter, resources: [{uri, digest}]}` — verbatim frontmatter, complete file set (SKILL.md first, then supporting files sorted), each file digested as `sha256:<hex>` over its raw bytes. Accepts the optional `cursor` param; never emits `nextCursor` since the whole in-memory catalog fits one page.
- `skills/get`: accepts `{uri}` of a SKILL.md, returns `{skill: <same entry shape>}`; `InvalidParams` for unknown skills or URIs not pointing at a SKILL.md.
- Both registered via `setRequestHandler` like the existing `resources/directory/read` — no SDK change needed (neither SDK v1 nor v2-beta ships skills support).
- Entries are computed once at registration from the manifest already in memory.
- `skill://index.json` is removed: it is no longer part of the SEP, and no host sources skills from it — ChatGPT's importer enters through `skills/list`, and the Alpic playground is migrating to it in alpic-ai/alpic#2308.
- Docs: one paragraph in `guides/skills.mdx` on host discovery via the new methods.

## Verification

- Unit tests for both handlers (entry shape, digest correctness, ordering, error paths) and an integration round-trip over `connectStatelessTransport` with a real MCP client asserting `skills/list` and `skills/get` return identical, digest-carrying entries.
- `pnpm test && pnpm build` green from root (398 unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
