### PR TITLE
feat(create-skybridge): scaffold a repo example via --example <name>

### DIFF
--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -36,8 +36,6 @@ You can also start from any app in the [examples](/examples) folder of the Skybr
 npx skybridge create my-app --example auth-descope
 ```
 
-The example is downloaded from GitHub and set up like a template. Pass an unknown name to get the list of available examples.
-
 ## Run Locally
 
 Start the development server from the project root:

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -30,6 +30,14 @@ The default `demo` template comes with two tools:
 To scaffold a bare-bones project without tools or view placeholders, select the `blank` template.
 </Info>
 
+You can also start from any app in the [examples](/examples) folder of the Skybridge repository:
+
+```bash
+npx skybridge create my-app --example auth-descope
+```
+
+The example is downloaded from GitHub and set up like a template. Pass an unknown name to get the list of available examples.
+
 ## Run Locally
 
 Start the development server from the project root:

--- a/packages/create-skybridge/src/index.test.ts
+++ b/packages/create-skybridge/src/index.test.ts
@@ -106,14 +106,14 @@ describe("create-skybridge", () => {
 
     beforeAll(async () => {
       const repo = await fs.mkdtemp(path.join(os.tmpdir(), "sky-repo-"));
-      const example = path.join(repo, "skybridge-main", "examples", "coffee");
+      const example = path.join(repo, "skybridge-9.9.9", "examples", "coffee");
       await fs.mkdir(path.join(example, "src"), { recursive: true });
       await fs.writeFile(
         path.join(example, "package.json"),
         '{"name":"skybridge-coffee-example"}',
       );
       await fs.writeFile(path.join(example, "src", "server.ts"), "");
-      execFileSync("tar", ["-czf", "repo.tgz", "skybridge-main"], {
+      execFileSync("tar", ["-czf", "repo.tgz", "skybridge-9.9.9"], {
         cwd: repo,
       });
       tarball = await fs.readFile(path.join(repo, "repo.tgz"));
@@ -123,7 +123,18 @@ describe("create-skybridge", () => {
     beforeEach(() => {
       vi.stubGlobal(
         "fetch",
-        vi.fn(async () => new Response(tarball)),
+        vi.fn(async (url: string) => {
+          if (url.endsWith("/releases/latest")) {
+            return Response.json({ tag_name: "v9.9.9" });
+          }
+          if (url.includes("/contents/examples")) {
+            return Response.json([
+              { name: "coffee", type: "dir" },
+              { name: "README.md", type: "file" },
+            ]);
+          }
+          return new Response(tarball);
+        }),
       );
     });
 

--- a/packages/create-skybridge/src/index.test.ts
+++ b/packages/create-skybridge/src/index.test.ts
@@ -1,11 +1,26 @@
+import { execFileSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
+const { default: realSpawn } =
+  await vi.importActual<typeof import("cross-spawn")>("cross-spawn");
 vi.mock("cross-spawn", () => ({
-  default: vi.fn(() => {
+  default: vi.fn((command: string, ...rest: unknown[]) => {
+    if (command === "tar") {
+      return (realSpawn as (...args: unknown[]) => unknown)(command, ...rest);
+    }
     const child = new EventEmitter();
     setImmediate(() => child.emit("close", 0));
     return child;
@@ -84,6 +99,95 @@ describe("create-skybridge", () => {
         path.join(process.cwd(), tempDirName, "project", "pnpm-workspace.yaml"),
       ),
     ).rejects.toThrow();
+  });
+
+  describe("--example", () => {
+    let tarball: Buffer;
+
+    beforeAll(async () => {
+      const repo = await fs.mkdtemp(path.join(os.tmpdir(), "sky-repo-"));
+      const example = path.join(repo, "skybridge-main", "examples", "coffee");
+      await fs.mkdir(path.join(example, "src"), { recursive: true });
+      await fs.writeFile(
+        path.join(example, "package.json"),
+        '{"name":"skybridge-coffee-example"}',
+      );
+      await fs.writeFile(path.join(example, "src", "server.ts"), "");
+      execFileSync("tar", ["-czf", "repo.tgz", "skybridge-main"], {
+        cwd: repo,
+      });
+      tarball = await fs.readFile(path.join(repo, "repo.tgz"));
+      await fs.rm(repo, { recursive: true, force: true });
+    });
+
+    beforeEach(() => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => new Response(tarball)),
+      );
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      vi.restoreAllMocks();
+    });
+
+    it("scaffolds a repo example from the GitHub tarball", async () => {
+      const name = `${tempDirName}/coffee-app`;
+      await init([name, "--yes", "--skip-skills", "--example", "coffee"]);
+
+      const projectDir = path.join(process.cwd(), tempDirName, "coffee-app");
+      await fs.access(path.join(projectDir, "src", "server.ts"));
+      const gitignore = await fs.readFile(
+        path.join(projectDir, ".gitignore"),
+        "utf-8",
+      );
+      expect(gitignore).toContain("node_modules");
+      const pkgRaw = await fs.readFile(
+        path.join(projectDir, "package.json"),
+        "utf-8",
+      );
+      expect(JSON.parse(pkgRaw).name).toBe("coffee-app");
+    });
+
+    it("rejects an unknown example with the available names", async () => {
+      const exit = vi.spyOn(process, "exit").mockImplementation((() => {
+        throw new Error("exit");
+      }) as never);
+      const errors: string[] = [];
+      vi.spyOn(console, "error").mockImplementation((msg) => {
+        errors.push(String(msg));
+      });
+      vi.spyOn(process.stdout, "write").mockImplementation(((
+        chunk: unknown,
+      ) => {
+        errors.push(String(chunk));
+        return true;
+      }) as never);
+
+      await expect(
+        init([
+          `${tempDirName}/x`,
+          "--yes",
+          "--skip-skills",
+          "--example",
+          "nope",
+        ]),
+      ).rejects.toThrow("exit");
+
+      expect(exit).toHaveBeenCalledWith(1);
+      expect(errors.join("\n")).toContain('Unknown example "nope"');
+      expect(errors.join("\n")).toContain("coffee");
+    });
+
+    it("refuses --example combined with a bundled template", async () => {
+      vi.spyOn(process, "exit").mockImplementation((() => {
+        throw new Error("exit");
+      }) as never);
+      await expect(
+        init([`${tempDirName}/x`, "--yes", "--blank", "--example", "coffee"]),
+      ).rejects.toThrow("exit");
+    });
   });
 
   it("sets package.json name to the project directory basename", async () => {

--- a/packages/create-skybridge/src/index.ts
+++ b/packages/create-skybridge/src/index.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import * as prompts from "@clack/prompts";
@@ -14,6 +15,9 @@ type PackageManager = (typeof PACKAGE_MANAGERS)[number];
 
 const TEMPLATES = ["demo", "blank", "ecom"] as const;
 type Template = (typeof TEMPLATES)[number];
+
+const REPO = "alpic-ai/skybridge";
+const REPO_REF = "main";
 
 const pkg = JSON.parse(
   fs.readFileSync(
@@ -31,14 +35,15 @@ Arguments:
   path           Where the project will be created. Prompted when omitted.
 
 Options:
-  --blank        scaffold a minimal project without demo tools and views
-  --ecom         scaffold the ecommerce template (search products, render carousel)
-  --overwrite    remove existing files if target directory is not empty
-  --pm <choice>  package manager to use (choices: ${PACKAGE_MANAGERS.join(", ")}. default to npm when none is provided or infered)
-  --skip-skills  skip installing coding agent skills
-  --start        start dev server
-  --yes          skip prompts and use default values for unprovided options
-  --help         display this help message
+  --blank           scaffold a minimal project without demo tools and views
+  --ecom            scaffold the ecommerce template (search products, render carousel)
+  --example <name>  scaffold a copy of github.com/${REPO}/tree/${REPO_REF}/examples/<name>
+  --overwrite       remove existing files if target directory is not empty
+  --pm <choice>     package manager to use (choices: ${PACKAGE_MANAGERS.join(", ")}. default to npm when none is provided or infered)
+  --skip-skills     skip installing coding agent skills
+  --start           start dev server
+  --yes             skip prompts and use default values for unprovided options
+  --help            display this help message
 
 Non-interactive usage:
   Mandatory: path argument and --yes option
@@ -76,6 +81,7 @@ export async function init(args: string[] = process.argv.slice(2)) {
     help?: boolean;
     blank?: boolean;
     ecom?: boolean;
+    example?: string;
     overwrite?: boolean;
     pm?: string;
     "skip-skills"?: boolean;
@@ -91,7 +97,7 @@ export async function init(args: string[] = process.argv.slice(2)) {
       "start",
       "yes",
     ],
-    string: ["pm"],
+    string: ["pm", "example"],
     alias: { h: "help" },
   });
 
@@ -108,6 +114,13 @@ export async function init(args: string[] = process.argv.slice(2)) {
       "The target directory is required in non-interactive mode.",
       "Example: skybridge create my-app --yes",
     );
+  }
+
+  if (argv.example !== undefined && !/^[\w.-]+$/.test(argv.example)) {
+    abort("--example requires a name, e.g. --example auth-descope.");
+  }
+  if (argv.example && (argv.blank || argv.ecom)) {
+    abort("Cannot combine --example with --blank or --ecom.");
   }
 
   let pm = parsePackageManager(argv.pm || "");
@@ -164,6 +177,7 @@ export async function init(args: string[] = process.argv.slice(2)) {
 
   // 3. Template
   let template: Template | undefined;
+  const example = argv.example;
   if (argv.blank) {
     template = "blank";
   }
@@ -173,7 +187,7 @@ export async function init(args: string[] = process.argv.slice(2)) {
     }
     template = "ecom";
   }
-  if (!template) {
+  if (!template && !example) {
     if (yes) {
       template = "demo";
     } else {
@@ -207,23 +221,38 @@ export async function init(args: string[] = process.argv.slice(2)) {
 
   // 4. Copy template
   const root = path.resolve(targetDir);
-  Spinner.start(`Copying ${template} template`);
+  const templatesDir = fileURLToPath(new URL("../templates", import.meta.url));
+  let source = path.join(templatesDir, template ?? "demo");
+  let cleanup = () => {};
+  if (example) {
+    Spinner.start(`Downloading ${example} example`);
+    try {
+      ({ source, cleanup } = await downloadExample(example));
+      Spinner.stop(`Downloaded ${example} example`);
+    } catch (error) {
+      Spinner.error(`Failed to download ${example} example`);
+      abort(error instanceof Error ? error.message : String(error));
+    }
+  }
+  Spinner.start(`Copying ${example ?? template} template`);
   try {
-    const templateDir = fileURLToPath(
-      new URL(`../templates/${template}`, import.meta.url),
-    );
-    fs.cpSync(templateDir, root, {
+    fs.cpSync(source, root, {
       recursive: true,
       filter: (src: string) => [".npmrc"].every((file) => !src.endsWith(file)),
     });
+    const gitignore = path.join(root, ".gitignore");
     const gitignoreSource = path.join(root, "_gitignore");
     if (fs.existsSync(gitignoreSource)) {
-      fs.renameSync(gitignoreSource, path.join(root, ".gitignore"));
+      fs.renameSync(gitignoreSource, gitignore);
+    } else if (!fs.existsSync(gitignore)) {
+      fs.copyFileSync(path.join(templatesDir, "demo", "_gitignore"), gitignore);
     }
-    Spinner.stop(`Copied ${template} template`);
+    Spinner.stop(`Copied ${example ?? template} template`);
   } catch (error) {
     Spinner.error("Failed to copy template");
     abort(String(error));
+  } finally {
+    cleanup();
   }
 
   // 5. Set package.json name to the project dir basename
@@ -390,6 +419,60 @@ ${scriptCommand(pm, "deploy")}`);
   prompts.outro(`🛟  Need help?
    Chat: https://discord.alpic.ai
    Docs: https://docs.skybridge.tech`);
+}
+
+async function downloadExample(name: string) {
+  const res = await fetch(
+    `https://codeload.github.com/${REPO}/tar.gz/${REPO_REF}`,
+  );
+  if (!res.ok) {
+    throw new Error(`GitHub returned ${res.status} while fetching ${REPO}.`);
+  }
+  const archive = Buffer.from(await res.arrayBuffer());
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "skybridge-example-"));
+  const cleanup = () => fs.rmSync(tmp, { recursive: true, force: true });
+  try {
+    const tar = spawn("tar", ["-xz", "-C", tmp], {
+      stdio: ["pipe", "ignore", "pipe"],
+    });
+    let stderr = "";
+    tar.stderr?.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    const exit = new Promise<void>((resolve, reject) => {
+      tar.on("error", reject);
+      tar.on("close", (status) =>
+        status === 0
+          ? resolve()
+          : reject(new Error(`tar exited with ${status}: ${stderr.trim()}`)),
+      );
+    });
+    tar.stdin?.on("error", () => {});
+    tar.stdin?.end(archive);
+    await exit;
+    const [extracted] = fs.readdirSync(tmp);
+    if (!extracted) {
+      throw new Error("Downloaded archive is empty.");
+    }
+    const examplesDir = path.join(tmp, extracted, "examples");
+    const available = fs
+      .readdirSync(examplesDir, { withFileTypes: true })
+      .filter(
+        (entry) =>
+          entry.isDirectory() &&
+          fs.existsSync(path.join(examplesDir, entry.name, "package.json")),
+      )
+      .map((entry) => entry.name);
+    if (!available.includes(name)) {
+      throw new Error(
+        `Unknown example "${name}". Available examples:\n  ${available.join("\n  ")}`,
+      );
+    }
+    return { source: path.join(examplesDir, name), cleanup };
+  } catch (error) {
+    cleanup();
+    throw error;
+  }
 }
 
 function cancel() {

--- a/packages/create-skybridge/src/index.ts
+++ b/packages/create-skybridge/src/index.ts
@@ -122,6 +122,7 @@ export async function init(args: string[] = process.argv.slice(2)) {
   if (argv.example && (argv.blank || argv.ecom)) {
     abort("Cannot combine --example with --blank or --ecom.");
   }
+  const example = argv.example;
 
   let pm = parsePackageManager(argv.pm || "");
   if (argv.pm && !pm) {
@@ -153,6 +154,17 @@ export async function init(args: string[] = process.argv.slice(2)) {
   }
 
   // 2. Existing-directory handling
+  let downloaded: Awaited<ReturnType<typeof downloadExample>> | undefined;
+  if (example) {
+    Spinner.start(`Downloading ${example} example`);
+    try {
+      downloaded = await downloadExample(example);
+      Spinner.stop(`Downloaded ${example} example`);
+    } catch (error) {
+      Spinner.error(`Failed to download ${example} example`);
+      abort(error instanceof Error ? error.message : String(error));
+    }
+  }
   if (fs.existsSync(targetDir) && !isEmpty(targetDir)) {
     if (argv.overwrite) {
       emptyDir(targetDir);
@@ -177,7 +189,6 @@ export async function init(args: string[] = process.argv.slice(2)) {
 
   // 3. Template
   let template: Template | undefined;
-  const example = argv.example;
   if (argv.blank) {
     template = "blank";
   }
@@ -222,18 +233,8 @@ export async function init(args: string[] = process.argv.slice(2)) {
   // 4. Copy template
   const root = path.resolve(targetDir);
   const templatesDir = fileURLToPath(new URL("../templates", import.meta.url));
-  let source = path.join(templatesDir, template ?? "demo");
-  let cleanup = () => {};
-  if (example) {
-    Spinner.start(`Downloading ${example} example`);
-    try {
-      ({ source, cleanup } = await downloadExample(example));
-      Spinner.stop(`Downloaded ${example} example`);
-    } catch (error) {
-      Spinner.error(`Failed to download ${example} example`);
-      abort(error instanceof Error ? error.message : String(error));
-    }
-  }
+  const source =
+    downloaded?.source ?? path.join(templatesDir, template ?? "demo");
   Spinner.start(`Copying ${example ?? template} template`);
   try {
     fs.cpSync(source, root, {
@@ -252,7 +253,7 @@ export async function init(args: string[] = process.argv.slice(2)) {
     Spinner.error("Failed to copy template");
     abort(String(error));
   } finally {
-    cleanup();
+    downloaded?.cleanup();
   }
 
   // 5. Set package.json name to the project dir basename
@@ -440,7 +441,13 @@ async function downloadExample(name: string) {
       stderr += chunk.toString();
     });
     const exit = new Promise<void>((resolve, reject) => {
-      tar.on("error", reject);
+      tar.on("error", (error: NodeJS.ErrnoException) =>
+        reject(
+          error.code === "ENOENT"
+            ? new Error("`tar` is required to extract the example.")
+            : error,
+        ),
+      );
       tar.on("close", (status) =>
         status === 0
           ? resolve()

--- a/packages/create-skybridge/src/index.ts
+++ b/packages/create-skybridge/src/index.ts
@@ -17,7 +17,6 @@ const TEMPLATES = ["demo", "blank", "ecom"] as const;
 type Template = (typeof TEMPLATES)[number];
 
 const REPO = "alpic-ai/skybridge";
-const REPO_REF = "main";
 
 const pkg = JSON.parse(
   fs.readFileSync(
@@ -37,7 +36,7 @@ Arguments:
 Options:
   --blank           scaffold a minimal project without demo tools and views
   --ecom            scaffold the ecommerce template (search products, render carousel)
-  --example <name>  scaffold a copy of github.com/${REPO}/tree/${REPO_REF}/examples/<name>
+  --example <name>  scaffold a copy of examples/<name> from the latest Skybridge release
   --overwrite       remove existing files if target directory is not empty
   --pm <choice>     package manager to use (choices: ${PACKAGE_MANAGERS.join(", ")}. default to npm when none is provided or infered)
   --skip-skills     skip installing coding agent skills
@@ -422,10 +421,33 @@ ${scriptCommand(pm, "deploy")}`);
    Docs: https://docs.skybridge.tech`);
 }
 
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, {
+    headers: { accept: "application/vnd.github+json" },
+  });
+  if (!res.ok) {
+    throw new Error(`GitHub returned ${res.status} for ${url}.`);
+  }
+  return res.json() as Promise<T>;
+}
+
 async function downloadExample(name: string) {
-  const res = await fetch(
-    `https://codeload.github.com/${REPO}/tar.gz/${REPO_REF}`,
+  const api = `https://api.github.com/repos/${REPO}`;
+  const { tag_name: tag } = await fetchJson<{ tag_name: string }>(
+    `${api}/releases/latest`,
   );
+  const entries = await fetchJson<{ name: string; type: string }[]>(
+    `${api}/contents/examples?ref=${tag}`,
+  );
+  const available = entries
+    .filter((entry) => entry.type === "dir")
+    .map((entry) => entry.name);
+  if (!available.includes(name)) {
+    throw new Error(
+      `Unknown example "${name}". Available examples:\n  ${available.join("\n  ")}`,
+    );
+  }
+  const res = await fetch(`https://codeload.github.com/${REPO}/tar.gz/${tag}`);
   if (!res.ok) {
     throw new Error(`GitHub returned ${res.status} while fetching ${REPO}.`);
   }
@@ -461,21 +483,7 @@ async function downloadExample(name: string) {
     if (!extracted) {
       throw new Error("Downloaded archive is empty.");
     }
-    const examplesDir = path.join(tmp, extracted, "examples");
-    const available = fs
-      .readdirSync(examplesDir, { withFileTypes: true })
-      .filter(
-        (entry) =>
-          entry.isDirectory() &&
-          fs.existsSync(path.join(examplesDir, entry.name, "package.json")),
-      )
-      .map((entry) => entry.name);
-    if (!available.includes(name)) {
-      throw new Error(
-        `Unknown example "${name}". Available examples:\n  ${available.join("\n  ")}`,
-      );
-    }
-    return { source: path.join(examplesDir, name), cleanup };
+    return { source: path.join(tmp, extracted, "examples", name), cleanup };
   } catch (error) {
     cleanup();
     throw error;

--- a/skills/chatgpt-app-builder/references/copy-template.md
+++ b/skills/chatgpt-app-builder/references/copy-template.md
@@ -14,7 +14,7 @@ Scaffold a project by setting up the Skybridge template starter. Skybridge is a 
 deno init --npm skybridge {target-dir}
 ```
 
-Template flags: `--blank` (minimal, no tools) or `--ecom` (ecommerce starter). With npm, separate flags: `npm create skybridge@latest {target-dir} -- --ecom`.
+Template flags: `--blank` (minimal, no tools), `--ecom` (ecommerce starter) or `--example <name>` (a copy of `examples/<name>` from the Skybridge repo, downloaded from GitHub). With npm, separate flags: `npm create skybridge@latest {target-dir} -- --ecom`.
 Scaffolding with `--ecom`? → follow [ecommerce.md](ecommerce.md) to fill it.
 
 3. [Start the dev server](run-locally.md). Read logs to assess readiness/health; fix any errors (TypeScript, etc.) before proceeding.


### PR DESCRIPTION
Closes SKY-559.

## Summary

- `npx create-skybridge my-app --example <name>` resolves the latest GitHub release, validates the name against the `examples/` listing, then downloads the release tarball and copies `examples/<name>` into the target dir, then follows the usual flow (package.json rename, skills, install, dev server).
- Unknown names abort with the list of available examples (directories under `examples/` at that release), checked before any download.
- `--example` is mutually exclusive with `--blank` / `--ecom`. Non-interactive only, the template picker is unchanged.
- Bundled templates and downloaded examples now share one copy path (`.npmrc` filter, `_gitignore` rename, demo `_gitignore` as fallback when the source has none).
- Extraction uses the system `tar` through the already-installed `cross-spawn`, no new dependency.
- Docs: `--help`, `docs/get-started/quickstart.mdx`, skill `copy-template.md`.

## Alternatives Considered

- **Bundling examples in the package.** Rejected by the ticket; the tarball keeps the package small and examples always current.