### PR TITLE
DevTools: warn on large tool output and view state

### DIFF
--- a/packages/core/src/context-warnings.test.ts
+++ b/packages/core/src/context-warnings.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  estimateContextTokens,
+  TOOL_OUTPUT_WARNING_TOKENS,
+  warnOnLargeToolOutput,
+} from "./context-warnings.js";
+
+describe("context warnings", () => {
+  it("estimates UTF-8 bytes and returns zero for no content", () => {
+    expect(estimateContextTokens("é")).toBe(1);
+    expect(estimateContextTokens(undefined)).toBe(0);
+  });
+
+  it("warns when model-visible tool output reaches the threshold", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    warnOnLargeToolOutput(
+      {
+        content: [
+          {
+            type: "text",
+            text: "x".repeat(TOOL_OUTPUT_WARNING_TOKENS * 4),
+          },
+        ],
+      },
+      "large-output",
+    );
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Tool "large-output" returned'),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("does not warn for large metadata", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    warnOnLargeToolOutput(
+      { content: [], _meta: { private: "x".repeat(100_000) } },
+      "large-meta",
+    );
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});

--- a/packages/core/src/context-warnings.ts
+++ b/packages/core/src/context-warnings.ts
@@ -1,0 +1,36 @@
+export const TOOL_OUTPUT_WARNING_TOKENS = 5_000;
+export const VIEW_STATE_WARNING_TOKENS = 20_000;
+
+export function estimateContextTokens(value: unknown): number {
+  try {
+    const serialized = JSON.stringify(value);
+    if (!serialized) {
+      return 0;
+    }
+    return Math.ceil(new TextEncoder().encode(serialized).length / 4);
+  } catch {
+    return 0;
+  }
+}
+
+export function warnOnLargeToolOutput(result: unknown, toolName: string): void {
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return;
+  }
+  const { _meta, ...modelVisibleResult } = result as Record<string, unknown>;
+  const tokenCount = estimateContextTokens(modelVisibleResult);
+  if (tokenCount >= TOOL_OUTPUT_WARNING_TOKENS) {
+    console.warn(
+      `[skybridge] Tool "${toolName}" returned ${tokenCount} estimated model-visible tokens; this reaches the ${TOOL_OUTPUT_WARNING_TOKENS}-token warning threshold and may overload model context. _meta is excluded from this estimate.`,
+    );
+  }
+}
+
+export function warnOnLargeViewState(value: unknown, source: string): void {
+  const tokenCount = estimateContextTokens(value);
+  if (tokenCount >= VIEW_STATE_WARNING_TOKENS) {
+    console.warn(
+      `[skybridge] ${source} is persisting ${tokenCount} estimated tokens in model-visible view state; this reaches the ${VIEW_STATE_WARNING_TOKENS}-token warning threshold and may overload model context.`,
+    );
+  }
+}

--- a/packages/core/src/context-warnings.ts
+++ b/packages/core/src/context-warnings.ts
@@ -21,7 +21,7 @@ export function warnOnLargeToolOutput(result: unknown, toolName: string): void {
   const tokenCount = estimateContextTokens(modelVisibleResult);
   if (tokenCount >= TOOL_OUTPUT_WARNING_TOKENS) {
     console.warn(
-      `[skybridge] Tool "${toolName}" returned ${tokenCount} estimated model-visible tokens; this reaches the ${TOOL_OUTPUT_WARNING_TOKENS}-token warning threshold and may overload model context. _meta is excluded from this estimate.`,
+      `[skybridge] Tool "${toolName}" returned ${tokenCount} estimated model-visible tokens; this reaches the ${TOOL_OUTPUT_WARNING_TOKENS}-token warning threshold and may overload model context. Content and structured content are included in this estimate.`,
     );
   }
 }
@@ -30,7 +30,7 @@ export function warnOnLargeViewState(value: unknown, source: string): void {
   const tokenCount = estimateContextTokens(value);
   if (tokenCount >= VIEW_STATE_WARNING_TOKENS) {
     console.warn(
-      `[skybridge] ${source} is persisting ${tokenCount} estimated tokens in model-visible view state; this reaches the ${VIEW_STATE_WARNING_TOKENS}-token warning threshold and may overload model context.`,
+      `[skybridge] ${source} is persisting ${tokenCount} estimated tokens in model-visible view state; this reaches the ${VIEW_STATE_WARNING_TOKENS}-token warning threshold and may overload model context. Persisted view state and data-llm context are included in this estimate.`,
     );
   }
 }

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -32,6 +32,7 @@ import express, {
   type Express,
   type RequestHandler,
 } from "express";
+import { warnOnLargeToolOutput } from "../context-warnings.js";
 import type { OAuthConfig } from "./auth/index.js";
 import {
   authToSecuritySchemes,
@@ -1303,7 +1304,12 @@ export class McpServer<
     {
       attachViewUUID,
       securitySchemes,
-    }: { attachViewUUID: boolean; securitySchemes?: SecurityScheme[] },
+      toolName,
+    }: {
+      attachViewUUID: boolean;
+      securitySchemes?: SecurityScheme[];
+      toolName: string;
+    },
   ): ToolHandler<InputArgs> {
     return async (args, extra) => {
       const toolExtra = extra ?? (args as unknown as McpExtra);
@@ -1331,6 +1337,7 @@ export class McpServer<
         captureToolError(toolExtra, error);
         throw error;
       }
+      warnOnLargeToolOutput(result, toolName);
       return {
         ...result,
         content: normalizeContent(result.content),
@@ -1506,6 +1513,7 @@ export class McpServer<
     const wrappedCb = this.decorateToolHandler(cb, {
       attachViewUUID: Boolean(view),
       securitySchemes,
+      toolName: name,
     });
 
     baseFn.call(this, name, { ...toolFields, _meta: toolMeta }, wrappedCb);

--- a/packages/core/src/test/view.test.ts
+++ b/packages/core/src/test/view.test.ts
@@ -15,6 +15,7 @@ import {
   type MockInstance,
   vi,
 } from "vitest";
+import { TOOL_OUTPUT_WARNING_TOKENS } from "../context-warnings.js";
 import type { McpServer, ViewName } from "../server/server.js";
 import { McpServer as McpServerClass } from "../server/server.js";
 import {
@@ -538,6 +539,31 @@ describe("McpServer.registerTool (unified API)", () => {
     expect(result._meta?.viewUUID).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
     );
+  });
+
+  it("warns when a tool callback returns large model-visible output", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    server.registerTool(
+      { name: "large-output", description: "Test tool" },
+      vi.fn().mockResolvedValue({
+        content: [
+          {
+            type: "text",
+            text: "x".repeat(TOOL_OUTPUT_WARNING_TOKENS * 4),
+          },
+        ],
+      }),
+    );
+
+    const wrappedCallback = mockRegisterTool.mock.calls[0]?.[2] as (
+      ...args: unknown[]
+    ) => Promise<unknown>;
+    await wrappedCallback({}, {});
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Tool "large-output" returned'),
+    );
+    warnSpy.mockRestore();
   });
 
   it("should preserve existing _meta when injecting viewUUID", async () => {

--- a/packages/core/src/web/bridges/adaptor.test.ts
+++ b/packages/core/src/web/bridges/adaptor.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { VIEW_STATE_WARNING_TOKENS } from "../../context-warnings.js";
 import { HostAdaptor } from "./adaptor.js";
 import { AppsSdkBridge } from "./apps-sdk/bridge.js";
 import { McpAppBridge } from "./mcp-app/bridge.js";
@@ -164,14 +165,14 @@ describe("HostAdaptor", () => {
     );
   });
 
-  it("warns when setViewState persists more than 4K tokens", async () => {
+  it("warns when setViewState reaches 20K tokens", async () => {
     const setWidgetState = vi.fn().mockResolvedValue(undefined);
     vi.stubGlobal("openai", { setWidgetState, widgetState: null });
     const adaptor = new HostAdaptor();
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     await adaptor.setViewState({
-      longText: "x".repeat(4096 * 4 + 50),
+      longText: "x".repeat(VIEW_STATE_WARNING_TOKENS * 4),
     });
 
     expect(warnSpy).toHaveBeenCalledWith(

--- a/packages/core/src/web/bridges/adaptor.ts
+++ b/packages/core/src/web/bridges/adaptor.ts
@@ -1,3 +1,4 @@
+import { warnOnLargeViewState } from "../../context-warnings.js";
 import { AppsSdkBridge } from "./apps-sdk/bridge.js";
 import type { AppsSdkWidgetState } from "./apps-sdk/types.js";
 import { McpAppBridge } from "./mcp-app/bridge.js";
@@ -23,24 +24,6 @@ import { NotSupportedError } from "./types.js";
 
 const STORAGE_PREFIX = "sb:";
 const MAX_STORAGE_ENTRIES = 200;
-const VIEW_STATE_TOKEN_WARNING_THRESHOLD = 4000;
-
-function getApproximateTokenCount(value: unknown): number {
-  try {
-    return Math.max(1, Math.ceil(JSON.stringify(value).length / 4));
-  } catch {
-    return 0;
-  }
-}
-
-function warnOnLargeViewState(value: unknown, source: string): void {
-  const tokenCount = getApproximateTokenCount(value);
-  if (tokenCount > VIEW_STATE_TOKEN_WARNING_THRESHOLD) {
-    console.warn(
-      `[skybridge] ${source} is persisting ${tokenCount} tokens in view state; this exceeds the ${VIEW_STATE_TOKEN_WARNING_THRESHOLD}-token warning threshold and may overload model context.`,
-    );
-  }
-}
 
 function isImage(mimeType: string | undefined): boolean {
   return mimeType?.startsWith("image/") ?? false;

--- a/packages/core/src/web/data-llm.test.tsx
+++ b/packages/core/src/web/data-llm.test.tsx
@@ -8,6 +8,7 @@ import {
   type Mock,
   vi,
 } from "vitest";
+import { VIEW_STATE_WARNING_TOKENS } from "../context-warnings.js";
 import { HostAdaptor } from "./bridges/adaptor.js";
 import { getAdaptor } from "./bridges/get-adaptor.js";
 import { McpAppBridge } from "./bridges/mcp-app/index.js";
@@ -90,11 +91,11 @@ describe("DataLLM", () => {
       expect(callArgs).toHaveProperty("__view_context");
     });
 
-    it("warns when DataLLM content exceeds the 4K token warning threshold", async () => {
+    it("warns when DataLLM content reaches the 20K token warning threshold", async () => {
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
       render(
-        <DataLLM content={"x".repeat(4096 * 4 + 50)}>
+        <DataLLM content={"x".repeat(VIEW_STATE_WARNING_TOKENS * 4)}>
           <div>Child</div>
         </DataLLM>,
       );

--- a/packages/devtools/src/components/layout/tool-panel/context-warning.tsx
+++ b/packages/devtools/src/components/layout/tool-panel/context-warning.tsx
@@ -13,13 +13,13 @@ const warningCopy = {
     badge: "Large response",
     title: "Large model-visible output",
     description:
-      "This can consume significant context or exceed limits in some clients and models. _meta is excluded from this warning.",
+      "Content and structured content count toward this estimate. Large responses can consume significant context or exceed limits in some clients and models.",
   },
   "view-state": {
     badge: "Large context",
     title: "Large model-visible view state",
     description:
-      "Keep only content the model needs. Private view state and image IDs are excluded from this warning.",
+      "Persisted view state and data-llm context count toward this estimate. Keep only content the model needs.",
   },
 } satisfies Record<
   ContextWarningKind,

--- a/packages/devtools/src/components/layout/tool-panel/context-warning.tsx
+++ b/packages/devtools/src/components/layout/tool-panel/context-warning.tsx
@@ -1,0 +1,52 @@
+import { WarningAlert } from "@alpic-ai/ui/components/alert";
+import { Badge } from "@alpic-ai/ui/components/badge";
+
+const tokenFormatter = new Intl.NumberFormat("en", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+
+type ContextWarningKind = "tool-output" | "view-state";
+
+const warningCopy = {
+  "tool-output": {
+    badge: "Large response",
+    title: "Large model-visible output",
+    description:
+      "This can consume significant context or exceed limits in some clients and models. _meta is excluded from this warning.",
+  },
+  "view-state": {
+    badge: "Large context",
+    title: "Large model-visible view state",
+    description:
+      "Keep only content the model needs. Private view state and image IDs are excluded from this warning.",
+  },
+} satisfies Record<
+  ContextWarningKind,
+  { badge: string; title: string; description: string }
+>;
+
+export function ContextWarningBadge({ kind }: { kind: ContextWarningKind }) {
+  return (
+    <Badge size="sm" variant="warning">
+      {warningCopy[kind].badge}
+    </Badge>
+  );
+}
+
+export function ContextWarningAlert({
+  kind,
+  tokenCount,
+}: {
+  kind: ContextWarningKind;
+  tokenCount: number;
+}) {
+  const copy = warningCopy[kind];
+  return (
+    <WarningAlert
+      className="shrink-0 rounded-none border-x-0 border-t-0 px-3 py-2"
+      title={`${copy.title} (~${tokenFormatter.format(tokenCount)} tokens)`}
+      description={copy.description}
+    />
+  );
+}

--- a/packages/devtools/src/components/layout/tool-panel/context-warning.tsx
+++ b/packages/devtools/src/components/layout/tool-panel/context-warning.tsx
@@ -1,5 +1,7 @@
 import { WarningAlert } from "@alpic-ai/ui/components/alert";
 import { Badge } from "@alpic-ai/ui/components/badge";
+import { X } from "lucide-react";
+import { useState } from "react";
 
 const tokenFormatter = new Intl.NumberFormat("en", {
   notation: "compact",
@@ -7,6 +9,9 @@ const tokenFormatter = new Intl.NumberFormat("en", {
 });
 
 type ContextWarningKind = "tool-output" | "view-state";
+
+const getDismissedWarningKey = (kind: ContextWarningKind) =>
+  `skybridge-devtools-dismissed-${kind}-warning`;
 
 const warningCopy = {
   "tool-output": {
@@ -42,11 +47,34 @@ export function ContextWarningAlert({
   tokenCount: number;
 }) {
   const copy = warningCopy[kind];
+  const [isDismissed, setIsDismissed] = useState(
+    () => sessionStorage.getItem(getDismissedWarningKey(kind)) === "true",
+  );
+
+  if (isDismissed) {
+    return null;
+  }
+
+  const dismiss = () => {
+    sessionStorage.setItem(getDismissedWarningKey(kind), "true");
+    setIsDismissed(true);
+  };
+
   return (
-    <WarningAlert
-      className="shrink-0 rounded-none border-x-0 border-t-0 px-3 py-2"
-      title={`${copy.title} (~${tokenFormatter.format(tokenCount)} tokens)`}
-      description={copy.description}
-    />
+    <div className="relative shrink-0">
+      <WarningAlert
+        className="rounded-none border-x-0 border-t-0 py-2 pl-3 pr-10"
+        title={`${copy.title} (~${tokenFormatter.format(tokenCount)} tokens)`}
+        description={copy.description}
+      />
+      <button
+        type="button"
+        aria-label={`Dismiss ${copy.badge.toLowerCase()} warning for this session`}
+        onClick={dismiss}
+        className="absolute right-2 top-2 inline-flex size-6 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-badge-warning/10 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      >
+        <X className="size-3.5" />
+      </button>
+    </div>
   );
 }

--- a/packages/devtools/src/components/layout/tool-panel/index.tsx
+++ b/packages/devtools/src/components/layout/tool-panel/index.tsx
@@ -7,12 +7,16 @@ import {
   Separator,
   useDefaultLayout,
 } from "react-resizable-panels";
-
+import {
+  getToolOutputTokenCount,
+  TOOL_OUTPUT_WARNING_TOKENS,
+} from "@/lib/context-warnings.js";
 import { CopyButton } from "@/lib/copy.js";
 import { useInspectorPreferencesStore } from "@/lib/inspector-preferences-store.js";
 import { useSelectedToolOrNull } from "@/lib/mcp/index.js";
 import { useCallToolResult } from "@/lib/store.js";
 import { cn, formatBytes } from "@/lib/utils.js";
+import { ContextWarningAlert, ContextWarningBadge } from "./context-warning.js";
 import { JsonSyntaxBlock } from "./json-syntax-block.js";
 import { LogsDrawer } from "./logs-drawer.js";
 import {
@@ -117,6 +121,9 @@ export const ToolPanel = () => {
     const response = data?.response;
     const responseJson = JSON.stringify(response ?? null, null, 2);
     const sizeBytes = new TextEncoder().encode(responseJson).length;
+    const toolOutputTokenCount = getToolOutputTokenCount(response);
+    const hasToolOutputWarning =
+      toolOutputTokenCount >= TOOL_OUTPUT_WARNING_TOKENS;
     const isError = response?.isError === true;
     const durationMs = data?.durationMs;
     return (
@@ -134,7 +141,12 @@ export const ToolPanel = () => {
           <Panel id={OUTPUT_PANEL_ID} minSize={320} className="min-h-0 min-w-0">
             <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
               <div className="flex h-9 w-full shrink-0 items-center border-b-2 border-border bg-white px-3 text-sm text-muted-foreground">
-                <div className="font-medium">Tool output</div>
+                <div className="flex items-center gap-2 font-medium">
+                  Tool output
+                  {hasToolOutputWarning && (
+                    <ContextWarningBadge kind="tool-output" />
+                  )}
+                </div>
                 <div className="ml-auto flex items-center gap-2 font-mono text-xs text-light-gray-foreground">
                   <span
                     className={isError ? "text-destructive" : "text-success"}
@@ -151,13 +163,21 @@ export const ToolPanel = () => {
                   <span>{formatBytes(sizeBytes)}</span>
                 </div>
               </div>
-              <section className="relative min-h-0 min-w-0 flex-1 overflow-auto bg-light-gray p-3">
-                <CopyButton
-                  value={responseJson}
-                  label="Copy tool output"
-                  className="absolute right-2 top-2 z-10"
-                />
-                <JsonSyntaxBlock code={responseJson} />
+              <section className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-light-gray">
+                {hasToolOutputWarning && (
+                  <ContextWarningAlert
+                    kind="tool-output"
+                    tokenCount={toolOutputTokenCount}
+                  />
+                )}
+                <div className="relative min-h-0 flex-1 overflow-auto p-3">
+                  <CopyButton
+                    value={responseJson}
+                    label="Copy tool output"
+                    className="absolute right-2 top-2 z-10"
+                  />
+                  <JsonSyntaxBlock code={responseJson} />
+                </div>
               </section>
             </div>
           </Panel>

--- a/packages/devtools/src/components/layout/tool-panel/tool-panel-header.tsx
+++ b/packages/devtools/src/components/layout/tool-panel/tool-panel-header.tsx
@@ -1,7 +1,14 @@
+import {
+  getToolOutputTokenCount,
+  getViewStateTokenCount,
+  TOOL_OUTPUT_WARNING_TOKENS,
+  VIEW_STATE_WARNING_TOKENS,
+} from "@/lib/context-warnings.js";
 import { CopyButton } from "@/lib/copy.js";
 import { useSelectedToolOrNull } from "@/lib/mcp/index.js";
 import { useCallToolResult } from "@/lib/store.js";
 import { cn, formatBytes } from "@/lib/utils.js";
+import { ContextWarningAlert, ContextWarningBadge } from "./context-warning.js";
 import { JsonSyntaxBlock } from "./json-syntax-block.js";
 
 interface ToolPanelHeaderProps {
@@ -22,17 +29,13 @@ export const ToolPanelHeader = ({
 
   const { response, openaiObject, durationMs } = data;
   const responseJson = JSON.stringify(response, null, 2);
-  const widgetStateJson = JSON.stringify(
-    openaiObject?.widgetState ?? null,
-    null,
-    2,
-  );
 
   const sizeBytes = new TextEncoder().encode(responseJson).length;
-  const viewStateTokenCount = Math.max(
-    1,
-    Math.round(widgetStateJson.length / 4),
-  );
+  const toolOutputTokenCount = getToolOutputTokenCount(response);
+  const viewStateTokenCount = getViewStateTokenCount(openaiObject?.widgetState);
+  const hasToolOutputWarning =
+    toolOutputTokenCount >= TOOL_OUTPUT_WARNING_TOKENS;
+  const hasViewStateWarning = viewStateTokenCount >= VIEW_STATE_WARNING_TOKENS;
   const isError = response.isError === true;
 
   return (
@@ -46,7 +49,10 @@ export const ToolPanelHeader = ({
       )}
     >
       <div className="text-sm text-muted-foreground flex-1 border-r border-dashed border-light-gray-foreground/40 px-3 h-full flex items-center">
-        <div className="font-medium">Tool output</div>
+        <div className="flex items-center gap-2 font-medium">
+          Tool output
+          {hasToolOutputWarning && <ContextWarningBadge kind="tool-output" />}
+        </div>
         <div className="text-xs text-light-gray-foreground flex items-center ml-auto gap-2 font-mono">
           <span className={isError ? "text-destructive" : "text-success"}>
             {isError ? "Error" : "OK"}
@@ -62,7 +68,10 @@ export const ToolPanelHeader = ({
         </div>
       </div>
       <div className="text-sm text-muted-foreground flex-1 px-3 h-full flex items-center">
-        <div className="font-medium">View state</div>
+        <div className="flex items-center gap-2 font-medium">
+          View state
+          {hasViewStateWarning && <ContextWarningBadge kind="view-state" />}
+        </div>
         <div className="text-xs text-light-gray-foreground flex items-center ml-auto gap-2 font-mono">
           <span>
             {viewStateTokenCount} token{viewStateTokenCount > 1 ? "s" : ""}
@@ -89,23 +98,45 @@ export const ToolPanelOutputContent = () => {
     2,
   );
 
+  const toolOutputTokenCount = getToolOutputTokenCount(response);
+  const viewStateTokenCount = getViewStateTokenCount(openaiObject?.widgetState);
+  const hasToolOutputWarning =
+    toolOutputTokenCount >= TOOL_OUTPUT_WARNING_TOKENS;
+  const hasViewStateWarning = viewStateTokenCount >= VIEW_STATE_WARNING_TOKENS;
+
   return (
     <div className="flex h-full min-h-0 w-full flex-row overflow-hidden bg-light-gray">
-      <section className="relative min-h-0 min-w-0 flex-1 overflow-auto p-3">
-        <CopyButton
-          value={responseJson}
-          label="Copy tool output"
-          className="absolute right-2 top-2 z-10"
-        />
-        <JsonSyntaxBlock code={responseJson} />
+      <section className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+        {hasToolOutputWarning && (
+          <ContextWarningAlert
+            kind="tool-output"
+            tokenCount={toolOutputTokenCount}
+          />
+        )}
+        <div className="relative min-h-0 flex-1 overflow-auto p-3">
+          <CopyButton
+            value={responseJson}
+            label="Copy tool output"
+            className="absolute right-2 top-2 z-10"
+          />
+          <JsonSyntaxBlock code={responseJson} />
+        </div>
       </section>
-      <section className="relative min-h-0 min-w-0 flex-1 overflow-auto border-l border-border p-3">
-        <CopyButton
-          value={widgetStateJson}
-          label="Copy view state"
-          className="absolute right-2 top-2 z-10"
-        />
-        <JsonSyntaxBlock code={widgetStateJson} />
+      <section className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden border-l border-border">
+        {hasViewStateWarning && (
+          <ContextWarningAlert
+            kind="view-state"
+            tokenCount={viewStateTokenCount}
+          />
+        )}
+        <div className="relative min-h-0 flex-1 overflow-auto p-3">
+          <CopyButton
+            value={widgetStateJson}
+            label="Copy view state"
+            className="absolute right-2 top-2 z-10"
+          />
+          <JsonSyntaxBlock code={widgetStateJson} />
+        </div>
       </section>
     </div>
   );

--- a/packages/devtools/src/components/layout/tool-panel/view/create-openai-mock.ts
+++ b/packages/devtools/src/components/layout/tool-panel/view/create-openai-mock.ts
@@ -12,26 +12,8 @@ import type {
 } from "skybridge/web";
 
 import { SET_GLOBALS_EVENT_TYPE, SetGlobalsEvent } from "skybridge/web";
+import { warnOnLargeViewState } from "@/lib/context-warnings.js";
 import { useInspectorPreferencesStore } from "@/lib/inspector-preferences-store.js";
-
-const VIEW_STATE_TOKEN_WARNING_THRESHOLD = 4000;
-
-function getApproximateTokenCount(value: unknown): number {
-  try {
-    return Math.max(1, Math.ceil(JSON.stringify(value).length / 4));
-  } catch {
-    return 0;
-  }
-}
-
-function warnOnLargeWidgetState(state: AppsSdkWidgetState): void {
-  const tokenCount = getApproximateTokenCount(state.modelContent);
-  if (tokenCount > VIEW_STATE_TOKEN_WARNING_THRESHOLD) {
-    console.warn(
-      `[skybridge] setWidgetState is persisting ${tokenCount} tokens in devtools preview view state; this exceeds the ${VIEW_STATE_TOKEN_WARNING_THRESHOLD}-token warning threshold.`,
-    );
-  }
-}
 
 function createOpenaiMethods(
   openai: AppsSdkContext & AppsSdkMethods,
@@ -80,7 +62,7 @@ function createOpenaiMethods(
       };
     },
     setWidgetState: async (state: AppsSdkWidgetState) => {
-      warnOnLargeWidgetState(state);
+      warnOnLargeViewState(state.modelContent, "setWidgetState");
       log("setWidgetState", state);
       openai.widgetState = state;
       setValue("widgetState", state);

--- a/packages/devtools/src/lib/context-warnings.test.ts
+++ b/packages/devtools/src/lib/context-warnings.test.ts
@@ -1,0 +1,67 @@
+import type { CallToolResponse } from "skybridge/web";
+import { describe, expect, it, vi } from "vitest";
+import {
+  estimateContextTokens,
+  getToolOutputTokenCount,
+  getViewStateTokenCount,
+  TOOL_OUTPUT_WARNING_TOKENS,
+  warnOnLargeToolOutput,
+} from "./context-warnings.js";
+
+const response = (
+  structuredContent: Record<string, unknown>,
+  meta?: Record<string, unknown>,
+): CallToolResponse => ({
+  content: [],
+  structuredContent,
+  isError: false,
+  meta,
+});
+
+describe("context warnings", () => {
+  it("estimates one token per four UTF-8 bytes and returns zero for no content", () => {
+    expect(estimateContextTokens("é")).toBe(1);
+    expect(estimateContextTokens(undefined)).toBe(0);
+  });
+
+  it("excludes tool response metadata from the estimate", () => {
+    expect(
+      getToolOutputTokenCount(response({}, { private: "x".repeat(100_000) })),
+    ).toBe(getToolOutputTokenCount(response({})));
+  });
+
+  it("only measures model-visible view state", () => {
+    expect(
+      getViewStateTokenCount({
+        modelContent: {},
+        privateContent: { private: "x".repeat(100_000) },
+      }),
+    ).toBe(estimateContextTokens({}));
+  });
+
+  it("warns when model-visible tool output reaches the threshold", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const largeResponse = response({
+      content: "x".repeat(TOOL_OUTPUT_WARNING_TOKENS * 4),
+    });
+
+    warnOnLargeToolOutput(largeResponse, "large-output");
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Tool "large-output" returned'),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("does not warn for large metadata", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    warnOnLargeToolOutput(
+      response({}, { private: "x".repeat(100_000) }),
+      "large-meta",
+    );
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});

--- a/packages/devtools/src/lib/context-warnings.ts
+++ b/packages/devtools/src/lib/context-warnings.ts
@@ -33,7 +33,7 @@ export function warnOnLargeToolOutput(
   const tokenCount = getToolOutputTokenCount(response);
   if (tokenCount >= TOOL_OUTPUT_WARNING_TOKENS) {
     console.warn(
-      `[skybridge] Tool "${toolName}" returned ${tokenCount} estimated model-visible tokens; this reaches the ${TOOL_OUTPUT_WARNING_TOKENS}-token warning threshold and may overload model context. _meta is excluded from this estimate.`,
+      `[skybridge] Tool "${toolName}" returned ${tokenCount} estimated model-visible tokens; this reaches the ${TOOL_OUTPUT_WARNING_TOKENS}-token warning threshold and may overload model context. Content and structured content are included in this estimate.`,
     );
   }
 }
@@ -42,7 +42,7 @@ export function warnOnLargeViewState(value: unknown, source: string): void {
   const tokenCount = estimateContextTokens(value);
   if (tokenCount >= VIEW_STATE_WARNING_TOKENS) {
     console.warn(
-      `[skybridge] ${source} is persisting ${tokenCount} estimated tokens in model-visible view state; this reaches the ${VIEW_STATE_WARNING_TOKENS}-token warning threshold and may overload model context.`,
+      `[skybridge] ${source} is persisting ${tokenCount} estimated tokens in model-visible view state; this reaches the ${VIEW_STATE_WARNING_TOKENS}-token warning threshold and may overload model context. Persisted view state and data-llm context are included in this estimate.`,
     );
   }
 }

--- a/packages/devtools/src/lib/context-warnings.ts
+++ b/packages/devtools/src/lib/context-warnings.ts
@@ -1,0 +1,48 @@
+import type { AppsSdkWidgetState, CallToolResponse } from "skybridge/web";
+
+export const TOOL_OUTPUT_WARNING_TOKENS = 5_000;
+export const VIEW_STATE_WARNING_TOKENS = 20_000;
+
+export function estimateContextTokens(value: unknown): number {
+  try {
+    const serialized = JSON.stringify(value);
+    if (!serialized) {
+      return 0;
+    }
+    return Math.ceil(new TextEncoder().encode(serialized).length / 4);
+  } catch {
+    return 0;
+  }
+}
+
+export function getToolOutputTokenCount(response: CallToolResponse): number {
+  const { meta: _meta, ...modelVisibleResponse } = response;
+  return estimateContextTokens(modelVisibleResponse);
+}
+
+export function getViewStateTokenCount(
+  widgetState: AppsSdkWidgetState | null | undefined,
+): number {
+  return estimateContextTokens(widgetState?.modelContent);
+}
+
+export function warnOnLargeToolOutput(
+  response: CallToolResponse,
+  toolName: string,
+): void {
+  const tokenCount = getToolOutputTokenCount(response);
+  if (tokenCount >= TOOL_OUTPUT_WARNING_TOKENS) {
+    console.warn(
+      `[skybridge] Tool "${toolName}" returned ${tokenCount} estimated model-visible tokens; this reaches the ${TOOL_OUTPUT_WARNING_TOKENS}-token warning threshold and may overload model context. _meta is excluded from this estimate.`,
+    );
+  }
+}
+
+export function warnOnLargeViewState(value: unknown, source: string): void {
+  const tokenCount = estimateContextTokens(value);
+  if (tokenCount >= VIEW_STATE_WARNING_TOKENS) {
+    console.warn(
+      `[skybridge] ${source} is persisting ${tokenCount} estimated tokens in model-visible view state; this reaches the ${VIEW_STATE_WARNING_TOKENS}-token warning threshold and may overload model context.`,
+    );
+  }
+}

--- a/packages/devtools/src/lib/mcp/index.ts
+++ b/packages/devtools/src/lib/mcp/index.ts
@@ -8,6 +8,7 @@ import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import type { AppsSdkContext, CallToolArgs } from "skybridge/web";
 import { useAuthStore } from "@/lib/auth-store.js";
+import { warnOnLargeToolOutput } from "@/lib/context-warnings.js";
 import { env } from "@/lib/env.js";
 import { getInspectorPreferences } from "@/lib/inspector-preferences-store.js";
 import { useStore } from "@/lib/store.js";
@@ -208,6 +209,7 @@ export const useCallTool = () => {
       });
       const startedAt = performance.now();
       const response = await client.callTool(toolName, args);
+      warnOnLargeToolOutput(response, toolName);
       const durationMs = Math.round(performance.now() - startedAt);
       const completedAt = Date.now();
       setToolData(toolName, {


### PR DESCRIPTION
## Summary

- surface warning badges and scoped inline alerts for large Tool output and View state
- warn at 5,000 estimated tool-output tokens and 20,000 estimated view-state tokens
- count model-visible tool content and structured content, plus persisted view state and data-llm context
- align browser and server console warnings while keeping the full payload inspectable

## Threshold rationale

We use a 200k-token Haiku context window as the baseline.

These thresholds are advisory, not hard limits. They are meant to prompt developers to review how their app uses model context; exceeding them may be perfectly reasonable depending on the app. DevTools does not block or truncate anything.

- **Tool output — 5k tokens (2.5%)**: one tool call at this size may be fine, but tool responses remain in the conversation and accumulate when an app makes multiple tool calls. The lower threshold warns before repeated calls rapidly consume the context window.
- **View state — 20k tokens (10%)**: view state gets a larger allowance because it does not accumulate across new rounds of inference. The latest state is sent to the model, so 20k represents a meaningful but bounded share of the context window.

Images taken with a 1 token threshold to trigger them:
<img width="1493" height="772" alt="image" src="https://github.com/user-attachments/assets/03bf873d-af25-4caa-9260-6251dbc8f538" />
<img width="721" height="94" alt="image" src="https://github.com/user-attachments/assets/8b90b84e-bb67-4af7-bfc7-190ffadc4d3c" />
<img width="525" height="127" alt="image" src="https://github.com/user-attachments/assets/e610d31c-5f4a-4ad3-a87b-88f944768163" />