### PR TITLE
fix(ci): make npm publish idempotent per version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
 
+    concurrency:
+      group: publish-${{ github.sha }}
+      cancel-in-progress: true
+
     steps:
       - uses: actions/checkout@v7
 
@@ -77,7 +81,7 @@ jobs:
 
       - name: Publish core to npm
         working-directory: ./packages/core
-        run: pnpm publish --tag ${{ steps.version.outputs.tag }} --access public --provenance --no-git-checks
+        run: ../../scripts/publish-if-new.sh ${{ steps.version.outputs.tag }}
 
       # Templates use `skybridge: workspace:*` so dev/CI build against the
       # local package. pnpm doesn't rewrite that when bundling the templates
@@ -93,11 +97,11 @@ jobs:
 
       - name: Publish create-skybridge to npm
         working-directory: ./packages/create-skybridge
-        run: pnpm publish --tag ${{ steps.version.outputs.tag }} --access public --provenance --no-git-checks
+        run: ../../scripts/publish-if-new.sh ${{ steps.version.outputs.tag }}
 
       - name: Publish devtools to npm
         working-directory: ./packages/devtools
-        run: pnpm publish --tag ${{ steps.version.outputs.tag }} --access public --provenance --no-git-checks
+        run: ../../scripts/publish-if-new.sh ${{ steps.version.outputs.tag }}
 
       - name: Restore templates workspace deps
         if: github.event_name == 'release'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     concurrency:
-      group: publish-${{ github.sha }}
+      group: publish-${{ github.event_name }}-${{ github.sha }}
       cancel-in-progress: false
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
 
     concurrency:
       group: publish-${{ github.sha }}
-      cancel-in-progress: true
+      cancel-in-progress: false
 
     steps:
       - uses: actions/checkout@v7

--- a/scripts/publish-if-new.sh
+++ b/scripts/publish-if-new.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tag=$1
+name=$(node -p 'require("./package.json").name')
+version=$(node -p 'require("./package.json").version')
+
+if npm view "$name@$version" version >/dev/null 2>&1; then
+  echo "$name@$version is already published, skipping"
+  exit 0
+fi
+
+pnpm publish --tag "$tag" --access public --provenance --no-git-checks


### PR DESCRIPTION
## Summary

- Guard each `pnpm publish` behind `scripts/publish-if-new.sh`, which checks `npm view <name>@<version>` and skips instead of failing when that exact version already exists.
- Add a `concurrency` group keyed on the event name and `github.sha` to the `publish` job, so two runs that would publish the same version serialize instead of racing.

## Context

`publish.yml` runs on every branch push and derives the version from the commit SHA (`0.0.0-dev.<sha7>` / `0.0.0-next.<sha7>`). Any second publish attempt for a commit already published gets npm's E403 "cannot publish over previously published versions", so the run goes red even though the package is on npm.

Concurrency alone only covers the simultaneous case. The same failure happens for non-concurrent attempts: a re-run of a failed job, or a second branch pushed at the same commit. The idempotence guard is what actually fixes those; the concurrency group closes the remaining window where two runs both read the version as unpublished before either writes.

The key includes `github.event_name` because a release run and a push run at the same commit publish different versions (`latest` vs `next.<sha>` / `dev.<sha>`), so they must not share a group: a group holds only one pending run, and a queued release run would be displaced by a later push.

The group uses `cancel-in-progress: false` so the second run queues rather than killing the first. Cancelling could interrupt a release mid-flight and drop the release-only steps (Mintlify deploy, bump PR, Discord notify), and queuing is harmless now that a duplicate run skips instead of 403ing.

The guard is per package rather than per job, so a run that published `skybridge` but died before `@skybridge/devtools` can be re-run and will publish only what is missing.

## Verification

The branch's own Publish run covers both paths:

- Fresh SHA: published `skybridge@0.0.0-dev.643ca28` and the other two packages normally.
- Re-run of that same run: green, with `skybridge@... is already published, skipping` for all three packages. That re-run is exactly the case that used to fail with E403.

## Notes

On a `release` event, re-publishing an existing tag now logs "already published, skipping" and passes green rather than failing. That is the intended behaviour for job re-runs, but it means a mistakenly re-cut release is no longer loud.

It also means a release re-run reaches the release-only steps instead of dying at the publish step. That is the point (you re-run because the Mintlify push or the bump PR failed), and those two are idempotent: the deploy force-pushes the same commit, and the bump PR updates the fixed `chore/bump-versions` branch. The Discord notification does fire a second time.
