### PR TITLE
feat(landing): install OpenAI Ads measurement pixel

### DIFF
--- a/landing/app/layout.tsx
+++ b/landing/app/layout.tsx
@@ -106,6 +106,20 @@ export default function RootLayout({
             });
           `}
         </Script>
+        <Script id="openai-ads-pixel" strategy="afterInteractive">
+          {`
+            if (!/^(localhost|127\\.0\\.0\\.1|\\[::1\\])$/.test(location.hostname)) {
+              window.oaiq = window.oaiq || function () {
+                (window.oaiq.q = window.oaiq.q || []).push(arguments);
+              };
+              oaiq('init', { pixelId: 'RpPGaGGhiF5XPRk8txqwoZ' });
+            }
+          `}
+        </Script>
+        <Script
+          src="https://bzrcdn.openai.com/sdk/oaiq.min.js"
+          strategy="afterInteractive"
+        />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}


### PR DESCRIPTION
## Summary

- Adds the OpenAI Ads measurement pixel (`oaiq`, pixel ID `RpPGaGGhiF5XPRk8txqwoZ`) to the landing root layout
- Loads via `next/script` with `afterInteractive`, matching the existing GA setup
- Skips init on localhost, same hostname guard GA already uses, so dev traffic stays out of reporting

## Scope

Base pixel only. No conversion events: none is defined in Ads Manager yet, and the landing has no completed action to fire on. The Conversions API (server events) needs a backend; the landing is a static export.