### PR TITLE
fix(core): restore per-view Apps SDK opt-in for ChatGPT file APIs

### DIFF
--- a/docs/api-reference/register-tool.mdx
+++ b/docs/api-reference/register-tool.mdx
@@ -122,7 +122,7 @@ type ViewConfig = {
 | --- | --- |
 | `component` | The view's file name, type-checked against your views. |
 | `description` | Label the host may show during view discovery. |
-| `hosts` | Restrict where the view renders; defaults to all. |
+| `hosts` | Include `"apps-sdk"` to also register the legacy Apps SDK resource on ChatGPT — currently required for the [file APIs](/api-reference/use-files) and `openai/fileParams` attachments, which MCP Apps does not expose yet. Defaults to the MCP Apps registration alone. |
 | `prefersBorder` | Apps SDK only: request a visible border around the view. |
 | `domain` | Apps SDK only: override the served domain (advanced). |
 | [`csp`](/api-reference/register-tool#csp) | Per-view CSP overrides; see below. |

--- a/docs/api-reference/register-tool.mdx
+++ b/docs/api-reference/register-tool.mdx
@@ -110,7 +110,7 @@ Bind the tool to a React view to render its result instead of plain text. Each v
 type ViewConfig = {
   component: ViewName;
   description?: string;
-  hosts?: Array<"apps-sdk" | "mcp-app">;
+  appsSdk?: boolean;
   prefersBorder?: boolean;
   domain?: string;
   csp?: ViewCsp;
@@ -122,7 +122,7 @@ type ViewConfig = {
 | --- | --- |
 | `component` | The view's file name, type-checked against your views. |
 | `description` | Label the host may show during view discovery. |
-| `hosts` | Include `"apps-sdk"` to also register the legacy Apps SDK resource on ChatGPT — currently required for the [file APIs](/api-reference/use-files) and `openai/fileParams` attachments, which MCP Apps does not expose yet. Defaults to the MCP Apps registration alone. |
+| `appsSdk` | Also register the legacy Apps SDK resource on ChatGPT — currently required for the [file APIs](/api-reference/use-files) and `openai/fileParams` attachments, which MCP Apps does not expose yet. Defaults to the MCP Apps registration alone. |
 | `prefersBorder` | Apps SDK only: request a visible border around the view. |
 | `domain` | Apps SDK only: override the served domain (advanced). |
 | [`csp`](/api-reference/register-tool#csp) | Per-view CSP overrides; see below. |

--- a/docs/api-reference/use-files.mdx
+++ b/docs/api-reference/use-files.mdx
@@ -93,7 +93,7 @@ server.registerTool(
   {
     name: "scan-receipt",
     description: "Scan a receipt",
-    view: { component: "scan-receipt", hosts: ["apps-sdk"] },
+    view: { component: "scan-receipt", appsSdk: true },
   },
   handler,
 );

--- a/docs/api-reference/use-files.mdx
+++ b/docs/api-reference/use-files.mdx
@@ -84,6 +84,23 @@ function ReceiptAttach() {
 
 Both paths resolve a download URL and build a [`FileRef`](/api-reference/file-ref) by hand: the hook returns camelCase fields, while `FileRef` wants snake_case with a required `download_url`.
 
+## Host support
+
+The file APIs run on ChatGPT's Apps SDK runtime. Since Skybridge 1.2.0 views render through MCP Apps by default, where ChatGPT does not expose them — a view that needs files must opt back in per tool:
+
+```ts
+server.registerTool(
+  {
+    name: "scan-receipt",
+    description: "Scan a receipt",
+    view: { component: "scan-receipt", hosts: ["apps-sdk"] },
+  },
+  handler,
+);
+```
+
+On every other host (and without the opt-in) the methods throw `NotSupportedError`, so feature-detect with `instanceof` when the view runs cross-host.
+
 ## Returns
 
 `useFiles` returns three functions.

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -74,7 +74,6 @@ export type {
   ToolMeta,
   ViewConfig,
   ViewCsp,
-  ViewHostType,
   ViewName,
   ViewNameRegistry,
 } from "./server.js";

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -74,6 +74,7 @@ export type {
   ToolMeta,
   ViewConfig,
   ViewCsp,
+  ViewHostType,
   ViewName,
   ViewNameRegistry,
 } from "./server.js";

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -120,15 +120,11 @@ export interface ViewConfig {
   /** Human-readable label the host may show alongside the view. */
   description?: string;
   /**
-   * Restrict where the view is rendered, and opt back into the legacy
-   * Apps SDK registration. `"apps-sdk"` also registers the
-   * `ui://views/apps-sdk/…` resource and sets `openai/outputTemplate` on
-   * ChatGPT, which is currently the only host path that exposes the
-   * ChatGPT file APIs (`uploadFile`, `getFileDownloadUrl`, `selectFiles`)
-   * to a view — MCP Apps has no equivalent yet (#1074). Defaults to the
-   * MCP Apps resource only.
+   * Also register the legacy Apps SDK resource and set `openai/outputTemplate`
+   * on ChatGPT. Use this for file APIs (`uploadFile`, `getFileDownloadUrl`,
+   * `selectFiles`) until MCP Apps has equivalents (#1074).
    */
-  hosts?: ViewHostType[];
+  appsSdk?: boolean;
   /** Request a visible border around the view (forwarded as `ui.prefersBorder`). */
   prefersBorder?: boolean;
   /** Override the iframe's served domain (advanced; forwarded as `ui.domain`). */
@@ -138,13 +134,6 @@ export interface ViewConfig {
   /** Free-form metadata forwarded on the view resource's `_meta`. */
   _meta?: Record<string, unknown>;
 }
-
-/**
- * Which host runtime a view targets — `"apps-sdk"` (ChatGPT) or `"mcp-app"`
- * (MCP Apps spec). Selecting `"apps-sdk"` opts the view into the legacy
- * Apps SDK registration that exposes the ChatGPT file APIs (#1074).
- */
-export type ViewHostType = "apps-sdk" | "mcp-app";
 
 export type SecurityScheme =
   | { type: "noauth" }
@@ -272,7 +261,7 @@ type McpAppsResourceMeta = {
 /**
  * `_meta` keys ChatGPT reads on a resource. The full `openai/widgetCSP`
  * shape is only emitted on the legacy Apps SDK registration
- * (`view.hosts: ["apps-sdk"]`, #1074); the MCP Apps registration forwards
+ * (`view.appsSdk`, #1074); the MCP Apps registration forwards
  * `redirect_domains` only, mirrored for cross-host parity.
  * @see https://developers.openai.com/apps-sdk/reference#component-resource-_meta-fields
  */
@@ -963,7 +952,7 @@ export class McpServer<
     // `openai/fileParams` attachments) must render through Apps SDK on
     // ChatGPT. `openai/outputTemplate` is what makes ChatGPT prefer that
     // registration.
-    if (view.hosts?.includes("apps-sdk")) {
+    if (view.appsSdk) {
       const appsSdkResource: ViewResourceConfig = {
         uri: `ui://views/apps-sdk/${view.component}.html${versionParam}`,
         mimeType: "text/html+skybridge",

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -119,6 +119,16 @@ export interface ViewConfig {
   component: ViewName;
   /** Human-readable label the host may show alongside the view. */
   description?: string;
+  /**
+   * Restrict where the view is rendered, and opt back into the legacy
+   * Apps SDK registration. `"apps-sdk"` also registers the
+   * `ui://views/apps-sdk/…` resource and sets `openai/outputTemplate` on
+   * ChatGPT, which is currently the only host path that exposes the
+   * ChatGPT file APIs (`uploadFile`, `getFileDownloadUrl`, `selectFiles`)
+   * to a view — MCP Apps has no equivalent yet (#1074). Defaults to the
+   * MCP Apps resource only.
+   */
+  hosts?: ViewHostType[];
   /** Request a visible border around the view (forwarded as `ui.prefersBorder`). */
   prefersBorder?: boolean;
   /** Override the iframe's served domain (advanced; forwarded as `ui.domain`). */
@@ -128,6 +138,13 @@ export interface ViewConfig {
   /** Free-form metadata forwarded on the view resource's `_meta`. */
   _meta?: Record<string, unknown>;
 }
+
+/**
+ * Which host runtime a view targets — `"apps-sdk"` (ChatGPT) or `"mcp-app"`
+ * (MCP Apps spec). Selecting `"apps-sdk"` opts the view into the legacy
+ * Apps SDK registration that exposes the ChatGPT file APIs (#1074).
+ */
+export type ViewHostType = "apps-sdk" | "mcp-app";
 
 export type SecurityScheme =
   | { type: "noauth" }
@@ -252,9 +269,25 @@ type McpAppsResourceMeta = {
   ui?: McpUiResourceMeta;
 };
 
+/**
+ * `_meta` keys ChatGPT reads on a resource. The full `openai/widgetCSP`
+ * shape is only emitted on the legacy Apps SDK registration
+ * (`view.hosts: ["apps-sdk"]`, #1074); the MCP Apps registration forwards
+ * `redirect_domains` only, mirrored for cross-host parity.
+ * @see https://developers.openai.com/apps-sdk/reference#component-resource-_meta-fields
+ */
+type OpenaiViewCSP = {
+  connect_domains: string[];
+  resource_domains: string[];
+  frame_domains?: string[];
+  redirect_domains?: string[];
+};
+
 type OpenaiResourceMeta = {
   "openai/widgetDescription"?: string;
-  "openai/widgetCSP"?: { redirect_domains?: string[] };
+  "openai/widgetDomain"?: string;
+  "openai/widgetPrefersBorder"?: boolean;
+  "openai/widgetCSP"?: OpenaiViewCSP;
 };
 
 type ResourceMeta = McpAppsResourceMeta & OpenaiResourceMeta;
@@ -902,7 +935,9 @@ export class McpServer<
             "openai/widgetDescription": view.description,
           }),
           ...(view.csp?.redirectDomains && {
-            "openai/widgetCSP": { redirect_domains: view.csp.redirectDomains },
+            "openai/widgetCSP": {
+              redirect_domains: view.csp.redirectDomains,
+            } as OpenaiViewCSP,
           }),
         };
 
@@ -921,6 +956,56 @@ export class McpServer<
     // @ts-expect-error - For backwards compatibility with Claude current implementation of the specs
     toolMeta["ui/resourceUri"] = viewResource.uri;
     toolMeta.ui = { ...toolMeta.ui, resourceUri: viewResource.uri };
+
+    // Opt back into the legacy Apps SDK registration. MCP Apps has no
+    // equivalent for the ChatGPT file APIs yet (#1074), so tools whose views
+    // need `uploadFile`/`getFileDownloadUrl`/`selectFiles` (or
+    // `openai/fileParams` attachments) must render through Apps SDK on
+    // ChatGPT. `openai/outputTemplate` is what makes ChatGPT prefer that
+    // registration.
+    if (view.hosts?.includes("apps-sdk")) {
+      const appsSdkResource: ViewResourceConfig = {
+        uri: `ui://views/apps-sdk/${view.component}.html${versionParam}`,
+        mimeType: "text/html+skybridge",
+        buildContentMeta: ({ resourceDomains, connectDomains, domain }) => {
+          const meta: OpenaiResourceMeta & McpAppsResourceMeta = {
+            "openai/widgetCSP": {
+              resource_domains: unionOf(
+                resourceDomains,
+                view.csp?.resourceDomains,
+              ),
+              connect_domains: unionOf(
+                connectDomains,
+                view.csp?.connectDomains,
+              ),
+              ...(view.csp?.frameDomains && {
+                frame_domains: view.csp.frameDomains,
+              }),
+              ...(view.csp?.redirectDomains && {
+                redirect_domains: view.csp.redirectDomains,
+              }),
+            },
+            "openai/widgetDomain": view.domain ?? domain,
+            ...(view.description && {
+              "openai/widgetDescription": view.description,
+            }),
+            ...(view.prefersBorder !== undefined && {
+              "openai/widgetPrefersBorder": view.prefersBorder,
+            }),
+          };
+          if (view._meta) {
+            return { ...meta, ...view._meta } as ResourceMeta;
+          }
+          return meta;
+        },
+      };
+      this.registerViewResource({
+        name: toolName,
+        viewResource: appsSdkResource,
+        view,
+      });
+      toolMeta["openai/outputTemplate"] = appsSdkResource.uri;
+    }
   }
 
   private registerViewResource({

--- a/packages/core/src/test/view.test.ts
+++ b/packages/core/src/test/view.test.ts
@@ -361,6 +361,69 @@ describe("McpServer.registerTool (unified API)", () => {
     expect(toolConfig._meta?.["openai/outputTemplate"]).toBeUndefined();
   });
 
+  it("should also register the legacy apps-sdk resource when view.hosts includes apps-sdk (#1074)", async () => {
+    server.registerTool(
+      {
+        name: "my-view",
+        description: "Test tool",
+        view: {
+          component: "my-view" as ViewName,
+          description: "Test view",
+          hosts: ["apps-sdk"],
+        },
+      },
+      vi.fn(),
+    );
+
+    // Both registrations: the MCP Apps resource and the legacy Apps SDK one.
+    expect(mockRegisterResource).toHaveBeenCalledTimes(2);
+    expect(mockRegisterResource.mock.calls[0]?.[1]).toBe(
+      "ui://views/ext-apps/my-view.html",
+    );
+    expect(mockRegisterResource.mock.calls[1]?.[1]).toBe(
+      "ui://views/apps-sdk/my-view.html",
+    );
+
+    const toolConfig = mockRegisterTool.mock.calls[0]?.[1] as {
+      _meta?: Record<string, unknown> & { ui?: { resourceUri?: string } };
+    };
+    expect(toolConfig._meta?.["openai/outputTemplate"]).toBe(
+      "ui://views/apps-sdk/my-view.html",
+    );
+    // The MCP Apps pointer stays authoritative for other hosts.
+    expect(toolConfig._meta?.ui?.resourceUri).toBe(
+      "ui://views/ext-apps/my-view.html",
+    );
+
+    // The apps-sdk resource serves the legacy registration: Apps SDK
+    // mimeType plus the openai/* `_meta` keys ChatGPT reads from it.
+    const appsSdkCallback = mockRegisterResource.mock
+      .calls[1]?.[3] as unknown as (
+      uri: URL,
+      extra: McpExtra,
+    ) => Promise<{
+      contents: Array<{
+        uri: URL | string;
+        mimeType: string;
+        text?: string;
+        _meta?: Record<string, unknown>;
+      }>;
+    }>;
+    const result = await appsSdkCallback(
+      new URL("ui://views/apps-sdk/my-view.html"),
+      createMockExtra("localhost:3000") as unknown as McpExtra,
+    );
+    expect(result.contents[0]?.mimeType).toBe("text/html+skybridge");
+    expect(result.contents[0]?._meta).toMatchObject({
+      "openai/widgetDescription": "Test view",
+      "openai/widgetCSP": {
+        resource_domains: ["http://localhost:3000"],
+        connect_domains: ["http://localhost:3000", "ws://localhost:3000"],
+      },
+      "openai/widgetDomain": "http://localhost:3000",
+    });
+  });
+
   it("should not version view URIs in development", () => {
     server.registerTool(
       {

--- a/packages/core/src/test/view.test.ts
+++ b/packages/core/src/test/view.test.ts
@@ -346,7 +346,11 @@ describe("McpServer.registerTool (unified API)", () => {
       {
         name: "my-view",
         description: "Test tool",
-        view: { component: "my-view" as ViewName, description: "Test view" },
+        view: {
+          component: "my-view" as ViewName,
+          description: "Test view",
+          appsSdk: false,
+        },
       },
       vi.fn(),
     );
@@ -361,7 +365,7 @@ describe("McpServer.registerTool (unified API)", () => {
     expect(toolConfig._meta?.["openai/outputTemplate"]).toBeUndefined();
   });
 
-  it("should also register the legacy apps-sdk resource when view.hosts includes apps-sdk (#1074)", async () => {
+  it("should also register the legacy apps-sdk resource when view.appsSdk is enabled (#1074)", async () => {
     server.registerTool(
       {
         name: "my-view",
@@ -369,7 +373,7 @@ describe("McpServer.registerTool (unified API)", () => {
         view: {
           component: "my-view" as ViewName,
           description: "Test view",
-          hosts: ["apps-sdk"],
+          appsSdk: true,
         },
       },
       vi.fn(),

--- a/packages/core/src/web/bridges/adaptor.test.ts
+++ b/packages/core/src/web/bridges/adaptor.test.ts
@@ -120,6 +120,25 @@ describe("HostAdaptor", () => {
     );
   });
 
+  it("file methods throw NotSupportedError when window.openai lacks them (MCP Apps compat shim)", async () => {
+    vi.stubGlobal("openai", {});
+    const adaptor = new HostAdaptor();
+
+    const uploadError = await adaptor
+      .uploadFile(new File([], "x"))
+      .catch((e: unknown) => e);
+    expect(uploadError).toBeInstanceOf(NotSupportedError);
+    expect((uploadError as NotSupportedError).method).toBe("uploadFile");
+
+    const downloadError = await adaptor
+      .getFileDownloadUrl({ fileId: "x" })
+      .catch((e: unknown) => e);
+    expect(downloadError).toBeInstanceOf(NotSupportedError);
+    expect((downloadError as NotSupportedError).method).toBe(
+      "getFileDownloadUrl",
+    );
+  });
+
   it("uploadFile delegates to window.openai.uploadFile and tracks fileId in widgetState", async () => {
     const setWidgetState = vi.fn().mockResolvedValue(undefined);
     const uploadFile = vi.fn().mockResolvedValue({

--- a/packages/core/src/web/bridges/adaptor.ts
+++ b/packages/core/src/web/bridges/adaptor.ts
@@ -266,6 +266,12 @@ export class HostAdaptor implements Adaptor {
     if (!this.openai) {
       throw new NotSupportedError("uploadFile");
     }
+    if (!this.openai.uploadFile) {
+      throw new NotSupportedError(
+        "uploadFile",
+        "not available on the current host version",
+      );
+    }
     const metadata = await this.openai.uploadFile(file, options);
     if (isImage(metadata.mimeType ?? file.type)) {
       await this.trackFileIds(metadata.fileId);
@@ -278,6 +284,14 @@ export class HostAdaptor implements Adaptor {
   ): Promise<{ downloadUrl: string }> => {
     if (!this.openai) {
       return Promise.reject(new NotSupportedError("getFileDownloadUrl"));
+    }
+    if (!this.openai.getFileDownloadUrl) {
+      return Promise.reject(
+        new NotSupportedError(
+          "getFileDownloadUrl",
+          "not available on the current host version",
+        ),
+      );
     }
     return this.openai.getFileDownloadUrl(file);
   };

--- a/packages/core/src/web/bridges/apps-sdk/types.ts
+++ b/packages/core/src/web/bridges/apps-sdk/types.ts
@@ -104,8 +104,8 @@ export type AppsSdkMethods<WS extends AppsSdkWidgetState = AppsSdkWidgetState> =
      */
     requestModal: (args: RequestModalOptions) => Promise<void>;
 
-    /** Uploads a new file to the host. Pass `{ library: true }` to also save to the user's ChatGPT file library. */
-    uploadFile: (
+    /** Uploads a new file to the host. Pass `{ library: true }` to also save to the user's ChatGPT file library. Feature-detect before using: this method may not be available on all host versions. */
+    uploadFile?: (
       file: File,
       options?: UploadFileOptions,
     ) => Promise<FileMetadata>;
@@ -119,8 +119,9 @@ export type AppsSdkMethods<WS extends AppsSdkWidgetState = AppsSdkWidgetState> =
     /**
      * Downloads a file from the host. Works for files uploaded by the widget,
      * files selected via selectFiles(), or files provided via tool/file params.
+     * Feature-detect before using: this method may not be available on all host versions.
      */
-    getFileDownloadUrl: (
+    getFileDownloadUrl?: (
       file: FileMetadata,
     ) => Promise<{ downloadUrl: string }>;
 


### PR DESCRIPTION
Fixes #1074

## Summary

- Since #833, `registerViewResources` only emits the ext-apps resource and `ui.resourceUri`, so on ChatGPT every view renders as an MCP App. The `window.openai` compat shim on that path has no `uploadFile`, `getFileDownloadUrl` or `selectFiles`, leaving `useFiles` and `openai/fileParams` attachments unreachable there.
- `view.appsSdk: true` additionally registers the legacy `ui://views/apps-sdk/<component>.html` resource (`text/html+skybridge` with the `openai/*` content meta) and sets `openai/outputTemplate`, so ChatGPT renders the Apps SDK registration where the file APIs exist. `ui.resourceUri` stays canonical for MCP Apps hosts.
- The default is unchanged: with `appsSdk` omitted or `false`, there is one ext-apps resource and no `openai/outputTemplate`.
- `uploadFile` and `getFileDownloadUrl` now throw `NotSupportedError` naming the method when the host object lacks it, like `selectFiles` already did, instead of a `TypeError`. The vendored `window.openai` type marks both optional to match the shim.

The locked ext-apps spec has no upload or select request to proxy over, so the per-view Apps SDK opt-in is the available path for file APIs.

## Verification

On current `main`, before the patch:

- `view: { appsSdk: true }` is a type error.
- With the ChatGPT MCP Apps shim, `useFiles().getDownloadUrl({ fileId: "x" })` rejects with `TypeError: this.openai.getFileDownloadUrl is not a function`.

After:

- `pnpm --filter skybridge exec vitest run src/test/view.test.ts src/web/bridges/adaptor.test.ts` passes 36 tests, including the explicit `appsSdk: true` and `appsSdk: false` registration cases and missing-method guards.
- `pnpm --filter skybridge build` and `pnpm --filter skybridge test:format` pass.
