### PR TITLE
docs(skill): clarify model context guidance

### DIFF
--- a/skills/chatgpt-app-builder/evals/fetch-and-render-data.json
+++ b/skills/chatgpt-app-builder/evals/fetch-and-render-data.json
@@ -14,5 +14,9 @@
   {
     "query": "Building a job board. Users search jobs by keywords and location, see listings with salary info, and apply with one click. Show loading state while searching.",
     "expected_behavior": "Server: registerTool('search-jobs') with view.component 'search-jobs' and inputSchema {keywords, location}, registerTool('apply-job'). UI: useToolInfo<'search-jobs'>() with isPending for loading state, useCallTool('apply-job') with jobId on Apply button."
+  },
+  {
+    "query": "My product search returns 50 products that the view needs for a carousel, but sending every product directly to the model would use too much context. How should the tool divide its output?",
+    "expected_behavior": "Return a concise summary or immediately useful product fields in structuredContent, keep additional product details or display-only content such as the full carousel dataset in _meta, and use content only for a short status such as 'Found 50 products.' The view can selectively expose the currently relevant products through concise data-llm annotations instead of copying all 50 products into model-visible context."
   }
 ]

--- a/skills/chatgpt-app-builder/evals/state-and-context.json
+++ b/skills/chatgpt-app-builder/evals/state-and-context.json
@@ -18,5 +18,9 @@
   {
     "query": "Photo gallery for selecting images. Users can pick multiple photos to create an album. Sometimes they browse without selecting anything, and might ask 'help me pick the best ones'.",
     "expected_behavior": "useViewState for selections (persists, LLM sees picks). data-llm with fallback: shows selected photo names OR 'Browsing N photos, none selected' when empty."
+  },
+  {
+    "query": "A product search tool already returns the products to both the model and the view. The view must preserve selected products and let the user ask 'compare this one'. What belongs in view state and data-llm?",
+    "expected_behavior": "Keep only the persistent selection state, preferably selected product IDs, in useViewState. Use data-llm for a concise description of the currently focused product. Do not copy the complete product search output into view state or data-llm because the model already received it through structuredContent."
   }
 ]

--- a/skills/chatgpt-app-builder/evals/update-existing.json
+++ b/skills/chatgpt-app-builder/evals/update-existing.json
@@ -5,7 +5,7 @@
   },
   {
     "query": "SPEC.md:\n# Plant Shop\n\n## Value Proposition\nBrowse houseplants, get care recommendations, and order plants.\n\n## Tools and Views\n**View: browse_plants**\n- Input: { category, lightLevel }\n- Output: { plants[] }\n- Views: plant grid, plant detail, cart\n\n**Tool: place_order**\n- Input: { items[], shippingAddress }\n- Output: { orderId, deliveryDate }\n\n---\nUser: I want to add a get_plant_info tool so the LLM can tell users about a specific plant's care needs.",
-    "expected_behavior": "REJECT per architecture.md: 'Don't duplicate - view output is returned to the LLM for conversation. Don't create a tool that duplicates what the view fetches.' The browse_plants view already returns plant data including details. Explain this and suggest the LLM re-invoke browse_plants instead."
+    "expected_behavior": "REJECT per architecture.md: don't create a tool that duplicates model-relevant data the view already returns through structuredContent. The browse_plants view already returns plant data including care details to the LLM. Explain this and suggest the LLM re-invoke browse_plants instead."
   },
   {
     "query": "SPEC.md:\n# Gym Class Booking\n\n## Value Proposition\nBrowse gym classes by schedule and book a spot.\n\n## Tools and Views\n**View: browse_classes**\n- Input: { date, classType }\n- Output: { classes[] }\n\n---\nUser: I want to add a save_favorite_class tool so users can bookmark classes they like.",
@@ -13,7 +13,7 @@
   },
   {
     "query": "SPEC.md:\n# Furniture Store\n\n## Value Proposition\nBrowse furniture catalog, see room previews, and purchase items.\n\n## Tools and Views\n**View: browse_furniture**\n- Input: { category, room }\n- Output: { items[] }\n- Views: item grid, item detail with room preview\n\n**Tool: create_checkout**\n- Input: { itemIds[] }\n- Output: { checkoutUrl }\n\n---\nUser: I want to add a load_room_preview tool that fetches the 3D room render when the user taps on an item.",
-    "expected_behavior": "REJECT per architecture.md: 'Don't lazy-load - tool calls are expensive. Return all needed data upfront.' The browse_furniture view should include room preview data in its output. Suggest returning preview URLs upfront in the view output instead."
+    "expected_behavior": "REJECT per architecture.md: don't add a tool whose only purpose is to hydrate the view. The browse_furniture view should return the room preview data needed for its initial interaction upfront, with additional preview details or display-only content such as image URLs in _meta rather than structuredContent."
   },
   {
     "query": "SPEC.md:\n# Vet Appointment\n\n## Value Proposition\nBook vet appointments for pets and view appointment history.\n\n## Tools and Views\n**View: find_vet**\n- Input: { location, specialty }\n- Output: { vets[], availability[] }\n\n**Tool: book_appointment**\n- Input: { vetId, petId, timeSlot }\n- Output: { appointmentId }\n\n---\nUser: I want to add the ability to cancel an appointment.",

--- a/skills/chatgpt-app-builder/references/architecture.md
+++ b/skills/chatgpt-app-builder/references/architecture.md
@@ -69,7 +69,7 @@ Based on the UX flow:
 ❌ `search_flights` view + `view_flight` view (same flow → merge into one view)
 ✅ `search_flights` view + `manage_bookings` view (different flows)
 
-**Don't duplicate:** View output is returned to the LLM for conversation. View can be re-invoked. Don't create a tool that duplicates what the view fetches.
+**Don't duplicate:** The view's `structuredContent` and optional `content` are returned to the LLM for conversation, while `_meta` is delivered only to the view. The view can be re-invoked. Don't create a tool that duplicates what the view fetches.
 ❌ `search_flights` view + `get_flights` tool (same data → view already fetches this)
 ✅ unique `search_flights` view that can be re-invoked by LLM or user
 
@@ -79,9 +79,9 @@ Based on the UX flow:
 ❌ `update_quantity` tool (form input is view state)
 ✅ Tools are for backend operations only: `create_checkout`, `submit_order`, `make_reservation`
 
-**Don't lazy-load:** Tool calls are expensive. Return all needed data upfront.
+**Don't lazy-load:** Tool calls are expensive. Return all data needed for the view's initial interaction upfront in one tool result. Keep fields immediately useful to the model concise in `structuredContent`, and put additional details or display-only content not worth their full context cost in `_meta` rather than adding a tool whose only purpose is to hydrate the view.
 ❌ `search_flights` view + `get_flight_details` tool (lazy-loading details)
-✅ `search_flights` view returns full flight data including details
+✅ `search_flights` view returns immediately useful flight data in `structuredContent`, and additional flight details or display-only content in `_meta`
 
 --- 
 

--- a/skills/chatgpt-app-builder/references/fetch-and-render-data.md
+++ b/skills/chatgpt-app-builder/references/fetch-and-render-data.md
@@ -24,8 +24,10 @@ my-app/
 
 Output:
 - **`structuredContent`**: concise JSON the view uses and the model reads. Include only what the model should see.
-- **`content`** (optional): narration (Markdown or plaintext) shown to LLM
-- **`_meta`** (optional): large or sensitive data exclusively for the view. _meta never reaches the model.
+- **`content`** (optional): concise narration (Markdown or plaintext) shown to the LLM.
+- **`_meta`** (optional): additional details or display-only content kept out of the model's direct context, such as large payloads or image URLs. The view can selectively expose relevant parts through `data-llm`. `_meta` is delivered to the client, so never put server secrets in it.
+
+Keep these channels complementary. Avoid copying the same payload into `content`, `structuredContent`, view state, and `data-llm`. A short status in `content` may summarize the result, while `structuredContent` carries the fields useful to the model immediately and `_meta` carries additional details or display-only content intentionally omitted from its direct context.
 
 Annotations (set `true` when):
 - **`readOnlyHint`**: only reads data, no side effects

--- a/skills/chatgpt-app-builder/references/state-and-context.md
+++ b/skills/chatgpt-app-builder/references/state-and-context.md
@@ -101,6 +101,17 @@ const [{ selected }, setState] = useViewState({ selected: null });
 <div data-llm={`Cart: ${cart.length} items, $${total}`}>
 ```
 
+## Avoid duplicated model context
+
+Model-visible context accumulates across tool `content`, `structuredContent`, persisted view state, and `data-llm`. Give each channel a distinct role instead of copying the same payload between them:
+
+- Keep tool `content` to a short status or summary.
+- Put model-relevant result fields in `structuredContent`.
+- Persist only UI state that must survive and help the conversation; don't copy the complete tool output into view state.
+- Use `data-llm` for a concise description of the user's current focus or action, not for data already available to the model.
+
+`_meta` is different: it is available to the view but not the model, so it can carry additional details or display-only content intentionally omitted from direct model context.
+
 ## Combined example
 
 Todo list. User checks off tasks, asks "what should I prioritize?"


### PR DESCRIPTION
## Summary

- clarify which tool output fields are visible to the model and the view
- reconcile returning view data upfront with keeping model context concise
- document how structuredContent, content, _meta, view state, and data-llm complement each other
- add eval coverage for large result sets and duplicated model context

## Testing

- pnpm test
- pnpm build
- Ran relevant evals

Linear: https://linear.app/alpic/issue/ALP-1737/skybridge-skill-guidance