### PR TITLE
feat(devtools): add inspect panel toggle in preview mode

### DIFF
--- a/packages/devtools/src/components/layout/preview/index.tsx
+++ b/packages/devtools/src/components/layout/preview/index.tsx
@@ -7,6 +7,12 @@ import {
   useState,
 } from "react";
 import {
+  Group,
+  Panel,
+  Separator,
+  useDefaultLayout,
+} from "react-resizable-panels";
+import {
   getToolOutputTokenCount,
   TOOL_OUTPUT_WARNING_TOKENS,
 } from "@/lib/context-warnings.js";
@@ -18,6 +24,10 @@ import {
 import { useSelectedToolOrNull } from "@/lib/mcp/index.js";
 import { useCallToolResult } from "@/lib/store.js";
 import { cn, formatBytes, PHONE_VIEWPORT } from "@/lib/utils.js";
+import {
+  ContextWarningAlert,
+  ContextWarningBadge,
+} from "../tool-panel/context-warning.js";
 import { JsonSyntaxBlock } from "../tool-panel/json-syntax-block.js";
 import { LogsDrawer } from "../tool-panel/logs-drawer.js";
 import { ToolPanelToolbar } from "../tool-panel/tool-panel-toolbar.js";
@@ -27,6 +37,10 @@ import { ClaudeShell } from "./claude-shell.js";
 
 const FRAME_MARGIN_X = 24;
 const FRAME_MARGIN_Y = 44;
+
+const PREVIEW_SPLIT_GROUP_ID = "devtools-preview-split";
+const PREVIEW_SHELL_PANEL_ID = "preview-shell";
+const PREVIEW_DEVTOOLS_PANEL_ID = "preview-devtools";
 
 const frameColors = {
   light: { backdrop: "#e8e8e6", label: "#6f6f6f" },
@@ -123,6 +137,15 @@ export const Preview = () => {
   const response = data?.response;
   const hasToolOutput = Boolean(tool && response);
 
+  const { defaultLayout, onLayoutChanged } = useDefaultLayout({
+    id: PREVIEW_SPLIT_GROUP_ID,
+    panelIds: [PREVIEW_SHELL_PANEL_ID, PREVIEW_DEVTOOLS_PANEL_ID],
+    storage: localStorage,
+  });
+  const toolOutputTokenCount = response ? getToolOutputTokenCount(response) : 0;
+  const hasToolOutputWarning =
+    toolOutputTokenCount >= TOOL_OUTPUT_WARNING_TOKENS;
+
   return (
     <div className="flex h-full min-h-0 w-full flex-col">
       <div className="flex h-11 shrink-0 items-center gap-3 bg-primary px-3 text-primary-foreground">
@@ -135,99 +158,121 @@ export const Preview = () => {
           />
         </div>
       </div>
-      <div className="min-h-0 flex-1 flex">
-        <div className="min-h-0 flex-1">
-          {isMobile ? <PhoneFrame theme={theme}>{shell}</PhoneFrame> : shell}
-        </div>
-        {showDevTools && (
-          <div className="flex w-[480px] min-w-[320px] max-w-[600px] min-h-0 flex-col border-l border-border bg-background">
-            <div className="flex h-9 shrink-0 items-center justify-between border-b border-border px-3">
-              <span className="text-xs font-semibold text-foreground">
-                DevTools
-              </span>
-              <button
-                type="button"
-                aria-label="Close DevTools"
-                onClick={() => setShowDevTools(false)}
-                className="inline-flex size-6 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-light-gray hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-              >
-                <X className="size-3.5" />
-              </button>
-            </div>
-            <div className="min-h-0 flex-1 flex flex-col overflow-hidden">
-              {hasToolOutput ? (
-                <>
-                  <section className="min-h-0 flex-1 flex flex-col overflow-hidden">
-                    <div
-                      className={cn(
-                        "flex h-9 w-full shrink-0 items-center border-b-2 border-border bg-white px-3 text-sm text-muted-foreground",
-                      )}
-                    >
-                      <div className="flex items-center gap-2 font-medium">
-                        Tool output
-                        {getToolOutputTokenCount(response) >=
-                          TOOL_OUTPUT_WARNING_TOKENS && (
-                          <span className="rounded bg-amber-100 px-1 text-[10px] font-medium text-amber-700">
-                            large
-                          </span>
-                        )}
-                      </div>
-                      <div className="ml-auto flex items-center gap-2 font-mono text-xs text-light-gray-foreground">
-                        <span
-                          className={
-                            response?.isError
-                              ? "text-destructive"
-                              : "text-success"
-                          }
-                        >
-                          {response?.isError ? "Error" : "OK"}
-                        </span>
-                        {data?.durationMs != null ? (
-                          <>
-                            <span>·</span>
-                            <span>{data.durationMs}ms</span>
-                          </>
-                        ) : null}
-                        <span>·</span>
-                        <span>
-                          {formatBytes(
-                            new TextEncoder().encode(
-                              JSON.stringify(response ?? null),
-                            ).length,
-                          )}
-                        </span>
-                      </div>
-                    </div>
-                    <div className="relative min-h-0 flex-1 overflow-auto p-3 bg-light-gray">
-                      <CopyButton
-                        value={JSON.stringify(response ?? null, null, 2)}
-                        label="Copy tool output"
-                        className="absolute right-2 top-2 z-10"
-                      />
-                      <JsonSyntaxBlock
-                        code={JSON.stringify(
-                          response ?? null,
-                          null,
-                          2,
-                        )}
-                      />
-                    </div>
-                  </section>
-                  <section className="h-1/3 min-h-[120px] flex flex-col overflow-hidden border-t border-border">
-                    <LogsDrawer />
-                  </section>
-                </>
-              ) : (
-                <div className="flex h-full items-center justify-center">
-                  <p className="text-xs text-muted-foreground">
-                    Select and run a tool to see output and logs.
-                  </p>
-                </div>
-              )}
-            </div>
+      <Group
+        orientation="horizontal"
+        id={PREVIEW_SPLIT_GROUP_ID}
+        className="flex min-h-0 min-w-0 flex-1"
+        defaultLayout={defaultLayout}
+        onLayoutChanged={onLayoutChanged}
+      >
+        <Panel
+          id={PREVIEW_SHELL_PANEL_ID}
+          minSize={320}
+          className="min-h-0 min-w-0"
+        >
+          <div className="h-full min-h-0 w-full">
+            {isMobile ? <PhoneFrame theme={theme}>{shell}</PhoneFrame> : shell}
           </div>
+        </Panel>
+        {showDevTools && (
+          <>
+            <Separator className="w-px shrink-0 bg-border transition-colors hover:bg-ring data-separator-active:bg-ring" />
+            <Panel
+              id={PREVIEW_DEVTOOLS_PANEL_ID}
+              defaultSize={480}
+              minSize={320}
+              maxSize={600}
+              className="min-h-0"
+            >
+              <div className="flex h-full min-h-0 flex-col bg-background">
+                <div className="flex h-9 shrink-0 items-center justify-between border-b border-border px-3">
+                  <span className="text-xs font-semibold text-foreground">
+                    DevTools
+                  </span>
+                  <button
+                    type="button"
+                    aria-label="Close DevTools"
+                    onClick={() => setShowDevTools(false)}
+                    className="inline-flex size-6 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-light-gray hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  >
+                    <X className="size-3.5" />
+                  </button>
+                </div>
+                <div className="min-h-0 flex-1 flex flex-col overflow-hidden">
+                  {hasToolOutput ? (
+                    <>
+                      <section className="min-h-0 flex-1 flex flex-col overflow-hidden">
+                        <div
+                          className={cn(
+                            "flex h-9 w-full shrink-0 items-center border-b-2 border-border bg-white px-3 text-sm text-muted-foreground",
+                          )}
+                        >
+                          <div className="flex items-center gap-2 font-medium">
+                            Tool output
+                            {hasToolOutputWarning && (
+                              <ContextWarningBadge kind="tool-output" />
+                            )}
+                          </div>
+                          <div className="ml-auto flex items-center gap-2 font-mono text-xs text-light-gray-foreground">
+                            <span
+                              className={
+                                response?.isError
+                                  ? "text-destructive"
+                                  : "text-success"
+                              }
+                            >
+                              {response?.isError ? "Error" : "OK"}
+                            </span>
+                            {data?.durationMs != null ? (
+                              <>
+                                <span>·</span>
+                                <span>{data.durationMs}ms</span>
+                              </>
+                            ) : null}
+                            <span>·</span>
+                            <span>
+                              {formatBytes(
+                                new TextEncoder().encode(
+                                  JSON.stringify(response ?? null),
+                                ).length,
+                              )}
+                            </span>
+                          </div>
+                        </div>
+                        {hasToolOutputWarning && (
+                          <ContextWarningAlert
+                            kind="tool-output"
+                            tokenCount={toolOutputTokenCount}
+                          />
+                        )}
+                        <div className="relative min-h-0 flex-1 overflow-auto p-3 bg-light-gray">
+                          <CopyButton
+                            value={JSON.stringify(response ?? null, null, 2)}
+                            label="Copy tool output"
+                            className="absolute right-2 top-2 z-10"
+                          />
+                          <JsonSyntaxBlock
+                            code={JSON.stringify(response ?? null, null, 2)}
+                          />
+                        </div>
+                      </section>
+                      <section className="h-1/3 min-h-[120px] flex flex-col overflow-hidden border-t border-border">
+                        <LogsDrawer />
+                      </section>
+                    </>
+                  ) : (
+                    <div className="flex h-full items-center justify-center">
+                      <p className="text-xs text-muted-foreground">
+                        Select and run a tool to see output and logs.
+                      </p>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </Panel>
+          </>
         )}
-      </div>
+      </Group>
     </div>
   );
 };

--- a/packages/devtools/src/components/layout/preview/index.tsx
+++ b/packages/devtools/src/components/layout/preview/index.tsx
@@ -1,3 +1,4 @@
+import { X } from "lucide-react";
 import {
   type ReactNode,
   Suspense,
@@ -6,12 +7,19 @@ import {
   useState,
 } from "react";
 import {
+  getToolOutputTokenCount,
+  TOOL_OUTPUT_WARNING_TOKENS,
+} from "@/lib/context-warnings.js";
+import { CopyButton } from "@/lib/copy.js";
+import {
   useInspectorPreferencesStore,
   useIsMobile,
 } from "@/lib/inspector-preferences-store.js";
 import { useSelectedToolOrNull } from "@/lib/mcp/index.js";
 import { useCallToolResult } from "@/lib/store.js";
-import { PHONE_VIEWPORT } from "@/lib/utils.js";
+import { cn, formatBytes, PHONE_VIEWPORT } from "@/lib/utils.js";
+import { JsonSyntaxBlock } from "../tool-panel/json-syntax-block.js";
+import { LogsDrawer } from "../tool-panel/logs-drawer.js";
 import { ToolPanelToolbar } from "../tool-panel/tool-panel-toolbar.js";
 import { View } from "../tool-panel/view/index.js";
 import { ChatgptShell } from "./chatgpt-shell.js";
@@ -96,6 +104,7 @@ export const Preview = () => {
   const previewClient = useInspectorPreferencesStore((s) => s.previewClient);
   const theme = useInspectorPreferencesStore((s) => s.theme);
   const isMobile = useIsMobile();
+  const [showDevTools, setShowDevTools] = useState(false);
   const templateUri = (tool?._meta?.ui as { resourceUri?: string } | undefined)
     ?.resourceUri;
   const hasWidget = Boolean(tool && data?.response && templateUri);
@@ -111,16 +120,113 @@ export const Preview = () => {
     </Shell>
   );
 
+  const response = data?.response;
+  const hasToolOutput = Boolean(tool && response);
+
   return (
     <div className="flex h-full min-h-0 w-full flex-col">
       <div className="flex h-11 shrink-0 items-center gap-3 bg-primary px-3 text-primary-foreground">
         <span className="font-medium text-xs">Preview mode</span>
         <div className="min-w-0 flex-1">
-          <ToolPanelToolbar variant="preview" />
+          <ToolPanelToolbar
+            variant="preview"
+            showDevTools={showDevTools}
+            onToggleDevTools={() => setShowDevTools((v) => !v)}
+          />
         </div>
       </div>
-      <div className="min-h-0 flex-1">
-        {isMobile ? <PhoneFrame theme={theme}>{shell}</PhoneFrame> : shell}
+      <div className="min-h-0 flex-1 flex">
+        <div className="min-h-0 flex-1">
+          {isMobile ? <PhoneFrame theme={theme}>{shell}</PhoneFrame> : shell}
+        </div>
+        {showDevTools && (
+          <div className="flex w-[480px] min-w-[320px] max-w-[600px] min-h-0 flex-col border-l border-border bg-background">
+            <div className="flex h-9 shrink-0 items-center justify-between border-b border-border px-3">
+              <span className="text-xs font-semibold text-foreground">
+                DevTools
+              </span>
+              <button
+                type="button"
+                aria-label="Close DevTools"
+                onClick={() => setShowDevTools(false)}
+                className="inline-flex size-6 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-light-gray hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                <X className="size-3.5" />
+              </button>
+            </div>
+            <div className="min-h-0 flex-1 flex flex-col overflow-hidden">
+              {hasToolOutput ? (
+                <>
+                  <section className="min-h-0 flex-1 flex flex-col overflow-hidden">
+                    <div
+                      className={cn(
+                        "flex h-9 w-full shrink-0 items-center border-b-2 border-border bg-white px-3 text-sm text-muted-foreground",
+                      )}
+                    >
+                      <div className="flex items-center gap-2 font-medium">
+                        Tool output
+                        {getToolOutputTokenCount(response) >=
+                          TOOL_OUTPUT_WARNING_TOKENS && (
+                          <span className="rounded bg-amber-100 px-1 text-[10px] font-medium text-amber-700">
+                            large
+                          </span>
+                        )}
+                      </div>
+                      <div className="ml-auto flex items-center gap-2 font-mono text-xs text-light-gray-foreground">
+                        <span
+                          className={
+                            response?.isError
+                              ? "text-destructive"
+                              : "text-success"
+                          }
+                        >
+                          {response?.isError ? "Error" : "OK"}
+                        </span>
+                        {data?.durationMs != null ? (
+                          <>
+                            <span>·</span>
+                            <span>{data.durationMs}ms</span>
+                          </>
+                        ) : null}
+                        <span>·</span>
+                        <span>
+                          {formatBytes(
+                            new TextEncoder().encode(
+                              JSON.stringify(response ?? null),
+                            ).length,
+                          )}
+                        </span>
+                      </div>
+                    </div>
+                    <div className="relative min-h-0 flex-1 overflow-auto p-3 bg-light-gray">
+                      <CopyButton
+                        value={JSON.stringify(response ?? null, null, 2)}
+                        label="Copy tool output"
+                        className="absolute right-2 top-2 z-10"
+                      />
+                      <JsonSyntaxBlock
+                        code={JSON.stringify(
+                          response ?? null,
+                          null,
+                          2,
+                        )}
+                      />
+                    </div>
+                  </section>
+                  <section className="h-1/3 min-h-[120px] flex flex-col overflow-hidden border-t border-border">
+                    <LogsDrawer />
+                  </section>
+                </>
+              ) : (
+                <div className="flex h-full items-center justify-center">
+                  <p className="text-xs text-muted-foreground">
+                    Select and run a tool to see output and logs.
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/packages/devtools/src/components/layout/tool-panel/tool-panel-toolbar.tsx
+++ b/packages/devtools/src/components/layout/tool-panel/tool-panel-toolbar.tsx
@@ -21,6 +21,7 @@ import {
   Maximize2,
   Monitor,
   Moon,
+  PanelRight,
   PictureInPicture2,
   Smartphone,
   SquareSplitVertical,
@@ -186,12 +187,16 @@ type ToolPanelToolbarProps = {
   variant?: ToolbarVariant;
   logsOpen?: boolean;
   onOpenLogs?: () => void;
+  showDevTools?: boolean;
+  onToggleDevTools?: () => void;
 };
 
 export const ToolPanelToolbar = ({
   variant = "panel",
   logsOpen,
   onOpenLogs,
+  showDevTools,
+  onToggleDevTools,
 }: ToolPanelToolbarProps) => {
   const displayMode = useInspectorPreferencesStore((s) => s.displayMode);
   const theme = useInspectorPreferencesStore((s) => s.theme);
@@ -359,6 +364,12 @@ export const ToolPanelToolbar = ({
 
       {variant === "preview" && (
         <>
+          <ToolbarButton
+            icon={PanelRight}
+            label="inspect"
+            selected={showDevTools}
+            onClick={onToggleDevTools}
+          />
           <ToolbarButton
             icon={ArrowLeftRight}
             label={


### PR DESCRIPTION
## Summary

Add a toggleable DevTools side panel accessible from fullscreen preview mode, allowing inspection of tool output and logs without leaving the preview.

## Changes

- Add "inspect" button to preview toolbar using `PanelRight` icon
- Show a resizable side panel with tool output (state) and logs when inspect is toggled
- Close button and visual indicator (`aria-pressed`) for active state
- Empty state placeholder when no tool output is available

## Testing

- Verified the inspect button appears in preview toolbar
- Panel toggles correctly showing tool output + logs side by side
- Close button and re-toggle work properly
- Empty state shows helpful message when no tool has been run

## Screenshots

N/A — this is a DevTools UI change. The inspect panel renders as a right-side sidebar next to the ChatGPT/Claude preview shell.

---

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do — you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop — no hard feelings.