### PR TITLE
fix: do not render views for failed tool calls

### DIFF
--- a/docs/api-reference/register-tool.mdx
+++ b/docs/api-reference/register-tool.mdx
@@ -231,11 +231,11 @@ The request context.
 | --- | --- |
 | `content` | Text for the model, shown in the conversation. A string, a `ContentBlock`, or an array. |
 | `structuredContent` | Typed data the model and the view read (via [`useToolInfo`](/api-reference/use-tool-info)). |
-| `isError` | Marks the call as failed. |
+| `isError` | Marks the call as failed. The host shows the `content` as text and skips the view. |
 | `_meta` | View-only response metadata, hidden from the model. |
 
 <Info>
-For a view tool, Skybridge adds a `viewUUID` to `_meta`, a reserved key used for state persistence.
+For a view tool, Skybridge adds a `viewUUID` to `_meta`, a reserved key used for state persistence. A failed call (`isError: true`, or a handler that throws) carries no `viewUUID`, so hosts render the error as text instead of the view. Return the failure as `content` the model can act on.
 </Info>
 
 ### Client hints

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -1331,15 +1331,20 @@ export class McpServer<
         captureToolError(toolExtra, error);
         throw error;
       }
+      // Hosts key view rendering off `viewUUID`, and a failed call has no data
+      // for the view to render, so errors stay text-only.
+      // @see https://github.com/modelcontextprotocol/ext-apps/issues/694
+      const isErrorResult = (result as { isError?: boolean }).isError === true;
       return {
         ...result,
         content: normalizeContent(result.content),
-        ...(attachViewUUID && {
-          _meta: {
-            ...(result as { _meta?: Record<string, unknown> })._meta,
-            viewUUID: crypto.randomUUID(),
-          },
-        }),
+        ...(attachViewUUID &&
+          !isErrorResult && {
+            _meta: {
+              ...(result as { _meta?: Record<string, unknown> })._meta,
+              viewUUID: crypto.randomUUID(),
+            },
+          }),
       };
     };
   }

--- a/packages/core/src/test/view.test.ts
+++ b/packages/core/src/test/view.test.ts
@@ -566,6 +566,32 @@ describe("McpServer.registerTool (unified API)", () => {
     expect(result._meta?.viewUUID).toBeDefined();
   });
 
+  it("should not inject viewUUID when the tool result is an error", async () => {
+    const mockToolCallback = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "boom" }],
+      isError: true,
+      _meta: { requestId: "req-123" },
+    });
+
+    server.registerTool(
+      {
+        name: "my-view",
+        description: "Test tool",
+        view: { component: "my-view" as ViewName, description: "Test view" },
+      },
+      mockToolCallback,
+    );
+
+    const wrappedCallback = mockRegisterTool.mock.calls[0]?.[2] as (
+      ...args: unknown[]
+    ) => Promise<{ _meta?: Record<string, unknown>; isError?: boolean }>;
+    const result = await wrappedCallback({}, {});
+
+    expect(result.isError).toBe(true);
+    expect(result._meta?.viewUUID).toBeUndefined();
+    expect(result._meta?.requestId).toBe("req-123");
+  });
+
   it("should generate unique viewUUIDs across calls", async () => {
     const mockToolCallback = vi.fn().mockResolvedValue({
       content: [{ type: "text", text: "result" }],

--- a/packages/devtools/e2e/fixtures/server.ts
+++ b/packages/devtools/e2e/fixtures/server.ts
@@ -88,6 +88,21 @@ const server = baseServer
   )
   .registerTool(
     {
+      name: "error-card",
+      description: "Fails on purpose to check that the view stays unrendered",
+      inputSchema: {},
+      view: {
+        component: "error-card",
+        description: "Error card widget",
+      },
+    },
+    async () => ({
+      content: [{ type: "text", text: "the tool failed" }],
+      isError: true,
+    }),
+  )
+  .registerTool(
+    {
       name: "every-input-type",
       description:
         "Exercises every common input type the form renderer handles.",

--- a/packages/devtools/e2e/fixtures/web/src/views/error-card.tsx
+++ b/packages/devtools/e2e/fixtures/web/src/views/error-card.tsx
@@ -1,0 +1,10 @@
+function ErrorCard() {
+  return (
+    <div style={{ padding: 16, fontFamily: "sans-serif" }}>
+      <style>{"html,body{margin:0;padding:0}"}</style>
+      <p style={{ margin: 0 }}>error-card view rendered</p>
+    </div>
+  );
+}
+
+export default ErrorCard;

--- a/packages/devtools/e2e/tests/tool-error.spec.ts
+++ b/packages/devtools/e2e/tests/tool-error.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("tool errors", () => {
+  test("keeps the view unrendered and shows the error output", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const errorCard = page.locator('[data-tool-name="error-card"]');
+    await errorCard.locator('[data-slot="accordion-trigger"]').click();
+    await errorCard.getByRole("button", { name: /^run$/i }).click();
+
+    await expect(page.getByRole("main")).toContainText("the tool failed");
+    await expect(page.getByTestId("view-skipped-on-error")).toBeVisible();
+    await expect(page.locator('iframe[title="html-preview"]')).toHaveCount(0);
+  });
+});

--- a/packages/devtools/src/components/layout/tool-panel/index.tsx
+++ b/packages/devtools/src/components/layout/tool-panel/index.tsx
@@ -91,7 +91,11 @@ export const ToolPanel = () => {
   const templateUri = (tool?._meta?.ui as { resourceUri?: string } | undefined)
     ?.resourceUri;
   const hasResult = Boolean(tool && data?.response);
-  const hasView = Boolean(templateUri);
+  const isErrorResponse = data?.response?.isError === true;
+  // Hosts leave the view unrendered when a tool call fails, so DevTools shows
+  // the raw error the same way they do.
+  // @see https://github.com/modelcontextprotocol/ext-apps/issues/694
+  const hasView = Boolean(templateUri) && !isErrorResponse;
 
   if (!tool) {
     return (
@@ -117,7 +121,6 @@ export const ToolPanel = () => {
     const response = data?.response;
     const responseJson = JSON.stringify(response ?? null, null, 2);
     const sizeBytes = new TextEncoder().encode(responseJson).length;
-    const isError = response?.isError === true;
     const durationMs = data?.durationMs;
     return (
       <div
@@ -137,9 +140,11 @@ export const ToolPanel = () => {
                 <div className="font-medium">Tool output</div>
                 <div className="ml-auto flex items-center gap-2 font-mono text-xs text-light-gray-foreground">
                   <span
-                    className={isError ? "text-destructive" : "text-success"}
+                    className={
+                      isErrorResponse ? "text-destructive" : "text-success"
+                    }
                   >
-                    {isError ? "Error" : "OK"}
+                    {isErrorResponse ? "Error" : "OK"}
                   </span>
                   {durationMs != null ? (
                     <>
@@ -151,6 +156,15 @@ export const ToolPanel = () => {
                   <span>{formatBytes(sizeBytes)}</span>
                 </div>
               </div>
+              {templateUri && isErrorResponse ? (
+                <div
+                  data-testid="view-skipped-on-error"
+                  className="shrink-0 border-b border-border bg-white px-3 py-2 text-xs text-muted-foreground"
+                >
+                  The view is not rendered because the tool returned an error.
+                  Hosts behave the same way.
+                </div>
+              ) : null}
               <section className="relative min-h-0 min-w-0 flex-1 overflow-auto bg-light-gray p-3">
                 <CopyButton
                   value={responseJson}

--- a/skills/chatgpt-app-builder/references/fetch-and-render-data.md
+++ b/skills/chatgpt-app-builder/references/fetch-and-render-data.md
@@ -26,6 +26,7 @@ Output:
 - **`structuredContent`**: concise JSON the view uses and the model reads. Include only what the model should see.
 - **`content`** (optional): concise narration (Markdown or plaintext) shown to the LLM.
 - **`_meta`** (optional): additional details or display-only content kept out of the model's direct context, such as large payloads or image URLs. The view can selectively expose relevant parts through `data-llm`. `_meta` is delivered to the client, so never put server secrets in it.
+- **`isError`** (optional): marks the call as failed. Hosts show `content` as text and skip the view entirely, so state the failure and the way out in `content` instead of relying on the view to render it.
 
 Keep these channels complementary. Avoid copying the same payload into `content`, `structuredContent`, view state, and `data-llm`. A short status in `content` may summarize the result, while `structuredContent` carries the fields useful to the model immediately and `_meta` carries additional details or display-only content intentionally omitted from its direct context.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

A view tool that returns `isError: true` still produced a result carrying `_meta.viewUUID`. Hosts key view rendering off that marker, so the playground (ALP-1535) and DevTools (SKY-465) rendered an empty view on top of the error text — see the empty map in the linked issue.

[ext-apps#694](https://github.com/modelcontextprotocol/ext-apps/issues/694) states hosts should not render the app view when a tool call fails.

## Changes

- `packages/core`: `decorateToolHandler` no longer attaches `viewUUID` when the handler returns `isError: true`. A handler that throws was already unaffected — the SDK builds the error result itself, without our `_meta`.
- `packages/devtools`: the tool panel treats an errored result as "no view": it shows the tool output JSON with the `Error` badge, plus a short note explaining why the view is not rendered (hosts behave the same way).
- Docs (`api-reference/register-tool`) and the app-builder skill reference now say the failure belongs in `content`, since the view is skipped.

DevTools running the new `error-card` fixture tool — no iframe, error output, and no `viewUUID` in the response:

![DevTools showing an errored tool call with no view rendered](https://cursor.com/artifacts/c/art-69ed4fc9-7539-4dde-92e4-faf423eeb187)

## Tests

- New unit test in `packages/core/src/test/view.test.ts`: an error result keeps its own `_meta` but gets no `viewUUID`.
- New DevTools Playwright spec (`e2e/tests/tool-error.spec.ts`) with an `error-card` fixture tool: the iframe is absent, the error text and the notice are visible. Verified it fails without the DevTools change.
- `pnpm test`, `pnpm build`, and the full DevTools e2e suite pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ALP-1535](https://linear.app/alpic/issue/ALP-1535/mcp-app-view-rendering-in-case-of-tool-error)

<div><a href="https://cursor.com/agents/bc-3b850fdb-9f2c-414f-80cd-237b84cf7dea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b850fdb-9f2c-414f-80cd-237b84cf7dea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

