### PR TITLE
fix(evals): collect scenarios without the evals option and widen test peers

### DIFF
--- a/docs/test/evals.mdx
+++ b/docs/test/evals.mdx
@@ -25,7 +25,7 @@ bun add -d @skybridge/test@beta vitest ai @ai-sdk/anthropic
 ```
 </CodeGroup>
 
-The plugin always picks up `evals/**/*.eval.ts`. Turn on `evals` to register the `expect.chat` matchers, raise the per-scenario timeout to two minutes, and load your `.env` so the provider key is available:
+Turn on `evals` in the Vite plugin. It registers the `expect.chat` matchers, picks up `evals/**/*.eval.ts`, raises the per-scenario timeout to two minutes, and loads your `.env` so the provider key is available:
 
 ```ts vite.config.ts highlight={7}
 import { skybridge } from "@skybridge/vite-plugin";

--- a/docs/test/evals.mdx
+++ b/docs/test/evals.mdx
@@ -12,16 +12,16 @@ Add the test runtime (published on the `beta` dist-tag while the API settles), v
 
 <CodeGroup>
 ```bash npm
-npm install -D @skybridge/test@beta vitest ai @ai-sdk/anthropic
+npm install -D @skybridge/test@beta vitest@^4 ai @ai-sdk/anthropic
 ```
 ```bash pnpm
-pnpm add -D @skybridge/test@beta vitest ai @ai-sdk/anthropic
+pnpm add -D @skybridge/test@beta vitest@^4 ai @ai-sdk/anthropic
 ```
 ```bash yarn
-yarn add -D @skybridge/test@beta vitest ai @ai-sdk/anthropic
+yarn add -D @skybridge/test@beta vitest@^4 ai @ai-sdk/anthropic
 ```
 ```bash bun
-bun add -d @skybridge/test@beta vitest ai @ai-sdk/anthropic
+bun add -d @skybridge/test@beta vitest@^4 ai @ai-sdk/anthropic
 ```
 </CodeGroup>
 

--- a/docs/test/evals.mdx
+++ b/docs/test/evals.mdx
@@ -25,7 +25,7 @@ bun add -d @skybridge/test@beta vitest ai @ai-sdk/anthropic
 ```
 </CodeGroup>
 
-Turn on `evals` in the Vite plugin. It registers the `expect.chat` matchers, picks up `evals/**/*.eval.ts`, raises the per-scenario timeout to two minutes, and loads your `.env` so the provider key is available:
+The plugin always picks up `evals/**/*.eval.ts`. Turn on `evals` to register the `expect.chat` matchers, raise the per-scenario timeout to two minutes, and load your `.env` so the provider key is available:
 
 ```ts vite.config.ts highlight={7}
 import { skybridge } from "@skybridge/vite-plugin";

--- a/examples/evals/package.json
+++ b/examples/evals/package.json
@@ -16,11 +16,11 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@ai-sdk/anthropic": "^2.0.90",
+    "@ai-sdk/anthropic": "^4.0.0",
     "@skybridge/test": "beta",
     "@skybridge/vite-plugin": "^2.0.0",
     "@types/node": "^24.13.2",
-    "ai": "^5.0.0",
+    "ai": "^7.0.0",
     "tsx": "^4.22.4",
     "typescript": "^5.9.3",
     "vite": "^8.1.5",

--- a/packages/create-skybridge/templates/demo/package.json
+++ b/packages/create-skybridge/templates/demo/package.json
@@ -25,7 +25,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@ai-sdk/anthropic": "^2.0.90",
+    "@ai-sdk/anthropic": "^4.0.0",
     "@skybridge/devtools": "workspace:*",
     "@skybridge/test": "workspace:*",
     "@skybridge/vite-plugin": "workspace:*",
@@ -34,7 +34,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.3",
-    "ai": "^5.0.0",
+    "ai": "^7.0.0",
     "alpic": "^1.155.0",
     "tailwindcss": "^4.3.3",
     "tsx": "^4.23.1",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -31,9 +31,9 @@
   },
   "peerDependencies": {
     "@skybridge/vite-plugin": "^2.0.0",
-    "ai": "^5.0.0",
+    "ai": "^5.0.0 || ^6.0.0 || ^7.0.0",
     "skybridge": "^2.0.0",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.0 || ^5.0.0"
   },
   "devDependencies": {
     "@skybridge/vite-plugin": "workspace:*",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -31,14 +31,14 @@
   },
   "peerDependencies": {
     "@skybridge/vite-plugin": "^2.0.0",
-    "ai": "^5.0.0 || ^6.0.0 || ^7.0.0",
+    "ai": "^7.0.0",
     "skybridge": "^2.0.0",
-    "vitest": "^4.1.0 || ^5.0.0"
+    "vitest": "^4.1.0"
   },
   "devDependencies": {
     "@skybridge/vite-plugin": "workspace:*",
     "@types/node": "^24.13.3",
-    "ai": "^5.0.0",
+    "ai": "^7.0.0",
     "skybridge": "workspace:*",
     "typescript": "^5.9.3",
     "vitest": "^4.1.10",

--- a/packages/test/src/in-process.test.ts
+++ b/packages/test/src/in-process.test.ts
@@ -1,10 +1,14 @@
-import { MockLanguageModelV2 } from "ai/test";
+import { MockLanguageModelV3 } from "ai/test";
 import { Skybridge } from "skybridge/server";
 import { expect, it } from "vitest";
 import { z } from "zod";
 import { start } from "./session-registry.js";
 
-const usage = { inputTokens: 1, outputTokens: 1, totalTokens: 2 };
+const usage = {
+  inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 1, text: 1, reasoning: 0 },
+  totalTokens: 2,
+};
 
 function buildApp(seen: string[]) {
   return new Skybridge({
@@ -64,7 +68,7 @@ function mockModel(call: {
   input: Record<string, unknown>;
   text: string;
 }) {
-  return new MockLanguageModelV2({
+  return new MockLanguageModelV3({
     doGenerate: [
       {
         content: [
@@ -75,13 +79,13 @@ function mockModel(call: {
             input: JSON.stringify(call.input),
           },
         ],
-        finishReason: "tool-calls",
+        finishReason: { unified: "tool-calls" as const, raw: undefined },
         usage,
         warnings: [],
       },
       {
         content: [{ type: "text", text: call.text }],
-        finishReason: "stop",
+        finishReason: { unified: "stop" as const, raw: undefined },
         usage,
         warnings: [],
       },

--- a/packages/vite-plugin/src/plugin.test.ts
+++ b/packages/vite-plugin/src/plugin.test.ts
@@ -3,25 +3,29 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { UserConfig } from "vite";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { skybridge } from "./plugin.js";
+import { type SkybridgePluginOptions, skybridge } from "./plugin.js";
 
 type RenderBuiltUrl = NonNullable<
   NonNullable<UserConfig["experimental"]>["renderBuiltUrl"]
 >;
 
-function getRenderBuiltUrl(root: string): RenderBuiltUrl {
-  const plugin = skybridge({ viewsDir: join(root, "views") });
+function getConfig(root: string, options?: SkybridgePluginOptions): UserConfig {
+  const plugin = skybridge({ viewsDir: join(root, "views"), ...options });
   const hook = plugin.config;
   if (!hook) {
     throw new Error("plugin.config is not defined");
   }
   const handler = typeof hook === "function" ? hook : hook.handler;
-  const config = handler.call(
+  return handler.call(
     // biome-ignore lint/suspicious/noExplicitAny: vitest harness for plugin hook
     {} as any,
     { root },
     { command: "build", mode: "production" },
   ) as UserConfig;
+}
+
+function getRenderBuiltUrl(root: string): RenderBuiltUrl {
+  const config = getConfig(root);
 
   const renderBuiltUrl = config.experimental?.renderBuiltUrl;
   if (!renderBuiltUrl) {
@@ -30,18 +34,18 @@ function getRenderBuiltUrl(root: string): RenderBuiltUrl {
   return renderBuiltUrl;
 }
 
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "skybridge-plugin-"));
+  mkdirSync(join(root, "views"), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
 describe("skybridge plugin renderBuiltUrl", () => {
-  let root: string;
-
-  beforeEach(() => {
-    root = mkdtempSync(join(tmpdir(), "skybridge-plugin-"));
-    mkdirSync(join(root, "views"), { recursive: true });
-  });
-
-  afterEach(() => {
-    rmSync(root, { recursive: true, force: true });
-  });
-
   // Assets referenced from JS can't use `import.meta.url`: views render in a
   // host sandbox iframe (web-sandbox.oaiusercontent.com), so the module origin
   // doesn't point back at the Skybridge server. They have to be resolved at
@@ -77,5 +81,14 @@ describe("skybridge plugin renderBuiltUrl", () => {
         ssr: false,
       }),
     ).toEqual({ relative: true });
+  });
+});
+
+describe("skybridge plugin eval discovery", () => {
+  it("collects eval scenarios even when the evals option is missing", () => {
+    const config = getConfig(root);
+
+    expect(config.test?.include).toContain("evals/**/*.eval.?(c|m)ts");
+    expect(config.test?.setupFiles).toBeUndefined();
   });
 });

--- a/packages/vite-plugin/src/plugin.test.ts
+++ b/packages/vite-plugin/src/plugin.test.ts
@@ -9,7 +9,11 @@ type RenderBuiltUrl = NonNullable<
   NonNullable<UserConfig["experimental"]>["renderBuiltUrl"]
 >;
 
-function getConfig(root: string, options?: SkybridgePluginOptions): UserConfig {
+function getConfig(
+  root: string,
+  options?: SkybridgePluginOptions,
+  projectConfig?: UserConfig,
+): UserConfig {
   const plugin = skybridge({ viewsDir: join(root, "views"), ...options });
   const hook = plugin.config;
   if (!hook) {
@@ -19,7 +23,7 @@ function getConfig(root: string, options?: SkybridgePluginOptions): UserConfig {
   return handler.call(
     // biome-ignore lint/suspicious/noExplicitAny: vitest harness for plugin hook
     {} as any,
-    { root },
+    { root, ...projectConfig },
     { command: "build", mode: "production" },
   ) as UserConfig;
 }
@@ -90,5 +94,13 @@ describe("skybridge plugin eval discovery", () => {
 
     expect(config.test?.include).toContain("evals/**/*.eval.?(c|m)ts");
     expect(config.test?.setupFiles).toBeUndefined();
+  });
+
+  it("adds only the eval pattern when the project narrowed its own include", () => {
+    const config = getConfig(root, undefined, {
+      test: { include: ["src/**/*.test.ts"] },
+    });
+
+    expect(config.test?.include).toEqual(["evals/**/*.eval.?(c|m)ts"]);
   });
 });

--- a/packages/vite-plugin/src/plugin.test.ts
+++ b/packages/vite-plugin/src/plugin.test.ts
@@ -1,8 +1,8 @@
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { UserConfig } from "vite";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { type SkybridgePluginOptions, skybridge } from "./plugin.js";
 
 type RenderBuiltUrl = NonNullable<
@@ -12,7 +12,7 @@ type RenderBuiltUrl = NonNullable<
 function getConfig(
   root: string,
   options?: SkybridgePluginOptions,
-  projectConfig?: UserConfig,
+  warn: (message: string) => void = () => {},
 ): UserConfig {
   const plugin = skybridge({ viewsDir: join(root, "views"), ...options });
   const hook = plugin.config;
@@ -22,8 +22,8 @@ function getConfig(
   const handler = typeof hook === "function" ? hook : hook.handler;
   return handler.call(
     // biome-ignore lint/suspicious/noExplicitAny: vitest harness for plugin hook
-    {} as any,
-    { root, ...projectConfig },
+    { warn } as any,
+    { root },
     { command: "build", mode: "production" },
   ) as UserConfig;
 }
@@ -89,18 +89,22 @@ describe("skybridge plugin renderBuiltUrl", () => {
 });
 
 describe("skybridge plugin eval discovery", () => {
-  it("collects eval scenarios even when the evals option is missing", () => {
-    const config = getConfig(root);
+  it("points at the missing evals option when scenarios exist", () => {
+    mkdirSync(join(root, "evals"), { recursive: true });
+    writeFileSync(join(root, "evals", "start.eval.ts"), "");
+    const warn = vi.fn();
 
-    expect(config.test?.include).toContain("evals/**/*.eval.?(c|m)ts");
-    expect(config.test?.setupFiles).toBeUndefined();
+    const config = getConfig(root, undefined, warn);
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("evals: {}"));
+    expect(config.test).toBeUndefined();
   });
 
-  it("adds only the eval pattern when the project narrowed its own include", () => {
-    const config = getConfig(root, undefined, {
-      test: { include: ["src/**/*.test.ts"] },
-    });
+  it("stays quiet when the project has no scenarios", () => {
+    const warn = vi.fn();
 
-    expect(config.test?.include).toEqual(["evals/**/*.eval.?(c|m)ts"]);
+    getConfig(root, undefined, warn);
+
+    expect(warn).not.toHaveBeenCalled();
   });
 });

--- a/packages/vite-plugin/src/plugin.ts
+++ b/packages/vite-plugin/src/plugin.ts
@@ -190,10 +190,11 @@ function viewsPlugin(options?: SkybridgePluginOptions): Plugin {
         },
       };
 
-      const include = [
-        "**/*.{test,spec}.?(c|m)[jt]s?(x)",
-        `${EVALS_DIR}/**/*.eval.?(c|m)ts`,
-      ];
+      const evalInclude = `${EVALS_DIR}/**/*.eval.?(c|m)ts`;
+      const include =
+        config.test?.include === undefined
+          ? ["**/*.{test,spec}.?(c|m)[jt]s?(x)", evalInclude]
+          : [evalInclude];
 
       if (!options?.evals) {
         return { ...base, test: { include } };

--- a/packages/vite-plugin/src/plugin.ts
+++ b/packages/vite-plugin/src/plugin.ts
@@ -190,8 +190,13 @@ function viewsPlugin(options?: SkybridgePluginOptions): Plugin {
         },
       };
 
+      const include = [
+        "**/*.{test,spec}.?(c|m)[jt]s?(x)",
+        `${EVALS_DIR}/**/*.eval.?(c|m)ts`,
+      ];
+
       if (!options?.evals) {
-        return base;
+        return { ...base, test: { include } };
       }
 
       return {
@@ -199,10 +204,7 @@ function viewsPlugin(options?: SkybridgePluginOptions): Plugin {
         test: {
           setupFiles: [here("./evals/matchers.js")],
           provide: { skybridgeEvals: options.evals },
-          include: [
-            "**/*.{test,spec}.?(c|m)[jt]s?(x)",
-            `${EVALS_DIR}/**/*.eval.?(c|m)ts`,
-          ],
+          include,
           testTimeout: options.evals.timeout ?? DEFAULT_EVAL_TIMEOUT_MS,
           env: loadEnv(mode, projectRoot, ""),
         },

--- a/packages/vite-plugin/src/plugin.ts
+++ b/packages/vite-plugin/src/plugin.ts
@@ -1,3 +1,4 @@
+import { existsSync, readdirSync } from "node:fs";
 import { isAbsolute, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -108,6 +109,16 @@ function here(file: string): string {
   return fileURLToPath(new URL(file, import.meta.url));
 }
 
+function hasEvalScenarios(projectRoot: string): boolean {
+  const dir = resolve(projectRoot, EVALS_DIR);
+  if (!existsSync(dir)) {
+    return false;
+  }
+  return readdirSync(dir, { recursive: true }).some((entry) =>
+    /\.eval\.(c|m)?ts$/.test(entry.toString()),
+  );
+}
+
 function viewsPlugin(options?: SkybridgePluginOptions): Plugin {
   const rawViewsDir = options?.viewsDir ?? "src/views";
   let resolvedViewsDir: string;
@@ -190,14 +201,13 @@ function viewsPlugin(options?: SkybridgePluginOptions): Plugin {
         },
       };
 
-      const evalInclude = `${EVALS_DIR}/**/*.eval.?(c|m)ts`;
-      const include =
-        config.test?.include === undefined
-          ? ["**/*.{test,spec}.?(c|m)[jt]s?(x)", evalInclude]
-          : [evalInclude];
-
       if (!options?.evals) {
-        return { ...base, test: { include } };
+        if (hasEvalScenarios(projectRoot)) {
+          this.warn(
+            `Found scenarios in "${EVALS_DIR}/" but the \`evals\` plugin option is not set, so they are not collected. Add \`skybridge({ evals: {} })\` to run them.`,
+          );
+        }
+        return base;
       }
 
       return {
@@ -205,7 +215,10 @@ function viewsPlugin(options?: SkybridgePluginOptions): Plugin {
         test: {
           setupFiles: [here("./evals/matchers.js")],
           provide: { skybridgeEvals: options.evals },
-          include,
+          include: [
+            "**/*.{test,spec}.?(c|m)[jt]s?(x)",
+            `${EVALS_DIR}/**/*.eval.?(c|m)ts`,
+          ],
           testTimeout: options.evals.timeout ?? DEFAULT_EVAL_TIMEOUT_MS,
           env: loadEnv(mode, projectRoot, ""),
         },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -865,8 +865,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@ai-sdk/anthropic':
-        specifier: ^2.0.90
-        version: 2.0.95(zod@4.4.3)
+        specifier: ^4.0.0
+        version: 4.0.49(zod@4.4.3)
       '@skybridge/test':
         specifier: workspace:*
         version: link:../../packages/test
@@ -877,8 +877,8 @@ importers:
         specifier: ^24.13.2
         version: 24.13.3
       ai:
-        specifier: ^5.0.0
-        version: 5.0.244(zod@4.4.3)
+        specifier: ^7.0.0
+        version: 7.0.93(zod@4.4.3)
       tsx:
         specifier: ^4.22.4
         version: 4.23.1
@@ -1820,8 +1820,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@ai-sdk/anthropic':
-        specifier: ^2.0.90
-        version: 2.0.95(zod@4.4.3)
+        specifier: ^4.0.0
+        version: 4.0.49(zod@4.4.3)
       '@skybridge/devtools':
         specifier: workspace:*
         version: link:../../../devtools
@@ -1847,8 +1847,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.1)(yaml@2.9.0))
       ai:
-        specifier: ^5.0.0
-        version: 5.0.244(zod@4.4.3)
+        specifier: ^7.0.0
+        version: 7.0.93(zod@4.4.3)
       alpic:
         specifier: ^1.155.0
         version: 1.157.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(arktype@2.1.27)(rxjs@7.8.2)(typescript@6.0.3)
@@ -2105,8 +2105,8 @@ importers:
         specifier: ^24.13.3
         version: 24.13.3
       ai:
-        specifier: ^5.0.0
-        version: 5.0.244(zod@4.4.3)
+        specifier: ^7.0.0
+        version: 7.0.93(zod@4.4.3)
       skybridge:
         specifier: workspace:*
         version: link:../core
@@ -2150,27 +2150,27 @@ packages:
   '@ag-ui/core@0.0.45':
     resolution: {integrity: sha512-Ccsarxb23TChONOWXDbNBqp1fIbOSMht8g7w6AsSYBTtdOwZ7h7AkjNkr3LSdVv+RbT30JMdSLtieJE0YepNPg==}
 
-  '@ai-sdk/anthropic@2.0.95':
-    resolution: {integrity: sha512-V0nIwhyv8f9rD+p6glm0uq30seid8y2CrvNvHCAbnuPm5bPpqVChEB63kixrIDNnogkgI+ZjSTtIbIL2q3QPvQ==}
-    engines: {node: '>=18'}
+  '@ai-sdk/anthropic@4.0.49':
+    resolution: {integrity: sha512-fzy2sLrs3vNsliIgx65fuovsa6a7OTXd6DllKUgLuVmPyqLnvoZCv9NlKgq+krzDzSxLb9d0zTaJJpsjBVLNyA==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@2.0.139':
-    resolution: {integrity: sha512-cunSy/lp6q48sOudMEnlWsCTITBg02LP0ZeLW5DophMH90IWxSm5DAspiTEfoS04UEZiZKKtrlNhmatI0ZK8Vg==}
-    engines: {node: '>=18'}
+  '@ai-sdk/gateway@4.0.75':
+    resolution: {integrity: sha512-HOnhw3oXtBnboBF7kAKipjToCN6+5w6EuukiUKiULcxBitS+vbHRRv9IUBcq+Z1wkXcJjfywKrt5r++I6OYyXg==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@3.0.32':
-    resolution: {integrity: sha512-izgUo50kamJMwoYCXoFwVccuJeyYp0y1+twf0FfpEz7kdQBloZLZbgLYUOUpannLWrV7xYSJR48BQJIQFbFiAQ==}
-    engines: {node: '>=18'}
+  '@ai-sdk/provider-utils@5.0.36':
+    resolution: {integrity: sha512-MFXBn6XDyf37PNQAge/HTatPJE8Vmg/g/w4WPtjSV53jq8FKAzoaN5+43hsdQa9bqgN+/13jxug9ChvsG+godQ==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider@2.0.3':
-    resolution: {integrity: sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==}
-    engines: {node: '>=18'}
+  '@ai-sdk/provider@4.0.10':
+    resolution: {integrity: sha512-fX2ENAc7iDpZ+Wp4+Rk06Usn/Ys7dI9uAkGv0jlF6XVrW13NkRWx5Ou+U6lIM2E1fTLkCs16GGrUAaVvroag7A==}
+    engines: {node: '>=22'}
 
   '@alcalzone/ansi-tokenize@0.2.5':
     resolution: {integrity: sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw==}
@@ -2964,10 +2964,6 @@ packages:
       '@noble/hashes':
         optional: true
 
-  '@fastify/busboy@2.1.1':
-    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
-    engines: {node: '>=14'}
-
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
 
@@ -3739,10 +3735,6 @@ packages:
 
   '@opentelemetry/api-logs@0.220.0':
     resolution: {integrity: sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==}
-    engines: {node: '>=8.0.0'}
-
-  '@opentelemetry/api@1.9.0':
-    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
 
   '@opentelemetry/api@1.9.1':
@@ -6876,8 +6868,8 @@ packages:
     resolution: {integrity: sha512-VYNCgUc0nOmC4WJmWw9GkrKdfr8Zl4/rxhC5SvgacBgxiW9W/9NRttUoHHXV8xdII3MaRgkZZVX8Ikzc/Jmjag==}
     engines: {node: '>=14'}
 
-  '@vercel/oidc@3.1.0':
-    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
 
   '@vitejs/plugin-react-swc@3.11.0':
@@ -6943,6 +6935,9 @@ packages:
 
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
 
   '@x0k/json-schema-merge@1.0.3':
     resolution: {integrity: sha512-lerJC4sI9CNUQWdff3PnU1YJOqazD6TjMcvxZIPXUBjn4j1cUiXE0LvzhMnGYzKKr271TkvXJtH7gEwksrtn+w==}
@@ -7015,9 +7010,9 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  ai@5.0.244:
-    resolution: {integrity: sha512-7hEVPeQdUS6EgScL4BOKwtV7uNxFJgYu80OFfhnl8wfH5NCMFW+WJEwp/UjdPgxgnhBxhNcn9MrANlC0Hp77tw==}
-    engines: {node: '>=18'}
+  ai@7.0.93:
+    resolution: {integrity: sha512-CJss6zb9mlltk/mCr8qom20NBnqEQxVawkqwtT62tCwsxilZpXfHNRMRwcS3XRpzdP1kEluVuDBUayYWEEd95g==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -8238,6 +8233,10 @@ packages:
 
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
     engines: {node: '>=18.0.0'}
 
   eventsource@3.0.7:
@@ -11743,16 +11742,16 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@5.29.0:
-    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
-    engines: {node: '>=14.0'}
-
   undici@6.27.0:
     resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
+
+  undici@7.29.1:
+    resolution: {integrity: sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==}
     engines: {node: '>=20.18.1'}
 
   unicode-emoji-modifier-base@1.0.0:
@@ -12332,28 +12331,29 @@ snapshots:
       rxjs: 7.8.1
       zod: 3.25.76
 
-  '@ai-sdk/anthropic@2.0.95(zod@4.4.3)':
+  '@ai-sdk/anthropic@4.0.49(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.32(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.10
+      '@ai-sdk/provider-utils': 5.0.36(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/gateway@2.0.139(zod@4.4.3)':
+  '@ai-sdk/gateway@4.0.75(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.32(zod@4.4.3)
-      '@vercel/oidc': 3.1.0
+      '@ai-sdk/provider': 4.0.10
+      '@ai-sdk/provider-utils': 5.0.36(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@3.0.32(zod@4.4.3)':
+  '@ai-sdk/provider-utils@5.0.36(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider': 4.0.10
       '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
-      undici: 5.29.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.1
+      undici: 7.29.1
       zod: 4.4.3
 
-  '@ai-sdk/provider@2.0.3':
+  '@ai-sdk/provider@4.0.10':
     dependencies:
       json-schema: 0.4.0
 
@@ -13171,8 +13171,6 @@ snapshots:
   '@exodus/bytes@1.15.0(@noble/hashes@1.8.0)':
     optionalDependencies:
       '@noble/hashes': 1.8.0
-
-  '@fastify/busboy@2.1.1': {}
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -14339,8 +14337,6 @@ snapshots:
   '@opentelemetry/api-logs@0.220.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
-
-  '@opentelemetry/api@1.9.0': {}
 
   '@opentelemetry/api@1.9.1': {}
 
@@ -17927,7 +17923,7 @@ snapshots:
 
   '@vercel/detect-agent@1.2.3': {}
 
-  '@vercel/oidc@3.1.0': {}
+  '@vercel/oidc@3.2.0': {}
 
   '@vitejs/plugin-react-swc@3.11.0(@swc/helpers@0.5.23)(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
@@ -18108,6 +18104,8 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@workflow/serde@4.1.0': {}
+
   '@x0k/json-schema-merge@1.0.3':
     dependencies:
       '@types/json-schema': 7.0.15
@@ -18177,12 +18175,11 @@ snapshots:
       screenfull: 5.2.0
       tslib: 2.8.1
 
-  ai@5.0.244(zod@4.4.3):
+  ai@7.0.93(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 2.0.139(zod@4.4.3)
-      '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.32(zod@4.4.3)
-      '@opentelemetry/api': 1.9.0
+      '@ai-sdk/gateway': 4.0.75(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.10
+      '@ai-sdk/provider-utils': 5.0.36(zod@4.4.3)
       zod: 4.4.3
 
   ajv-draft-04@1.0.0(ajv@8.20.0):
@@ -19492,6 +19489,8 @@ snapshots:
       - bare-abort-controller
 
   eventsource-parser@3.0.6: {}
+
+  eventsource-parser@3.1.1: {}
 
   eventsource@3.0.7:
     dependencies:
@@ -22206,29 +22205,29 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-import@15.1.0(postcss@8.5.20):
+  postcss-import@15.1.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.20
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
       read-cache: 1.0.2
       resolve: 1.22.12
 
-  postcss-js@4.1.0(postcss@8.5.20):
+  postcss-js@4.1.0(postcss@8.5.23):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.20
+      postcss: 8.5.23
 
-  postcss-load-config@4.0.2(postcss@8.5.20)(ts-node@10.9.2(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@25.9.5)(typescript@6.0.3)):
+  postcss-load-config@4.0.2(postcss@8.5.23)(ts-node@10.9.2(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@25.9.5)(typescript@6.0.3)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.9.0
     optionalDependencies:
-      postcss: 8.5.20
+      postcss: 8.5.23
       ts-node: 10.9.2(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@25.9.5)(typescript@6.0.3)
 
-  postcss-nested@6.2.0(postcss@8.5.20):
+  postcss-nested@6.2.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.20
+      postcss: 8.5.23
       postcss-selector-parser: 6.1.4
 
   postcss-selector-parser@6.1.4:
@@ -23930,11 +23929,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.20
-      postcss-import: 15.1.0(postcss@8.5.20)
-      postcss-js: 4.1.0(postcss@8.5.20)
-      postcss-load-config: 4.0.2(postcss@8.5.20)(ts-node@10.9.2(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@25.9.5)(typescript@6.0.3))
-      postcss-nested: 6.2.0(postcss@8.5.20)
+      postcss: 8.5.23
+      postcss-import: 15.1.0(postcss@8.5.23)
+      postcss-js: 4.1.0(postcss@8.5.23)
+      postcss-load-config: 4.0.2(postcss@8.5.23)(ts-node@10.9.2(@swc/core@1.15.43(@swc/helpers@0.5.23))(@types/node@25.9.5)(typescript@6.0.3))
+      postcss-nested: 6.2.0(postcss@8.5.23)
       postcss-selector-parser: 6.1.4
       resolve: 1.22.12
       sucrase: 3.35.1
@@ -24258,13 +24257,11 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@5.29.0:
-    dependencies:
-      '@fastify/busboy': 2.1.1
-
   undici@6.27.0: {}
 
   undici@7.28.0: {}
+
+  undici@7.29.1: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 

--- a/skills/chatgpt-app-builder/references/evals.md
+++ b/skills/chatgpt-app-builder/references/evals.md
@@ -6,7 +6,7 @@ DevTools proves a tool works when called. An eval proves the model *calls* it, w
 
 ## Setup
 
-1. Dev dependencies: `@skybridge/test@beta` (published on the `beta` dist-tag only), `vitest`, `ai`, and an AI SDK provider (`@ai-sdk/anthropic`, `@ai-sdk/openai`, ...).
+1. Dev dependencies: `@skybridge/test@beta` (published on the `beta` dist-tag only), `vitest@^4` (vitest 5 is not supported yet), `ai`, and an AI SDK provider (`@ai-sdk/anthropic`, `@ai-sdk/openai`, ...).
 2. `vite.config.ts`: `skybridge({ evals: {} })`. This registers the `expect.chat` matchers, picks up `evals/**/*.eval.ts`, raises the per-scenario timeout to two minutes, and loads `.env`.
 3. `package.json`: `"evals": "vitest run evals"`.
 4. The provider key in `.env` (`ANTHROPIC_API_KEY` for `@ai-sdk/anthropic`). If the app has `oauth`, its provider env is needed too: `setup` and `oauth` resolve on the first request.


### PR DESCRIPTION
Fixes from the [Evals QA](https://app.notion.com/p/Evals-3d61e5ce535b805fbe88e0d996f6d248), tracked in [SKY-570](https://linear.app/alpic/issue/SKY-570/evals-qa-follow-up-2026-09-09).

## Summary

- Forgetting `evals: {}` used to leave vitest reporting "No test files found" with nothing pointing at the missing option. The plugin now warns at config time when it sees `evals/**/*.eval.ts` scenarios and the option is off, naming what to add. Discovery itself stays gated on the option, so a project never collects scenarios it has no matchers for.
- The AI SDK moves to v7 (`@ai-sdk/anthropic` v4) in `@skybridge/test`, both examples and the demo template, and the peer becomes `ai: ^7`.
- Vitest stays on 4: the peer is unchanged, and the install commands in the docs and the skill now pin `vitest@^4`, since an unpinned install resolves to vitest 5 today.

## Why declare ai 7 rather than a range

The first version of this PR widened the peer to `^5 || ^6 || ^7`, which promised three majors that CI never runs. Declaring the version the repo actually installs and tests is the honest contract, and an unpinned `pnpm add -D ai` gives a new user v7 anyway.

The package's own scenario test (`packages/test/src/in-process.test.ts`) now runs against ai@7: a tool-call turn and a text turn through the real MCP session, with the matchers asserting on both.

All three eval scenarios in the repo (`examples/capitals`, `examples/auth-descope` including its `authInfo` path, and the demo template) were also run for real against Anthropic on ai@7 and `@ai-sdk/anthropic@4`, and pass. Those are live model calls, so CI does not run them.

`chat.ts` needed no change. The surface it uses (`generateText`, `dynamicTool`, `jsonSchema`, `stepCountIs`, `result.steps[].toolCalls[]`, `result.response.messages`) is identical in v7. What did change is the provider-level mock in that test: `LanguageModelV3Usage` now nests token counts under `inputTokens` / `outputTokens`, and `finishReason` is an object (`{ unified, raw }`) rather than a string. Both are below the API an eval author writes against.

Vitest 5 is a separate, repo-wide bump: eight package.json files across core, devtools, vite-plugin and create-skybridge, unrelated to evals. Worth its own chore rather than riding along here.
