### PR TITLE
feat: add shopify

### DIFF
--- a/packages/create-skybridge/templates/ecom/.env.template
+++ b/packages/create-skybridge/templates/ecom/.env.template
@@ -1,2 +1,7 @@
 # Copy to .env and fill in. Sourced by the server at startup.
 API_KEY=
+
+# Only for the Shopify catalog provider (src/catalog/shopify.ts).
+# The token is the public Storefront API access token, not an Admin key.
+SHOPIFY_STORE_DOMAIN=
+SHOPIFY_STOREFRONT_TOKEN=

--- a/packages/create-skybridge/templates/ecom/src/catalog/index.ts
+++ b/packages/create-skybridge/templates/ecom/src/catalog/index.ts
@@ -1,0 +1,19 @@
+// The catalog: the app's single data seam. Both tools read products through
+// these two functions, and nothing else in the app touches a backend.
+//
+// @todo: pick your provider. Ship one of the modules next to this file, or add
+// your own (same two exports, same types) and re-export it here:
+//   ./mock.js      placeholder catalog, no backend needed (default)
+//   ./shopify.js   Shopify Storefront API, set the SHOPIFY_* vars in .env
+//
+// Writing your own: `search(input)` returns a `SearchResult`, `getProducts(ids)`
+// resolves ids in the requested order (that is the display order, so resolve by
+// id, never by catalog order). Both map your backend's rows into `Product`s, and
+// how you group them depends on your catalog:
+//   - simple products: one `Product` with a single variant, `options: []`
+//   - grouped: one `Product` per product, `card` = union of its variants
+//   - one card per variant: `card` = that variant
+// Either way `variants` holds ALL variants the source returns for the product;
+// the detail view reads them so the client can switch variant. Order `options`
+// with the imagery-driving axis first (see `Product`: order is semantic).
+export { getProducts, search } from "./mock.js";

--- a/packages/create-skybridge/templates/ecom/src/catalog/mock.ts
+++ b/packages/create-skybridge/templates/ecom/src/catalog/mock.ts
@@ -1,10 +1,9 @@
-import type { Product } from "./tools/render-carousel.js";
-import type { Spec } from "./types.js";
+import type { SearchInput } from "../tools/search-products.js";
+import type { Product, SearchResult, Spec } from "../types.js";
 
-// Placeholder catalog, so both tools answer before a backend exists: search
-// projects its model-facing results from it, render-carousel resolves ids
-// against it. Images are inline SVG placeholders, so no CSP domain is needed.
-// @todo: delete this module once the tools query your product API / DB.
+// Placeholder catalog provider, so both tools answer before a backend exists.
+// Images are inline SVG placeholders, so no CSP domain is needed.
+// @todo: delete this module once you point `./index.js` at a real provider.
 
 function shot(fill: string): string {
   return `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='400'%3E%3Crect width='400' height='400' fill='%23${fill}'/%3E%3C/svg%3E`;
@@ -18,7 +17,7 @@ const JACKET_SPECS: Spec[] = [
 // Deliberately long, to exercise the detail page's scroll and "read more".
 const JACKET_DESCRIPTION = "Relaxed-fit jacket in water-repellent cotton.";
 
-export const MOCK_PRODUCTS: Product[] = [
+const MOCK_PRODUCTS: Product[] = [
   {
     id: "field-jacket",
     options: [
@@ -110,3 +109,26 @@ export const MOCK_PRODUCTS: Product[] = [
     },
   },
 ];
+
+// Ignores the input: every mock product matches every query.
+export async function search(_input: SearchInput): Promise<SearchResult> {
+  return {
+    products: MOCK_PRODUCTS,
+    pages: { current: 1, total: 1 },
+    totalHits: MOCK_PRODUCTS.length,
+  };
+}
+
+// Requested order is the display order, so resolve by id, not catalog order.
+export async function getProducts(ids: string[]): Promise<Product[]> {
+  const products: Product[] = [];
+  for (const id of ids) {
+    for (const product of MOCK_PRODUCTS) {
+      if (product.id === id) {
+        products.push(product);
+        break;
+      }
+    }
+  }
+  return products;
+}

--- a/packages/create-skybridge/templates/ecom/src/catalog/shopify.ts
+++ b/packages/create-skybridge/templates/ecom/src/catalog/shopify.ts
@@ -1,0 +1,264 @@
+import type { SearchInput } from "../tools/search-products.js";
+import type {
+  Option,
+  Price,
+  Product,
+  SearchResult,
+  Spec,
+  Variant,
+} from "../types.js";
+
+// Shopify Storefront API provider. To use it:
+//   1. re-export this module from `./index.js` instead of `./mock.js`
+//   2. set SHOPIFY_STORE_DOMAIN and SHOPIFY_STOREFRONT_TOKEN in .env
+//   3. uncomment the `csp` block in `src/tools/render-carousel.ts` with
+//      `https://cdn.shopify.com` and your store domain
+//
+// Product ids are Shopify handles, not GIDs: stable, readable, and far cheaper
+// in model context than `gid://shopify/Product/8123456789`.
+
+const API_VERSION = "2026-07";
+const PAGE_SIZE = 20;
+
+// Only the fields this app renders. Options are derived from the variants'
+// `selectedOptions`, so the product-level `options` field is not queried.
+const PRODUCT_FIELDS = `
+fragment ProductFields on Product {
+  handle
+  title
+  description
+  vendor
+  productType
+  onlineStoreUrl
+  availableForSale
+  priceRange { minVariantPrice { amount currencyCode } }
+  images(first: 10) { nodes { url } }
+  variants(first: 100) {
+    nodes {
+      id
+      title
+      availableForSale
+      price { amount currencyCode }
+      image { url }
+      selectedOptions { name value }
+    }
+  }
+}`;
+
+type ShopifyMoney = { amount: string; currencyCode: string };
+
+type ShopifyProduct = {
+  handle: string;
+  title: string;
+  description: string;
+  vendor: string;
+  productType: string;
+  onlineStoreUrl: string | null;
+  availableForSale: boolean;
+  priceRange: { minVariantPrice: ShopifyMoney };
+  images: { nodes: { url: string }[] };
+  variants: {
+    nodes: {
+      id: string;
+      title: string;
+      availableForSale: boolean;
+      price: ShopifyMoney;
+      image: { url: string } | null;
+      selectedOptions: { name: string; value: string }[];
+    }[];
+  };
+};
+
+async function storefront(query: string, variables: Record<string, unknown>) {
+  const domain = process.env.SHOPIFY_STORE_DOMAIN;
+  const token = process.env.SHOPIFY_STOREFRONT_TOKEN;
+  if (!domain || !token) {
+    throw new Error(
+      "Missing SHOPIFY_STORE_DOMAIN or SHOPIFY_STOREFRONT_TOKEN in the environment.",
+    );
+  }
+
+  const response = await fetch(
+    `https://${domain}/api/${API_VERSION}/graphql.json`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Shopify-Storefront-Access-Token": token,
+      },
+      body: JSON.stringify({ query, variables }),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`Shopify ${response.status}: ${await response.text()}`);
+  }
+
+  const { data, errors } = await response.json();
+  if (errors) {
+    throw new Error(`Shopify: ${JSON.stringify(errors)}`);
+  }
+  return data;
+}
+
+function toPrice(money: ShopifyMoney): Price {
+  return { amount: Number(money.amount), currency: money.currencyCode };
+}
+
+// @todo: Shopify has no generic "specs" field. Vendor and product type are a
+// starting point; swap in your own metafields once you know their namespace.
+function toSpecs(node: ShopifyProduct): Spec[] {
+  const specs: Spec[] = [];
+  if (node.vendor) {
+    specs.push({ label: "Brand", value: node.vendor });
+  }
+  if (node.productType) {
+    specs.push({ label: "Type", value: node.productType });
+  }
+  return specs;
+}
+
+function toProduct(node: ShopifyProduct): Product {
+  const specs = toSpecs(node);
+  const images: string[] = [];
+  for (const image of node.images.nodes) {
+    images.push(image.url);
+  }
+
+  // Walk the variants once, building both the variants and the axes they vary
+  // on. Shopify option names are used as-is for ids, so a variant's
+  // `selectedOptions` maps straight onto `selection`.
+  const options: Option[] = [];
+  const variants: Variant[] = [];
+  for (const variant of node.variants.nodes) {
+    const selection: Record<string, string> = {};
+    for (const selected of variant.selectedOptions) {
+      selection[selected.name] = selected.value;
+
+      let option: Option | undefined;
+      for (const candidate of options) {
+        if (candidate.id === selected.name) {
+          option = candidate;
+          break;
+        }
+      }
+      if (!option) {
+        option = { id: selected.name, label: selected.name, values: [] };
+        options.push(option);
+      }
+
+      let known = false;
+      for (const value of option.values) {
+        if (value.id === selected.value) {
+          known = true;
+          break;
+        }
+      }
+      if (!known) {
+        option.values.push({
+          id: selected.value,
+          label: selected.value,
+          media: variant.image?.url,
+        });
+      }
+    }
+
+    variants.push({
+      id: variant.id,
+      selection,
+      title: variant.title === "Default Title" ? node.title : variant.title,
+      description: node.description,
+      price: toPrice(variant.price),
+      media: variant.image ? [variant.image.url] : images,
+      url: node.onlineStoreUrl ?? undefined,
+      outOfStock: !variant.availableForSale,
+      specs,
+    });
+  }
+
+  // A single-variant product has no axes to pick from.
+  if (variants.length < 2) {
+    options.length = 0;
+  }
+
+  return {
+    id: node.handle,
+    options,
+    variants,
+    card: {
+      title: node.title,
+      description: node.description,
+      price: toPrice(node.priceRange.minVariantPrice),
+      media: images,
+      url: node.onlineStoreUrl ?? undefined,
+      outOfStock: !node.availableForSale,
+      specs,
+    },
+  };
+}
+
+export async function search({
+  keyword,
+  sort,
+  priceRange,
+}: SearchInput): Promise<SearchResult> {
+  // Shopify's search DSL: a bare term matches title, vendor, type and tags;
+  // extra clauses narrow it. @todo: add your own (`tag:`, `product_type:`…).
+  let query = keyword;
+  if (priceRange) {
+    const [min, max] = priceRange.split("-");
+    query += ` variants.price:>=${min} variants.price:<=${max}`;
+  }
+
+  const data = await storefront(
+    `${PRODUCT_FIELDS}
+    query Search($query: String!, $sortKey: ProductSortKeys!, $reverse: Boolean!, $first: Int!) {
+      products(query: $query, sortKey: $sortKey, reverse: $reverse, first: $first) {
+        nodes { ...ProductFields }
+      }
+    }`,
+    {
+      query,
+      sortKey: sort ? "PRICE" : "RELEVANCE",
+      reverse: sort === "price-desc",
+      first: PAGE_SIZE,
+    },
+  );
+
+  const products: Product[] = [];
+  for (const node of data.products.nodes) {
+    products.push(toProduct(node));
+  }
+  // Storefront paginates by cursor and reports no total, so both counts are
+  // left out rather than faked.
+  return { products };
+}
+
+export async function getProducts(ids: string[]): Promise<Product[]> {
+  // One aliased lookup per handle, so the response comes back in the order the
+  // model asked for.
+  const declarations: string[] = [];
+  const fields: string[] = [];
+  const variables: Record<string, string> = {};
+  for (let index = 0; index < ids.length; index++) {
+    declarations.push(`$h${index}: String!`);
+    fields.push(`p${index}: product(handle: $h${index}) { ...ProductFields }`);
+    variables[`h${index}`] = ids[index];
+  }
+
+  const data = await storefront(
+    `${PRODUCT_FIELDS}
+    query Products(${declarations.join(", ")}) {
+      ${fields.join("\n      ")}
+    }`,
+    variables,
+  );
+
+  const products: Product[] = [];
+  for (let index = 0; index < ids.length; index++) {
+    const node = data[`p${index}`];
+    if (node) {
+      products.push(toProduct(node));
+    }
+  }
+  return products;
+}

--- a/packages/create-skybridge/templates/ecom/src/components/variant-picker.stories.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/variant-picker.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { initialSelection, type Selection } from "../lib/variants.js";
-import type { Product } from "../tools/render-carousel.js";
+import type { Product } from "../types.js";
 import { VariantPicker } from "./variant-picker";
 
 // A sparse catalog: {white,42} does not exist, so "42" is hard-disabled under

--- a/packages/create-skybridge/templates/ecom/src/components/variant-picker.tsx
+++ b/packages/create-skybridge/templates/ecom/src/components/variant-picker.tsx
@@ -1,7 +1,7 @@
 import { text } from "../design/tokens";
 import { cx } from "../lib/cx";
 import { applyChoice, axisStates, type Selection } from "../lib/variants.js";
-import type { Product } from "../tools/render-carousel.js";
+import type { Product } from "../types.js";
 import { Chip } from "./chip";
 import * as styles from "./variant-picker.css";
 

--- a/packages/create-skybridge/templates/ecom/src/lib/variants.ts
+++ b/packages/create-skybridge/templates/ecom/src/lib/variants.ts
@@ -1,4 +1,4 @@
-import type { Product, Variant } from "../tools/render-carousel.js";
+import type { Product, Variant } from "../types.js";
 
 // Pure helpers that turn the client's option choices into a concrete variant.
 // The `variants` list is SPARSE: only combinations that exist are present, and

--- a/packages/create-skybridge/templates/ecom/src/tools/render-carousel.ts
+++ b/packages/create-skybridge/templates/ecom/src/tools/render-carousel.ts
@@ -1,76 +1,11 @@
 import { z } from "zod";
+import { getProducts } from "../catalog/index.js";
 import { CAROUSEL_MAX_SIZE, CAROUSEL_RANGE } from "../config.js";
-import { MOCK_PRODUCTS } from "../mock.js";
-import { type Price, PriceSchema, type Spec, SpecSchema } from "../types.js";
+import { PriceSchema, type Product, SpecSchema } from "../types.js";
 
 // The `render-carousel` tool: takes the IDs the model curated and returns the
-// matching products for the carousel view to render.
-// Everything this tool needs lives in this file.
-
-// ---------------------------------------------------------------------------
-// Product model
-// ---------------------------------------------------------------------------
-// Model: variant-as-full-product. Each `Variant` is a complete, buyable product
-// (its own title, price, media). A `Product` ties sibling variants together and
-// declares the axes (`Option`s) they vary on. A product with no variations is
-// just a product with a single variant and no options.
-
-// One selectable value on an axis, e.g. the "Black" choice on the "Color" axis.
-type OptionValue = {
-  id: string; // stable key referenced by Variant.selection, e.g. "black"
-  label: string; // shown to the user, e.g. "Black"
-  media?: string; // optional swatch / image representing this value
-};
-
-// A variation axis the variants differ on, e.g. Color or Size.
-type Option = {
-  id: string; // stable key, used as a key in Variant.selection, e.g. "color"
-  label: string; // shown to the user, e.g. "Color"
-  values: OptionValue[]; // in display order
-};
-
-// Display fields shared by a Variant and by a product's `card`.
-type Meta = {
-  title: string;
-  description?: string;
-  price?: Price;
-  media: string[]; // images for this item; media[0] is the primary/cover
-  url?: string; // link to this item's external product page
-  outOfStock?: boolean; // true = not purchasable
-  // Objective, product-specific facts (material, dimensions, capacity, care…),
-  // rendered as-is. Each fact's label is optional.
-  specs: Spec[];
-
-  // @todo: Add whatever custom fields the carousel should render as real types
-  // (e.g. `rating` → stars, `discountPct` → badge, `badges` → chips).
-};
-
-// One buyable product: full display Meta plus which value it takes on each axis.
-export type Variant = Meta & {
-  id: string; // SKU / article number; unique within the catalog
-  // The chosen value per axis: keys are Option.id, values are OptionValue.id.
-  // e.g. { color: "black", size: "40" }
-  selection: Record<string, string>;
-};
-
-// A product: one carousel card backed by one or more variants and the axes they
-// vary on (none for a single-variant product).
-export type Product = {
-  id: string; // stable product key
-  // The axes the variants vary on, in display order. Order is semantic: the
-  // detail picker narrows availability top-down (each axis constrained by the
-  // ones before it), so put the imagery-driving axis (usually color) first.
-  options: Option[];
-  // Only the variants that actually exist. A missing combination (e.g. no
-  // { color: "black", size: "40" }) is simply absent from this list — that is how
-  // contingent variations are expressed. Derive the selectable values for an axis
-  // by filtering this list on the choices already made.
-  variants: Variant[];
-  // The product's carousel card. Surfaced both in the carousel (the view
-  // renders it) and to the model (structuredContent is projected from it).
-  // How you build it depends on your mapping strategy: see getProducts.
-  card: Meta;
-};
+// matching products for the carousel view to render. Data access lives in
+// `src/catalog/`; everything else this tool needs lives in this file.
 
 // ---------------------------------------------------------------------------
 // Input
@@ -115,35 +50,6 @@ const outputSchema = {
 };
 
 type RenderOutput = z.infer<z.ZodObject<typeof outputSchema>>;
-
-// ---------------------------------------------------------------------------
-// Data access
-// ---------------------------------------------------------------------------
-
-async function getProducts(ids: string[]): Promise<Product[]> {
-  // @todo: fetch each id from your product API / DB and map the results into
-  // `Product`s.
-  //
-  // First decide your mapping strategy — it depends on your catalog:
-  //   - no variants (simple products): one `Product`, a single variant, card = that variant, options: [],
-  //   - grouped: one `Product` per product; `card` = union of its variants, one picture per requested variant
-  //   - one card per requested variant: `card` = that variant
-  // Either way, set `variants` to ALL variants the source returns for the product;
-  // the detail view reads them so the client can switch variant. Order `options`
-  // with the imagery-driving axis first (see the Product type: order is semantic).
-  //
-  // Requested order is the display order, so resolve by id, not by catalog order.
-  const products: Product[] = [];
-  for (const id of ids) {
-    for (const product of MOCK_PRODUCTS) {
-      if (product.id === id) {
-        products.push(product);
-        break;
-      }
-    }
-  }
-  return products;
-}
 
 // ---------------------------------------------------------------------------
 // Mapping: trim each product's `card` and `options` into the model-facing

--- a/packages/create-skybridge/templates/ecom/src/tools/search-products.ts
+++ b/packages/create-skybridge/templates/ecom/src/tools/search-products.ts
@@ -1,16 +1,17 @@
 import { z } from "zod";
+import { search } from "../catalog/index.js";
 import {
   CAROUSEL_MAX_SIZE,
   CAROUSEL_RANGE,
   MIN_SEARCH_ITERATIONS,
 } from "../config.js";
-import { MOCK_PRODUCTS } from "../mock.js";
-import { PriceSchema, SpecSchema } from "../types.js";
+import { PriceSchema, type SearchResult, SpecSchema } from "../types.js";
 
 // The `search-products` tool: keyword + filters in, matching products out as
 // structured output for the model. It has NO view — include only what the model
 // needs to curate (ids + properties), never presentational data (images, media);
-// render-carousel handles that. Everything this tool needs lives in this file.
+// render-carousel handles that. Data access lives in `src/catalog/`; everything
+// else this tool needs lives in this file.
 
 // ---------------------------------------------------------------------------
 // Input
@@ -40,7 +41,7 @@ For vague gift or occasion queries without a clear product type, use broad categ
     ),
 };
 
-type SearchInput = z.infer<z.ZodObject<typeof inputSchema>>;
+export type SearchInput = z.infer<z.ZodObject<typeof inputSchema>>;
 
 // ---------------------------------------------------------------------------
 // Output — model-facing grounding, returned in structuredContent.
@@ -81,17 +82,20 @@ const outputSchema = {
 type SearchOutput = z.infer<z.ZodObject<typeof outputSchema>>;
 
 // ---------------------------------------------------------------------------
-// Data access
+// Mapping: project each product's `card` into the model-facing grounding
+// (outputSchema), dropping presentational fields (media, url).
+// @todo: choose what the model sees per product. Grounding only: the model
+// curates on facts, so presentational data never belongs here.
 // ---------------------------------------------------------------------------
 
-function search(_input: SearchInput): SearchOutput {
-  // @todo: plug in your product API / DB. Query it with the input params and map
-  // each result into `products` below. `pages` and `totalHits` are optional.
-  // Until then: every mock product, projected from its card (the model curates
-  // on facts, so presentational fields like media stay out).
-  const products: SearchOutput["products"] = [];
-  for (const { id, card } of MOCK_PRODUCTS) {
-    products.push({
+function toStructuredContent({
+  products,
+  pages,
+  totalHits,
+}: SearchResult): SearchOutput {
+  const results: SearchOutput["products"] = [];
+  for (const { id, card } of products) {
+    results.push({
       id,
       title: card.title,
       description: card.description,
@@ -100,11 +104,7 @@ function search(_input: SearchInput): SearchOutput {
       specs: card.specs,
     });
   }
-  return {
-    products,
-    pages: { current: 1, total: 1 },
-    totalHits: products.length,
-  };
+  return { products: results, pages, totalHits };
 }
 
 // ---------------------------------------------------------------------------
@@ -186,8 +186,8 @@ The sweet spot is ${CAROUSEL_RANGE} products.
   outputSchema,
 };
 
-export function searchProductsHandler(input: SearchInput) {
-  const results = search(input);
+export async function searchProductsHandler(input: SearchInput) {
+  const results = toStructuredContent(await search(input));
   return {
     structuredContent: results,
     content: [{ type: "text" as const, text: narrate(results) }],

--- a/packages/create-skybridge/templates/ecom/src/types.ts
+++ b/packages/create-skybridge/templates/ecom/src/types.ts
@@ -13,3 +13,75 @@ export const SpecSchema = z.object({
   value: z.string(),
 });
 export type Spec = z.infer<typeof SpecSchema>;
+
+// ---------------------------------------------------------------------------
+// Product model — what the catalog providers in `src/catalog/` return and the
+// views render. Model: variant-as-full-product. Each `Variant` is a complete,
+// buyable product (its own title, price, media). A `Product` ties sibling
+// variants together and declares the axes (`Option`s) they vary on. A product
+// with no variations is just a product with a single variant and no options.
+// ---------------------------------------------------------------------------
+
+// One selectable value on an axis, e.g. the "Black" choice on the "Color" axis.
+type OptionValue = {
+  id: string; // stable key referenced by Variant.selection, e.g. "black"
+  label: string; // shown to the user, e.g. "Black"
+  media?: string; // optional swatch / image representing this value
+};
+
+// A variation axis the variants differ on, e.g. Color or Size.
+export type Option = {
+  id: string; // stable key, used as a key in Variant.selection, e.g. "color"
+  label: string; // shown to the user, e.g. "Color"
+  values: OptionValue[]; // in display order
+};
+
+// Display fields shared by a Variant and by a product's `card`.
+type Meta = {
+  title: string;
+  description?: string;
+  price?: Price;
+  media: string[]; // images for this item; media[0] is the primary/cover
+  url?: string; // link to this item's external product page
+  outOfStock?: boolean; // true = not purchasable
+  // Objective, product-specific facts (material, dimensions, capacity, care…),
+  // rendered as-is. Each fact's label is optional.
+  specs: Spec[];
+
+  // @todo: Add whatever custom fields the carousel should render as real types
+  // (e.g. `rating` → stars, `discountPct` → badge, `badges` → chips).
+};
+
+// One buyable product: full display Meta plus which value it takes on each axis.
+export type Variant = Meta & {
+  id: string; // SKU / article number; unique within the catalog
+  // The chosen value per axis: keys are Option.id, values are OptionValue.id.
+  // e.g. { color: "black", size: "40" }
+  selection: Record<string, string>;
+};
+
+// A product: one carousel card backed by one or more variants and the axes they
+// vary on (none for a single-variant product).
+export type Product = {
+  id: string; // stable product key
+  // The axes the variants vary on, in display order. Order is semantic: the
+  // detail picker narrows availability top-down (each axis constrained by the
+  // ones before it), so put the imagery-driving axis (usually color) first.
+  options: Option[];
+  // Only the variants that actually exist. A missing combination (e.g. no
+  // { color: "black", size: "40" }) is simply absent from this list — that is how
+  // contingent variations are expressed. Derive the selectable values for an axis
+  // by filtering this list on the choices already made.
+  variants: Variant[];
+  // The product's carousel card. Surfaced both in the carousel (the view
+  // renders it) and to the model (structuredContent is projected from it).
+  card: Meta;
+};
+
+// What a catalog provider's `search` returns. `pages` and `totalHits` are
+// optional: not every backend reports them.
+export type SearchResult = {
+  products: Product[];
+  pages?: { current: number; total: number };
+  totalHits?: number;
+};

--- a/packages/create-skybridge/templates/ecom/src/views/carousel/detail/detail.stories.tsx
+++ b/packages/create-skybridge/templates/ecom/src/views/carousel/detail/detail.stories.tsx
@@ -1,4 +1,4 @@
-import type { Product } from "../../../tools/render-carousel.js";
+import type { Product } from "../../../types.js";
 import { DetailView } from "./index";
 
 function shot(fill: string) {

--- a/packages/create-skybridge/templates/ecom/src/views/carousel/detail/index.tsx
+++ b/packages/create-skybridge/templates/ecom/src/views/carousel/detail/index.tsx
@@ -12,7 +12,7 @@ import {
   resolveVariant,
   type Selection,
 } from "../../../lib/variants.js";
-import type { Product, Variant } from "../../../tools/render-carousel.js";
+import type { Product, Variant } from "../../../types.js";
 import * as styles from "./detail.css";
 
 // Price to show: the resolved variant's price, else the range across variants

--- a/packages/create-skybridge/templates/ecom/src/views/carousel/index.tsx
+++ b/packages/create-skybridge/templates/ecom/src/views/carousel/index.tsx
@@ -20,8 +20,7 @@ import { sprinkles } from "../../design/tokens";
 import { useToolInfo } from "../../helpers.js";
 import { useLabels } from "../../i18n";
 import { formatPrice } from "../../lib/format";
-import type { Product } from "../../tools/render-carousel.js";
-import type { Price, Spec } from "../../types.js";
+import type { Price, Product, Spec } from "../../types.js";
 import { DetailView } from "./detail";
 
 const SKELETON_COUNT = 4;

--- a/skills/chatgpt-app-builder/references/ecommerce.md
+++ b/skills/chatgpt-app-builder/references/ecommerce.md
@@ -26,8 +26,12 @@ Orientation map (curated; each phase details its own files):
 ```
 src/
   config.ts                    shared tuning (carousel size, search iterations)
-  types.ts                     shared Price / Attribute schemas
+  types.ts                     Price / Spec schemas, Product / Variant / Option model
   server.ts                    name, version, prompt, tool registration
+  catalog/                     the data seam: search + getProducts
+    index.ts                     picks the provider (one re-export line)
+    mock.ts                      placeholder catalog, no backend
+    shopify.ts                   Shopify Storefront API
   tools/
     search-products.ts         keyword + filters -> matching products (no view)
     render-carousel.ts         curated ids -> products for the carousel view
@@ -43,7 +47,7 @@ src/
 
 Prompt the user for the resources below, in one turn, and wait for their answer. Do not research the catalog or brand on your own yet. For whatever they say they lack, write a short complementary research plan (what you would look up, where, and why) and get the user to sign off on it before running any of it.
 
-**Data source.** API or database, base URL or connection string, auth method, the product schema (fields and types), the filters and sort options it supports, the image and price fields, and how it paginates. Request any reference docs and save them under `docs/` (create it if missing); read them before writing code.
+**Data source.** API or database, base URL or connection string, auth method, the product schema (fields and types), the filters and sort options it supports, the image and price fields, and how it paginates. Request any reference docs and save them under `docs/` (create it if missing); read them before writing code. Shopify store? `src/catalog/shopify.ts` already implements it: ask only for the store domain and a Storefront access token.
 
 **Brand assets.** A Figma link if the brand has one (a design system, or the design of an existing web / mobile / desktop app). Otherwise the web app URL and/or screenshots. Either way, the brand's font files. No brand at all (internal tool, prototype)? Note that and move on.
 
@@ -72,7 +76,7 @@ The subagent's brief:
 - **Sample the imagery.** A handful of real image URLs from different categories: aspect ratios, cutout vs in-context photography, transparent or white backgrounds, resolution, and any URL-based resizing params. Phase 6 chooses the card and gallery aspect ratio / fit by looking at these, never by guessing.
 - **Note the sharp edges.** Rate limits, auth quirks, encoding oddities, slow endpoints, fields whose content is HTML rather than text.
 
-Have it return the findings mapped onto the template's shapes (`productSchema` in search-products, `Product`/`Variant`/`Option` in render-carousel), a full raw JSON sample of one representative product, plus one variant-rich and one edge-case example (out of stock, single image, or missing description).
+Have it return the findings mapped onto the template's shapes (`Product`/`Variant`/`Option` in `src/types.ts`, `productSchema` in search-products), a full raw JSON sample of one representative product, plus one variant-rich and one edge-case example (out of stock, single image, or missing description).
 
 **Gate 2:**
 
@@ -146,7 +150,7 @@ gallery sticky on desktop; CTA follows the selected variant's url
 
 ## Phase 4: server
 
-Fill `config.ts`, `types.ts`, `server.ts`, and the two tools. Start the dev server and keep it running:
+Fill `config.ts`, `types.ts`, `server.ts`, the catalog provider, and the two tools. Start the dev server and keep it running:
 
 ```bash
 {pm} run dev   # prints the local MCP URL (default http://localhost:3000/mcp)
@@ -160,6 +164,23 @@ Fill `config.ts`, `types.ts`, `server.ts`, and the two tools. Start the dev serv
 - [ ] `src/config.ts` `CAROUSEL_MAX_SIZE`: max products the carousel shows.
 - [ ] `src/config.ts` `MIN_SEARCH_ITERATIONS`: minimum searches before rendering.
 
+### Catalog (`src/catalog/`)
+
+The app's only data seam: both tools read products through `search()` and `getProducts()`, re-exported from `src/catalog/index.ts`. Providers return domain types (`Product`, `SearchResult` from `src/types.ts`), never tool-shaped output; each tool projects its own.
+
+- [ ] Product model (`Product`, `Variant`, `Option`, `Meta` in `src/types.ts`): match your catalog. A `Product` groups sibling `Variant`s and declares the `Option` axes. `variants` is sparse (list only the combinations that exist; a missing one encodes a contingent variation). `card` (required) is what the carousel shows for the product, surfaced both to the view and to the model (`structuredContent` is projected from it).
+- [ ] Provider: point `index.ts` at `./shopify.js` for a Shopify store, or write your own module next to it with the same two exports. Delete `mock.ts` once you do.
+- [ ] `search()`: query the data source with the input params and map each hit into a `Product`; set `pages` and `totalHits` if the backend reports them.
+- [ ] `getProducts()`: fetch each id and map results into `Product[]` (mapping strategy below).
+
+**Mapping ids to products (`getProducts`).** Whatever `search()` put in each `id` is what arrives here; the two must stay consistent. Preserve the `ids` order, and decide how to handle ids with no match (skip, or surface them).
+
+- **No variants (simple products):** one `Product` per id with a single variant, `card` set to that variant, `options: []`. Nothing else to decide.
+- **Variants, grouped (one card per product):** all queried variants of a product collapse into one carousel item. `card` is the union of the available variants (a "from" price, in stock if any variant is), and `card.media` holds one picture per requested variant.
+- **Variants, one card per requested variant:** each requested variant is its own carousel item, `card` set to that variant.
+
+Either way, each item's `Product` must hold ALL the variants the data source returned in `variants` (only `card` differs): the detail view reads `variants` so the client can switch to any of them.
+
 ### `search-products` (`src/tools/search-products.ts`)
 
 Keyword/filter search returning model-facing grounding. No view, so keep the output to what the model needs to curate (ids + facts), never presentational data (images, media): render-carousel handles that.
@@ -171,28 +192,18 @@ Keyword/filter search returning model-facing grounding. No view, so keep the out
 - [ ] `inputSchema` filters: replace `priceRange` with one optional param per real facet.
 - [ ] `productSchema` / `outputSchema`: adjust the model-facing fields (`id`, `title`, `description`, `price`, `outOfStock`, `specs`).
 - [ ] `productSchema` custom fields (optional): add any typed field the model should curate on (e.g. `rating`, `discountPct`).
-- [ ] `search()`: query the data source with the input params and map each hit into `productSchema`; set `pages` and `totalHits`.
+- [ ] `toStructuredContent()`: project each product's `card` into the model-facing grounding, dropping presentational fields (media, url).
 - [ ] `narrate()` NEXT STEPS: adapt the post-search guidance to your flow (framing only; it carries no result data).
 
 ### `render-carousel` (`src/tools/render-carousel.ts`)
 
 Takes the curated ids and returns the products for the carousel. The full product data (variants, media, options) rides in `_meta` for the view; a trimmed grounding subset goes to `structuredContent` for the model.
 
-- [ ] Product model (`Product`, `Variant`, `Option`, `Meta`): match your catalog. A `Product` groups sibling `Variant`s and declares the `Option` axes. `variants` is sparse (list only the combinations that exist; a missing one encodes a contingent variation). `card` (required) is what the carousel shows for the product, surfaced both to the view and to the model (`structuredContent` is projected from it).
-- [ ] `getProducts()`: fetch each id and map results into `Product[]` (mapping strategy below).
 - [ ] `toStructuredContent()`: trim each product's `card` and `options` into the model-facing grounding, dropping presentational fields (media, url). The view reads the full products from `_meta`.
 - [ ] `Meta` custom fields (optional): add any typed field the view renders (e.g. `rating`, `discountPct`).
 - [ ] `description`: adapt the wording and brand voice; the behavioral rules (order, no-repeat, accuracy) apply to any catalog.
 - [ ] `_meta`: the invoking and invoked status messages.
-- [ ] `view.csp`: add your image host to `resourceDomains` (product images) and the product site to `redirectDomains` (the detail CTA and the host "open in app" URL). `view` itself is already wired to the `carousel` view.
-
-**Mapping ids to products (`getProducts`).** Whatever `search-products` put in each `id` is what arrives here; keep the two tools consistent. Preserve the `ids` order, and decide how to handle ids with no match (skip, or surface them).
-
-- **No variants (simple products):** one `Product` per id with a single variant, `card` set to that variant, `options: []`. Nothing else to decide.
-- **Variants, grouped (one card per product):** all queried variants of a product collapse into one carousel item. `card` is the union of the available variants (a "from" price, in stock if any variant is), and `card.media` holds one picture per requested variant.
-- **Variants, one card per requested variant:** each requested variant is its own carousel item, `card` set to that variant.
-
-Either way, each item's `Product` must hold ALL the variants the data source returned in `variants` (only `card` differs): the detail view reads `variants` so the client can switch to any of them.
+- [ ] `view.csp`: add your image host to `resourceDomains` (product images) and the product site to `redirectDomains` (the detail CTA and the host "open in app" URL). Shopify: `https://cdn.shopify.com` and your store domain. `view` itself is already wired to the `carousel` view.
 
 **Gate 4: verify both tools with curl** against the running server. `Accept` must include `text/event-stream` or the SDK rejects the request. (`"method":"tools/list"` with no `params` lists the registered schemas.)
 


### PR DESCRIPTION
Data access lived inline in `search-products.ts` and `render-carousel.ts`, each returning its own tool-shaped output, so there was no single place to swap a backend in.

Both functions now live in `src/catalog/`, behind `search` and `getProducts`. Providers return domain types (`Product`, `SearchResult`, moved to `types.ts` with the rest of the model) and each tool projects its own output. Two providers ship: `mock.ts` as before, and `shopify.ts` against the Storefront API with no new dependency, ids as handles rather than GIDs to keep model context cheap. Picking one is a single re-export line in `catalog/index.ts`. The ecommerce skill reference gets a catalog section and a Shopify shortcut in its gather phase.