### PR TITLE
fix(cli): report a crashed dev server child instead of showing it as healthy

### DIFF
--- a/packages/core/src/cli/nodemon.d.ts
+++ b/packages/core/src/cli/nodemon.d.ts
@@ -7,4 +7,5 @@ export type ExtendedNodemon = import("nodemon").default & {
     event: "restart",
     listener: (files: string[]) => void,
   ): import("nodemon").Nodemon;
+  on(event: "crash", listener: () => void): import("nodemon").Nodemon;
 };

--- a/packages/core/src/cli/run-plain.ts
+++ b/packages/core/src/cli/run-plain.ts
@@ -1,5 +1,5 @@
 import type { TunnelManager, TunnelState } from "./tunnel.js";
-import { startNodemon } from "./use-nodemon.js";
+import { CRASH_MESSAGE, startNodemon } from "./use-nodemon.js";
 import { startTypeScriptCheck, type TsError } from "./use-typescript-check.js";
 
 export interface RunPlainOptions {
@@ -67,6 +67,7 @@ export function runPlain(options: RunPlainOptions): () => void {
     onStderr: (message) => info(message),
     onRestart: (files) =>
       info(`✓  Server restarted due to file changes: ${files.join(", ")}`),
+    onCrash: () => info(CRASH_MESSAGE),
   });
 
   let lastTsErrorKey = "";

--- a/packages/core/src/cli/use-nodemon.ts
+++ b/packages/core/src/cli/use-nodemon.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import { resolve } from "node:path";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import type { ExtendedNodemon } from "./nodemon.d.ts";
 import type { PushMessage } from "./use-messages.js";
 
@@ -15,6 +15,9 @@ function loadNodemon(): ExtendedNodemon {
   }
 }
 
+export const CRASH_MESSAGE =
+  "💥  Server crashed. Fix the error, then save a file under src/ to restart it.";
+
 const SOURCEMAP_WARNING = /^Sourcemap for ".*" points to missing source files$/;
 
 export interface NodemonHandlers {
@@ -24,6 +27,11 @@ export interface NodemonHandlers {
   onStderr: (message: string) => void;
   /** The server restarted because the listed files changed. */
   onRestart: (files: string[]) => void;
+  /**
+   * The server exited with a non-zero code. nodemon does not restart it on its
+   * own: it waits for the next file change.
+   */
+  onCrash: () => void;
 }
 
 /**
@@ -83,15 +91,20 @@ export function startNodemon(
     }
   };
 
-  nodemon.on("readable", () => {
+  const reattachListeners = () => {
     setupStdoutListener();
     setupStderrListener();
+  };
+
+  nodemon.on("readable", reattachListeners);
+
+  nodemon.on("crash", () => {
+    handlers.onCrash();
   });
 
   nodemon.on("restart", (files: string[]) => {
     handlers.onRestart(files);
-    setupStdoutListener();
-    setupStderrListener();
+    reattachListeners();
   });
 
   return () => {
@@ -105,10 +118,16 @@ export function startNodemon(
   };
 }
 
+/**
+ * Boot nodemon for the Ink dev UI. Returns whether the server is currently
+ * down after a crash, so the UI can stop advertising a URL nothing listens on.
+ */
 export function useNodemon(
   env: NodeJS.ProcessEnv,
   pushMessage: PushMessage,
-): void {
+): boolean {
+  const [crashed, setCrashed] = useState(false);
+
   useEffect(
     () =>
       startNodemon(env, {
@@ -119,12 +138,17 @@ export function useNodemon(
           }
         },
         onStderr: (message) => pushMessage(message, "error"),
-        onRestart: (files) =>
+        onRestart: (files) => {
+          setCrashed(false);
           pushMessage(
             `Server restarted due to file changes: ${files.join(", ")}`,
             "restart",
-          ),
+          );
+        },
+        onCrash: () => setCrashed(true),
       }),
     [env, pushMessage],
   );
+
+  return crashed;
 }

--- a/packages/core/src/cli/use-nodemon.ts
+++ b/packages/core/src/cli/use-nodemon.ts
@@ -16,7 +16,7 @@ function loadNodemon(): ExtendedNodemon {
 }
 
 export const CRASH_MESSAGE =
-  "💥  Server crashed. Fix the error, then save a file under src/ to restart it.";
+  "💥  Server crashed. Fix the error, then save a watched file to restart it.";
 
 const SOURCEMAP_WARNING = /^Sourcemap for ".*" points to missing source files$/;
 

--- a/packages/core/src/commands/dev.tsx
+++ b/packages/core/src/commands/dev.tsx
@@ -6,7 +6,7 @@ import { resolveSkybridgeConfig } from "../cli/resolve-skybridge-config.js";
 import { runPlain } from "../cli/run-plain.js";
 import { startTunnelControlServer } from "../cli/tunnel-control-server.js";
 import { useMessages } from "../cli/use-messages.js";
-import { useNodemon } from "../cli/use-nodemon.js";
+import { CRASH_MESSAGE, useNodemon } from "../cli/use-nodemon.js";
 import { useOpenBrowser } from "../cli/use-open-browser.js";
 import { useTunnel } from "../cli/use-tunnel.js";
 import { useTypeScriptCheck } from "../cli/use-typescript-check.js";
@@ -108,7 +108,7 @@ export default class Dev extends Command {
     const App = () => {
       const tsErrors = useTypeScriptCheck();
       const [messages, pushMessage] = useMessages();
-      useNodemon(env, pushMessage);
+      const crashed = useNodemon(env, pushMessage);
       useOpenBrowser(port, flags.open);
       const tunnelState = useTunnel(
         port,
@@ -121,22 +121,30 @@ export default class Dev extends Command {
         <Box flexDirection="column" padding={1} marginLeft={1}>
           <Header version={this.config.version} />
 
-          <Box>
-            <Text>🏠{"  "}</Text>
-            {fallback ? (
-              <Text color="yellow">3000 in use, running on </Text>
-            ) : (
-              <Text>Running on </Text>
-            )}
-            <Text color="green">{`http://localhost:${port}/mcp`}</Text>
-          </Box>
-          <Box marginBottom={1}>
-            <Text color="#20a832">→{"  "}</Text>
-            <Text color="white" bold>
-              Test locally with DevTools:{" "}
-            </Text>
-            <Text color="green">{`http://localhost:${port}/`}</Text>
-          </Box>
+          {crashed ? (
+            <Box marginBottom={1}>
+              <Text color="red">{CRASH_MESSAGE}</Text>
+            </Box>
+          ) : (
+            <>
+              <Box>
+                <Text>🏠{"  "}</Text>
+                {fallback ? (
+                  <Text color="yellow">3000 in use, running on </Text>
+                ) : (
+                  <Text>Running on </Text>
+                )}
+                <Text color="green">{`http://localhost:${port}/mcp`}</Text>
+              </Box>
+              <Box marginBottom={1}>
+                <Text color="#20a832">→{"  "}</Text>
+                <Text color="white" bold>
+                  Test locally with DevTools:{" "}
+                </Text>
+                <Text color="green">{`http://localhost:${port}/`}</Text>
+              </Box>
+            </>
+          )}
 
           {tunnelState.status === "idle" && (
             <Box>

--- a/packages/core/src/commands/dev.tsx
+++ b/packages/core/src/commands/dev.tsx
@@ -162,7 +162,7 @@ export default class Dev extends Command {
               <Text color="yellow">{tunnelState.message}</Text>
             </Box>
           )}
-          {tunnelState.status === "connected" && (
+          {tunnelState.status === "connected" && !crashed && (
             <Box flexDirection="column" marginBottom={1}>
               <Box>
                 <Text>🌍{"  "}</Text>


### PR DESCRIPTION
Closes #1075

## Summary

- `skybridge dev` now knows when the server child has died. nodemon emits `crash` on a nonzero exit and then sits idle waiting for a file change; we only wired `readable` and `restart`, so the dev UI kept advertising a URL nothing was listening on.
- `NodemonHandlers` gains `onCrash`, wired to nodemon's `crash` event and declared in `nodemon.d.ts`.
- `useNodemon` returns a `crashed` flag, cleared on the next restart. While crashed, the Ink UI drops the `🏠 Running on …` and DevTools lines and shows `💥 Server crashed. Fix the error, then save a file under src/ to restart it.` in red.
- `--plain` prints the same sentence on stderr, from one shared `CRASH_MESSAGE`.

## Notes

The issue's claim that a boot-time stack trace can be lost does not hold: nodemon assigns its stdout/stderr and emits `readable` from its own `start` handler, before the child can write anything. No fix needed there, and the stack trace shows up in the logs as expected.

Two gaps left deliberately, both worth a follow-up only if they show up in practice:

- A child that exits with code 0 without listening leaves the server equally down, but nodemon emits `exit` rather than `crash`, so the UI does not flag it. Telling that apart from the `exit` nodemon emits while killing the child for a restart depends on an undocumented signal argument, and a code-0 exit is a much rarer shape than a throw.
- `crashed` clears on `restart`, so between saving a file and the new child booting the UI shows the URL again. That is the same behaviour as a healthy restart, where the URL never goes away.

## Verification

Manual, against `examples/capitals` with a top-level `throw` in `src/index.ts`: the banner replaces the URLs, the stack trace lands in the logs, and saving a file clears the banner and brings the URLs back. Same sentence on stderr with `--plain`.

No test added: the change is event wiring plus a boolean, and a test would be entirely a nodemon mock.
