### PR TITLE
feat(devtools): add a Discover Evals page

### DIFF
--- a/packages/devtools/src/components/layout/app-layout.tsx
+++ b/packages/devtools/src/components/layout/app-layout.tsx
@@ -10,6 +10,8 @@ import {
 import { useAuthStore } from "@/lib/auth-store.js";
 import { useInspectorPreferencesStore } from "@/lib/inspector-preferences-store.js";
 import { connectToServer } from "@/lib/mcp/index.js";
+import { useEvalsPage } from "@/lib/nuqs.js";
+import { EvalsPage } from "./evals-page.js";
 import { Header } from "./header.js";
 import { Preview } from "./preview/index.js";
 import { ToolPanel } from "./tool-panel/index.js";
@@ -22,6 +24,7 @@ const TOOL_PANEL_ID = "tool-panel";
 function AppLayout() {
   const { status, requiresAuth } = useAuthStore();
   const previewClient = useInspectorPreferencesStore((s) => s.previewClient);
+  const [evalsOpen] = useEvalsPage();
 
   const isConnected = status === "authenticated";
 
@@ -34,7 +37,9 @@ function AppLayout() {
   return (
     <div className="grid h-screen grid-rows-[auto_1fr] overflow-hidden bg-background text-foreground">
       <Header />
-      {isConnected && previewClient ? (
+      {evalsOpen ? (
+        <EvalsPage />
+      ) : isConnected && previewClient ? (
         <Suspense fallback={null}>
           <Preview />
         </Suspense>

--- a/packages/devtools/src/components/layout/evals-page.tsx
+++ b/packages/devtools/src/components/layout/evals-page.tsx
@@ -1,0 +1,171 @@
+import { Button } from "@alpic-ai/ui/components/button";
+import {
+  ArrowLeft,
+  Check,
+  Copy,
+  ExternalLinkIcon,
+  Sparkles,
+} from "lucide-react";
+import type { ReactNode } from "react";
+import { PrismLight } from "react-syntax-highlighter";
+import typescript from "react-syntax-highlighter/dist/esm/languages/prism/typescript";
+import { useCopyToClipboard } from "@/lib/copy.js";
+import { useEvalsPage } from "@/lib/nuqs.js";
+import { cn } from "@/lib/utils.js";
+import { devtoolsJsonPrismTheme } from "./tool-panel/json-syntax-theme.js";
+
+PrismLight.registerLanguage("typescript", typescript);
+
+const DOCS_URL = "https://docs.skybridge.tech/test/evals";
+
+const EXAMPLE = `import { anthropic } from "@ai-sdk/anthropic";
+import { start } from "@skybridge/test";
+import { expect, it } from "vitest";
+import { app } from "../src/server.js";
+
+it("reaches the search tool from a natural prompt", async () => {
+  const chat = await start({ app, model: anthropic("claude-sonnet-4-5") });
+  await chat.send("Find me running shoes under 100 dollars");
+
+  expect.chat(chat).toHaveCalledToolWith("search-products", {
+    query: "running shoes",
+  });
+});`;
+
+const SETUP_PROMPT = `First, make sure the Skybridge skill is installed and up to date:
+
+npx skills add alpic-ai/skybridge -s skybridge
+
+Then set up evals for this app, following the skill's evals reference.`;
+
+function CodeCard({
+  label,
+  code,
+  action,
+  wrap,
+  highlight,
+}: {
+  label: string;
+  code: string;
+  action?: ReactNode;
+  wrap?: boolean;
+  highlight?: boolean;
+}) {
+  return (
+    <div className="overflow-hidden rounded-lg border bg-background">
+      <div className="flex items-center justify-between gap-3 border-b bg-light-gray px-4 py-2">
+        <span className="text-xs font-medium text-light-gray-foreground">
+          {label}
+        </span>
+        {action}
+      </div>
+      {highlight ? (
+        <div className="overflow-x-auto px-4 py-3 text-xs leading-relaxed">
+          <PrismLight
+            language="typescript"
+            style={devtoolsJsonPrismTheme}
+            customStyle={{
+              margin: 0,
+              padding: 0,
+              background: "transparent",
+              fontSize: "0.75rem",
+            }}
+            codeTagProps={{ className: "font-mono whitespace-pre" }}
+          >
+            {code}
+          </PrismLight>
+        </div>
+      ) : (
+        <pre
+          className={cn(
+            "overflow-x-auto px-4 py-3 font-mono text-xs leading-relaxed",
+            wrap && "whitespace-pre-wrap",
+          )}
+        >
+          {code}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+function PromptCard() {
+  const { copied, copy } = useCopyToClipboard();
+  return (
+    <CodeCard
+      label="Paste this to your coding agent"
+      code={SETUP_PROMPT}
+      wrap
+      action={
+        <Button variant="cta" onClick={() => copy(SETUP_PROMPT)}>
+          {copied ? (
+            <Check className="size-3.5" />
+          ) : (
+            <Copy className="size-3.5" />
+          )}
+          {copied ? "Copied" : "Copy"}
+        </Button>
+      }
+    />
+  );
+}
+
+export function EvalsPage() {
+  const [, setOpen] = useEvalsPage();
+  return (
+    <div className="relative min-h-0 overflow-y-auto bg-background">
+      <div
+        className="preview-region evals-grid-fade pointer-events-none absolute inset-0"
+        aria-hidden
+      />
+      <div
+        className="evals-wash pointer-events-none absolute inset-0"
+        aria-hidden
+      />
+
+      <div className="relative mx-auto flex max-w-2xl flex-col gap-6 px-6 py-10">
+        <Button
+          variant="tertiary"
+          className="self-start"
+          onClick={() => setOpen(null)}
+        >
+          <ArrowLeft className="size-3.5" />
+          Back
+        </Button>
+
+        <div className="space-y-3">
+          <span className="inline-flex items-center gap-1.5 rounded-md border bg-background px-2 py-1 text-xs text-light-gray-foreground">
+            <Sparkles className="size-3.5" aria-hidden />
+            Evals
+          </span>
+          <h1 className="text-2xl font-medium">
+            Check what the model does with your app, in a test
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            A tool that works is not the same as a tool the model decides to
+            call. An eval runs a real conversation against your app and asserts
+            on the tools it reached for, so you catch a change that quietly
+            breaks discovery.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <h2 className="text-sm font-medium">What an eval looks like</h2>
+          <CodeCard label="evals/search.eval.ts" code={EXAMPLE} highlight />
+        </div>
+
+        <div className="space-y-3">
+          <h2 className="text-sm font-medium">Getting started</h2>
+          <PromptCard />
+        </div>
+
+        <Button asChild variant="tertiary" className="self-start">
+          <a href={DOCS_URL} target="_blank" rel="noreferrer noopener">
+            <ExternalLinkIcon className="size-3.5" />
+            Read the evals docs
+          </a>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/devtools/src/components/layout/header.tsx
+++ b/packages/devtools/src/components/layout/header.tsx
@@ -1,8 +1,9 @@
 import { Button } from "@alpic-ai/ui/components/button";
 import { Separator } from "@alpic-ai/ui/components/separator";
-import { LogIn, LogOut } from "lucide-react";
+import { LogIn, LogOut, Sparkles } from "lucide-react";
 import { useAuthStore } from "@/lib/auth-store.js";
 import { logout, signIn, useServerInfo } from "@/lib/mcp/index.js";
+import { useEvalsPage } from "@/lib/nuqs.js";
 import { StatusBadge } from "./status-badge.js";
 import {
   AuditButton,
@@ -24,6 +25,20 @@ function Chip({ children }: { children: React.ReactNode }) {
     <div className="inline-flex h-8 items-center gap-2 rounded-md px-2.5 text-sm  bg-light-gray border">
       {children}
     </div>
+  );
+}
+
+function DiscoverEvalsButton() {
+  const [, setOpen] = useEvalsPage();
+  return (
+    <Button
+      variant="tertiary"
+      className="sparkle-twinkle"
+      onClick={() => setOpen(true)}
+    >
+      <Sparkles className="size-3.5" aria-hidden />
+      Discover Evals
+    </Button>
   );
 }
 
@@ -60,6 +75,7 @@ export const Header = () => {
     <header className="flex h-13 items-center justify-between gap-3 border-b border-border px-4">
       <div className="flex items-center gap-2">
         <BrandChip />
+        <DiscoverEvalsButton />
         <LiveUrlChip />
       </div>
 

--- a/packages/devtools/src/index.css
+++ b/packages/devtools/src/index.css
@@ -61,3 +61,61 @@
     16px 16px;
   background-position: 0 0;
 }
+
+.evals-grid-fade {
+  mask-image: radial-gradient(
+    ellipse 90% 65% at 50% 0%,
+    black 0%,
+    color-mix(in srgb, black 45%, transparent) 45%,
+    transparent 80%
+  );
+}
+
+.evals-wash {
+  background-image: radial-gradient(
+    ellipse 80% 50% at 50% 0%,
+    color-mix(in oklab, var(--color-primary) 12%, transparent),
+    transparent 70%
+  );
+}
+
+@keyframes sparkle-twinkle {
+  0%,
+  86%,
+  100% {
+    opacity: 1;
+    transform: scale(1) rotate(0deg);
+  }
+  90% {
+    opacity: 0.5;
+    transform: scale(0.8) rotate(-14deg);
+  }
+  94% {
+    opacity: 1;
+    transform: scale(1.2) rotate(12deg);
+  }
+  97% {
+    transform: scale(0.95) rotate(-4deg);
+  }
+}
+
+.sparkle-twinkle svg > * {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: sparkle-twinkle 5s ease-in-out infinite;
+}
+
+.sparkle-twinkle svg > *:nth-child(2),
+.sparkle-twinkle svg > *:nth-child(3) {
+  animation-delay: 0.14s;
+}
+
+.sparkle-twinkle svg > *:nth-child(4) {
+  animation-delay: 0.28s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sparkle-twinkle svg > * {
+    animation: none;
+  }
+}

--- a/packages/devtools/src/lib/nuqs.ts
+++ b/packages/devtools/src/lib/nuqs.ts
@@ -1,5 +1,9 @@
-import { parseAsString, useQueryState } from "nuqs";
+import { parseAsBoolean, parseAsString, useQueryState } from "nuqs";
 
 export function useSelectedToolName() {
   return useQueryState("tool", parseAsString);
+}
+
+export function useEvalsPage() {
+  return useQueryState("evals", parseAsBoolean.withDefault(false));
 }


### PR DESCRIPTION
Closes SKY-552.

## Summary

- A `Discover Evals` button in the devtools header, next to the server name/version chip
- The page it opens: what evals are, a syntax-highlighted example of one, and a prompt to paste to a coding agent
- Reachable at all times on `?evals=true`, with no detection of whether evals already exist

![Discover Evals page](https://raw.githubusercontent.com/alpic-ai/skybridge/947991db6fbc8f757636a98452f805b2b9643f15/.pr-assets/evals-page.png)

## Notes

The page is a fourth branch in `AppLayout`, checked before preview and tools-split, rather than a new router. Navigation is a nuqs query param alongside the existing `?tool=`, so a refresh keeps you on the page and the URL is shareable. Opening it unmounts `Preview` and `ToolPanel`, so their local state is lost on Back; URL-held state survives. That matches how `Preview` already swaps the body.

The header icon twinkles on a 5s loop, all motion between 86% and 100% of the keyframe so it is ~0.7s of movement and 4.3s idle. `transform-box: fill-box` makes each SVG child scale about its own centre, and the four children are staggered so it reads as a ripple. It is guarded by `prefers-reduced-motion`. The stagger addresses lucide's `Sparkles` children by `nth-child`, so if that icon's markup changes the phasing drifts, though the animation still runs.

Deliberately left out: the setup steps the page first carried. The pasted prompt has the agent do the wiring, so listing the steps for a human to follow was redundant. Anyone who wants them has the docs link.

Highlighting reuses `react-syntax-highlighter` and `devtoolsJsonPrismTheme`, both already in the package, so the example matches the JSON blocks in the tool panel and no dependency was added.

No tests. It is a static page, a copy button and a CSS keyframe; the existing devtools suite covers the logic, and CLAUDE.md rules out e2e for styling.

`.pr-assets/` exists only to host the screenshot above and is removed in the next commit.
