### PR TITLE
fix(core): always pass (args, extra) to schema-less tool handlers

### DIFF
--- a/examples/auth-auth0/src/server.ts
+++ b/examples/auth-auth0/src/server.ts
@@ -32,8 +32,8 @@ const server = new McpServer(
       audience: env.AUTH0_AUDIENCE, // Auth0 API Identifier
       serverUrl: env.SERVER_URL, // public URL (skybridge-as-AS)
       // Narrow to what the app needs: Auth0 won't grant a third-party (DCR) client
-      // its full OIDC scope set, so advertising it yields "not all authorizations
-      // granted".
+      // its full OIDC scope set, so advertising it yields "Not all requested
+      // permissions were granted".
       scopes: ["openid", "profile", "email"],
     }),
   },

--- a/packages/core/src/server/register-tool.test.ts
+++ b/packages/core/src/server/register-tool.test.ts
@@ -1,0 +1,34 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it } from "vitest";
+import { McpServer } from "./server.js";
+
+describe("registerTool handler invocation", () => {
+  it("passes empty args and a usable extra to a schema-less tool handler", async () => {
+    let received: { args: unknown; extra: unknown } | undefined;
+    const server = new McpServer({
+      name: "test",
+      version: "1.0.0",
+    }).registerTool(
+      { name: "no-input", description: "no-input" },
+      async (args, extra) => {
+        received = { args, extra };
+        return { content: [{ type: "text", text: "ok" }] };
+      },
+    );
+
+    const client = new Client({ name: "client", version: "1.0.0" });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    await client.callTool({ name: "no-input" });
+
+    expect(received?.args).toEqual({});
+    expect(received?.extra).toHaveProperty("sendRequest");
+
+    await client.close();
+    await server.close();
+  });
+});

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -1312,14 +1312,13 @@ export class McpServer<
     },
   ): ToolHandler<InputArgs> {
     return async (args, extra) => {
-      const toolExtra = extra ?? (args as unknown as McpExtra);
       if (this.oauthEnabled) {
         const failure = evaluateSecuritySchemes(
           securitySchemes,
-          toolExtra?.authInfo,
+          extra.authInfo,
         );
         if (failure) {
-          const headers = toolExtra?.requestInfo?.headers ?? {};
+          const headers = extra.requestInfo?.headers ?? {};
           const header = (key: string) => {
             const value = headers[key];
             return Array.isArray(value) ? value[0] : value;
@@ -1334,7 +1333,7 @@ export class McpServer<
       try {
         result = await cb(args, extra);
       } catch (error) {
-        captureToolError(toolExtra, error);
+        captureToolError(extra, error);
         throw error;
       }
       warnOnLargeToolOutput(result, toolName);
@@ -1516,7 +1515,15 @@ export class McpServer<
       toolName: name,
     });
 
-    baseFn.call(this, name, { ...toolFields, _meta: toolMeta }, wrappedCb);
+    baseFn.call(
+      this,
+      name,
+      { ...toolFields, _meta: toolMeta },
+      toolFields.inputSchema === undefined
+        ? (extra: ToolHandlerExtra) =>
+            wrappedCb({} as ShapeOutput<ZodRawShapeCompat>, extra)
+        : wrappedCb,
+    );
 
     return this;
   }


### PR DESCRIPTION
## Summary

- The MCP SDK invokes the callback of a tool registered without `inputSchema` with a single argument, so a handler written `(args, extra)` received the extra object as `args` and `undefined` as `extra`. Skybridge's `ToolHandler` type and the register-tool docs both promise `(input, extra)`, so reading `extra.authInfo` in a schema-less tool crashed at runtime.
- `registerTool` now adapts schema-less callbacks so the user handler always receives `({}, extra)`. The `extra ?? args` fallback in `decorateToolHandler`, which papered over the single-arg call internally, is removed as dead code.
- Adds a regression test asserting a schema-less handler receives empty args and a usable `extra`.
- Side fix: the auth-auth0 example comment now quotes Auth0's actual consent error, "Not all requested permissions were granted".