### PR TITLE
feat(devtools): mimic more host chrome in the conversation preview

### DIFF
--- a/packages/devtools/src/components/layout/preview/chatgpt-shell.tsx
+++ b/packages/devtools/src/components/layout/preview/chatgpt-shell.tsx
@@ -408,9 +408,11 @@ export function ChatgptShell({ children }: { children: ReactNode }) {
         <div
           aria-hidden
           className={cn(
-            "w-full shrink-0 cursor-not-allowed px-4",
+            "w-full cursor-not-allowed px-4",
             isMobile ? "pb-4" : "pb-6",
-            isFullscreen && "hidden",
+            isFullscreen
+              ? "pointer-events-none absolute inset-x-0 bottom-0 z-30"
+              : "shrink-0",
           )}
         >
           <div className="mx-auto w-full max-w-[768px]">

--- a/packages/devtools/src/components/layout/preview/claude-icons.tsx
+++ b/packages/devtools/src/components/layout/preview/claude-icons.tsx
@@ -54,6 +54,41 @@ export function ChevronDownIcon(props: IconProps) {
   );
 }
 
+const BURST_SPOKES = [
+  { angle: 0, length: 7.4, width: 2.1 },
+  { angle: 36, length: 6.2, width: 1.7 },
+  { angle: 72, length: 7.4, width: 2.1 },
+  { angle: 108, length: 6.2, width: 1.7 },
+  { angle: 144, length: 7.4, width: 2.1 },
+  { angle: 180, length: 6.2, width: 1.7 },
+  { angle: 216, length: 7.4, width: 2.1 },
+  { angle: 252, length: 6.2, width: 1.7 },
+  { angle: 288, length: 7.4, width: 2.1 },
+  { angle: 324, length: 6.2, width: 1.7 },
+];
+
+export function ClaudeLogomark(props: IconProps) {
+  return (
+    <svg viewBox="0 0 20 20" fill="none" aria-hidden="true" {...props}>
+      {BURST_SPOKES.map(({ angle, length, width }) => {
+        const radians = (angle * Math.PI) / 180;
+        return (
+          <line
+            key={angle}
+            x1={10}
+            y1={10}
+            x2={10 + Math.cos(radians) * length}
+            y2={10 + Math.sin(radians) * length}
+            stroke="currentColor"
+            strokeWidth={width}
+            strokeLinecap="round"
+          />
+        );
+      })}
+    </svg>
+  );
+}
+
 export function ClaudeWaveformIcon(props: IconProps) {
   return (
     <svg viewBox="0 0 21.2 21.2" fill="none" aria-hidden="true" {...props}>

--- a/packages/devtools/src/components/layout/preview/claude-shell.tsx
+++ b/packages/devtools/src/components/layout/preview/claude-shell.tsx
@@ -28,6 +28,8 @@ import {
 
 const FONT_STACK = '"Anthropic Sans", ui-sans-serif, system-ui, sans-serif';
 
+const SCROLL_ARROW_THRESHOLD_PX = 24;
+
 const shellColors = {
   light: {
     "--shell-surface": "#faf9f5",
@@ -162,8 +164,25 @@ export function ClaudeShell({ children }: { children: ReactNode }) {
   const isFullscreen = displayMode === "fullscreen";
   const isModal = displayMode === "modal";
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [scrolledUp, setScrolledUp] = useState(false);
   const scrollerRef = useRef<HTMLDivElement>(null);
   const threadRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const scroller = scrollerRef.current;
+    if (!scroller || isFullscreen) {
+      setScrolledUp(false);
+      return;
+    }
+    const update = () => {
+      const distanceToBottom =
+        scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight;
+      setScrolledUp(distanceToBottom > SCROLL_ARROW_THRESHOLD_PX);
+    };
+    update();
+    scroller.addEventListener("scroll", update, { passive: true });
+    return () => scroller.removeEventListener("scroll", update);
+  }, [isFullscreen]);
 
   useEffect(() => {
     const scroller = scrollerRef.current;
@@ -381,7 +400,7 @@ export function ClaudeShell({ children }: { children: ReactNode }) {
               >
                 {children ?? <Bar className="h-96 w-full rounded-2xl" />}
               </div>
-              {isFullscreen && !isMobile ? (
+              {isFullscreen ? (
                 <div className="pointer-events-none absolute inset-x-0 bottom-4 mx-auto w-[min(680px,85%)]">
                   <div className="flex min-h-[100px] flex-col justify-between rounded-[20px] border border-(--shell-composer-border) bg-(--shell-card) p-4 shadow-[0_4px_16px_rgba(0,0,0,0.08)]">
                     <span className="text-(--shell-text-tertiary)">
@@ -414,6 +433,27 @@ export function ClaudeShell({ children }: { children: ReactNode }) {
             </div>
           </div>
         </div>
+        {scrolledUp && (
+          <button
+            type="button"
+            aria-label="Scroll to bottom"
+            onClick={() => {
+              const scroller = scrollerRef.current;
+              if (scroller) {
+                scroller.scrollTo({
+                  top: scroller.scrollHeight,
+                  behavior: "smooth",
+                });
+              }
+            }}
+            className={cn(
+              "absolute left-1/2 z-20 flex size-8 -translate-x-1/2 cursor-pointer items-center justify-center rounded-full border border-(--shell-border) bg-(--shell-card) text-(--shell-text-secondary) shadow-[0_2px_8px_rgba(0,0,0,0.12)]",
+              isMobile ? "bottom-24" : "bottom-32",
+            )}
+          >
+            <ChevronDownIcon className="size-3.5" />
+          </button>
+        )}
         <div
           className={cn(
             "w-full shrink-0 cursor-not-allowed",

--- a/packages/devtools/src/components/layout/tool-panel/tool-panel-toolbar.tsx
+++ b/packages/devtools/src/components/layout/tool-panel/tool-panel-toolbar.tsx
@@ -12,7 +12,6 @@ import {
   PopoverTrigger,
 } from "@alpic-ai/ui/components/popover";
 import {
-  ArrowLeftRight,
   Check,
   Eye,
   Languages,
@@ -27,11 +26,13 @@ import {
   Sun,
   X,
 } from "lucide-react";
-import { useRef, useState } from "react";
+import { type ComponentType, useRef, useState } from "react";
 import type { RequestDisplayMode } from "skybridge/web";
 
 import { useInspectorPreferencesStore } from "@/lib/inspector-preferences-store.js";
 import { cn } from "@/lib/utils.js";
+import { BlossomIcon } from "../preview/chatgpt-icons.js";
+import { ClaudeLogomark } from "../preview/claude-icons.js";
 import { locales } from "./locales.js";
 import { isOneOf } from "./utils.js";
 
@@ -120,7 +121,7 @@ function ToolbarButton({
   onClick,
   className,
 }: {
-  icon: LucideIcon;
+  icon: ComponentType<{ className?: string }>;
   label: string;
   selected?: boolean;
   onClick?: () => void;
@@ -360,7 +361,7 @@ export const ToolPanelToolbar = ({
       {variant === "preview" && (
         <>
           <ToolbarButton
-            icon={ArrowLeftRight}
+            icon={previewClient === "claude" ? BlossomIcon : ClaudeLogomark}
             label={
               previewClient === "claude"
                 ? "switch to ChatGPT"


### PR DESCRIPTION
Stacked on #1063. Covers the QA requests from the [realistic UI session](https://app.notion.com/p/3c31e5ce535b80788943ef8cb1832efd) that #1063 deliberately left out, all of them host-chrome fidelity rather than breakage. Tracked in SKY-557.

## What it adds

- **Host logos in the switch button.** The preview toolbar showed a generic swap arrow; it now shows the logo of the host you are switching to. ChatGPT reuses the existing `BlossomIcon`; Claude needed a compact logomark, which did not exist in the repo (only the wordmark), so `ClaudeLogomark` is a new geometric burst. **Swap it for the official asset if it reads off-brand.**
- **Composer in fullscreen.** `chatgpt-shell` hid the composer entirely in fullscreen, and `claude-shell` only skipped it on mobile. Both now float it over the bottom of the widget, which is the shape Claude desktop already used here and what the real apps do.
- **Claude's scroll-to-bottom arrow.** Appears once the thread is scrolled more than 24px from the bottom, centered above the composer, and it can overlap the widget exactly as QA observed. Clicking it smooth-scrolls to the bottom. It tears down in fullscreen so it cannot fight the pin-to-bottom effect from #1063.

## How to test

Run any tool in the everything example, then click **preview**.

- Switch clients and check both logos.
- Go fullscreen in each shell, on desktop and mobile, and confirm the composer floats at the bottom. It covers the bottom of the widget, which matches the real hosts.
- Scroll the Claude thread up: the arrow appears above the composer, over the widget. Click it to return to the bottom.

Verified in both shells, light and dark, desktop and mobile, across inline, pip and fullscreen. No tests: this is preview chrome, and an e2e test asserting on shell markup would cost more than it protects.

## Not included

An earlier revision of this branch also rendered ChatGPT's open-in-app pill above the widget, driven by the `openInAppUrl` the store already tracks. Removed on review; that data is still stored and still displayed nowhere.

ChatGPT's dedicated open-external confirmation modal, the last request in the QA batch, is deliberately left for its own PR: it changes the behaviour of a call views depend on (`useOpenExternal`), rather than adding static chrome, and it should be built after #1062 / SKY-558 so it targets the bridge each preview should actually be running.

ChatGPT has a scroll arrow too; QA asked only for Claude's, so only Claude's is here.