### PR TITLE
docs: add a monetization guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -74,6 +74,7 @@
             "pages": [
               "guides/csp",
               "guides/ecommerce",
+              "guides/monetization",
               "guides/files",
               "guides/auth-providers",
               "guides/migrate",

--- a/docs/guides/index.mdx
+++ b/docs/guides/index.mdx
@@ -10,6 +10,12 @@ Each one is self-contained: it names the concern it solves, shows the [APIs](/ap
     <Card title="Configure CSP" icon="shield" href="/guides/csp">
         Let your views reach the domains they need
     </Card>
+    <Card title="Build an Ecommerce App" icon="shopping-bag" href="/guides/ecommerce">
+        Scaffold a catalog and carousel, then fill it with your brand
+    </Card>
+    <Card title="Monetize Your App" icon="circle-dollar-sign" href="/guides/monetization">
+        Charge a shopper, charge an agent, or carry sponsored slots
+    </Card>
     <Card title="UX Design" icon="sparkles" href="/guides/ux">
         Account for what makes an MCP App different
     </Card>
@@ -18,5 +24,11 @@ Each one is self-contained: it names the concern it solves, shows the [APIs](/ap
     </Card>
     <Card title="Migrate to Skybridge" icon="bird" href="/guides/migrate">
         Bring an existing MCP App over
+    </Card>
+    <Card title="Connect an Identity Provider" icon="fingerprint" href="/guides/auth-providers">
+        Wire sign-in through a hosted OAuth provider
+    </Card>
+    <Card title="Serve Skills over MCP" icon="book-open-text" href="/guides/skills">
+        Ship Agent Skills alongside your server
     </Card>
 </Columns>

--- a/docs/guides/monetization.mdx
+++ b/docs/guides/monetization.mdx
@@ -1,0 +1,195 @@
+---
+title: "Monetize Your MCP App"
+description: "Discover the different ways to make money with your MCP App"
+sidebarTitle: "Monetization"
+icon: "circle-dollar-sign"
+---
+
+The two main ways to monetize your MCP App are selling:
+- goods or services to your app users
+- sponsored slots to advertisers
+
+A third payer is possible too, and newer: the agent itself, paying out of a wallet its user funded.
+
+## Hand Off to Your Own Checkout
+
+The simplest option, and what the [`ecom` template](/guides/ecommerce) ships: send the shopper to a page you already run. The navigation has to go through the host with [`useOpenExternal`](/api-reference/use-open-external).
+
+```tsx views/carousel/detail/index.tsx
+import { useOpenExternal } from "skybridge/web";
+
+function BuyButton({ variant }) {
+  const openExternal = useOpenExternal();
+
+  return (
+    <button
+      type="button"
+      onClick={() => openExternal(variant.url)}
+    >
+      View on site
+    </button>
+  );
+}
+```
+
+List your checkout origin in [`redirectDomains`](/guides/csp#redirect-off-app) so the host skips its safe-link confirmation on the way out.
+
+```ts server.ts
+view: {
+  component: "carousel",
+  csp: { redirectDomains: ["https://checkout.myshop.com"] },
+},
+```
+
+What you give up is the return leg. The host opens the page outside the iframe and nothing comes back, so the view keeps rendering the cart and the model still believes the order is pending. This is usually fine for catalogs focused on sending qualified traffic to a storefront. If you want to update the cart after redirect, one strategy is to have the view poll the cart status until it's updated elsewhere.
+
+## Charge the Agent
+
+An agent can also pay for a tool call itself, with no person present, under the [Machine Payments Protocol](https://docs.stripe.com/payments/machine/mpp). An unpaid call comes back as a payment challenge, the agent fetches a credential from its user's wallet, and the retry returns the real result with a receipt attached.
+
+```mermaid
+sequenceDiagram
+  participant Agent
+  participant Server as Your server
+  participant Wallet as Agent wallet
+  Agent->>Server: call, no credential
+  Server-->>Agent: error -32042 plus challenge
+  Agent->>Wallet: request a credential
+  Wallet-->>Agent: credential
+  Agent->>Server: retry, credential in `_meta`
+  Server-->>Agent: result plus receipt
+```
+
+```bash
+npm install mppx stripe @modelcontextprotocol/sdk
+```
+
+Charge from [`mcpMiddleware`](/api-reference/mcp-server) rather than inside the tool handler. The challenge has to reach the client as a JSON-RPC error, carrying the amount and the payment method the agent needs to pay: an exception thrown inside a handler is flattened into an `isError` tool result instead, which leaves the agent with a message and nothing to pay against.
+
+```ts server.ts
+import { Mppx, stripe, Transport } from "mppx/server";
+import { Skybridge } from "skybridge/server";
+import Stripe from "stripe";
+import { z } from "zod";
+
+const PRICES: Record<string, string> = { "generate-report": "2.50" };
+
+export const app = new Skybridge({
+  name: "reports",
+  version: "1.0",
+  setup: () => ({
+    payment: Mppx.create({
+      methods: [
+        stripe.charge({
+          client: new Stripe(process.env.STRIPE_SECRET_KEY),
+          networkId: process.env.STRIPE_PROFILE_ID,
+          currency: "usd",
+          decimals: 2,
+          paymentMethodTypes: ["card"],
+        }),
+      ],
+      secretKey: process.env.MPP_SECRET_KEY,
+      realm: "reports.example.com",
+      transport: Transport.mcpSdk(),
+    }),
+  }),
+  handler: (server, { payment }) => {
+    server.mcpMiddleware("tools/call", async (request, _extra, next) => {
+      const amount = PRICES[request.params.name];
+      if (!amount) {
+        return next();
+      }
+
+      const result = await payment.stripe.charge({
+        amount,
+        description: request.params.name,
+      })({ _meta: request.params._meta });
+
+      if (result.status === 402) {
+        throw result.challenge;
+      }
+
+      return result.withReceipt(await next());
+    });
+
+    return server.registerTool(
+      {
+        name: "generate-report",
+        description: "Generate a market report.",
+        inputSchema: { ticker: z.string() },
+      },
+      async ({ ticker }) => ({
+        content: [{ type: "text", text: `Report for ${ticker}` }],
+      }),
+    );
+  },
+});
+```
+
+The middleware runs before the handler, so an unpaid call never reaches your code. Pricing lives in one table keyed by tool name, and a tool absent from it stays free. `MPP_SECRET_KEY` signs the challenges, so it has to be at least 32 bytes (`openssl rand -base64 32`), and setting `realm` avoids a fallback warning at boot.
+
+<Warning>
+This is experimental on every side. It needs [Shared Payment Token](https://docs.stripe.com/agentic-commerce/concepts/shared-payment-tokens) access and a Stripe profile, the protocol is young, and no chat host pays for a tool call on a user's behalf today. Agent harnesses with their own wallet, such as a coding agent, are where it currently applies. We have verified the challenge leg against a live Skybridge server; paying one and redeeming the receipt is untested.
+</Warning>
+
+Note that `mppx` imports `@modelcontextprotocol/sdk` (the v1 SDK) to build the error, so it has to be installed alongside Skybridge's own v2 packages. Without it the charge fails at runtime with a missing-dependency message.
+
+Stripe [documents a different shape](https://docs.stripe.com/agentic-commerce/monetize-mcp) for the same protocol, where a tool returns a payment link and a separate HTTP endpoint handles the exchange. That endpoint also serves human browsers, so it covers both audiences with one URL, at the cost of a custom route Alpic Cloud does not serve.
+
+## Carry Sponsored Slots
+
+Instead of charging anyone for your app, you can let an advertiser pay for a slot in it. [Lulu](https://getlulu.dev) is an ad network for MCP servers and agent tools: it sells the demand, matches an advertiser to each tool call, and pays publishers 70% of the conversions it bills, with a $100 payout minimum.
+
+Its SDK attaches one labeled sponsored field to your tool results, through a Skybridge adapter built on [`mcpMiddleware`](/api-reference/mcp-server).
+
+```bash
+npm install lulu-ads
+```
+
+```ts server.ts
+import { withLuluAdsSkybridge } from "lulu-ads/skybridge";
+
+handler: (server) => {
+  withLuluAdsSkybridge(server);
+  return server.registerTool(/* ... */);
+},
+```
+
+Credentials come from `LULU_ADS_PUBLISHER_ID` and `LULU_ADS_API_KEY`. Every tool registered on the server then carries a field like this one:
+
+```json
+{
+  "label": "Sponsored",
+  "text": "Direct flights TLV to BKK from $412",
+  "url": "https://ads.getlulu.dev/c/9f2a1c"
+}
+```
+
+Two properties matter more than the integration. The field is data rather than an instruction, so the model decides on its own whether to surface it and nothing tells it to. And it fails open within 800ms, so a slow or dead ad backend leaves your tool result untouched instead of breaking the call.
+
+The payload lands on `_meta["ads.getlulu.dev/sponsored"]` and never on `structuredContent`. Protocol middleware sees the result but not the tool's `outputSchema`, and an undeclared field in `structuredContent` would fail validation.
+
+Charging some users and showing ads to the rest comes down to the `enabled` flag, which your own code decides:
+
+```ts server.ts
+const sponsored = await ads.sponsoredSlot({
+  context: { tool: "search-flights" },
+  enabled: user.tier !== "paid",
+});
+```
+
+Lulu also ships [result widgets](https://github.com/Lulu-The-Narwhal/lulu-ads#result-widgets), four templates that render your own tool output with the sponsored strip built in, for hosts that support rendered widgets.
+
+## Go Further
+
+<Columns cols={3}>
+    <Card title="Register Tools" icon="wrench" href="/build/tools">
+        Define what humans and agents can do
+    </Card>
+    <Card title="Configure CSP" icon="shield" href="/guides/csp">
+        Let your views reach the domains they need
+    </Card>
+    <Card title="Build an Ecommerce App" icon="shopping-bag" href="/guides/ecommerce">
+        Scaffold a catalog and carousel UI
+    </Card>
+</Columns>

--- a/docs/guides/monetization.mdx
+++ b/docs/guides/monetization.mdx
@@ -5,11 +5,13 @@ sidebarTitle: "Monetization"
 icon: "circle-dollar-sign"
 ---
 
-The two main ways to monetize your MCP App are selling:
-- goods or services to your app users
-- sponsored slots to advertisers
+Three parties can pay you for an MCP App, and which one you pick decides the rest of the integration:
 
-A third payer is possible too, and newer: the agent itself, paying out of a wallet its user funded.
+- a person, paying on a checkout page you already run
+- the agent itself, paying for a tool call out of a wallet its user funded
+- an advertiser, paying for a labeled slot in your tool results
+
+The first is where almost every app shipping today sits. The second is newer and still experimental. They are not exclusive: an app can hand off to checkout and carry sponsored slots on the tools it gives away.
 
 ## Hand Off to Your Own Checkout
 
@@ -141,7 +143,7 @@ The middleware runs before the handler, so an unpaid call never reaches your cod
 This is experimental on every side. It needs [Shared Payment Token](https://docs.stripe.com/agentic-commerce/concepts/shared-payment-tokens) access and a Stripe profile, the protocol is young, and no chat host pays for a tool call on a user's behalf today. Agent harnesses with their own wallet, such as a coding agent, are where it currently applies. We have verified the challenge leg against a live Skybridge server; paying one and redeeming the receipt is untested.
 </Warning>
 
-Note that `mppx` imports `@modelcontextprotocol/sdk` (the v1 SDK) to build the error, so it has to be installed alongside Skybridge's own v2 packages. Without it the charge fails at runtime with a missing-dependency message.
+`mppx` needs the v1 `@modelcontextprotocol/sdk` to build the payment error and declares it as an optional peer, so install it yourself alongside Skybridge's v2 packages.
 
 Stripe [documents a different shape](https://docs.stripe.com/agentic-commerce/monetize-mcp) for the same protocol, where a tool returns a payment link and a separate HTTP endpoint handles the exchange. That endpoint also serves human browsers, so it covers both audiences with one URL, at the cost of a custom route Alpic Cloud does not serve.
 

--- a/docs/guides/monetization.mdx
+++ b/docs/guides/monetization.mdx
@@ -35,10 +35,19 @@ function BuyButton({ variant }) {
 List your checkout origin in [`redirectDomains`](/guides/csp#redirect-off-app) so the host skips its safe-link confirmation on the way out.
 
 ```ts server.ts
-view: {
-  component: "carousel",
-  csp: { redirectDomains: ["https://checkout.myshop.com"] },
-},
+server.registerTool(
+  {
+    name: "browse-catalog",
+    inputSchema: { query: z.string() },
+    view: {
+      component: "carousel",
+      csp: { redirectDomains: ["https://checkout.myshop.com"] },
+    },
+  },
+  async ({ query }) => {
+    /* … */
+  },
+);
 ```
 
 What you give up is the return leg. The host opens the page outside the iframe and nothing comes back, so the view keeps rendering the cart and the model still believes the order is pending. This is usually fine for catalogs focused on sending qualified traffic to a storefront. If you want to update the cart after redirect, one strategy is to have the view poll the cart status until it's updated elsewhere.
@@ -169,14 +178,36 @@ Two properties matter more than the integration. The field is data rather than a
 
 The payload lands on `_meta["ads.getlulu.dev/sponsored"]` and never on `structuredContent`. Protocol middleware sees the result but not the tool's `outputSchema`, and an undeclared field in `structuredContent` would fail validation.
 
-Charging some users and showing ads to the rest comes down to the `enabled` flag, which your own code decides:
+Charging some users and showing ads to the rest needs the client directly, because the adapter above takes no per-request decision. Build a `LuluAds` yourself, and let the `enabled` flag read whatever your auth already knows about the caller.
 
 ```ts server.ts
-const sponsored = await ads.sponsoredSlot({
-  context: { tool: "search-flights" },
-  enabled: user.tier !== "paid",
+import { LuluAds } from "lulu-ads";
+
+const ads = new LuluAds({
+  publisherId: process.env.LULU_ADS_PUBLISHER_ID,
+  apiKey: process.env.LULU_ADS_API_KEY,
 });
+
+server.registerTool(
+  {
+    name: "search-flights",
+    inputSchema: { from: z.string(), to: z.string() },
+  },
+  async ({ from, to }, extra) => {
+    const sponsored = await ads.sponsoredSlot({
+      context: { tool: "search-flights" },
+      enabled: extra.http?.authInfo?.extra.tier !== "paid",
+    });
+
+    return {
+      content: [{ type: "text", text: await searchFlights(from, to) }],
+      _meta: { "ads.getlulu.dev/sponsored": sponsored },
+    };
+  },
+);
 ```
+
+Reach for this instead of `withLuluAdsSkybridge`, not alongside it: the adapter already decorates every tool, so a tool doing its own slot would get two.
 
 Lulu also ships [result widgets](https://github.com/Lulu-The-Narwhal/lulu-ads#result-widgets), four templates that render your own tool output with the sponsored strip built in, for hosts that support rendered widgets.
 


### PR DESCRIPTION
## Summary

- Adds `docs/guides/monetization.mdx`, a guide to the three ways money can reach a Skybridge app: a shopper paying on your own checkout, the agent paying for a tool call, or an advertiser paying for a slot.
- Registers the page in `docs.json` and adds its card to the guides index.
- Adds the four cards the guides index was missing (`ecommerce`, `monetization`, `auth-providers`, `skills`) and orders them to match the sidebar.

Closes SKY-560.

_Screenshot of the full page: to be attached._

## Architecture Notes

The MPP section charges from `mcpMiddleware`, not from inside the tool handler. This is not a style choice: a challenge thrown inside a handler is flattened into an `isError` tool result, so the machine-readable payload never reaches the client and the agent gets a message with nothing to pay against. From middleware the challenge arrives as a JSON-RPC error with the signed challenge intact. Verified against a running server rather than inferred.

The upstream Stripe guide documents a different shape (a tool returns a payment link, a separate HTTP endpoint runs the exchange). That needs a custom Express route, and Alpic Cloud routes only `/mcp`, so it is mentioned as an alternative for self-hosted deployments instead of being the recommended path.

## Verification

Both code samples were run, not just written.

- The MPP flow was exercised against a live Skybridge server: an unpaid `tools/call` returns `-32042` with a signed challenge carrying amount, currency, method and expiry.
- Three constraints came out of that run and are documented: `MPP_SECRET_KEY` must be at least 32 bytes, `realm` should be set to avoid a boot warning, and `@modelcontextprotocol/sdk` (v1) must be installed alongside because `mppx` imports it to build the error.
- `pnpm test` (458 tests) and `pnpm build` pass. `mintlify broken-links` passes.

Not verified: paying a challenge and redeeming the receipt, which needs Shared Payment Token access. The section carries a warning saying so.

## Alternatives Considered

A "Sell with Stripe Checkout" section was written and then cut. Closing the payment loop meant a server-side long poll bounded under the MCP client request timeout (60s by default), which a shopper entering card details will often exceed. A `get-payment-status` tool polled from the view is the better shape, and the section will come back built that way.

A dedicated access-gating section was also dropped. The mechanism is entirely `/build/auth` and `/guides/auth-providers`, with nothing monetization-specific to add.

## Screenshot

<img width="1440" height="6454" alt="image" src="https://github.com/user-attachments/assets/6665da64-21e8-4b5f-8094-d0f7defd61fb" />

